### PR TITLE
ci: publish Docker images to Docker Hub on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,9 @@ on:
 
 # Minimal permissions — only grant what's needed.
 permissions:
-  contents: write   # create GitHub releases & upload assets
-  id-token: write   # OIDC token for keyless cosign signing
+  contents: write    # create GitHub releases & upload assets
+  id-token: write    # OIDC token for keyless cosign signing
+  packages: write    # push Docker images
 
 jobs:
   release:
@@ -30,6 +31,18 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,6 +76,42 @@ changelog:
 #     test: |
 #       system "#{bin}/agent-vault", "version"
 
+dockers:
+  - id: amd64
+    goos: linux
+    goarch: amd64
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    image_templates:
+      - "infisical/agent-vault:{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    extra_files:
+      - scripts/docker-entrypoint.sh
+
+  - id: arm64
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    image_templates:
+      - "infisical/agent-vault:{{ .Version }}-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+    extra_files:
+      - scripts/docker-entrypoint.sh
+
+docker_manifests:
+  - name_template: "infisical/agent-vault:{{ .Version }}"
+    image_templates:
+      - "infisical/agent-vault:{{ .Version }}-amd64"
+      - "infisical/agent-vault:{{ .Version }}-arm64"
+
+  - name_template: "infisical/agent-vault:latest"
+    image_templates:
+      - "infisical/agent-vault:{{ .Version }}-amd64"
+      - "infisical/agent-vault:{{ .Version }}-arm64"
+
 release:
   github:
     owner: Infisical

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,21 @@
+# Minimal runtime image for GoReleaser — the binary is pre-built.
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates \
+    && addgroup -S agentvault && adduser -S -G agentvault -u 65532 agentvault \
+    && mkdir -p /data/.agent-vault && chown -R agentvault:agentvault /data
+
+COPY agent-vault /usr/local/bin/agent-vault
+COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENV HOME=/data
+VOLUME /data
+EXPOSE 14321
+USER agentvault
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -qO- http://localhost:14321/health || exit 1
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["server", "--host", "0.0.0.0", "--port", "14321"]


### PR DESCRIPTION
## Summary
- Adds multi-arch Docker image publishing (linux/amd64 + arm64) to the GoReleaser release pipeline
- On `v*` tag push, images are pushed to `infisical/agent-vault` on Docker Hub with `:version` and `:latest` tags
- Adds `Dockerfile.goreleaser` (minimal runtime image for pre-built binaries)

### Changes
- **`.goreleaser.yml`** — `dockers` (per-arch builds via Buildx) + `docker_manifests` (multi-arch `:version` and `:latest`)
- **`.github/workflows/release.yml`** — QEMU, Buildx, Docker Hub login steps + `packages: write` permission
- **`Dockerfile.goreleaser`** — Alpine runtime image that copies the GoReleaser-built binary

### Prerequisites
- `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` org secrets must include the `agent-vault` repo ✅

## Test plan
- [ ] Merge and tag `v0.1.1` — verify images appear on Docker Hub
- [ ] `docker pull infisical/agent-vault:0.1.1` works on both amd64 and arm64
- [ ] `docker run --rm infisical/agent-vault:0.1.1 version` shows correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)