### PR TITLE
feat: direct connect sessions and security hardening

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -401,3 +401,55 @@ func TestInviteCreatePersistentFlags(t *testing.T) {
 		t.Errorf("expected --name default to be empty, got %q", f.DefValue)
 	}
 }
+
+func TestInviteCreateDirectFlags(t *testing.T) {
+	// Find vault > agent > invite > create command.
+	vCmd := findSubcommand(rootCmd, "vault")
+	if vCmd == nil {
+		t.Fatal("vault command not found")
+	}
+	agCmd := findSubcommand(vCmd, "agent")
+	if agCmd == nil {
+		t.Fatal("agent command not found under vault")
+	}
+
+	var invCmd *cobra.Command
+	for _, c := range agCmd.Commands() {
+		if c.Name() == "invite" {
+			invCmd = c
+			break
+		}
+	}
+	if invCmd == nil {
+		t.Fatal("invite command not found under agent")
+	}
+
+	var createCmd *cobra.Command
+	for _, c := range invCmd.Commands() {
+		if c.Name() == "create" {
+			createCmd = c
+			break
+		}
+	}
+	if createCmd == nil {
+		t.Fatal("create command not found under invite")
+	}
+
+	// Verify --direct flag exists.
+	f := createCmd.Flags().Lookup("direct")
+	if f == nil {
+		t.Fatal("expected --direct flag on invite create command")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("expected --direct default to be false, got %q", f.DefValue)
+	}
+
+	// Verify --label flag exists.
+	f = createCmd.Flags().Lookup("label")
+	if f == nil {
+		t.Fatal("expected --label flag on invite create command")
+	}
+	if f.DefValue != "" {
+		t.Errorf("expected --label default to be empty, got %q", f.DefValue)
+	}
+}

--- a/cmd/invite.go
+++ b/cmd/invite.go
@@ -24,11 +24,22 @@ var inviteCreateCmd = &cobra.Command{
 		vault := resolveVault(cmd)
 		ttl, _ := cmd.Flags().GetDuration("ttl")
 		persistent, _ := cmd.Flags().GetBool("persistent")
+		direct, _ := cmd.Flags().GetBool("direct")
 		agentName, _ := cmd.Flags().GetString("name")
 		vaultRole, _ := cmd.Flags().GetString("role")
+		label, _ := cmd.Flags().GetString("label")
 
 		if agentName != "" && !persistent {
 			return fmt.Errorf("--name requires --persistent")
+		}
+		if direct && persistent {
+			return fmt.Errorf("--direct and --persistent are mutually exclusive")
+		}
+		if direct && agentName != "" {
+			return fmt.Errorf("--direct and --name are mutually exclusive")
+		}
+		if label != "" && !direct {
+			return fmt.Errorf("--label requires --direct")
 		}
 		if vaultRole != "" && vaultRole != "consumer" && vaultRole != "member" && vaultRole != "admin" {
 			return fmt.Errorf("--role must be one of: consumer, member, admin")
@@ -42,6 +53,51 @@ var inviteCreateCmd = &cobra.Command{
 		addr := sess.Address
 		if flagAddr, _ := cmd.Flags().GetString("address"); flagAddr != "" {
 			addr = flagAddr
+		}
+
+		// Direct connect: mint credentials immediately.
+		if direct {
+			reqBody := map[string]interface{}{
+				"vault":       vault,
+				"ttl_seconds": int(ttl.Seconds()),
+			}
+			if vaultRole != "" {
+				reqBody["vault_role"] = vaultRole
+			}
+			if label != "" {
+				reqBody["label"] = label
+			}
+			body, err := json.Marshal(reqBody)
+			if err != nil {
+				return err
+			}
+
+			url := fmt.Sprintf("%s/v1/sessions/direct", addr)
+			respBody, err := doAdminRequestWithBody("POST", url, sess.Token, body)
+			if err != nil {
+				return err
+			}
+
+			var resp struct {
+				AVAddr         string `json:"av_addr"`
+				AVSessionToken string `json:"av_session_token"`
+				AVVault        string `json:"av_vault"`
+				VaultRole      string `json:"vault_role"`
+				ExpiresAt      string `json:"expires_at"`
+			}
+			if err := json.Unmarshal(respBody, &resp); err != nil {
+				return fmt.Errorf("parsing response: %w", err)
+			}
+
+			envBlock := fmt.Sprintf("export AGENT_VAULT_ADDR=%q\nexport AGENT_VAULT_SESSION_TOKEN=%q\nexport AGENT_VAULT_VAULT=%q",
+				resp.AVAddr, resp.AVSessionToken, resp.AVVault)
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Direct connect session created (role: %s, expires in %s).\n\n", resp.VaultRole, formatDuration(ttl))
+			fmt.Fprintf(cmd.OutOrStdout(), "---\n\n%s\n\n---\n", envBlock)
+			if err := copyToClipboard(envBlock); err == nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "\n(Copied to clipboard)\n")
+			}
+			return nil
 		}
 
 		reqBody := map[string]interface{}{
@@ -290,6 +346,8 @@ func init() {
 	inviteCreateCmd.Flags().Bool("persistent", false, "create a persistent agent invite")
 	inviteCreateCmd.Flags().String("name", "", "pre-set the agent name (requires --persistent)")
 	inviteCreateCmd.Flags().String("role", "", "vault role for the invited agent (consumer, member, admin; default: consumer)")
+	inviteCreateCmd.Flags().Bool("direct", false, "mint credentials immediately (skip invite ceremony)")
+	inviteCreateCmd.Flags().String("label", "", "optional label for the session (direct connect only)")
 	inviteListCmd.Flags().String("status", "", "filter by status (pending, redeemed, expired, revoked)")
 
 	inviteCmd.AddCommand(inviteCreateCmd)

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -3,7 +3,7 @@ title: "Agents"
 description: "Understand the two types of agents in Agent Vault and how to connect them."
 ---
 
-An `Agent` is any AI-powered process that connects to a [vault](/learn/vaults) to proxy requests and raise [proposals](/learn/proposals) through Agent Vault. Agent Vault recognizes two types of agents: **temporary** and **persistent**.
+An `Agent` is any AI-powered process that connects to a [vault](/learn/vaults) to proxy requests and raise [proposals](/learn/proposals) through Agent Vault. Agent Vault supports three ways to connect agents: **temporary**, **direct connect**, and **persistent**.
 
 ## Temporary agents
 
@@ -29,6 +29,36 @@ agent-vault vault agent invite create --vault my-vault
 ```
 
 Outputs a prompt with the invite URL. Paste it into the agent's chat. The token is burned on redemption and the agent receives a single session token.
+
+## Direct connect
+
+Direct connect skips the invite ceremony entirely. Instead of creating an invite link for the agent to redeem, it mints a scoped session token immediately and outputs the environment variables you can paste into any agent.
+
+```bash
+agent-vault vault agent invite create --direct --vault my-vault
+```
+
+This prints an `export` block with `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT` (and copies it to your clipboard). Paste these into the agent's environment or chat.
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--role` | `consumer` | Vault role: `consumer`, `member`, or `admin` |
+| `--ttl` | `24h` | Session lifetime (min 5m, max 7d) |
+| `--label` | | Optional label to identify the session |
+
+```bash
+# Create a 1-hour consumer session
+agent-vault vault agent invite create --direct --ttl 1h
+
+# Create an admin session with a label
+agent-vault vault agent invite create --direct --role admin --label "ci-pipeline" --ttl 4h
+```
+
+<Note>
+Direct connect sessions have a maximum TTL of 7 days. For agents that need indefinite access, use [persistent agents](#persistent-agents) instead.
+</Note>
 
 ## Persistent agents
 
@@ -74,6 +104,7 @@ This creates a rotation invite. Paste the prompt into the agent's chat. The agen
 |---|---|---|
 | Local dev with Claude Code or Cursor | Temporary (`agent-vault vault run`) | Simplest setup, no tokens to manage |
 | Paste into a cloud agent for a task | Temporary (one-time invite) | Session expires when the task is done |
+| Quick scripted access, CI jobs | Direct connect | Instant token, no invite ceremony |
 | CI/CD pipeline on every push | Persistent | Reconnects without human intervention |
 | Always-on assistant (e.g. OpenClaw) | Persistent | Survives process restarts |
 

--- a/docs/agents/protocol.mdx
+++ b/docs/agents/protocol.mdx
@@ -17,6 +17,7 @@ Every request an agent makes to Agent Vault requires a session token. How the ag
 |---|---|
 | `agent-vault vault run` | Agent Vault sets `AGENT_VAULT_SESSION_TOKEN` on the child process automatically |
 | One-time invite | Agent calls `GET {invite_url}` and receives a token in the response |
+| Direct connect | A human runs `agent-vault vault agent invite create --direct` and pastes the resulting env vars into the agent |
 | Persistent invite | Agent calls `POST {invite_url}` and receives both a `av_agent_token` (service token) and an initial session token |
 
 All three methods deliver the same set of connection details:
@@ -26,6 +27,47 @@ All three methods deliver the same set of connection details:
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_SESSION_TOKEN` | Bearer token for all Agent Vault requests |
 | `AGENT_VAULT_VAULT` | Vault the session is scoped to |
+
+### Direct session API
+
+The direct connect flow uses `POST /v1/sessions/direct` to mint a scoped session without an invite. This is called by the CLI on behalf of the human, not by the agent itself.
+
+```json
+POST {AGENT_VAULT_ADDR}/v1/sessions/direct
+Authorization: Bearer {user_or_agent_session_token}
+Content-Type: application/json
+
+{
+  "vault": "default",
+  "vault_role": "consumer",
+  "ttl_seconds": 3600,
+  "label": "ci-pipeline"
+}
+```
+
+```json Response
+{
+  "av_addr": "http://127.0.0.1:14321",
+  "av_session_token": "...",
+  "av_vault": "default",
+  "vault_role": "consumer",
+  "proxy_url": "http://127.0.0.1:14321/proxy",
+  "services": [{ "host": "api.stripe.com", "description": "Stripe API" }],
+  "instructions": "...",
+  "expires_at": "2025-01-02T03:04:05Z"
+}
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `vault` | `default` | Target vault |
+| `vault_role` | `consumer` | Role for the new session (`consumer`, `member`, or `admin`). Capped based on the caller's own role. |
+| `ttl_seconds` | `86400` (24h) | Session lifetime in seconds (min 300, max 604800) |
+| `label` | | Optional label for identifying the session (max 128 chars) |
+
+Role capping: vault members can only mint `consumer` sessions. Vault admins can mint any role. The requested role is silently downgraded if needed.
+
+### Persistent agent sessions
 
 Persistent agents also receive a `av_agent_token` (no expiry, revocable). When the session token expires after 24 hours, the agent mints a new one:
 

--- a/docs/guides/instance-settings.mdx
+++ b/docs/guides/instance-settings.mdx
@@ -74,6 +74,10 @@ Both settings stack — invite-only controls *whether* someone can register, and
 | Domain restrictions only | Anyone with a matching email domain can self-register. |
 | Both | No self-registration. Only [vault invites](/learn/vaults#invite-users-to-a-vault) with a matching email domain. |
 
+## SMTP status
+
+The settings response includes an `smtp_configured` field (boolean) indicating whether [SMTP](/guides/smtp) is configured on the instance. This is visible in the web UI settings page and in the API response from `GET /v1/admin/settings`.
+
 ## View current settings
 
 ```bash

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -379,16 +379,20 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault agent invite create [flags]
     ```
 
-    Create an agent invite and print the onboarding prompt (copies to clipboard). By default creates a one-time invite. Use `--persistent` for agents that need ongoing access with a long-lived service token.
+    Create an agent invite and print the onboarding prompt (copies to clipboard). By default creates a one-time invite. Use `--persistent` for agents that need ongoing access with a long-lived service token. Use `--direct` to skip the invite ceremony and mint a session token immediately.
 
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--vault` | `default` | Target vault |
-    | `--ttl` | `15m` | Invite expiration time |
+    | `--ttl` | `15m` | Invite expiration time (direct connect: session lifetime, min 5m, max 7d) |
     | `--persistent` | `false` | Create a persistent agent invite |
+    | `--direct` | `false` | Mint a session token immediately (skip invite ceremony) |
     | `--name` | | Agent name (persistent invites only) |
+    | `--label` | | Optional session label (direct connect only) |
     | `--address` | | Server address override (default: from session) |
     | `--role` | `consumer` | Vault role for the invited agent: `consumer`, `member`, or `admin` |
+
+    `--direct` and `--persistent` are mutually exclusive. `--label` requires `--direct`.
   </Accordion>
 
   <Accordion title="agent-vault vault agent invite list">

--- a/docs/self-hosting/fly-io.mdx
+++ b/docs/self-hosting/fly-io.mdx
@@ -14,14 +14,14 @@ description: "Deploy Agent Vault to Fly.io with persistent storage"
     ```
   </Step>
 
-  <Step title="Clone the repo and launch">
+  <Step title="Clone the repo and create the app">
     ```bash
     git clone https://github.com/infisical/agent-vault.git
     cd agent-vault
-    fly launch
+    fly launch --no-deploy
     ```
 
-    The included `fly.toml` configures port 14321, HTTPS, health checks, and a persistent volume automatically. Fly will prompt you to create the volume on first deploy.
+    When prompted, keep the existing `fly.toml` configuration. The `--no-deploy` flag prevents deploying before secrets are set.
   </Step>
 
   <Step title="Set secrets">
@@ -42,6 +42,13 @@ description: "Deploy Agent Vault to Fly.io with persistent storage"
 
   <Step title="Deploy">
     ```bash
+    fly deploy
+    ```
+
+    On first deploy, Fly will prompt you to create the persistent volume. If it doesn't, create one manually:
+
+    ```bash
+    fly volumes create agent_vault_data --region sjc --size 1
     fly deploy
     ```
   </Step>
@@ -67,9 +74,8 @@ description: "Deploy Agent Vault to Fly.io with persistent storage"
 - **Config**: `fly.toml` sets port 14321, forces HTTPS, and enables auto-stop/auto-start machines
 - **Entrypoint**: `scripts/docker-entrypoint.sh` forwards arguments to the `agent-vault` binary, which natively reads `AGENT_VAULT_MASTER_PASSWORD` from the environment
 - **Storage**: Persistent volume `agent_vault_data` mounted at `/data` -- all state is in a single SQLite file
+- **Cold starts**: `min_machines_running` defaults to `0`, so the app scales to zero when idle. The first request after sleep incurs a few seconds of cold-start latency. Set it to `1` in `fly.toml` if you need always-on availability.
 
 <Warning>
   Use a consistent master password across deploys. Changing it makes existing encrypted credentials unreadable. If you need to rotate, export your data first.
 </Warning>
-
-

--- a/fly.toml
+++ b/fly.toml
@@ -12,7 +12,7 @@ primary_region = "sjc"
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 0  # Set to 1 to avoid cold-start latency
 
 [[vm]]
   size = "shared-cpu-1x"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -88,7 +88,7 @@ type Store interface {
 	CountOwners(ctx context.Context) (int, error)
 	RegisterFirstUser(ctx context.Context, email string, passwordHash, passwordSalt []byte, defaultVaultID string, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) (*store.User, error)
 	CreateSession(ctx context.Context, userID string, expiresAt time.Time) (*store.Session, error)
-	CreateScopedSession(ctx context.Context, vaultID, vaultRole string, expiresAt time.Time) (*store.Session, error)
+	CreateScopedSession(ctx context.Context, vaultID, vaultRole, label string, expiresAt time.Time) (*store.Session, error)
 	GetSession(ctx context.Context, id string) (*store.Session, error)
 	DeleteSession(ctx context.Context, id string) error
 	DeleteUserSessions(ctx context.Context, userID string) error
@@ -464,6 +464,7 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("POST /v1/auth/change-password", s.requireInitialized(s.requireAuth(limitBody(s.handleChangePassword))))
 	mux.HandleFunc("DELETE /v1/auth/account", s.requireInitialized(s.requireAuth(s.handleDeleteAccount)))
 	mux.HandleFunc("POST /v1/sessions/scoped", s.requireInitialized(s.requireAuth(limitBody(s.handleScopedSession))))
+	mux.HandleFunc("POST /v1/sessions/direct", s.requireInitialized(s.requireAuth(limitBody(s.handleDirectSession))))
 	mux.HandleFunc("GET /v1/credentials", s.requireInitialized(s.requireAuth(s.handleCredentialsList)))
 	mux.HandleFunc("POST /v1/credentials", s.requireInitialized(s.requireAuth(limitBody(s.handleCredentialsSet))))
 	mux.HandleFunc("DELETE /v1/credentials", s.requireInitialized(s.requireAuth(limitBody(s.handleCredentialsDelete))))
@@ -1804,7 +1805,7 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sess, err := s.store.CreateScopedSession(ctx, ns.ID, "", time.Now().Add(sessionTTL))
+	sess, err := s.store.CreateScopedSession(ctx, ns.ID, "", "", time.Now().Add(sessionTTL))
 	if err != nil {
 		http.Error(w, `{"error":"Failed to create scoped session"}`, http.StatusInternalServerError)
 		return
@@ -1814,6 +1815,145 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(scopedSessionResponse{
 		Token:     sess.ID,
 		ExpiresAt: sess.ExpiresAt.Format(time.RFC3339),
+	})
+}
+
+// capRequestedRole enforces role-capping rules: consumers cannot mint sessions,
+// members can only mint consumer sessions, admins can mint any role.
+// Returns the (possibly capped) role, or an error string if the caller lacks permission.
+func (s *Server) capRequestedRole(ctx context.Context, sess *store.Session, vaultID, requestedRole string) (string, string) {
+	if requestedRole == "" {
+		requestedRole = "consumer"
+	}
+
+	if sess.VaultID != "" {
+		// Scoped session (agent or temp invite).
+		if sess.VaultID != vaultID {
+			return "", "Session not authorized for this vault"
+		}
+		if !agentRoleSatisfies(sess.VaultRole, "member") {
+			return "", "Member role required"
+		}
+		// Members can only mint consumer sessions.
+		if sess.VaultRole == "member" && requestedRole != "consumer" {
+			requestedRole = "consumer"
+		}
+		return requestedRole, ""
+	}
+
+	// User session: require vault access.
+	user, err := s.userFromSession(ctx, sess)
+	if err != nil || user == nil {
+		return "", "Invalid session"
+	}
+	has, err := s.store.HasVaultAccess(ctx, user.ID, vaultID)
+	if err != nil || !has {
+		return "", "No access to this vault"
+	}
+	// User vault members can only mint consumer sessions.
+	role, err2 := s.store.GetVaultRole(ctx, user.ID, vaultID)
+	if err2 != nil {
+		return "", "Failed to check vault role"
+	}
+	if role != "admin" && requestedRole != "consumer" {
+		requestedRole = "consumer"
+	}
+	return requestedRole, ""
+}
+
+type directSessionRequest struct {
+	Vault      string `json:"vault"`
+	VaultRole  string `json:"vault_role"`
+	TTLSeconds int    `json:"ttl_seconds"`
+	Label      string `json:"label"`
+}
+
+type directSessionResponse struct {
+	AVAddr         string            `json:"av_addr"`
+	AVSessionToken string            `json:"av_session_token"`
+	AVVault        string            `json:"av_vault"`
+	VaultRole      string            `json:"vault_role"`
+	ProxyURL       string            `json:"proxy_url"`
+	Services       []discoverService `json:"services"`
+	Instructions   string            `json:"instructions"`
+	ExpiresAt      string            `json:"expires_at"`
+}
+
+const (
+	directSessionMinTTL = 5 * 60        // 5 minutes
+	directSessionMaxTTL = 7 * 24 * 3600 // 7 days
+	directSessionDefTTL = 24 * 3600     // 24 hours
+	maxLabelLength      = 128
+)
+
+func (s *Server) handleDirectSession(w http.ResponseWriter, r *http.Request) {
+	var req directSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	if req.Vault == "" {
+		req.Vault = "default"
+	}
+	if req.VaultRole == "" {
+		req.VaultRole = "consumer"
+	}
+	if req.VaultRole != "consumer" && req.VaultRole != "member" && req.VaultRole != "admin" {
+		jsonError(w, http.StatusBadRequest, "vault_role must be one of: consumer, member, admin")
+		return
+	}
+	if req.TTLSeconds == 0 {
+		req.TTLSeconds = directSessionDefTTL
+	}
+	if req.TTLSeconds < directSessionMinTTL || req.TTLSeconds > directSessionMaxTTL {
+		jsonError(w, http.StatusBadRequest, fmt.Sprintf("ttl_seconds must be between %d and %d", directSessionMinTTL, directSessionMaxTTL))
+		return
+	}
+	if len(req.Label) > maxLabelLength {
+		jsonError(w, http.StatusBadRequest, fmt.Sprintf("label must be at most %d characters", maxLabelLength))
+		return
+	}
+
+	ctx := r.Context()
+
+	ns, err := s.store.GetVault(ctx, req.Vault)
+	if err != nil || ns == nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", req.Vault))
+		return
+	}
+
+	sess := sessionFromContext(ctx)
+	if sess == nil {
+		jsonError(w, http.StatusForbidden, "Authentication required")
+		return
+	}
+
+	cappedRole, errMsg := s.capRequestedRole(ctx, sess, ns.ID, req.VaultRole)
+	if errMsg != "" {
+		jsonError(w, http.StatusForbidden, errMsg)
+		return
+	}
+
+	expiresAt := time.Now().Add(time.Duration(req.TTLSeconds) * time.Second)
+	newSess, err := s.store.CreateScopedSession(ctx, ns.ID, cappedRole, req.Label, expiresAt)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to create session")
+		return
+	}
+
+	services := s.buildServiceList(ctx, ns.ID)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(directSessionResponse{
+		AVAddr:         s.baseURL,
+		AVSessionToken: newSess.ID,
+		AVVault:        ns.Name,
+		VaultRole:      cappedRole,
+		ProxyURL:       s.baseURL + "/proxy",
+		Services:       services,
+		Instructions:   instructionsForRole(cappedRole),
+		ExpiresAt:      newSess.ExpiresAt.Format(time.RFC3339),
 	})
 }
 
@@ -2793,7 +2933,7 @@ func (s *Server) handleInviteRedeem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a vault-scoped session for the agent with the invite's role.
-	sess, err := s.store.CreateScopedSession(ctx, inv.VaultID, inv.VaultRole, time.Now().Add(sessionTTL))
+	sess, err := s.store.CreateScopedSession(ctx, inv.VaultID, inv.VaultRole, "", time.Now().Add(sessionTTL))
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create session")
 		return
@@ -5022,38 +5162,12 @@ func (s *Server) handleInviteCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if sess.VaultID != "" {
-		// Scoped session (agent or temp invite).
-		if sess.VaultID != ns.ID {
-			jsonError(w, http.StatusForbidden, "Session not authorized for this vault")
-			return
-		}
-		if !agentRoleSatisfies(sess.VaultRole, "member") {
-			jsonError(w, http.StatusForbidden, "Member role required to create agent invites")
-			return
-		}
-		// Members can only invite consumers.
-		if sess.VaultRole == "member" && req.VaultRole != "consumer" {
-			req.VaultRole = "consumer"
-		}
-	} else {
-		// User session: require vault access.
-		user, err := s.userFromSession(ctx, sess)
-		if err != nil || user == nil {
-			jsonError(w, http.StatusForbidden, "Invalid session")
-			return
-		}
-		has, err := s.store.HasVaultAccess(ctx, user.ID, ns.ID)
-		if err != nil || !has {
-			jsonError(w, http.StatusForbidden, "No access to this vault")
-			return
-		}
-		// User vault members can only invite consumers.
-		role, _ := s.store.GetVaultRole(ctx, user.ID, ns.ID)
-		if role != "admin" && req.VaultRole != "consumer" {
-			req.VaultRole = "consumer"
-		}
+	cappedRole, errMsg := s.capRequestedRole(ctx, sess, ns.ID, req.VaultRole)
+	if errMsg != "" {
+		jsonError(w, http.StatusForbidden, errMsg)
+		return
 	}
+	req.VaultRole = cappedRole
 
 	// Check pending invite limit.
 	count, err := s.store.CountPendingInvites(ctx, ns.ID)
@@ -5673,6 +5787,7 @@ func (s *Server) writeSettingsResponse(w http.ResponseWriter, ctx context.Contex
 	resp := map[string]interface{}{
 		"allowed_email_domains": []string{},
 		"invite_only":          false,
+		"smtp_configured":      s.notifier.Enabled(),
 	}
 	if raw, ok := settings[settingAllowedDomains]; ok {
 		var domains []string

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -117,11 +117,12 @@ func (m *mockStore) CreateSession(_ context.Context, userID string, expiresAt ti
 	return s, nil
 }
 
-func (m *mockStore) CreateScopedSession(_ context.Context, vaultID, vaultRole string, expiresAt time.Time) (*store.Session, error) {
+func (m *mockStore) CreateScopedSession(_ context.Context, vaultID, vaultRole, label string, expiresAt time.Time) (*store.Session, error) {
 	s := &store.Session{
 		ID:        "scoped-session-id",
 		VaultID:   vaultID,
 		VaultRole: vaultRole,
+		Label:     label,
 		ExpiresAt: expiresAt,
 		CreatedAt: time.Now(),
 	}
@@ -1416,7 +1417,7 @@ func setupMockStoreWithScopedSessionRole(t *testing.T, vaultName, vaultID, role 
 		ms.vaults[vaultName] = &store.Vault{ID: vaultID, Name: vaultName}
 	}
 	// Create a scoped session locked to the given vault
-	sess, err := ms.CreateScopedSession(context.Background(), vaultID, role, time.Now().Add(time.Hour))
+	sess, err := ms.CreateScopedSession(context.Background(), vaultID, role, "", time.Now().Add(time.Hour))
 	if err != nil {
 		t.Fatalf("CreateScopedSession: %v", err)
 	}
@@ -1589,7 +1590,7 @@ func setupProxyTest(t *testing.T, rulesJSON string) (*mockStore, string, []byte)
 	encKey := make([]byte, 32)
 
 	// Create a scoped session for root vault.
-	sess, err := ms.CreateScopedSession(context.Background(), "root-ns-id", "consumer", time.Now().Add(time.Hour))
+	sess, err := ms.CreateScopedSession(context.Background(), "root-ns-id", "consumer", "", time.Now().Add(time.Hour))
 	if err != nil {
 		t.Fatalf("CreateScopedSession: %v", err)
 	}
@@ -1954,7 +1955,7 @@ func TestDiscoverEmptyRules(t *testing.T) {
 
 func TestDiscoverNoCredentials(t *testing.T) {
 	ms := newMockStore()
-	sess, err := ms.CreateScopedSession(context.Background(), "root-ns-id", "consumer", time.Now().Add(time.Hour))
+	sess, err := ms.CreateScopedSession(context.Background(), "root-ns-id", "consumer", "", time.Now().Add(time.Hour))
 	if err != nil {
 		t.Fatalf("CreateScopedSession: %v", err)
 	}
@@ -3703,6 +3704,35 @@ func TestSettingsGetIncludesInviteOnly(t *testing.T) {
 	if resp["invite_only"] != true {
 		t.Fatalf("expected invite_only=true in settings, got %v", resp["invite_only"])
 	}
+	if resp["smtp_configured"] != false {
+		t.Fatalf("expected smtp_configured=false (nil notifier), got %v", resp["smtp_configured"])
+	}
+}
+
+func TestSettingsGetIncludesSMTPConfigured(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	n := notify.New(nil) // disabled notifier
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), n, true, "http://127.0.0.1:14321", nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/settings", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+
+	smtpVal, ok := resp["smtp_configured"]
+	if !ok {
+		t.Fatal("expected smtp_configured field in settings response")
+	}
+	if smtpVal != false {
+		t.Fatalf("expected smtp_configured=false (nil config), got %v", smtpVal)
+	}
 }
 
 func TestSettingsSetInviteOnly(t *testing.T) {
@@ -3934,5 +3964,204 @@ func TestVaultInviteCreateNoDomainRestrictions(t *testing.T) {
 
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("expected 201 with no domain restrictions, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// --- Direct Session Tests ---
+
+func TestDirectSessionSuccess(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	body := `{"vault":"default","vault_role":"consumer","ttl_seconds":3600}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/direct", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp directSessionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.AVSessionToken == "" {
+		t.Fatal("expected non-empty session token")
+	}
+	if resp.AVAddr != "http://127.0.0.1:14321" {
+		t.Fatalf("expected av_addr http://127.0.0.1:14321, got %q", resp.AVAddr)
+	}
+	if resp.AVVault != "default" {
+		t.Fatalf("expected av_vault default, got %q", resp.AVVault)
+	}
+	if resp.VaultRole != "consumer" {
+		t.Fatalf("expected vault_role consumer, got %q", resp.VaultRole)
+	}
+	if resp.ProxyURL != "http://127.0.0.1:14321/proxy" {
+		t.Fatalf("expected proxy_url with /proxy, got %q", resp.ProxyURL)
+	}
+	if resp.ExpiresAt == "" {
+		t.Fatal("expected non-empty expires_at")
+	}
+}
+
+func TestDirectSessionDefaultsVaultAndRole(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/direct", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp directSessionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.AVVault != "default" {
+		t.Fatalf("expected default vault, got %q", resp.AVVault)
+	}
+	if resp.VaultRole != "consumer" {
+		t.Fatalf("expected consumer role, got %q", resp.VaultRole)
+	}
+}
+
+func TestDirectSessionRoleCapping(t *testing.T) {
+	// Create a member user (non-admin) with vault access
+	ms := newMockStore()
+	ms.users["member@test.com"] = &store.User{
+		ID: "member-user-id", Email: "member@test.com",
+		Role: "member", IsActive: true,
+	}
+	ms.GrantVaultRole(context.Background(), "member-user-id", "root-ns-id", "member")
+	sess, err := ms.CreateSession(context.Background(), "member-user-id", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	// Request admin role — should be capped to consumer
+	body := `{"vault":"default","vault_role":"admin"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/direct", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+sess.ID)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp directSessionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.VaultRole != "consumer" {
+		t.Fatalf("expected role capped to consumer, got %q", resp.VaultRole)
+	}
+}
+
+func TestDirectSessionTTLBounds(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	// TTL too short
+	body := `{"vault":"default","ttl_seconds":60}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/direct", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for short TTL, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// TTL too long (8 days)
+	body = `{"vault":"default","ttl_seconds":691200}`
+	req = httptest.NewRequest(http.MethodPost, "/v1/sessions/direct", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec = httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for long TTL, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDirectSessionInvalidRole(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	body := `{"vault":"default","vault_role":"superadmin"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/direct", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid role, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDirectSessionUnauthenticated(t *testing.T) {
+	ms := newMockStore()
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	body := `{"vault":"default"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/direct", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDirectSessionVaultNotFound(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	body := `{"vault":"nonexistent"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/direct", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDirectSessionWithLabel(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	body := `{"vault":"default","label":"testing stripe"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/direct", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp directSessionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Verify label was stored on the session
+	storedSess := ms.sessions[resp.AVSessionToken]
+	if storedSess == nil {
+		t.Fatal("session not found in store")
+	}
+	if storedSess.Label != "testing stripe" {
+		t.Fatalf("expected label 'testing stripe', got %q", storedSess.Label)
 	}
 }

--- a/internal/store/migrations/029_session_label.sql
+++ b/internal/store/migrations/029_session_label.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions ADD COLUMN label TEXT;

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -647,33 +647,38 @@ func (s *SQLiteStore) CreateSession(ctx context.Context, userID string, expiresA
 	return &Session{ID: rawToken, UserID: userID, ExpiresAt: expiresAt.UTC(), CreatedAt: now}, nil
 }
 
-func (s *SQLiteStore) CreateScopedSession(ctx context.Context, vaultID, vaultRole string, expiresAt time.Time) (*Session, error) {
+func (s *SQLiteStore) CreateScopedSession(ctx context.Context, vaultID, vaultRole, label string, expiresAt time.Time) (*Session, error) {
 	rawToken := newSessionToken()
 	tokenHash := hashSessionToken(rawToken)
 	now := time.Now().UTC()
 
+	var labelVal interface{}
+	if label != "" {
+		labelVal = label
+	}
+
 	_, err := s.db.ExecContext(ctx,
-		"INSERT INTO sessions (id, vault_id, vault_role, expires_at, created_at) VALUES (?, ?, ?, ?, ?)",
-		tokenHash, vaultID, vaultRole, expiresAt.UTC().Format(time.DateTime), now.Format(time.DateTime),
+		"INSERT INTO sessions (id, vault_id, vault_role, label, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+		tokenHash, vaultID, vaultRole, labelVal, expiresAt.UTC().Format(time.DateTime), now.Format(time.DateTime),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating scoped session: %w", err)
 	}
 
-	return &Session{ID: rawToken, VaultID: vaultID, VaultRole: vaultRole, ExpiresAt: expiresAt.UTC(), CreatedAt: now}, nil
+	return &Session{ID: rawToken, VaultID: vaultID, VaultRole: vaultRole, Label: label, ExpiresAt: expiresAt.UTC(), CreatedAt: now}, nil
 }
 
 func (s *SQLiteStore) GetSession(ctx context.Context, rawToken string) (*Session, error) {
 	tokenHash := hashSessionToken(rawToken)
 	row := s.db.QueryRowContext(ctx,
-		"SELECT id, user_id, vault_id, agent_id, vault_role, expires_at, created_at FROM sessions WHERE id = ?", tokenHash,
+		"SELECT id, user_id, vault_id, agent_id, vault_role, label, expires_at, created_at FROM sessions WHERE id = ?", tokenHash,
 	)
 
 	var sess Session
 	var storedID string
-	var userID, vaultID, agentID, vaultRole sql.NullString
+	var userID, vaultID, agentID, vaultRole, label sql.NullString
 	var expiresAt, createdAt string
-	if err := row.Scan(&storedID, &userID, &vaultID, &agentID, &vaultRole, &expiresAt, &createdAt); err != nil {
+	if err := row.Scan(&storedID, &userID, &vaultID, &agentID, &vaultRole, &label, &expiresAt, &createdAt); err != nil {
 		return nil, err
 	}
 	// Return the raw token as ID (not the hash) so callers can reference it.
@@ -682,6 +687,7 @@ func (s *SQLiteStore) GetSession(ctx context.Context, rawToken string) (*Session
 	sess.VaultID = vaultID.String
 	sess.AgentID = agentID.String
 	sess.VaultRole = vaultRole.String
+	sess.Label = label.String
 	sess.ExpiresAt, _ = time.Parse(time.DateTime, expiresAt)
 	sess.CreatedAt, _ = time.Parse(time.DateTime, createdAt)
 	return &sess, nil

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -26,8 +26,8 @@ func TestOpenAndMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("querying schema_migrations: %v", err)
 	}
-	if version != 28 {
-		t.Fatalf("expected migration version 28, got %d", version)
+	if version != 29 {
+		t.Fatalf("expected migration version 29, got %d", version)
 	}
 }
 
@@ -335,7 +335,7 @@ func TestScopedSessionCRUD(t *testing.T) {
 
 	expires := time.Now().Add(1 * time.Hour).UTC().Truncate(time.Second)
 
-	sess, err := s.CreateScopedSession(ctx, ns.ID, "consumer", expires)
+	sess, err := s.CreateScopedSession(ctx, ns.ID, "consumer", "", expires)
 	if err != nil {
 		t.Fatalf("CreateScopedSession: %v", err)
 	}
@@ -1553,7 +1553,7 @@ func TestGetSessionBackwardCompat(t *testing.T) {
 	ctx := context.Background()
 
 	ns, _ := s.GetVault(ctx, "default")
-	sess, _ := s.CreateScopedSession(ctx, ns.ID, "consumer", time.Now().Add(24*time.Hour))
+	sess, _ := s.CreateScopedSession(ctx, ns.ID, "consumer", "", time.Now().Add(24*time.Hour))
 
 	fetched, err := s.GetSession(ctx, sess.ID)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -63,6 +63,7 @@ type Session struct {
 	VaultID   string // empty = global (admin), non-empty = scoped to vault
 	AgentID   string // non-empty for sessions minted by a persistent agent
 	VaultRole string // "consumer", "member", or "admin" — set for scoped sessions (temp invite + agent)
+	Label     string // optional label for direct-connect sessions
 	ExpiresAt time.Time
 	CreatedAt time.Time
 }
@@ -259,7 +260,7 @@ type Store interface {
 
 	// Sessions
 	CreateSession(ctx context.Context, userID string, expiresAt time.Time) (*Session, error)
-	CreateScopedSession(ctx context.Context, vaultID, vaultRole string, expiresAt time.Time) (*Session, error)
+	CreateScopedSession(ctx context.Context, vaultID, vaultRole, label string, expiresAt time.Time) (*Session, error)
 	GetSession(ctx context.Context, id string) (*Session, error)
 	DeleteSession(ctx context.Context, id string) error
 

--- a/web/src/pages/instance/SettingsTab.tsx
+++ b/web/src/pages/instance/SettingsTab.tsx
@@ -1,9 +1,13 @@
 import { useState, useEffect, type FormEvent } from "react";
+import { useRouteContext } from "@tanstack/react-router";
 import { apiFetch } from "../../lib/api";
 import Button from "../../components/Button";
 import Input from "../../components/Input";
+import type { AuthContext } from "../../router";
 
 export default function InstanceSettingsTab() {
+  const { auth } = useRouteContext({ from: "/_auth" }) as { auth: AuthContext };
+
   const [inviteOnly, setInviteOnly] = useState(false);
   const [domains, setDomains] = useState<string[]>([]);
   const [inputValue, setInputValue] = useState("");
@@ -12,12 +16,19 @@ export default function InstanceSettingsTab() {
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
 
+  const [smtpConfigured, setSmtpConfigured] = useState(false);
+  const [testEmailTo, setTestEmailTo] = useState("");
+  const [testEmailSending, setTestEmailSending] = useState(false);
+  const [testEmailError, setTestEmailError] = useState("");
+  const [testEmailSuccess, setTestEmailSuccess] = useState("");
+
   useEffect(() => {
     apiFetch("/v1/admin/settings")
       .then((r) => r.json())
       .then((data) => {
         setInviteOnly(data.invite_only ?? false);
         setDomains(data.allowed_email_domains || []);
+        setSmtpConfigured(data.smtp_configured ?? false);
         setLoading(false);
       })
       .catch(() => setLoading(false));
@@ -44,6 +55,29 @@ export default function InstanceSettingsTab() {
   function removeDomain(domain: string) {
     setDomains(domains.filter((d) => d !== domain));
     setSuccess("");
+  }
+
+  async function handleSendTestEmail() {
+    setTestEmailSending(true);
+    setTestEmailError("");
+    setTestEmailSuccess("");
+    try {
+      const to = testEmailTo.trim();
+      const resp = await apiFetch("/v1/admin/email/test", {
+        method: "POST",
+        ...(to ? { body: JSON.stringify({ to }) } : {}),
+      });
+      const data = await resp.json();
+      if (resp.ok) {
+        setTestEmailSuccess(`Test email sent to ${data.to}`);
+      } else {
+        setTestEmailError(data.error || "Failed to send test email.");
+      }
+    } catch {
+      setTestEmailError("Network error.");
+    } finally {
+      setTestEmailSending(false);
+    }
   }
 
   async function handleSave() {
@@ -199,6 +233,58 @@ export default function InstanceSettingsTab() {
           <Button onClick={handleSave} loading={saving}>
             Save Changes
           </Button>
+        </div>
+      </section>
+
+      <section className="mb-8">
+        <div className="border border-border rounded-xl bg-surface p-5">
+          <h3 className="text-sm font-semibold text-text mb-1">
+            Test Email
+          </h3>
+          <p className="text-sm text-text-muted mb-4">
+            Send a test email to verify your SMTP configuration is working.
+          </p>
+
+          {!smtpConfigured ? (
+            <p className="text-sm text-text-dim">
+              SMTP is not configured. Set the <code className="text-text-muted">AGENT_VAULT_SMTP_*</code> environment variables to enable email sending.
+            </p>
+          ) : (
+            <>
+              <div className="flex gap-2 mb-4 max-w-md">
+                <div className="flex-1">
+                  <Input
+                    type="email"
+                    placeholder={auth.email}
+                    value={testEmailTo}
+                    onChange={(e) => {
+                      setTestEmailTo(e.target.value);
+                      setTestEmailError("");
+                      setTestEmailSuccess("");
+                    }}
+                  />
+                </div>
+                <Button
+                  onClick={handleSendTestEmail}
+                  loading={testEmailSending}
+                  variant="secondary"
+                >
+                  Send
+                </Button>
+              </div>
+
+              {testEmailError && (
+                <div className="bg-danger-bg border border-danger/20 rounded-lg p-3 text-sm text-danger">
+                  {testEmailError}
+                </div>
+              )}
+              {testEmailSuccess && (
+                <div className="bg-success-bg border border-success/20 rounded-lg p-3 text-sm text-success">
+                  {testEmailSuccess}
+                </div>
+              )}
+            </>
+          )}
         </div>
       </section>
     </div>

--- a/web/src/pages/vault/AgentsTab.tsx
+++ b/web/src/pages/vault/AgentsTab.tsx
@@ -224,7 +224,7 @@ export default function AgentsTab() {
   );
 }
 
-type InviteType = "temporary" | "persistent";
+type InviteType = "temporary" | "persistent" | "direct";
 type InviteStep = "select" | "configure" | "done";
 
 type VaultRoleOption = "consumer" | "member" | "admin";
@@ -308,6 +308,15 @@ function InviteAgentButton({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [inviteToken, setInviteToken] = useState("");
+  const [directTTL, setDirectTTL] = useState(86400);
+  const [directLabel, setDirectLabel] = useState("");
+  const [directResult, setDirectResult] = useState<{
+    av_addr: string;
+    av_session_token: string;
+    av_vault: string;
+    vault_role: string;
+    expires_at: string;
+  } | null>(null);
 
   // Members can only invite consumers
   const canSelectRole = vaultRole === "admin";
@@ -320,6 +329,9 @@ function InviteAgentButton({
     setSelectedRole("consumer");
     setError("");
     setInviteToken("");
+    setDirectTTL(86400);
+    setDirectLabel("");
+    setDirectResult(null);
   }
 
   async function handleCreate() {
@@ -351,12 +363,47 @@ function InviteAgentButton({
     }
   }
 
+  async function handleDirectConnect() {
+    setSubmitting(true);
+    setError("");
+    try {
+      const resp = await apiFetch("/v1/sessions/direct", {
+        method: "POST",
+        body: JSON.stringify({
+          vault: vaultName,
+          vault_role: canSelectRole ? selectedRole : "consumer",
+          ttl_seconds: directTTL,
+          ...(directLabel.trim() ? { label: directLabel.trim() } : {}),
+        }),
+      });
+      const data = await resp.json();
+      if (resp.ok) {
+        setDirectResult(data);
+        setStep("done");
+      } else {
+        setError(data.error || "Failed to create session.");
+      }
+    } catch {
+      setError("Network error.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   function handleNext() {
     if (inviteType === "temporary") {
       handleCreate();
+    } else if (inviteType === "direct") {
+      handleDirectConnect();
     } else {
       setStep("configure");
     }
+  }
+
+  function buildEnvBlock(): string {
+    if (!directResult) return "";
+    const q = (s: string) => `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+    return `export AGENT_VAULT_ADDR=${q(directResult.av_addr)}\nexport AGENT_VAULT_SESSION_TOKEN=${q(directResult.av_session_token)}\nexport AGENT_VAULT_VAULT=${q(directResult.av_vault)}`;
   }
 
   function buildPrompt(): string {
@@ -402,14 +449,18 @@ function InviteAgentButton({
 
   const title =
     step === "done"
-      ? "Invite Created"
+      ? inviteType === "direct"
+        ? "Session Created"
+        : "Invite Created"
       : step === "configure"
         ? "Agent Details"
         : "Invite Agent";
 
   const description =
     step === "done"
-      ? "Share this prompt to connect the agent."
+      ? inviteType === "direct"
+        ? "Copy these credentials into your agent's environment."
+        : "Share this prompt to connect the agent."
       : step === "configure"
         ? "Configure the agent identity before creating the invite."
         : "Connect an AI agent to this vault.";
@@ -430,7 +481,7 @@ function InviteAgentButton({
       <>
         <Button variant="secondary" onClick={close}>Cancel</Button>
         <Button onClick={handleNext} loading={submitting}>
-          {inviteType === "temporary" ? "Create invite" : "Next"}
+          {inviteType === "persistent" ? "Next" : inviteType === "direct" ? "Create session" : "Create invite"}
         </Button>
       </>
     );
@@ -463,6 +514,29 @@ function InviteAgentButton({
 
       <Modal open={open} onClose={close} title={title} description={description} footer={footer}>
         {step === "done" ? (
+          inviteType === "direct" && directResult ? (
+          <div className="space-y-4">
+            <p className="text-sm text-text-muted">
+              Set these environment variables in your agent's shell or config.
+            </p>
+            <div className="relative">
+              <textarea
+                readOnly
+                value={buildEnvBlock()}
+                rows={5}
+                className="w-full px-4 py-3 bg-bg border border-border rounded-lg text-text text-sm font-mono outline-none select-all resize-none leading-relaxed"
+                onFocus={(e) => e.target.select()}
+              />
+              <CopyButton
+                value={buildEnvBlock()}
+                className="absolute top-2 right-2 px-3 py-1.5 bg-primary text-primary-text rounded-md text-xs font-semibold hover:bg-primary-hover transition-colors"
+              />
+            </div>
+            <p className="text-xs text-text-dim">
+              Role: {directResult.vault_role} &middot; Expires: {new Date(directResult.expires_at).toLocaleString()}
+            </p>
+          </div>
+          ) : (
           <div className="space-y-4">
             <p className="text-sm text-text-muted">
               Paste this prompt into your agent's chat to connect it.
@@ -481,6 +555,7 @@ function InviteAgentButton({
               />
             </div>
           </div>
+          )
         ) : step === "configure" ? (
           <div className="space-y-4">
             <FormField
@@ -502,7 +577,7 @@ function InviteAgentButton({
           </div>
         ) : (
           <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-3 gap-3">
               <button
                 onClick={() => setInviteType("temporary")}
                 className={`relative text-left p-4 rounded-xl border-2 transition-all ${
@@ -560,7 +635,78 @@ function InviteAgentButton({
                   </div>
                 </div>
               </button>
+
+              <button
+                onClick={() => setInviteType("direct")}
+                className={`relative text-left p-4 rounded-xl border-2 transition-all ${
+                  inviteType === "direct"
+                    ? "border-primary bg-primary/[0.04]"
+                    : "border-border hover:border-border-focus bg-surface"
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  <div
+                    className={`mt-0.5 w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 transition-colors ${
+                      inviteType === "direct"
+                        ? "border-primary"
+                        : "border-text-dim"
+                    }`}
+                  >
+                    {inviteType === "direct" && (
+                      <div className="w-2 h-2 rounded-full bg-primary" />
+                    )}
+                  </div>
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold text-text mb-1">Direct connect</div>
+                    <p className="text-xs text-text-muted leading-relaxed">
+                      Mint credentials now. Copy env vars into your agent's sandbox.
+                    </p>
+                  </div>
+                </div>
+              </button>
             </div>
+
+            {inviteType === "direct" && (
+              <div className="space-y-3">
+                <div>
+                  <label className="block text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+                    Session duration
+                  </label>
+                  <div className="flex gap-2">
+                    {([
+                      { label: "1h", value: 3600 },
+                      { label: "8h", value: 28800 },
+                      { label: "24h", value: 86400 },
+                      { label: "7d", value: 604800 },
+                    ] as const).map((opt) => (
+                      <button
+                        key={opt.value}
+                        onClick={() => setDirectTTL(opt.value)}
+                        className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                          directTTL === opt.value
+                            ? "bg-primary text-primary-text"
+                            : "bg-bg border border-border text-text-muted hover:border-border-focus"
+                        }`}
+                      >
+                        {opt.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <FormField
+                  label="Label"
+                  helperText="Optional. Helps identify this session later."
+                >
+                  <Input
+                    type="text"
+                    placeholder="e.g. testing stripe"
+                    value={directLabel}
+                    onChange={(e) => setDirectLabel(e.target.value)}
+                    maxLength={128}
+                  />
+                </FormField>
+              </div>
+            )}
 
             <RoleSelector
               value={selectedRole}

--- a/web/src/pages/vault/ProposalsTab.tsx
+++ b/web/src/pages/vault/ProposalsTab.tsx
@@ -163,7 +163,7 @@ export default function ProposalsTab() {
           data={proposals}
           rowKey={(cs) => cs.id}
           onRowClick={(cs) => setSelected(cs)}
-          emptyTitle={totalCount === 0 ? "No requests yet" : "Nothing needs your attention"}
+          emptyTitle={totalCount === 0 ? "No proposals yet" : "Nothing needs your attention"}
           emptyDescription={
             totalCount === 0 ? (
               <div className="flex flex-col items-center">


### PR DESCRIPTION
## Summary
- **Direct connect endpoint** (`POST /v1/sessions/direct`): mints scoped sessions immediately, skipping the invite ceremony. Supports configurable TTL (5min–7d), vault role selection with role-capping, and optional labels.
- **CLI `--direct` flag** on `vault agent invite create`: outputs shell-safe `export` env vars for quick agent setup.
- **Frontend UI**: direct connect option in agent invite modal (with TTL picker + label input), test email button in instance settings, `smtp_configured` status.
- **Security hardening**: shell-safe quoting in env block output, error handling for `GetVaultRole` in `capRequestedRole`, refactored role-capping into shared helper.
- **Migration 029**: adds `label` column to sessions table.
- **Docs**: improved Fly.io deploy steps, cold-start note.

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Lint clean (`golangci-lint run`)
- [x] Build succeeds (`make build`)
- [x] New tests: `TestDirectSession*` (success, defaults, role capping, TTL bounds, invalid role, unauthenticated, vault not found, label)
- [x] New test: `TestSettingsGetIncludesSMTPConfigured`
- [ ] Manual: test direct connect via CLI `--direct` flag
- [ ] Manual: test direct connect via frontend agent invite modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)