### PR TITLE
feat: HTML email templates and proposal notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ sudo mv agent-vault /usr/local/bin/
 ## Quickstart
 
 ```bash
-# Start the server (runs on localhost:14321 by default)
+# Start the server (runs on localhost:14321 by default; use --host and --port to change)
 agent-vault server -d
 agent-vault register
 agent-vault login

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -113,7 +113,9 @@ var registerCmd = &cobra.Command{
 			return nil
 		}
 
-		if result.EmailSent {
+		if result.Message != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n", successText("✓"), result.Message)
+		} else if result.EmailSent {
 			fmt.Fprintf(cmd.OutOrStdout(), "%s Account created. Check your email for a verification code.\n", successText("✓"))
 		} else {
 			fmt.Fprintf(cmd.OutOrStdout(), "%s Account created. Ask your Agent Vault instance owner for the verification code.\n", successText("✓"))

--- a/internal/server/password_reset_email.html
+++ b/internal/server/password_reset_email.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background:#0b0d10;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#0b0d10;padding:40px 20px;">
+<tr><td align="center">
+<table width="480" cellpadding="0" cellspacing="0" style="background:#1e1f22;border:1px solid rgba(68,69,71,0.6);border-radius:12px;overflow:hidden;">
+  <!-- Header -->
+  <tr><td style="padding:32px 32px 0 32px;">
+    <table cellpadding="0" cellspacing="0"><tr>
+      <td style="width:36px;height:36px;background:#E7F256;border-radius:8px;text-align:center;vertical-align:middle;">
+        <span style="font-size:18px;">&#128274;</span>
+      </td>
+      <td style="padding-left:10px;font-family:'Anonymous Pro',Consolas,monospace;font-size:15px;font-weight:600;color:#e6edf3;letter-spacing:-0.3px;">
+        Agent Vault
+      </td>
+    </tr></table>
+  </td></tr>
+
+  <!-- Body -->
+  <tr><td style="padding:28px 32px;">
+    <h1 style="margin:0 0 8px 0;font-size:20px;font-weight:600;color:#e6edf3;letter-spacing:-0.3px;">Password Reset Code</h1>
+    <p style="margin:0 0 24px 0;font-size:14px;color:#8b949e;line-height:1.5;">
+      Use the code below to reset your password.
+    </p>
+
+    <!-- Code Display -->
+    <table width="100%" cellpadding="0" cellspacing="0" style="background:#0d1117;border:1px solid rgba(68,69,71,0.6);border-radius:8px;margin-bottom:24px;">
+      <tr><td style="padding:20px 16px;text-align:center;">
+        <span style="font-family:'Anonymous Pro',Consolas,monospace;font-size:32px;font-weight:700;color:#E7F256;letter-spacing:6px;">{{CODE}}</span>
+      </td></tr>
+    </table>
+
+    <p style="margin:0 0 8px 0;font-size:13px;color:#8b949e;line-height:1.5;">
+      This code expires in 15 minutes.
+    </p>
+    <p style="margin:0;font-size:13px;color:#8b949e;line-height:1.5;">
+      If you didn't request this, you can safely ignore this email.
+    </p>
+  </td></tr>
+
+  <!-- Footer -->
+  <tr><td style="padding:0 32px 28px 32px;border-top:1px solid rgba(68,69,71,0.6);">
+    <p style="margin:20px 0 0 0;font-size:11px;color:#8b949e;line-height:1.5;text-align:center;">
+      This email was sent by Agent Vault. If you didn't expect this email, you can safely ignore it.
+    </p>
+  </td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/internal/server/proposal_notification_email.html
+++ b/internal/server/proposal_notification_email.html
@@ -19,9 +19,9 @@
 
   <!-- Body -->
   <tr><td style="padding:28px 32px;">
-    <h1 style="margin:0 0 8px 0;font-size:20px;font-weight:600;color:#e6edf3;letter-spacing:-0.3px;">You've been invited</h1>
+    <h1 style="margin:0 0 8px 0;font-size:20px;font-weight:600;color:#e6edf3;letter-spacing:-0.3px;">New Proposal Awaiting Review</h1>
     <p style="margin:0 0 24px 0;font-size:14px;color:#8b949e;line-height:1.5;">
-      You've been invited to join Agent Vault. Click the button below to set a password and create your account.
+      A new proposal has been created in vault <strong style="color:#e6edf3;">{{VAULT_NAME}}</strong> and is waiting for your review.
     </p>
 
     <!-- Meta -->
@@ -29,18 +29,23 @@
       <tr><td style="padding:14px 16px;">
         <table width="100%" cellpadding="0" cellspacing="0">
           <tr>
-            <td style="font-family:'Anonymous Pro',Consolas,monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:#8b949e;">Invited By</td>
-            <td align="right" style="font-family:'Anonymous Pro',Consolas,monospace;font-size:13px;color:#e6edf3;">{{INVITER_EMAIL}}</td>
-          </tr>
-          <tr><td colspan="2" style="height:10px;"></td></tr>
-          <tr>
             <td style="font-family:'Anonymous Pro',Consolas,monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:#8b949e;">Vault</td>
-            <td align="right" style="font-family:'Anonymous Pro',Consolas,monospace;font-size:13px;color:#E7F256;">{{VAULTS}}</td>
+            <td align="right" style="font-family:'Anonymous Pro',Consolas,monospace;font-size:13px;color:#E7F256;">{{VAULT_NAME}}</td>
           </tr>
           <tr><td colspan="2" style="height:10px;"></td></tr>
           <tr>
-            <td style="font-family:'Anonymous Pro',Consolas,monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:#8b949e;">Expires</td>
-            <td align="right" style="font-family:'Anonymous Pro',Consolas,monospace;font-size:13px;color:#8b949e;">48 hours</td>
+            <td style="font-family:'Anonymous Pro',Consolas,monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:#8b949e;">Agent</td>
+            <td align="right" style="font-family:'Anonymous Pro',Consolas,monospace;font-size:13px;color:#e6edf3;">{{AGENT_NAME}}</td>
+          </tr>
+          <tr><td colspan="2" style="height:10px;"></td></tr>
+          <tr>
+            <td style="font-family:'Anonymous Pro',Consolas,monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:#8b949e;">Proposal</td>
+            <td align="right" style="font-family:'Anonymous Pro',Consolas,monospace;font-size:13px;color:#e6edf3;">#{{PROPOSAL_ID}}</td>
+          </tr>
+          <tr><td colspan="2" style="height:10px;"></td></tr>
+          <tr>
+            <td style="font-family:'Anonymous Pro',Consolas,monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:#8b949e;">Message</td>
+            <td align="right" style="font-family:'Anonymous Pro',Consolas,monospace;font-size:13px;color:#8b949e;">{{MESSAGE}}</td>
           </tr>
         </table>
       </td></tr>
@@ -49,8 +54,8 @@
     <!-- CTA Button -->
     <table width="100%" cellpadding="0" cellspacing="0">
       <tr><td align="center">
-        <a href="{{INVITE_LINK}}" target="_blank" style="display:inline-block;padding:12px 32px;background:#E7F256;color:#0b0d10;text-decoration:none;border-radius:8px;font-size:14px;font-weight:600;">
-          Accept Invitation
+        <a href="{{APPROVAL_URL}}" target="_blank" style="display:inline-block;padding:12px 32px;background:#E7F256;color:#0b0d10;text-decoration:none;border-radius:8px;font-size:14px;font-weight:600;">
+          Review Proposal
         </a>
       </td></tr>
     </table>
@@ -58,14 +63,14 @@
     <!-- Fallback link -->
     <p style="margin:20px 0 0 0;font-size:12px;color:#8b949e;line-height:1.5;word-break:break-all;">
       If the button doesn't work, copy and paste this link into your browser:<br><br>
-      <a href="{{INVITE_LINK}}" style="color:#E7F256;text-decoration:none;">{{INVITE_LINK}}</a>
+      <a href="{{APPROVAL_URL}}" style="color:#E7F256;text-decoration:none;">{{APPROVAL_URL}}</a>
     </p>
   </td></tr>
 
   <!-- Footer -->
   <tr><td style="padding:0 32px 28px 32px;border-top:1px solid rgba(68,69,71,0.6);">
     <p style="margin:20px 0 0 0;font-size:11px;color:#8b949e;line-height:1.5;text-align:center;">
-      This invitation was sent by Agent Vault. If you didn't expect this email, you can safely ignore it.
+      This notification was sent by Agent Vault. If you didn't expect this email, you can safely ignore it.
     </p>
   </td></tr>
 </table>

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -51,6 +51,18 @@ var webDistFS embed.FS
 //go:embed invite_email.html
 var userInviteEmailHTML string
 
+//go:embed proposal_notification_email.html
+var proposalNotificationEmailHTML string
+
+//go:embed verification_code_email.html
+var verificationCodeEmailHTML string
+
+//go:embed password_reset_email.html
+var passwordResetEmailHTML string
+
+//go:embed test_email.html
+var testEmailHTML string
+
 // Server is the Agent Vault HTTP server.
 type Server struct {
 	httpServer  *http.Server
@@ -587,9 +599,9 @@ func (s *Server) Start() error {
 
 	errCh := make(chan error, 1)
 	go func() {
-		fmt.Printf("Agent Vault server listening on %s\n", s.httpServer.Addr)
+		fmt.Printf("Agent Vault server listening on %s\n", s.baseURL)
 		if !s.initialized {
-			fmt.Printf("  → Visit %s/register to create the owner account\n", s.baseURL)
+			fmt.Printf("Run `agent-vault register` or visit %s to create the owner account\n", s.baseURL)
 		}
 		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			errCh <- err
@@ -755,8 +767,8 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 		emailSent := false
 		if s.notifier.Enabled() {
-			body := fmt.Sprintf("Your Agent Vault verification code is: %s\n\nThis code expires in 15 minutes.", code)
-			if err := s.notifier.SendMail([]string{req.Email}, "Agent Vault verification code", body); err != nil {
+			body := strings.Replace(verificationCodeEmailHTML, "{{CODE}}", html.EscapeString(code), 1)
+			if err := s.notifier.SendHTMLMail([]string{req.Email}, "Agent Vault verification code", body); err != nil {
 				fmt.Fprintf(os.Stderr, "[agent-vault] Failed to send verification email to %s: %v\n", req.Email, err)
 				fmt.Fprintf(os.Stderr, "[agent-vault] Email verification code for %s: %s\n", req.Email, code)
 			} else {
@@ -851,8 +863,8 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	// Send verification code via email or log to stderr.
 	emailSent := false
 	if s.notifier.Enabled() {
-		body := fmt.Sprintf("Your Agent Vault verification code is: %s\n\nThis code expires in 15 minutes.", code)
-		if err := s.notifier.SendMail([]string{req.Email}, "Agent Vault verification code", body); err != nil {
+		body := strings.Replace(verificationCodeEmailHTML, "{{CODE}}", html.EscapeString(code), 1)
+		if err := s.notifier.SendHTMLMail([]string{req.Email}, "Agent Vault verification code", body); err != nil {
 			fmt.Fprintf(os.Stderr, "[agent-vault] Failed to send verification email to %s: %v\n", req.Email, err)
 			fmt.Fprintf(os.Stderr, "[agent-vault] Email verification code for %s: %s\n", req.Email, code)
 		} else {
@@ -1016,8 +1028,8 @@ func (s *Server) handleForgotPassword(w http.ResponseWriter, r *http.Request) {
 	// Send code via email or log to stderr.
 	emailSent := false
 	if s.notifier.Enabled() {
-		body := fmt.Sprintf("Your Agent Vault password reset code is: %s\n\nThis code expires in 15 minutes.\n\nIf you didn't request this, you can safely ignore this email.", code)
-		if err := s.notifier.SendMail([]string{req.Email}, "Agent Vault password reset code", body); err != nil {
+		body := strings.Replace(passwordResetEmailHTML, "{{CODE}}", html.EscapeString(code), 1)
+		if err := s.notifier.SendHTMLMail([]string{req.Email}, "Agent Vault password reset code", body); err != nil {
 			fmt.Fprintf(os.Stderr, "[agent-vault] Failed to send password reset email to %s: %v\n", req.Email, err)
 			fmt.Fprintf(os.Stderr, "[agent-vault] Password reset code for %s: %s\n", req.Email, code)
 		} else {
@@ -1323,6 +1335,14 @@ func (s *Server) handleProposalApproveDetails(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// Resolve agent name via session -> agent chain.
+	agentName := ""
+	if sess, err := s.store.GetSession(ctx, cs.SessionID); err == nil && sess != nil && sess.AgentID != "" {
+		if agent, err := s.store.GetAgentByID(ctx, sess.AgentID); err == nil && agent != nil {
+			agentName = agent.Name
+		}
+	}
+
 	authenticated := false
 	canApprove := false
 	userEmail := ""
@@ -1351,6 +1371,7 @@ func (s *Server) handleProposalApproveDetails(w http.ResponseWriter, r *http.Req
 		"rules":         json.RawMessage(cs.RulesJSON),
 		"credentials":       json.RawMessage(cs.CredentialsJSON),
 		"created_at":    cs.CreatedAt.Format(time.RFC3339),
+		"agent_name":    agentName,
 		"authenticated": authenticated,
 		"can_approve":   canApprove,
 		"user_email":    userEmail,
@@ -2105,6 +2126,19 @@ func (s *Server) handleProposalCreate(w http.ResponseWriter, r *http.Request) {
 
 	approvalURL := fmt.Sprintf("%s/approve/%d?token=%s", s.baseURL, cs.ID, cs.ApprovalToken)
 
+	// Resolve agent name for the notification email.
+	proposalAgentName := ""
+	if sess.AgentID != "" {
+		if agent, err := s.store.GetAgentByID(ctx, sess.AgentID); err == nil && agent != nil {
+			proposalAgentName = agent.Name
+		}
+	}
+
+	// Notify vault members about the new proposal (fire-and-forget).
+	if s.notifier.Enabled() {
+		go s.notifyProposalCreated(sess.VaultID, nsName, cs.ID, req.Message, approvalURL, proposalAgentName)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(map[string]interface{}{
@@ -2114,6 +2148,45 @@ func (s *Server) handleProposalCreate(w http.ResponseWriter, r *http.Request) {
 		"approval_url": approvalURL,
 		"message":      fmt.Sprintf("Proposal created. Approve here: %s", approvalURL),
 	})
+}
+
+// notifyProposalCreated sends an email notification to all vault members
+// when a new proposal is created. Intended to be called in a goroutine.
+func (s *Server) notifyProposalCreated(vaultID, vaultName string, proposalID int, message, approvalURL, agentName string) {
+	ctx := context.Background()
+
+	grants, err := s.store.ListVaultUsers(ctx, vaultID)
+	if err != nil || len(grants) == 0 {
+		return
+	}
+
+	var emails []string
+	for _, g := range grants {
+		if u, err := s.store.GetUserByID(ctx, g.UserID); err == nil && u != nil {
+			emails = append(emails, u.Email)
+		}
+	}
+	if len(emails) == 0 {
+		return
+	}
+
+	// Truncate message for the email body.
+	msg := message
+	if len(msg) > 200 {
+		msg = msg[:200] + "..."
+	}
+
+	subject := fmt.Sprintf("New proposal (#%d) in vault %q", proposalID, vaultName)
+	body := proposalNotificationEmailHTML
+	body = strings.ReplaceAll(body, "{{VAULT_NAME}}", html.EscapeString(vaultName))
+	body = strings.ReplaceAll(body, "{{PROPOSAL_ID}}", strconv.Itoa(proposalID))
+	body = strings.ReplaceAll(body, "{{MESSAGE}}", html.EscapeString(msg))
+	body = strings.ReplaceAll(body, "{{AGENT_NAME}}", html.EscapeString(agentName))
+	body = strings.ReplaceAll(body, "{{APPROVAL_URL}}", html.EscapeString(approvalURL))
+
+	if err := s.notifier.SendHTMLMail(emails, subject, body); err != nil {
+		fmt.Fprintf(os.Stderr, "[agent-vault] Failed to send proposal notification: %v\n", err)
+	}
 }
 
 func (s *Server) handleProposalGet(w http.ResponseWriter, r *http.Request) {
@@ -3155,10 +3228,10 @@ func (s *Server) handleEmailTest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := s.notifier.SendMail(
+	if err := s.notifier.SendHTMLMail(
 		[]string{to},
 		"Agent Vault \u2014 Test Email",
-		"This is a test email from Agent Vault.\nIf you received this, your SMTP configuration is working correctly.",
+		testEmailHTML,
 	); err != nil {
 		jsonError(w, http.StatusBadGateway, fmt.Sprintf("Failed to send test email: %v", err))
 		return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2135,8 +2135,9 @@ func (s *Server) handleProposalCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Notify vault members about the new proposal (fire-and-forget).
+	// The goroutine intentionally outlives the request, so we use a detached context.
 	if s.notifier.Enabled() {
-		go s.notifyProposalCreated(sess.VaultID, nsName, cs.ID, req.Message, approvalURL, proposalAgentName)
+		go s.notifyProposalCreated(sess.VaultID, nsName, cs.ID, req.Message, approvalURL, proposalAgentName) //nolint:gosec // G118: intentional fire-and-forget goroutine
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/server/test_email.html
+++ b/internal/server/test_email.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background:#0b0d10;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#0b0d10;padding:40px 20px;">
+<tr><td align="center">
+<table width="480" cellpadding="0" cellspacing="0" style="background:#1e1f22;border:1px solid rgba(68,69,71,0.6);border-radius:12px;overflow:hidden;">
+  <!-- Header -->
+  <tr><td style="padding:32px 32px 0 32px;">
+    <table cellpadding="0" cellspacing="0"><tr>
+      <td style="width:36px;height:36px;background:#E7F256;border-radius:8px;text-align:center;vertical-align:middle;">
+        <span style="font-size:18px;">&#128274;</span>
+      </td>
+      <td style="padding-left:10px;font-family:'Anonymous Pro',Consolas,monospace;font-size:15px;font-weight:600;color:#e6edf3;letter-spacing:-0.3px;">
+        Agent Vault
+      </td>
+    </tr></table>
+  </td></tr>
+
+  <!-- Body -->
+  <tr><td style="padding:28px 32px;">
+    <h1 style="margin:0 0 8px 0;font-size:20px;font-weight:600;color:#e6edf3;letter-spacing:-0.3px;">SMTP Configuration Test</h1>
+    <p style="margin:0;font-size:14px;color:#8b949e;line-height:1.5;">
+      This is a test email from Agent Vault. If you received this, your SMTP configuration is working correctly.
+    </p>
+  </td></tr>
+
+  <!-- Footer -->
+  <tr><td style="padding:0 32px 28px 32px;border-top:1px solid rgba(68,69,71,0.6);">
+    <p style="margin:20px 0 0 0;font-size:11px;color:#8b949e;line-height:1.5;text-align:center;">
+      This email was sent by Agent Vault.
+    </p>
+  </td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/internal/server/verification_code_email.html
+++ b/internal/server/verification_code_email.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background:#0b0d10;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#0b0d10;padding:40px 20px;">
+<tr><td align="center">
+<table width="480" cellpadding="0" cellspacing="0" style="background:#1e1f22;border:1px solid rgba(68,69,71,0.6);border-radius:12px;overflow:hidden;">
+  <!-- Header -->
+  <tr><td style="padding:32px 32px 0 32px;">
+    <table cellpadding="0" cellspacing="0"><tr>
+      <td style="width:36px;height:36px;background:#E7F256;border-radius:8px;text-align:center;vertical-align:middle;">
+        <span style="font-size:18px;">&#128274;</span>
+      </td>
+      <td style="padding-left:10px;font-family:'Anonymous Pro',Consolas,monospace;font-size:15px;font-weight:600;color:#e6edf3;letter-spacing:-0.3px;">
+        Agent Vault
+      </td>
+    </tr></table>
+  </td></tr>
+
+  <!-- Body -->
+  <tr><td style="padding:28px 32px;">
+    <h1 style="margin:0 0 8px 0;font-size:20px;font-weight:600;color:#e6edf3;letter-spacing:-0.3px;">Your Verification Code</h1>
+    <p style="margin:0 0 24px 0;font-size:14px;color:#8b949e;line-height:1.5;">
+      Use the code below to verify your email address.
+    </p>
+
+    <!-- Code Display -->
+    <table width="100%" cellpadding="0" cellspacing="0" style="background:#0d1117;border:1px solid rgba(68,69,71,0.6);border-radius:8px;margin-bottom:24px;">
+      <tr><td style="padding:20px 16px;text-align:center;">
+        <span style="font-family:'Anonymous Pro',Consolas,monospace;font-size:32px;font-weight:700;color:#E7F256;letter-spacing:6px;">{{CODE}}</span>
+      </td></tr>
+    </table>
+
+    <p style="margin:0;font-size:13px;color:#8b949e;line-height:1.5;">
+      This code expires in 15 minutes.
+    </p>
+  </td></tr>
+
+  <!-- Footer -->
+  <tr><td style="padding:0 32px 28px 32px;border-top:1px solid rgba(68,69,71,0.6);">
+    <p style="margin:20px 0 0 0;font-size:11px;color:#8b949e;line-height:1.5;text-align:center;">
+      This email was sent by Agent Vault. If you didn't expect this email, you can safely ignore it.
+    </p>
+  </td></tr>
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/web/src/components/ProposalPreview.tsx
+++ b/web/src/components/ProposalPreview.tsx
@@ -34,6 +34,7 @@ export interface ProposalData {
   rules?: Rule[];
   credentials?: CredentialSlot[];
   created_at?: string;
+  agent_name?: string;
 }
 
 /** Parse rules from a JSON string (as stored on proposal rows). */
@@ -126,6 +127,23 @@ export default function ProposalPreview({ data }: { data: ProposalData }) {
               ? (setRules.length > 0 ? "Connect to " : "") + titleParts.join(" & ")
               : "Policy change"}
           </h1>
+          {(data.vault || data.agent_name) && (
+            <div className="flex items-center gap-2 mt-1.5 text-xs text-text-muted">
+              {data.vault && (
+                <span className="inline-flex items-center gap-1">
+                  <span className="font-medium">Vault:</span>
+                  <span className="font-mono">{data.vault}</span>
+                </span>
+              )}
+              {data.vault && data.agent_name && <span>&middot;</span>}
+              {data.agent_name && (
+                <span className="inline-flex items-center gap-1">
+                  <span className="font-medium">Agent:</span>
+                  <span className="font-mono">{data.agent_name}</span>
+                </span>
+              )}
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Replace plain-text emails with branded HTML templates (verification codes, password resets, test emails, vault invites) using the app's dark theme and `#E7F256` accent color
- Add proposal notification emails — vault members are notified when agents create new proposals, with a direct link to the approval page
- Show agent name on the proposal approval page for better context
- Minor UX improvements: clearer server startup messages, register command surfaces server-provided messages

## Test plan
- [ ] Verify HTML emails render correctly in major email clients (Gmail, Outlook, Apple Mail)
- [ ] Test proposal creation triggers notification emails to vault members
- [ ] Confirm agent name appears on the proposal approval page
- [ ] Run `agent-vault email test` and verify branded HTML test email
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)