### PR TITLE
refactor: rename Requests to Proposals in frontend

### DIFF
--- a/web/src/components/VaultLayout.tsx
+++ b/web/src/components/VaultLayout.tsx
@@ -3,7 +3,7 @@ import { Link, Outlet, useLocation, useNavigate, useRouteContext } from "@tansta
 import type { AuthContext, VaultContext } from "../router";
 import Navbar from "./Navbar";
 
-type VaultTab = "requests" | "policy" | "credentials" | "users" | "agents" | "settings";
+type VaultTab = "proposals" | "policy" | "credentials" | "users" | "agents" | "settings";
 
 interface NavItem {
   id: VaultTab;
@@ -43,14 +43,14 @@ export default function VaultLayout() {
   // Derive active tab from current URL path
   const pathSegments = location.pathname.split("/");
   const lastSegment = pathSegments[pathSegments.length - 1] as VaultTab;
-  const activeTab: VaultTab = ["requests", "policy", "credentials", "users", "agents", "settings"].includes(lastSegment)
+  const activeTab: VaultTab = ["proposals", "policy", "credentials", "users", "agents", "settings"].includes(lastSegment)
     ? lastSegment
-    : "requests";
+    : "proposals";
 
   const mainNav: NavItem[] = [
     {
-      id: "requests",
-      label: "Requests",
+      id: "proposals",
+      label: "Proposals",
       badge: pendingCount > 0 ? pendingCount : undefined,
       icon: (
         <svg className="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/web/src/pages/vault/ProposalsTab.tsx
+++ b/web/src/pages/vault/ProposalsTab.tsx
@@ -20,7 +20,7 @@ interface Proposal {
   created_at: string;
 }
 
-export default function RequestsTab() {
+export default function ProposalsTab() {
   const { vaultName } = useVaultParams();
   const [proposals, setProposals] = useState<Proposal[]>([]);
   const [loading, setLoading] = useState(true);
@@ -117,7 +117,7 @@ export default function RequestsTab() {
     <div className="p-8 w-full max-w-[960px]">
       <div className="mb-6">
         <h2 className="text-[22px] font-semibold text-text tracking-tight mb-1">
-          Requests
+          Proposals
         </h2>
         <p className="text-sm text-text-muted">
           Review and approve access requests proposed by agents.

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -12,7 +12,7 @@ import Vaults from "./pages/Vaults";
 import VaultInvite from "./pages/VaultInvite";
 import ProposalApprove from "./pages/ProposalApprove";
 import VaultLayout from "./components/VaultLayout";
-import RequestsTab from "./pages/vault/RequestsTab";
+import ProposalsTab from "./pages/vault/ProposalsTab";
 import PolicyTab from "./pages/vault/PolicyTab";
 import CredentialsTab from "./pages/vault/CredentialsTab";
 import UsersTab from "./pages/vault/UsersTab";
@@ -239,14 +239,14 @@ const vaultIndexRoute = createRoute({
   getParentRoute: () => vaultLayoutRoute,
   path: "/",
   beforeLoad: async ({ params }) => {
-    throw redirect({ to: "/vaults/$name/requests", params });
+    throw redirect({ to: "/vaults/$name/proposals", params });
   },
 });
 
-const requestsTabRoute = createRoute({
+const proposalsTabRoute = createRoute({
   getParentRoute: () => vaultLayoutRoute,
-  path: "/requests",
-  component: RequestsTab,
+  path: "/proposals",
+  component: ProposalsTab,
 });
 
 const policyTabRoute = createRoute({
@@ -316,7 +316,7 @@ const routeTree = rootRoute.addChildren([
     ]),
     vaultLayoutRoute.addChildren([
       vaultIndexRoute,
-      requestsTabRoute,
+      proposalsTabRoute,
       policyTabRoute,
       credentialsTabRoute,
       usersTabRoute,


### PR DESCRIPTION
## Summary
- Rename `RequestsTab` to `ProposalsTab` and update the route from `/requests` to `/proposals`
- Aligns frontend terminology with the backend API and domain model

## Test plan
- [ ] Navigate to a vault — default tab should be "Proposals"
- [ ] URL should be `/vaults/{name}/proposals`
- [ ] Proposal list, filtering, and approval modal work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)