### PR TITLE
feat: invite session options, docs improvements, and UI refinements

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,7 +16,8 @@
       "Bash(grep -A 10 \"agent-vault account delete\\\\|agent-vault account\\\\s\\\\|Account$\\\\|## Account\" /Users/tuandang/Desktop/Projects/agent-vault/docs/reference/cli.mdx)",
       "Bash(ls -1 /Users/tuandang/Desktop/Projects/agent-vault/internal/store/migrations/*.sql)",
       "Bash(python3 -c \":*)",
-      "Bash(grep -n 'jsonError.*\"\"\"\"\\)\\)$' internal/server/server.go)"
+      "Bash(grep -n 'jsonError.*\"\"\"\"\\)\\)$' internal/server/server.go)",
+      "Bash(grep -r direct /Users/tuandang/Desktop/Projects/agent-vault/docs --include=*.mdx)"
     ]
   },
   "enabledPlugins": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Agent Vault requires two things before it becomes operational: a **master passwo
 - **Login**: Uses email + password or Google OAuth (owner or member account), not the master password. The master password is only used at server startup for encryption. Login rejects inactive (unverified) accounts.
 - **OAuth (Google)**: When `AGENT_VAULT_OAUTH_GOOGLE_CLIENT_ID` and `AGENT_VAULT_OAUTH_GOOGLE_CLIENT_SECRET` env vars are set, "Continue with Google" appears on login/register pages. OAuth uses PKCE (S256), CSRF state, and validates Google ID tokens via JWKS. No automatic account linking from unauthenticated contexts (security: prevents pre-hijack attacks). Users can connect/disconnect Google from account settings. First user must register with email/password. OAuth-only users can set a password from settings for CLI access.
 - **Auth methods**: Users can have password, OAuth (Google), or both. The `oauth_accounts` table tracks OAuth identities. The `handleAuthMe` response includes `has_password` (bool) and `oauth_providers` (string array).
-- **Roles**: Two independent axes, instance-level (`owner` vs `member`) and vault-level (`admin` vs `member`). See Multi-User Permission Model for details.
+- **Roles**: Two independent axes, instance-level (`owner` vs `member`) and vault-level (`admin` vs `member` vs `consumer`). See Multi-User Permission Model for details.
 
 ## CLI Commands
 
@@ -92,8 +92,9 @@ Agent Vault requires two things before it becomes operational: a **master passwo
   - `agent-vault proposal reject <number> [--reason "..."]` -- reject a pending proposal (requires active login session)
   - `agent-vault proposal review` -- interactively walk through all pending proposals (approve, reject, skip, or quit each; requires active login session)
 - `agent-vault vault agent [invite|list|info|revoke|rotate|rename]` -- manage agents and invite links
-  - `agent-vault vault agent invite create [--ttl 15m]` -- create a one-time invite and print the onboarding prompt (copies to clipboard)
-  - `agent-vault vault agent invite create --persistent [--name agent-name]` -- create a persistent agent invite (agent gets a long-lived service token)
+  - `agent-vault vault agent invite create [--ttl 15m] [--role consumer|member|admin]` -- create a one-time invite and print the onboarding prompt (copies to clipboard; default role: consumer)
+  - `agent-vault vault agent invite create --persistent [--name agent-name] [--role consumer|member|admin]` -- create a persistent agent invite (agent gets a long-lived service token)
+  - `agent-vault vault agent invite create --direct [--role consumer|member|admin] [--ttl 24h] [--label "my agent"]` -- mint a scoped session token immediately, skipping the invite ceremony; outputs env vars to paste into the agent's environment
   - `agent-vault vault agent invite list [--status pending]` -- list invites for vault
   - `agent-vault vault agent invite revoke <token_suffix>` -- revoke a pending invite by last 8+ chars of token
   - `agent-vault vault agent list [--vault default]` -- list registered agents
@@ -220,6 +221,19 @@ Invites let a human onboard any agent (including cloud-hosted agents like Devin 
 
 Invite states: `pending`, `redeemed`, `expired`, or `revoked`. Token format: `av_inv_` + 64 hex chars. Max 10 pending invites per vault. Default TTL: 15 minutes.
 
+## Direct Connect Sessions
+
+Direct connect skips the invite ceremony entirely. Instead of creating an invite link for an agent to redeem, it uses the caller's login session to mint a scoped session token immediately. The output is a set of env vars (`AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, `AGENT_VAULT_VAULT`) that can be pasted directly into any agent's environment.
+
+- `POST /v1/sessions/direct` -- mint a scoped session token (requires user or agent session with at least member role on the vault)
+  - Request: `{"vault": "default", "vault_role": "consumer", "ttl_seconds": 86400, "label": "my agent"}`
+  - Defaults: vault=`"default"`, vault_role=`"consumer"`, ttl_seconds=`86400` (24h)
+  - TTL bounds: min 5 minutes (300s), max 7 days (604800s)
+  - Label: optional, max 128 characters
+  - Response: `{"av_addr", "av_session_token", "av_vault", "vault_role", "proxy_url", "services", "instructions", "expires_at"}`
+
+**Role capping**: The minted session's role is capped to the caller's own vault role. Members can only mint `consumer` sessions; admins can mint any role (`consumer`, `member`, `admin`). Consumers cannot mint sessions at all.
+
 ## Persistent Agent API
 
 Persistent agents have named identities with long-lived service tokens that can mint short-lived session tokens. This is for agents that need ongoing access without human intervention.
@@ -242,7 +256,11 @@ Persistent agents have named identities with long-lived service tokens that can 
 Agent Vault uses two independent permission axes:
 
 - **Instance-level role** -- `owner` (can manage users, list/delete all vaults, all admin settings) vs `member` (regular user). Owners can see all vaults and join any vault as admin (`POST /v1/vaults/{name}/join`), but are not automatic members — they must explicitly join to access vault contents.
-- **Vault-level role** -- `admin` (can invite members, manage vault settings, approve/reject proposals) vs `member` (can view credentials, use proxy). All vault memberships require invite acceptance (or owner self-join).
+- **Vault-level role** -- three-tier hierarchy: `consumer` < `member` < `admin`.
+  - `consumer` -- proxy requests and discover services, raise proposals; cannot manage credentials, policy, or invites
+  - `member` -- all consumer capabilities + set/delete credentials, approve/reject proposals, manage vault policy, invite agents (as consumer only)
+  - `admin` -- all member capabilities + invite agents with any role, invite human users to the vault
+  All vault memberships require invite acceptance (or owner self-join).
 
 The first user to register is always an instance owner and is automatically invited as vault admin on the default vault. User deletion removes the user and their vault grants but leaves vaults intact. Orphaned vaults (no remaining members) can be recovered by an instance owner joining them.
 

--- a/cmd/invite.go
+++ b/cmd/invite.go
@@ -28,6 +28,7 @@ var inviteCreateCmd = &cobra.Command{
 		agentName, _ := cmd.Flags().GetString("name")
 		vaultRole, _ := cmd.Flags().GetString("role")
 		label, _ := cmd.Flags().GetString("label")
+		sessionTTL, _ := cmd.Flags().GetDuration("session-ttl")
 
 		if agentName != "" && !persistent {
 			return fmt.Errorf("--name requires --persistent")
@@ -38,11 +39,20 @@ var inviteCreateCmd = &cobra.Command{
 		if direct && agentName != "" {
 			return fmt.Errorf("--direct and --name are mutually exclusive")
 		}
-		if label != "" && !direct {
-			return fmt.Errorf("--label requires --direct")
+		if label != "" && persistent {
+			return fmt.Errorf("--label cannot be used with --persistent")
 		}
 		if vaultRole != "" && vaultRole != "consumer" && vaultRole != "member" && vaultRole != "admin" {
 			return fmt.Errorf("--role must be one of: consumer, member, admin")
+		}
+		if sessionTTL > 0 && persistent {
+			return fmt.Errorf("--session-ttl cannot be used with --persistent")
+		}
+		if sessionTTL > 7*24*time.Hour {
+			return fmt.Errorf("--session-ttl cannot exceed 7 days")
+		}
+		if sessionTTL > 0 && sessionTTL < 5*time.Minute {
+			return fmt.Errorf("--session-ttl must be at least 5 minutes")
 		}
 
 		sess, err := loadSession()
@@ -57,9 +67,15 @@ var inviteCreateCmd = &cobra.Command{
 
 		// Direct connect: mint credentials immediately.
 		if direct {
+			directTTL := 0 // let server apply its default (24h)
+			if sessionTTL > 0 {
+				directTTL = int(sessionTTL.Seconds())
+			} else if cmd.Flags().Changed("ttl") {
+				directTTL = int(ttl.Seconds())
+			}
 			reqBody := map[string]interface{}{
 				"vault":       vault,
-				"ttl_seconds": int(ttl.Seconds()),
+				"ttl_seconds": directTTL,
 			}
 			if vaultRole != "" {
 				reqBody["vault_role"] = vaultRole
@@ -92,7 +108,11 @@ var inviteCreateCmd = &cobra.Command{
 			envBlock := fmt.Sprintf("export AGENT_VAULT_ADDR=%q\nexport AGENT_VAULT_SESSION_TOKEN=%q\nexport AGENT_VAULT_VAULT=%q",
 				resp.AVAddr, resp.AVSessionToken, resp.AVVault)
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Direct connect session created (role: %s, expires in %s).\n\n", resp.VaultRole, formatDuration(ttl))
+			displayTTL := 24 * time.Hour
+			if directTTL > 0 {
+				displayTTL = time.Duration(directTTL) * time.Second
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Direct connect session created (role: %s, expires in %s).\n\n", resp.VaultRole, formatDuration(displayTTL))
 			fmt.Fprintf(cmd.OutOrStdout(), "---\n\n%s\n\n---\n", envBlock)
 			if err := copyToClipboard(envBlock); err == nil {
 				fmt.Fprintf(cmd.OutOrStdout(), "\n(Copied to clipboard)\n")
@@ -108,6 +128,14 @@ var inviteCreateCmd = &cobra.Command{
 		}
 		if vaultRole != "" {
 			reqBody["vault_role"] = vaultRole
+		}
+		if !persistent {
+			if sessionTTL > 0 {
+				reqBody["session_ttl_seconds"] = int(sessionTTL.Seconds())
+			}
+			if label != "" {
+				reqBody["session_label"] = label
+			}
 		}
 		body, err := json.Marshal(reqBody)
 		if err != nil {
@@ -347,7 +375,8 @@ func init() {
 	inviteCreateCmd.Flags().String("name", "", "pre-set the agent name (requires --persistent)")
 	inviteCreateCmd.Flags().String("role", "", "vault role for the invited agent (consumer, member, admin; default: consumer)")
 	inviteCreateCmd.Flags().Bool("direct", false, "mint credentials immediately (skip invite ceremony)")
-	inviteCreateCmd.Flags().String("label", "", "optional label for the session (direct connect only)")
+	inviteCreateCmd.Flags().String("label", "", "optional label for the session (direct connect and temporary invites)")
+	inviteCreateCmd.Flags().Duration("session-ttl", 0, "session lifetime when invite is redeemed (default: 24h; temporary invites only)")
 	inviteListCmd.Flags().String("status", "", "filter by status (pending, redeemed, expired, revoked)")
 
 	inviteCmd.AddCommand(inviteCreateCmd)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -25,14 +25,28 @@
         ]
       },
       {
-        "group": "Self-Hosting",
+        "group": "Guides",
         "pages": [
-          "self-hosting/docker",
-          "self-hosting/fly-io",
-          "self-hosting/environment-variables",
-          "guides/instance-settings",
-          "guides/smtp",
-          "guides/oauth"
+          {
+            "group": "Connect Agents",
+            "pages": [
+              "guides/connect-coding-agent",
+              "guides/connect-custom-agent"
+            ]
+          },
+          {
+            "group": "Self-Hosting",
+            "pages": [
+              "self-hosting/overview",
+              "self-hosting/local",
+              "self-hosting/docker",
+              "self-hosting/fly-io",
+              "self-hosting/environment-variables",
+              "guides/instance-settings",
+              "guides/smtp",
+              "guides/oauth"
+            ]
+          }
         ]
       },
       {
@@ -71,8 +85,8 @@
     { "source": "/configuration/secrets", "destination": "/learn/credentials" },
     { "source": "/configuration/policies", "destination": "/learn/policies" },
     { "source": "/agents/persistent-agents", "destination": "/agents/overview" },
-    { "source": "/self-hosting/local", "destination": "/installation" },
     { "source": "/learn/oauth", "destination": "/guides/oauth" },
-    { "source": "/how-it-works", "destination": "/" }
+    { "source": "/how-it-works", "destination": "/" },
+    { "source": "/learn/connect-custom-agent", "destination": "/guides/connect-custom-agent" }
   ]
 }

--- a/docs/guides/connect-coding-agent.mdx
+++ b/docs/guides/connect-coding-agent.mdx
@@ -1,0 +1,94 @@
+---
+title: "Connect a coding agent"
+description: "Connect Claude Code, Cursor, or any chat-based coding agent to Agent Vault."
+---
+
+This guide covers connecting coding agents like Claude Code, Cursor, or any agent that accepts prompts in a chat interface. These agents handle the Agent Vault protocol automatically — you just paste a prompt and they take care of the rest.
+
+<Note>
+For agents that don't have a chat interface or need raw environment variables, see [Connect a custom agent](/guides/connect-custom-agent).
+</Note>
+
+## Prerequisites
+
+- A running Agent Vault server ([installation](/installation))
+- A user account with vault access ([member or admin](/learn/permissions#vault-roles))
+
+## Option 1: Wrap with `agent-vault vault run`
+
+The simplest approach for local development. Wraps your agent process with the environment variables it needs — no invite, no token management.
+
+```bash
+agent-vault vault run -- claude
+agent-vault vault run -- cursor
+```
+
+The agent can immediately make proxied requests and raise [proposals](/learn/proposals).
+
+Use `--vault` to target a specific vault:
+
+```bash
+agent-vault vault run --vault my-vault -- claude
+```
+
+## Option 2: Paste an invite prompt
+
+For agents you can't wrap with `vault run` (e.g. cloud-hosted agents, or when you want to paste into an existing session).
+
+<Tabs>
+  <Tab title="Web UI">
+    <Steps>
+      <Step title="Open the Agents tab">
+        Navigate to your vault and click the **Agents** tab.
+      </Step>
+      <Step title="Create an invite">
+        Click **Invite agent**, choose **Session**, and configure the role and TTL.
+      </Step>
+      <Step title="Copy the prompt">
+        On the **Paste into chat** tab, copy the invite prompt.
+      </Step>
+      <Step title="Paste into the agent">
+        Paste the prompt into your agent's chat. The agent redeems the invite automatically and receives a session token.
+      </Step>
+    </Steps>
+  </Tab>
+  <Tab title="CLI">
+    ```bash
+    agent-vault vault agent invite create
+    ```
+
+    This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into the agent's chat.
+  </Tab>
+</Tabs>
+
+## What happens next
+
+Once connected, the agent follows the Agent Vault protocol automatically:
+
+1. Routes API requests through the Agent Vault proxy
+2. If a service isn't configured yet, the agent creates a [proposal](/learn/proposals) and shares an approval link
+3. You click the link, provide any required credentials, and approve
+4. The agent retries and the request succeeds
+
+<Tip>
+You don't need to pre-configure anything. The agent discovers what it needs, asks for approval, and handles the rest.
+</Tip>
+
+## For long-lived agents
+
+Session invites expire (default 24 hours). If your agent needs ongoing access without human intervention, use a [persistent agent](/agents/overview#persistent-agents) instead:
+
+```bash
+agent-vault vault agent invite create --persistent --name my-agent
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Agents overview" icon="robot" href="/agents/overview">
+    Temporary, direct connect, and persistent agent types.
+  </Card>
+  <Card title="Proposals" icon="file-circle-check" href="/learn/proposals">
+    How agents request access to new services.
+  </Card>
+</CardGroup>

--- a/docs/guides/connect-custom-agent.mdx
+++ b/docs/guides/connect-custom-agent.mdx
@@ -1,0 +1,200 @@
+---
+title: "Connect a custom agent"
+description: "Wire up a custom agent or script to Agent Vault using environment variables and the HTTP protocol."
+---
+
+This guide walks through connecting a custom agent to Agent Vault. Use this when you're building your own sandboxed agent, a CI pipeline, or any process that needs to make authenticated API calls through Agent Vault.
+
+<Note>
+If you're using Claude Code, Cursor, or another supported agent, see the [Quickstart](/quickstart/claude-code) guides instead. Those agents handle the connection protocol automatically.
+</Note>
+
+## Prerequisites
+
+- A running Agent Vault server
+- A user account with vault access ([member or admin](/learn/permissions#vault-roles))
+
+## Get connection credentials
+
+<Tabs>
+  <Tab title="Web UI">
+    <Steps>
+      <Step title="Open the Agents tab">
+        Navigate to your vault and click the **Agents** tab.
+      </Step>
+      <Step title="Create an invite">
+        Click **Invite agent**, choose **Session**, and configure the role and TTL.
+      </Step>
+      <Step title="Switch to Manual setup">
+        After creating the invite, click the **Manual setup** tab. This shows the environment variables your agent needs.
+      </Step>
+      <Step title="Copy the values">
+        Copy `AGENT_VAULT_ADDR` and `AGENT_VAULT_SESSION_TOKEN` into your agent's environment.
+      </Step>
+    </Steps>
+  </Tab>
+  <Tab title="CLI">
+    ```bash
+    agent-vault vault agent invite create --direct --vault my-vault
+    ```
+
+    This prints an `export` block you can paste directly into a shell or `.env` file:
+
+    ```bash
+    export AGENT_VAULT_ADDR="http://127.0.0.1:14321"
+    export AGENT_VAULT_SESSION_TOKEN="..."
+    export AGENT_VAULT_VAULT="my-vault"
+    ```
+
+    Use `--ttl` and `--role` to control session lifetime and permissions:
+
+    ```bash
+    # 4-hour session with member permissions
+    agent-vault vault agent invite create --direct --ttl 4h --role member
+    ```
+  </Tab>
+</Tabs>
+
+## Environment variables
+
+Your agent needs two values to operate. A third is optional but recommended.
+
+| Variable | Required | Description |
+|---|---|---|
+| `AGENT_VAULT_ADDR` | Yes | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
+| `AGENT_VAULT_SESSION_TOKEN` | Yes | Bearer token for authenticating all requests to Agent Vault |
+| `AGENT_VAULT_VAULT` | No | Vault name the session is scoped to (useful for logging/display) |
+
+## Make proxied requests
+
+The core of Agent Vault is the proxy. Your agent makes HTTP requests to Agent Vault, which injects the real credentials and forwards to the target service over HTTPS. Your agent never sees or handles the actual API keys.
+
+The proxy URL format is:
+
+```
+{AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
+```
+
+Every request to the proxy must include your session token in the `Authorization` header. Agent Vault strips it before forwarding and replaces it with the real credentials from the vault's policy.
+
+<CodeGroup>
+
+```python Python
+import os, requests
+
+ADDR = os.environ["AGENT_VAULT_ADDR"]
+TOKEN = os.environ["AGENT_VAULT_SESSION_TOKEN"]
+
+headers = {"Authorization": f"Bearer {TOKEN}"}
+
+# GET request through the proxy
+charges = requests.get(
+    f"{ADDR}/proxy/api.stripe.com/v1/charges",
+    params={"limit": 10},
+    headers=headers,
+)
+print(charges.json())
+
+# POST request through the proxy
+new_charge = requests.post(
+    f"{ADDR}/proxy/api.stripe.com/v1/charges",
+    headers={**headers, "Content-Type": "application/x-www-form-urlencoded"},
+    data="amount=2000&currency=usd",
+)
+print(new_charge.json())
+```
+
+```typescript TypeScript
+const ADDR = process.env.AGENT_VAULT_ADDR;
+const TOKEN = process.env.AGENT_VAULT_SESSION_TOKEN;
+
+const headers = { Authorization: `Bearer ${TOKEN}` };
+
+// GET request through the proxy
+const charges = await fetch(
+  `${ADDR}/proxy/api.stripe.com/v1/charges?limit=10`,
+  { headers },
+);
+console.log(await charges.json());
+
+// POST request through the proxy
+const newCharge = await fetch(
+  `${ADDR}/proxy/api.stripe.com/v1/charges`,
+  {
+    method: "POST",
+    headers: { ...headers, "Content-Type": "application/x-www-form-urlencoded" },
+    body: "amount=2000&currency=usd",
+  },
+);
+console.log(await newCharge.json());
+```
+
+```bash curl
+# GET
+curl "${AGENT_VAULT_ADDR}/proxy/api.stripe.com/v1/charges?limit=10" \
+  -H "Authorization: Bearer ${AGENT_VAULT_SESSION_TOKEN}"
+
+# POST
+curl -X POST "${AGENT_VAULT_ADDR}/proxy/api.stripe.com/v1/charges" \
+  -H "Authorization: Bearer ${AGENT_VAULT_SESSION_TOKEN}" \
+  -d "amount=2000&currency=usd"
+```
+
+</CodeGroup>
+
+Any HTTP method works (GET, POST, PUT, DELETE, PATCH). Query parameters, request bodies, and headers (other than `Authorization`) are forwarded as-is.
+
+## Discover available services
+
+Your agent can call `/discover` to check which hosts have credentials configured before making proxy requests.
+
+```bash
+curl ${AGENT_VAULT_ADDR}/discover \
+  -H "Authorization: Bearer ${AGENT_VAULT_SESSION_TOKEN}"
+```
+
+```json Response
+{
+  "vault": "default",
+  "proxy_url": "http://127.0.0.1:14321/proxy",
+  "services": [
+    { "host": "api.stripe.com", "description": "Stripe API" },
+    { "host": "api.github.com", "description": "GitHub API" }
+  ],
+  "available_credentials": ["STRIPE_KEY", "GITHUB_TOKEN"]
+}
+```
+
+- **`services`** lists the hosts your agent can route through the proxy.
+- **`available_credentials`** lists credential key names in the vault (values are never exposed).
+- Requests to hosts **not** in this list should go direct, not through the proxy.
+
+<Tip>
+Discovery is optional. If your agent already knows which hosts are configured, it can skip straight to proxying. If it hits a host that isn't configured, Agent Vault returns a 403 with a `proposal_hint`.
+</Tip>
+
+## Handle errors
+
+| Status | Meaning | What to do |
+|---|---|---|
+| 401 | Invalid or expired session token | Re-authenticate. For persistent agents, mint a new session with the service token. |
+| 403 | Host not allowed | The service isn't configured in the vault. Create a [proposal](/learn/proposals) to request access, or ask the vault admin to add it. The response body includes a `proposal_hint`. |
+| 429 | Too many pending proposals | Wait for existing proposals to be reviewed before creating new ones. |
+| 502 | Missing credential or upstream error | A credential may need to be added to the vault. Inform the user. |
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Agent protocol" icon="code" href="/agents/protocol">
+    Full HTTP reference for sessions, discovery, proxy, and proposals.
+  </Card>
+  <Card title="Proposals" icon="file-circle-check" href="/learn/proposals">
+    Request access to new services via the proposal API.
+  </Card>
+  <Card title="Credentials" icon="key" href="/learn/credentials">
+    Managing secrets in Agent Vault.
+  </Card>
+  <Card title="Persistent agents" icon="rotate" href="/agents/overview#persistent-agents">
+    Long-lived agents that survive session expiry.
+  </Card>
+</CardGroup>

--- a/docs/guides/oauth.mdx
+++ b/docs/guides/oauth.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Login with Google"
+title: "Configure Google SSO"
 description: "Set up Google OAuth for one-click sign-in to Agent Vault"
 ---
 

--- a/docs/guides/smtp.mdx
+++ b/docs/guides/smtp.mdx
@@ -1,9 +1,9 @@
 ---
-title: "SMTP configuration"
+title: "Configure Email SMTP"
 description: "Configure SMTP to enable email verification, vault invites, and notifications."
 ---
 
-Agent Vault uses SMTP to send registration verification codes, vault invite emails, and test emails. If `AGENT_VAULT_SMTP_HOST` is unset, email notifications are silently disabled.
+Agent Vault uses SMTP to send registration verification codes, vault invite emails, proposal approval links, and test emails. If `AGENT_VAULT_SMTP_HOST` is unset, email notifications are silently disabled.
 
 See [environment variables](/self-hosting/environment-variables#smtp-configuration) for the full list of SMTP variables.
 

--- a/docs/quickstart/nanoclaw.mdx
+++ b/docs/quickstart/nanoclaw.mdx
@@ -8,7 +8,7 @@ description: "Learn how to connect NanoClaw to Agent Vault so it can make authen
 To get the most out of this guide, you'll need to:
 
 - A deployed Agent Vault instance ([see installation guide](/installation))
-- Have NanoClaw installed
+- Have [NanoClaw](https://nanoclaw.dev/) installed
 
 ## 1. Log in
 

--- a/docs/self-hosting/environment-variables.mdx
+++ b/docs/self-hosting/environment-variables.mdx
@@ -36,7 +36,7 @@ Configure SMTP to enable Agent Vault to send emails for verification codes, vaul
 | `AGENT_VAULT_SMTP_TLS_SKIP_VERIFY` | `false` | Skip TLS certificate verification. Set to `true` or `1` to enable. Useful for self-signed certificates in development. |
 
 <Tip>
-  To verify SMTP is working, run `agent-vault email test`. It sends a test email to the owner's address. See the [SMTP configuration guide](/guides/smtp) for step-by-step setup instructions for popular providers like SendGrid, AWS SES, Resend, and more.
+  To verify SMTP is working, run `agent-vault email test`. It sends a test email to the owner's address. See the [Configure Email SMTP](/guides/smtp) guide for step-by-step setup instructions for popular providers like SendGrid, AWS SES, Resend, and more.
 </Tip>
 
 ## OAuth configuration
@@ -51,7 +51,7 @@ When both variables for a provider are set, the corresponding "Continue with ...
 The callback URL configured in Google Cloud Console must be `{AGENT_VAULT_ADDR}/v1/auth/oauth/google/callback`.
 
 <Tip>
-  See the [Login with Google](/guides/oauth) guide for step-by-step setup instructions.
+  See the [Configure Google SSO](/guides/oauth) guide for step-by-step setup instructions.
 </Tip>
 
 ## Agent runtime variables

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -1,0 +1,105 @@
+---
+title: "Linux & macOS"
+description: "Install and run Agent Vault on Linux or macOS using the install script"
+---
+
+## Install
+
+Auto-detects your OS and architecture, downloads the latest release, and installs. Works for both fresh installs and upgrades.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Infisical/agent-vault/main/install.sh | sh
+```
+
+Supports macOS (Intel + Apple Silicon) and Linux (x86\_64 + ARM64).
+
+Verify the installation:
+
+```bash
+agent-vault --help
+```
+
+### Build from source
+
+**Prerequisites**: [Go 1.25+](https://go.dev/dl/), [Node.js 22+](https://nodejs.org/)
+
+```bash
+git clone https://github.com/Infisical/agent-vault.git
+cd agent-vault
+make build
+sudo mv agent-vault /usr/local/bin/
+```
+
+## Start the server
+
+```bash
+agent-vault server
+```
+
+Agent Vault prompts for a **master password** on first run. This password encrypts all [credentials](/learn/credentials) at rest using AES-256-GCM with an Argon2id-derived key. It is never stored on disk.
+
+For non-interactive or automated environments, set the `AGENT_VAULT_MASTER_PASSWORD` environment variable or pass `--password-stdin` instead. See [environment variables](/self-hosting/environment-variables) for all options.
+
+To run in the background:
+
+```bash
+agent-vault server -d
+```
+
+To stop a background server:
+
+```bash
+agent-vault server stop
+```
+
+## Register and log in
+
+The first user to register becomes the instance [owner](/learn/permissions#instance-roles) with full admin privileges and is automatically granted [admin](/learn/permissions#vault-roles) on the default [vault](/learn/vaults).
+
+<Tabs>
+  <Tab title="CLI">
+    ```bash
+    agent-vault register
+    agent-vault login
+    ```
+  </Tab>
+  <Tab title="Web UI">
+    Open [http://localhost:14321/register](http://localhost:14321/register) (or the address you configured with `AGENT_VAULT_ADDR`) and create your account from the browser.
+  </Tab>
+</Tabs>
+
+Subsequent users can self-register via `agent-vault register`, the web registration page, or be [invited to a vault](/learn/vaults#invite-users-to-a-vault) by a vault admin.
+
+## Upgrade
+
+Re-run the same install command — the script detects your existing installation, stops the running server, backs up your database, and installs the latest version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Infisical/agent-vault/main/install.sh | sh
+```
+
+Restart the server afterward:
+
+```bash
+agent-vault server
+```
+
+Database migrations run automatically on server startup — no manual steps required.
+
+## Verify a release (optional)
+
+Every release includes SHA-256 checksums and a [cosign](https://github.com/sigstore/cosign) signature for supply-chain security. No keys to manage — verification uses GitHub's OIDC identity.
+
+```bash
+# Download the checksums and signature bundle from the release page, then:
+
+# 1. Verify the binary hasn't been tampered with
+sha256sum --check checksums.txt
+
+# 2. Verify the checksums were signed by the Infisical/agent-vault GitHub Actions workflow
+cosign verify-blob \
+  --bundle checksums.txt.bundle \
+  --certificate-identity-regexp "github.com/Infisical/agent-vault" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  checksums.txt
+```

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -1,0 +1,12 @@
+---
+title: "Overview"
+description: "Choose how to deploy Agent Vault."
+---
+
+Agent Vault ships as a single binary and a Docker image. Pick the deployment method that fits your infrastructure.
+
+- **[Linux & macOS](/self-hosting/local)**: Install via script or build from source. Works on bare metal, VMs, and cloud instances.
+- **[Docker](/self-hosting/docker)**: Run as a container with persistent storage.
+- **[Fly.io](/self-hosting/fly-io)**: Deploy to Fly.io with a persistent volume and custom domain.
+
+See the [environment variables](/self-hosting/environment-variables) reference for all configuration options. You can also set up [email notifications](/guides/smtp) and [Google SSO](/guides/oauth).

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -135,7 +135,7 @@ type Store interface {
 	ExpirePendingProposals(ctx context.Context, before time.Time) (int, error)
 
 	// Invites
-	CreateInvite(ctx context.Context, vaultID, vaultRole, createdBy string, expiresAt time.Time) (*store.Invite, error)
+	CreateInvite(ctx context.Context, vaultID, vaultRole, createdBy string, expiresAt time.Time, sessionTTLSeconds int, sessionLabel string) (*store.Invite, error)
 	GetInviteByToken(ctx context.Context, token string) (*store.Invite, error)
 	ListInvites(ctx context.Context, vaultID, status string) ([]store.Invite, error)
 	RedeemInvite(ctx context.Context, token, sessionID string) error
@@ -2933,7 +2933,11 @@ func (s *Server) handleInviteRedeem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a vault-scoped session for the agent with the invite's role.
-	sess, err := s.store.CreateScopedSession(ctx, inv.VaultID, inv.VaultRole, "", time.Now().Add(sessionTTL))
+	sessDuration := sessionTTL
+	if inv.SessionTTLSeconds > 0 {
+		sessDuration = time.Duration(inv.SessionTTLSeconds) * time.Second
+	}
+	sess, err := s.store.CreateScopedSession(ctx, inv.VaultID, inv.VaultRole, inv.SessionLabel, time.Now().Add(sessDuration))
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create session")
 		return
@@ -5109,11 +5113,13 @@ func (s *Server) handleInviteCreate(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	var req struct {
-		Vault      string `json:"vault"`
-		Persistent bool   `json:"persistent"`
-		TTLSeconds int    `json:"ttl_seconds"`
-		AgentName  string `json:"agent_name"`
-		VaultRole  string `json:"vault_role"`
+		Vault             string `json:"vault"`
+		Persistent        bool   `json:"persistent"`
+		TTLSeconds        int    `json:"ttl_seconds"`
+		AgentName         string `json:"agent_name"`
+		VaultRole         string `json:"vault_role"`
+		SessionTTLSeconds int    `json:"session_ttl_seconds"`
+		SessionLabel      string `json:"session_label"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, http.StatusBadRequest, "Invalid request body")
@@ -5132,6 +5138,18 @@ func (s *Server) handleInviteCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.TTLSeconds > maxTTL {
 		req.TTLSeconds = maxTTL
+	}
+	// Cap session TTL using the same bounds as direct connect sessions.
+	if req.SessionTTLSeconds > 0 {
+		if req.SessionTTLSeconds < directSessionMinTTL {
+			req.SessionTTLSeconds = directSessionMinTTL
+		} else if req.SessionTTLSeconds > directSessionMaxTTL {
+			req.SessionTTLSeconds = directSessionMaxTTL
+		}
+	}
+	if len(req.SessionLabel) > maxLabelLength {
+		jsonError(w, http.StatusBadRequest, fmt.Sprintf("session_label must be at most %d characters", maxLabelLength))
+		return
 	}
 	if req.VaultRole == "" {
 		req.VaultRole = "consumer"
@@ -5215,7 +5233,7 @@ func (s *Server) handleInviteCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	inv, err := s.store.CreateInvite(ctx, ns.ID, req.VaultRole, createdBy, expiresAt)
+	inv, err := s.store.CreateInvite(ctx, ns.ID, req.VaultRole, createdBy, expiresAt, req.SessionTTLSeconds, req.SessionLabel)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create invite")
 		return

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -293,10 +293,11 @@ func (m *mockStore) ExpirePendingProposals(_ context.Context, before time.Time) 
 
 // --- Invite mocks ---
 
-func (m *mockStore) CreateInvite(_ context.Context, vaultID, vaultRole, createdBy string, expiresAt time.Time) (*store.Invite, error) {
+func (m *mockStore) CreateInvite(_ context.Context, vaultID, vaultRole, createdBy string, expiresAt time.Time, sessionTTLSeconds int, sessionLabel string) (*store.Invite, error) {
 	inv := &store.Invite{
 		ID: len(m.invites) + 1, Token: "av_inv_test" + fmt.Sprintf("%d", len(m.invites)),
 		VaultID: vaultID, VaultRole: vaultRole, Status: "pending", CreatedBy: createdBy,
+		SessionTTLSeconds: sessionTTLSeconds, SessionLabel: sessionLabel,
 		CreatedAt: time.Now(), ExpiresAt: expiresAt,
 	}
 	m.invites[inv.Token] = inv

--- a/internal/store/migrations/030_invite_session_opts.sql
+++ b/internal/store/migrations/030_invite_session_opts.sql
@@ -1,0 +1,2 @@
+ALTER TABLE invites ADD COLUMN session_ttl_seconds INTEGER;
+ALTER TABLE invites ADD COLUMN session_label TEXT;

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -29,6 +29,22 @@ func hashToken(token string) string {
 	return hex.EncodeToString(h[:])
 }
 
+// nullableString returns nil for empty strings, enabling SQL NULL inserts.
+func nullableString(s string) interface{} {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// nullableInt returns nil for zero/negative ints, enabling SQL NULL inserts.
+func nullableInt(n int) interface{} {
+	if n <= 0 {
+		return nil
+	}
+	return n
+}
+
 // SQLiteStore implements Store backed by a SQLite database.
 type SQLiteStore struct {
 	db *sql.DB
@@ -652,14 +668,9 @@ func (s *SQLiteStore) CreateScopedSession(ctx context.Context, vaultID, vaultRol
 	tokenHash := hashSessionToken(rawToken)
 	now := time.Now().UTC()
 
-	var labelVal interface{}
-	if label != "" {
-		labelVal = label
-	}
-
 	_, err := s.db.ExecContext(ctx,
 		"INSERT INTO sessions (id, vault_id, vault_role, label, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?)",
-		tokenHash, vaultID, vaultRole, labelVal, expiresAt.UTC().Format(time.DateTime), now.Format(time.DateTime),
+		tokenHash, vaultID, vaultRole, nullableString(label), expiresAt.UTC().Format(time.DateTime), now.Format(time.DateTime),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating scoped session: %w", err)
@@ -1105,27 +1116,29 @@ func newInviteToken() string {
 	return "av_inv_" + hex.EncodeToString(b[:])
 }
 
-func (s *SQLiteStore) CreateInvite(ctx context.Context, vaultID, vaultRole, createdBy string, expiresAt time.Time) (*Invite, error) {
+func (s *SQLiteStore) CreateInvite(ctx context.Context, vaultID, vaultRole, createdBy string, expiresAt time.Time, sessionTTLSeconds int, sessionLabel string) (*Invite, error) {
 	now := time.Now().UTC()
 	token := newInviteToken()
 
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO invites (token_hash, vault_id, vault_role, status, created_by, created_at, expires_at)
-		 VALUES (?, ?, ?, 'pending', ?, ?, ?)`,
-		hashToken(token), vaultID, vaultRole, createdBy, now.Format(time.DateTime), expiresAt.UTC().Format(time.DateTime),
+		`INSERT INTO invites (token_hash, vault_id, vault_role, status, created_by, created_at, expires_at, session_ttl_seconds, session_label)
+		 VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?)`,
+		hashToken(token), vaultID, vaultRole, createdBy, now.Format(time.DateTime), expiresAt.UTC().Format(time.DateTime), nullableInt(sessionTTLSeconds), nullableString(sessionLabel),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("inserting invite: %w", err)
 	}
 
 	return &Invite{
-		Token:     token,
-		VaultID:   vaultID,
-		VaultRole: vaultRole,
-		Status:    "pending",
-		CreatedBy: createdBy,
-		CreatedAt: now,
-		ExpiresAt: expiresAt.UTC(),
+		Token:             token,
+		VaultID:           vaultID,
+		VaultRole:         vaultRole,
+		Status:            "pending",
+		CreatedBy:         createdBy,
+		SessionTTLSeconds: sessionTTLSeconds,
+		SessionLabel:      sessionLabel,
+		CreatedAt:         now,
+		ExpiresAt:         expiresAt.UTC(),
 	}, nil
 }
 
@@ -1133,7 +1146,8 @@ func (s *SQLiteStore) GetInviteByToken(ctx context.Context, token string) (*Invi
 	row := s.db.QueryRowContext(ctx,
 		`SELECT id, '' as token, vault_id, vault_role, status, session_id, created_by,
 		        persistent, agent_name, agent_id,
-		        created_at, expires_at, redeemed_at, revoked_at
+		        created_at, expires_at, redeemed_at, revoked_at,
+		        session_ttl_seconds, session_label
 		 FROM invites WHERE token_hash = ?`, hashToken(token),
 	)
 	return scanInvite(row)
@@ -1153,7 +1167,8 @@ func (s *SQLiteStore) ListInvites(ctx context.Context, vaultID, status string) (
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT id, '' as token, vault_id, vault_role, status, session_id, created_by,
 			        persistent, agent_name, agent_id,
-			        created_at, expires_at, redeemed_at, revoked_at
+			        created_at, expires_at, redeemed_at, revoked_at,
+			        session_ttl_seconds, session_label
 			 FROM invites WHERE vault_id = ? AND status = ? ORDER BY created_at DESC`,
 			vaultID, status,
 		)
@@ -1161,7 +1176,8 @@ func (s *SQLiteStore) ListInvites(ctx context.Context, vaultID, status string) (
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT id, '' as token, vault_id, vault_role, status, session_id, created_by,
 			        persistent, agent_name, agent_id,
-			        created_at, expires_at, redeemed_at, revoked_at
+			        created_at, expires_at, redeemed_at, revoked_at,
+			        session_ttl_seconds, session_label
 			 FROM invites WHERE vault_id = ? ORDER BY created_at DESC`,
 			vaultID,
 		)
@@ -1241,7 +1257,7 @@ func (s *SQLiteStore) ExpirePendingInvites(ctx context.Context, before time.Time
 }
 
 // scanInviteFields populates an Invite from pre-scanned fields.
-func scanInviteFields(inv *Invite, sessionID, agentName, agentID sql.NullString, persistent int, createdAt, expiresAt string, redeemedAt, revokedAt sql.NullString) {
+func scanInviteFields(inv *Invite, sessionID, agentName, agentID sql.NullString, persistent int, createdAt, expiresAt string, redeemedAt, revokedAt sql.NullString, sessionTTL sql.NullInt64, sessionLabel sql.NullString) {
 	inv.SessionID = sessionID.String
 	inv.Persistent = persistent != 0
 	inv.AgentName = agentName.String
@@ -1256,6 +1272,10 @@ func scanInviteFields(inv *Invite, sessionID, agentName, agentID sql.NullString,
 		t, _ := time.Parse(time.DateTime, revokedAt.String)
 		inv.RevokedAt = &t
 	}
+	if sessionTTL.Valid {
+		inv.SessionTTLSeconds = int(sessionTTL.Int64)
+	}
+	inv.SessionLabel = sessionLabel.String
 }
 
 // scanInvite scans a single invite row from a *sql.Row.
@@ -1265,14 +1285,17 @@ func scanInvite(row *sql.Row) (*Invite, error) {
 	var persistent int
 	var createdAt, expiresAt string
 	var redeemedAt, revokedAt sql.NullString
+	var sessionTTL sql.NullInt64
+	var sessionLabel sql.NullString
 
 	if err := row.Scan(&inv.ID, &inv.Token, &inv.VaultID, &inv.VaultRole, &inv.Status,
 		&sessionID, &inv.CreatedBy, &persistent, &agentName, &agentID,
-		&createdAt, &expiresAt, &redeemedAt, &revokedAt); err != nil {
+		&createdAt, &expiresAt, &redeemedAt, &revokedAt,
+		&sessionTTL, &sessionLabel); err != nil {
 		return nil, err
 	}
 
-	scanInviteFields(&inv, sessionID, agentName, agentID, persistent, createdAt, expiresAt, redeemedAt, revokedAt)
+	scanInviteFields(&inv, sessionID, agentName, agentID, persistent, createdAt, expiresAt, redeemedAt, revokedAt, sessionTTL, sessionLabel)
 	return &inv, nil
 }
 
@@ -1283,14 +1306,17 @@ func scanInviteRow(rows *sql.Rows) (*Invite, error) {
 	var persistent int
 	var createdAt, expiresAt string
 	var redeemedAt, revokedAt sql.NullString
+	var sessionTTL sql.NullInt64
+	var sessionLabel sql.NullString
 
 	if err := rows.Scan(&inv.ID, &inv.Token, &inv.VaultID, &inv.VaultRole, &inv.Status,
 		&sessionID, &inv.CreatedBy, &persistent, &agentName, &agentID,
-		&createdAt, &expiresAt, &redeemedAt, &revokedAt); err != nil {
+		&createdAt, &expiresAt, &redeemedAt, &revokedAt,
+		&sessionTTL, &sessionLabel); err != nil {
 		return nil, err
 	}
 
-	scanInviteFields(&inv, sessionID, agentName, agentID, persistent, createdAt, expiresAt, redeemedAt, revokedAt)
+	scanInviteFields(&inv, sessionID, agentName, agentID, persistent, createdAt, expiresAt, redeemedAt, revokedAt, sessionTTL, sessionLabel)
 	return &inv, nil
 }
 

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -26,8 +26,8 @@ func TestOpenAndMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("querying schema_migrations: %v", err)
 	}
-	if version != 29 {
-		t.Fatalf("expected migration version 29, got %d", version)
+	if version != 30 {
+		t.Fatalf("expected migration version 30, got %d", version)
 	}
 }
 
@@ -883,7 +883,7 @@ func TestCreateInvite(t *testing.T) {
 	ctx := context.Background()
 	ns, _ := s.CreateVault(ctx, "inv-test")
 
-	inv, err := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute))
+	inv, err := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute), 0, "")
 	if err != nil {
 		t.Fatalf("CreateInvite: %v", err)
 	}
@@ -900,7 +900,7 @@ func TestRedeemInvite(t *testing.T) {
 	ctx := context.Background()
 	ns, _ := s.CreateVault(ctx, "inv-redeem")
 
-	inv, _ := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute))
+	inv, _ := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute), 0, "")
 
 	err := s.RedeemInvite(ctx, inv.Token, "sess-123")
 	if err != nil {
@@ -927,7 +927,7 @@ func TestRedeemInvite_Expired(t *testing.T) {
 	ctx := context.Background()
 	ns, _ := s.CreateVault(ctx, "inv-expired")
 
-	inv, _ := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(-1*time.Minute))
+	inv, _ := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(-1*time.Minute), 0, "")
 
 	err := s.RedeemInvite(ctx, inv.Token, "sess-456")
 	if err != sql.ErrNoRows {
@@ -940,7 +940,7 @@ func TestRedeemInvite_AlreadyRedeemed(t *testing.T) {
 	ctx := context.Background()
 	ns, _ := s.CreateVault(ctx, "inv-double")
 
-	inv, _ := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute))
+	inv, _ := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute), 0, "")
 	s.RedeemInvite(ctx, inv.Token, "sess-1")
 
 	err := s.RedeemInvite(ctx, inv.Token, "sess-2")
@@ -954,7 +954,7 @@ func TestRevokeInvite(t *testing.T) {
 	ctx := context.Background()
 	ns, _ := s.CreateVault(ctx, "inv-revoke")
 
-	inv, _ := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute))
+	inv, _ := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute), 0, "")
 
 	if err := s.RevokeInvite(ctx, inv.Token); err != nil {
 		t.Fatalf("RevokeInvite: %v", err)
@@ -974,8 +974,8 @@ func TestCountPendingInvites(t *testing.T) {
 	ctx := context.Background()
 	ns, _ := s.CreateVault(ctx, "inv-count")
 
-	inv1, _ := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute))
-	s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute))
+	inv1, _ := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute), 0, "")
+	s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute), 0, "")
 
 	count, err := s.CountPendingInvites(ctx, ns.ID)
 	if err != nil {
@@ -1000,8 +1000,8 @@ func TestExpirePendingInvites(t *testing.T) {
 	ns, _ := s.CreateVault(ctx, "inv-expire")
 
 	// Create two invites: one already expired, one still valid.
-	s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(-1*time.Minute))
-	s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute))
+	s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(-1*time.Minute), 0, "")
+	s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute), 0, "")
 
 	n, err := s.ExpirePendingInvites(ctx, time.Now())
 	if err != nil {
@@ -1022,8 +1022,8 @@ func TestListInvites(t *testing.T) {
 	ctx := context.Background()
 	ns, _ := s.CreateVault(ctx, "inv-list")
 
-	s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute))
-	inv2, _ := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute))
+	s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute), 0, "")
+	inv2, _ := s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute), 0, "")
 	s.RevokeInvite(ctx, inv2.Token)
 
 	// All invites.
@@ -1049,7 +1049,7 @@ func TestInviteCascadeDelete(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 	ns, _ := s.CreateVault(ctx, "inv-cascade")
-	s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute))
+	s.CreateInvite(ctx, ns.ID, "consumer", "admin", time.Now().Add(15*time.Minute), 0, "")
 
 	if err := s.DeleteVault(ctx, "inv-cascade"); err != nil {
 		t.Fatal(err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -120,20 +120,22 @@ type EncryptedCredential struct {
 // Invite represents a one-time-use, time-limited token that an agent
 // can redeem to receive a vault-scoped session.
 type Invite struct {
-	ID         int
-	Token      string
-	VaultID    string
-	VaultRole  string // "consumer", "member", or "admin" — role granted to the agent on redemption
-	Status     string // pending, redeemed, expired, revoked
-	SessionID  string // populated after redemption
-	CreatedBy  string // session ID of the creator
-	Persistent bool   // true for persistent agent invites (redeemed via POST)
-	AgentName  string // pre-set agent name (persistent invites only)
-	AgentID    string // set for rotation invites (references existing agent)
-	CreatedAt  time.Time
-	ExpiresAt  time.Time
-	RedeemedAt *time.Time
-	RevokedAt  *time.Time
+	ID                int
+	Token             string
+	VaultID           string
+	VaultRole         string     // "consumer", "member", or "admin"
+	Status            string     // pending, redeemed, expired, revoked
+	SessionID         string     // populated after redemption
+	CreatedBy         string     // session ID of the creator
+	Persistent        bool       // true for persistent agent invites (redeemed via POST)
+	AgentName         string     // pre-set agent name (persistent invites only)
+	AgentID           string     // set for rotation invites (references existing agent)
+	SessionTTLSeconds int        // desired session lifetime when redeemed (0 = use default)
+	SessionLabel      string     // label to attach to the session created on redemption
+	CreatedAt         time.Time
+	ExpiresAt         time.Time
+	RedeemedAt        *time.Time
+	RevokedAt         *time.Time
 }
 
 // Agent represents a named, persistent agent with a long-lived service token.
@@ -284,7 +286,7 @@ type Store interface {
 	ApplyProposal(ctx context.Context, vaultID string, proposalID int, mergedRulesJSON string, credentials map[string]EncryptedCredential, deleteCredentialKeys []string) error
 
 	// Invites
-	CreateInvite(ctx context.Context, vaultID, vaultRole, createdBy string, expiresAt time.Time) (*Invite, error)
+	CreateInvite(ctx context.Context, vaultID, vaultRole, createdBy string, expiresAt time.Time, sessionTTLSeconds int, sessionLabel string) (*Invite, error)
 	GetInviteByToken(ctx context.Context, token string) (*Invite, error)
 	ListInvites(ctx context.Context, vaultID, status string) ([]Invite, error)
 	RedeemInvite(ctx context.Context, token, sessionID string) error

--- a/web/src/components/Select.tsx
+++ b/web/src/components/Select.tsx
@@ -1,0 +1,35 @@
+import { forwardRef, type SelectHTMLAttributes } from "react";
+
+interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  error?: boolean;
+}
+
+const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  ({ error, className = "", children, ...props }, ref) => {
+    return (
+      <div className="relative">
+        <select
+          ref={ref}
+          className={`w-full px-4 py-3 pr-10 bg-surface-raised border rounded-lg text-text text-sm outline-none transition-colors focus:border-border-focus focus:shadow-[0_0_0_3px_var(--color-primary-ring)] appearance-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${error ? "border-danger" : "border-border"} ${className}`}
+          {...props}
+        >
+          {children}
+        </select>
+        <svg
+          className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </div>
+    );
+  }
+);
+
+Select.displayName = "Select";
+export default Select;

--- a/web/src/pages/vault/AgentsTab.tsx
+++ b/web/src/pages/vault/AgentsTab.tsx
@@ -5,6 +5,7 @@ import Modal from "../../components/Modal";
 import DropdownMenu from "../../components/DropdownMenu";
 import Button from "../../components/Button";
 import Input from "../../components/Input";
+import Select from "../../components/Select";
 import FormField from "../../components/FormField";
 import CopyButton from "../../components/CopyButton";
 import { apiFetch } from "../../lib/api";
@@ -224,8 +225,9 @@ export default function AgentsTab() {
   );
 }
 
-type InviteType = "temporary" | "persistent" | "direct";
+type InviteType = "temporary" | "persistent";
 type InviteStep = "select" | "configure" | "done";
+type DeliveryTab = "prompt" | "envvars";
 
 type VaultRoleOption = "consumer" | "member" | "admin";
 
@@ -244,50 +246,21 @@ function RoleSelector({
   onChange: (role: VaultRoleOption) => void;
   disabled: boolean;
 }) {
-  const roles: VaultRoleOption[] = ["consumer", "member", "admin"];
-
-  if (disabled) {
-    return (
-      <div>
-        <label className="block text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
-          Role
-        </label>
-        <div className="px-4 py-3 bg-bg border border-border rounded-lg text-sm text-text-muted">
-          Consumer
-          <span className="ml-2 text-xs text-text-dim">(members can only invite consumers)</span>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div>
-      <label className="block text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
-        Role
-      </label>
-      <div className="space-y-2">
-        {roles.map((role) => (
-          <button
-            key={role}
-            type="button"
-            onClick={() => onChange(role)}
-            className={`w-full text-left px-4 py-3 rounded-lg border-2 transition-all ${
-              value === role
-                ? "border-primary bg-primary/[0.04]"
-                : "border-border hover:border-border-focus bg-surface"
-            }`}
-          >
-            <div className="text-sm font-medium text-text capitalize">
-              {role}
-              {role === "consumer" && (
-                <span className="ml-1.5 text-xs font-normal text-text-muted">(Default)</span>
-              )}
-            </div>
-            <p className="text-xs text-text-muted mt-0.5">{roleDescriptions[role]}</p>
-          </button>
-        ))}
-      </div>
-    </div>
+    <FormField
+      label="Role"
+      helperText={<>{disabled ? "Members can only invite consumers." : roleDescriptions[value]} <a href="https://docs.agent-vault.dev/learn/permissions#vault-roles" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Learn more</a></>}
+    >
+      <Select
+        value={value}
+        onChange={(e) => onChange(e.target.value as VaultRoleOption)}
+        disabled={disabled}
+      >
+        <option value="consumer">Consumer</option>
+        <option value="member">Member</option>
+        <option value="admin">Admin</option>
+      </Select>
+    </FormField>
   );
 }
 
@@ -308,15 +281,18 @@ function InviteAgentButton({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [inviteToken, setInviteToken] = useState("");
-  const [directTTL, setDirectTTL] = useState(86400);
-  const [directLabel, setDirectLabel] = useState("");
-  const [directResult, setDirectResult] = useState<{
+  const [sessionTTL, setSessionTTL] = useState(86400);
+  const [sessionLabel, setSessionLabel] = useState("");
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [deliveryTab, setDeliveryTab] = useState<DeliveryTab>("prompt");
+  const [directConnectResult, setDirectConnectResult] = useState<{
     av_addr: string;
     av_session_token: string;
     av_vault: string;
     vault_role: string;
     expires_at: string;
   } | null>(null);
+  const [loadingEnvVars, setLoadingEnvVars] = useState(false);
 
   // Members can only invite consumers
   const canSelectRole = vaultRole === "admin";
@@ -329,9 +305,12 @@ function InviteAgentButton({
     setSelectedRole("consumer");
     setError("");
     setInviteToken("");
-    setDirectTTL(86400);
-    setDirectLabel("");
-    setDirectResult(null);
+    setSessionTTL(86400);
+    setSessionLabel("");
+    setShowAdvanced(false);
+    setDeliveryTab("prompt");
+    setDirectConnectResult(null);
+    setLoadingEnvVars(false);
   }
 
   async function handleCreate() {
@@ -346,6 +325,8 @@ function InviteAgentButton({
           persistent,
           vault_role: canSelectRole ? selectedRole : "consumer",
           ...(persistent && name.trim() ? { agent_name: name.trim() } : {}),
+          ...(!persistent ? { session_ttl_seconds: sessionTTL } : {}),
+          ...(!persistent && sessionLabel.trim() ? { session_label: sessionLabel.trim() } : {}),
         }),
       });
       const data = await resp.json();
@@ -363,47 +344,38 @@ function InviteAgentButton({
     }
   }
 
-  async function handleDirectConnect() {
-    setSubmitting(true);
-    setError("");
+  async function fetchEnvVars() {
+    if (directConnectResult) return;
+    setLoadingEnvVars(true);
     try {
       const resp = await apiFetch("/v1/sessions/direct", {
         method: "POST",
         body: JSON.stringify({
           vault: vaultName,
           vault_role: canSelectRole ? selectedRole : "consumer",
-          ttl_seconds: directTTL,
-          ...(directLabel.trim() ? { label: directLabel.trim() } : {}),
+          ttl_seconds: sessionTTL,
+          ...(sessionLabel.trim() ? { label: sessionLabel.trim() } : {}),
         }),
       });
       const data = await resp.json();
       if (resp.ok) {
-        setDirectResult(data);
-        setStep("done");
+        setDirectConnectResult(data);
       } else {
         setError(data.error || "Failed to create session.");
       }
     } catch {
       setError("Network error.");
     } finally {
-      setSubmitting(false);
+      setLoadingEnvVars(false);
     }
   }
 
   function handleNext() {
     if (inviteType === "temporary") {
       handleCreate();
-    } else if (inviteType === "direct") {
-      handleDirectConnect();
     } else {
       setStep("configure");
     }
-  }
-
-  function buildEnvBlock(): string {
-    if (!directResult) return "";
-    const q = (s: string) => `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-    return `export AGENT_VAULT_ADDR=${q(directResult.av_addr)}\nexport AGENT_VAULT_SESSION_TOKEN=${q(directResult.av_session_token)}\nexport AGENT_VAULT_VAULT=${q(directResult.av_vault)}`;
   }
 
   function buildPrompt(): string {
@@ -449,18 +421,14 @@ function InviteAgentButton({
 
   const title =
     step === "done"
-      ? inviteType === "direct"
-        ? "Session Created"
-        : "Invite Created"
+      ? "Connect Your Agent"
       : step === "configure"
         ? "Agent Details"
         : "Invite Agent";
 
   const description =
     step === "done"
-      ? inviteType === "direct"
-        ? "Copy these credentials into your agent's environment."
-        : "Share this prompt to connect the agent."
+      ? "Choose how you'd like to connect."
       : step === "configure"
         ? "Configure the agent identity before creating the invite."
         : "Connect an AI agent to this vault.";
@@ -481,7 +449,7 @@ function InviteAgentButton({
       <>
         <Button variant="secondary" onClick={close}>Cancel</Button>
         <Button onClick={handleNext} loading={submitting}>
-          {inviteType === "persistent" ? "Next" : inviteType === "direct" ? "Create session" : "Create invite"}
+          {inviteType === "persistent" ? "Next" : "Create invite"}
         </Button>
       </>
     );
@@ -514,48 +482,97 @@ function InviteAgentButton({
 
       <Modal open={open} onClose={close} title={title} description={description} footer={footer}>
         {step === "done" ? (
-          inviteType === "direct" && directResult ? (
           <div className="space-y-4">
-            <p className="text-sm text-text-muted">
-              Set these environment variables in your agent's shell or config.
-            </p>
-            <div className="relative">
-              <textarea
-                readOnly
-                value={buildEnvBlock()}
-                rows={5}
-                className="w-full px-4 py-3 bg-bg border border-border rounded-lg text-text text-sm font-mono outline-none select-all resize-none leading-relaxed"
-                onFocus={(e) => e.target.select()}
-              />
-              <CopyButton
-                value={buildEnvBlock()}
-                className="absolute top-2 right-2 px-3 py-1.5 bg-primary text-primary-text rounded-md text-xs font-semibold hover:bg-primary-hover transition-colors"
-              />
-            </div>
-            <p className="text-xs text-text-dim">
-              Role: {directResult.vault_role} &middot; Expires: {new Date(directResult.expires_at).toLocaleString()}
-            </p>
+            {inviteType === "temporary" && (
+              <div className="flex border-b border-border">
+                <button
+                  onClick={() => setDeliveryTab("prompt")}
+                  className={`px-4 py-2 text-sm font-medium transition-colors relative ${
+                    deliveryTab === "prompt"
+                      ? "text-primary"
+                      : "text-text-muted hover:text-text"
+                  }`}
+                >
+                  Paste into chat
+                  {deliveryTab === "prompt" && (
+                    <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
+                  )}
+                </button>
+                <button
+                  onClick={() => {
+                    setDeliveryTab("envvars");
+                    fetchEnvVars();
+                  }}
+                  className={`px-4 py-2 text-sm font-medium transition-colors relative ${
+                    deliveryTab === "envvars"
+                      ? "text-primary"
+                      : "text-text-muted hover:text-text"
+                  }`}
+                >
+                  Manual setup
+                  {deliveryTab === "envvars" && (
+                    <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
+                  )}
+                </button>
+              </div>
+            )}
+
+            {deliveryTab === "prompt" || inviteType === "persistent" ? (
+              <>
+                <p className="text-sm text-text-muted">
+                  Paste this into your agent's chat and it will connect automatically to Agent Vault.
+                </p>
+                <div className="relative">
+                  <textarea
+                    readOnly
+                    value={buildPrompt()}
+                    rows={10}
+                    className="w-full px-4 py-3 bg-bg border border-border rounded-lg text-text text-sm font-mono outline-none select-all resize-none leading-relaxed"
+                    onFocus={(e) => e.target.select()}
+                  />
+                  <CopyButton
+                    value={buildPrompt()}
+                    className="absolute top-2 right-2 px-3 py-1.5 bg-primary text-primary-text rounded-md text-xs font-semibold hover:bg-primary-hover transition-colors"
+                  />
+                </div>
+                <p className="text-xs text-text-dim">
+                  Works with Claude Code, Cursor, ChatGPT, and other chat-based agents.
+                </p>
+              </>
+            ) : loadingEnvVars ? (
+              <div className="py-8 flex justify-center">
+                <LoadingSpinner />
+              </div>
+            ) : directConnectResult ? (
+              <>
+                <p className="text-sm text-text-muted">
+                  Your agent needs these values to connect to Agent Vault. <a href="https://docs.agent-vault.dev/guides/connect-custom-agent" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Learn more</a>
+                </p>
+                <div className="space-y-2">
+                  {([
+                    { label: "AGENT_VAULT_ADDR", value: directConnectResult.av_addr },
+                    { label: "AGENT_VAULT_SESSION_TOKEN", value: directConnectResult.av_session_token },
+                  ] as const).map((env) => (
+                    <div key={env.label}>
+                      <label className="block text-xs font-medium text-text-muted mb-1">{env.label}</label>
+                      <div className="flex items-center gap-2">
+                        <input
+                          readOnly
+                          value={env.value}
+                          className="flex-1 px-3 py-2 bg-bg border border-border rounded-lg text-text text-sm font-mono outline-none select-all"
+                          onFocus={(e) => e.target.select()}
+                        />
+                        <CopyButton value={env.value} />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <p className="text-xs text-text-dim">
+                  Role: {directConnectResult.vault_role} &middot; Expires: {new Date(directConnectResult.expires_at).toLocaleString()}
+                </p>
+              </>
+            ) : null}
           </div>
-          ) : (
-          <div className="space-y-4">
-            <p className="text-sm text-text-muted">
-              Paste this prompt into your agent's chat to connect it.
-            </p>
-            <div className="relative">
-              <textarea
-                readOnly
-                value={buildPrompt()}
-                rows={10}
-                className="w-full px-4 py-3 bg-bg border border-border rounded-lg text-text text-sm font-mono outline-none select-all resize-none leading-relaxed"
-                onFocus={(e) => e.target.select()}
-              />
-              <CopyButton
-                value={buildPrompt()}
-                className="absolute top-2 right-2 px-3 py-1.5 bg-primary text-primary-text rounded-md text-xs font-semibold hover:bg-primary-hover transition-colors"
-              />
-            </div>
-          </div>
-          )
         ) : step === "configure" ? (
           <div className="space-y-4">
             <FormField
@@ -577,7 +594,7 @@ function InviteAgentButton({
           </div>
         ) : (
           <div className="space-y-4">
-            <div className="grid grid-cols-3 gap-3">
+            <div className="grid grid-cols-2 gap-3">
               <button
                 onClick={() => setInviteType("temporary")}
                 className={`relative text-left p-4 rounded-xl border-2 transition-all ${
@@ -601,7 +618,7 @@ function InviteAgentButton({
                   <div className="min-w-0">
                     <div className="text-sm font-semibold text-text mb-1">Session</div>
                     <p className="text-xs text-text-muted leading-relaxed">
-                      Single-use token for a one-off coding session. Best for tools like Claude Code or Cursor.
+                      Temporary access for a coding session. Best for Claude Code, Cursor, etc.
                     </p>
                   </div>
                 </div>
@@ -630,89 +647,83 @@ function InviteAgentButton({
                   <div className="min-w-0">
                     <div className="text-sm font-semibold text-text mb-1">Persistent</div>
                     <p className="text-xs text-text-muted leading-relaxed">
-                      Long-lived service token for always-on agents. Best for tools like OpenClaw or Devin.
-                    </p>
-                  </div>
-                </div>
-              </button>
-
-              <button
-                onClick={() => setInviteType("direct")}
-                className={`relative text-left p-4 rounded-xl border-2 transition-all ${
-                  inviteType === "direct"
-                    ? "border-primary bg-primary/[0.04]"
-                    : "border-border hover:border-border-focus bg-surface"
-                }`}
-              >
-                <div className="flex items-start gap-3">
-                  <div
-                    className={`mt-0.5 w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 transition-colors ${
-                      inviteType === "direct"
-                        ? "border-primary"
-                        : "border-text-dim"
-                    }`}
-                  >
-                    {inviteType === "direct" && (
-                      <div className="w-2 h-2 rounded-full bg-primary" />
-                    )}
-                  </div>
-                  <div className="min-w-0">
-                    <div className="text-sm font-semibold text-text mb-1">Direct connect</div>
-                    <p className="text-xs text-text-muted leading-relaxed">
-                      Mint credentials now. Copy env vars into your agent's sandbox.
+                      Long-lived access for always-on agents like Devin or custom services.
                     </p>
                   </div>
                 </div>
               </button>
             </div>
 
-            {inviteType === "direct" && (
-              <div className="space-y-3">
-                <div>
-                  <label className="block text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
-                    Session duration
-                  </label>
-                  <div className="flex gap-2">
-                    {([
-                      { label: "1h", value: 3600 },
-                      { label: "8h", value: 28800 },
-                      { label: "24h", value: 86400 },
-                      { label: "7d", value: 604800 },
-                    ] as const).map((opt) => (
-                      <button
-                        key={opt.value}
-                        onClick={() => setDirectTTL(opt.value)}
-                        className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-                          directTTL === opt.value
-                            ? "bg-primary text-primary-text"
-                            : "bg-bg border border-border text-text-muted hover:border-border-focus"
-                        }`}
-                      >
-                        {opt.label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-                <FormField
-                  label="Label"
-                  helperText="Optional. Helps identify this session later."
-                >
-                  <Input
-                    type="text"
-                    placeholder="e.g. testing stripe"
-                    value={directLabel}
-                    onChange={(e) => setDirectLabel(e.target.value)}
-                    maxLength={128}
-                  />
-                </FormField>
-              </div>
-            )}
-
             <RoleSelector
               value={selectedRole}
               onChange={setSelectedRole}
               disabled={!canSelectRole}
             />
+
+            {inviteType !== "persistent" && (
+              <div>
+                <button
+                  type="button"
+                  onClick={() => setShowAdvanced((v) => !v)}
+                  className="flex items-center gap-1.5 text-xs font-medium text-text-muted hover:text-text transition-colors"
+                >
+                  <svg
+                    className={`w-3 h-3 transition-transform ${showAdvanced ? "rotate-90" : ""}`}
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <polyline points="9 18 15 12 9 6" />
+                  </svg>
+                  Advanced options
+                </button>
+                {showAdvanced && (
+                  <div className="mt-3 space-y-3">
+                    <div>
+                      <label className="block text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+                        Session duration
+                      </label>
+                      <div className="flex gap-2">
+                        {([
+                          { label: "1h", value: 3600 },
+                          { label: "8h", value: 28800 },
+                          { label: "24h", value: 86400 },
+                          { label: "7d", value: 604800 },
+                        ] as const).map((opt) => (
+                          <button
+                            key={opt.value}
+                            type="button"
+                            onClick={() => setSessionTTL(opt.value)}
+                            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                              sessionTTL === opt.value
+                                ? "bg-primary text-primary-text"
+                                : "bg-bg border border-border text-text-muted hover:border-border-focus"
+                            }`}
+                          >
+                            {opt.label}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    <FormField
+                      label="Label"
+                      helperText="Optional. Helps identify this session later."
+                    >
+                      <Input
+                        type="text"
+                        placeholder="e.g. testing stripe"
+                        value={sessionLabel}
+                        onChange={(e) => setSessionLabel(e.target.value)}
+                        maxLength={128}
+                      />
+                    </FormField>
+                  </div>
+                )}
+              </div>
+            )}
 
             {error && <ErrorBanner message={error} />}
           </div>

--- a/web/src/pages/vault/UsersTab.tsx
+++ b/web/src/pages/vault/UsersTab.tsx
@@ -10,6 +10,7 @@ import Modal from "../../components/Modal";
 import DropdownMenu, { type DropdownMenuItem } from "../../components/DropdownMenu";
 import Button from "../../components/Button";
 import Input from "../../components/Input";
+import Select from "../../components/Select";
 import FormField from "../../components/FormField";
 import CopyButton from "../../components/CopyButton";
 import { apiFetch } from "../../lib/api";
@@ -403,37 +404,20 @@ function InviteUserButton({
                 autoFocus
               />
             </FormField>
-            <div>
-              <label className="block text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
-                Role
-              </label>
-              <div className="space-y-2">
-                {(["member", "admin"] as const).map((r) => (
-                  <button
-                    key={r}
-                    type="button"
-                    onClick={() => setRole(r)}
-                    className={`w-full text-left px-4 py-3 rounded-lg border-2 transition-all ${
-                      role === r
-                        ? "border-primary bg-primary/[0.04]"
-                        : "border-border hover:border-border-focus bg-surface"
-                    }`}
-                  >
-                    <div className="text-sm font-medium text-text capitalize">
-                      {r}
-                      {r === "member" && (
-                        <span className="ml-1.5 text-xs font-normal text-text-muted">(Default)</span>
-                      )}
-                    </div>
-                    <p className="text-xs text-text-muted mt-0.5">
-                      {r === "member"
-                        ? "View credentials, use proxy, and raise proposals."
-                        : "All member permissions, plus invite users, manage vault settings, and approve proposals."}
-                    </p>
-                  </button>
-                ))}
-              </div>
-            </div>
+            <FormField
+              label="Role"
+              helperText={<>{role === "member"
+                ? "Manage credentials, use proxy, approve proposals, and manage policy."
+                : "All member permissions, plus invite users and agents with any role."} <a href="https://docs.agent-vault.dev/learn/permissions#vault-roles" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Learn more</a></>}
+            >
+              <Select
+                value={role}
+                onChange={(e) => setRole(e.target.value as "member" | "admin")}
+              >
+                <option value="member">Member</option>
+                <option value="admin">Admin</option>
+              </Select>
+            </FormField>
             {error && <ErrorBanner message={error} />}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Add `session_ttl_seconds` and `session_label` fields to temporary agent invites, allowing callers to control the lifetime and label of sessions minted on invite redemption
- Fix `--direct` connect defaulting to 15m invite TTL instead of server's 24h session default; add `--session-ttl` flag support for direct connect
- Add `session_label` length validation (max 128 chars) to invite creation endpoint
- Restructure docs navigation with new self-hosting and agent connection guides
- Refine AgentsTab and UsersTab UI components with shared Select component
- Update CLAUDE.md with new invite session options documentation

## Test plan
- [x] All existing tests pass (`make test`)
- [ ] Verify `agent-vault vault agent invite create --direct` defaults to 24h session
- [ ] Verify `agent-vault vault agent invite create --session-ttl 1h` sets correct session lifetime on redemption
- [ ] Verify `session_label` > 128 chars is rejected with 400
- [ ] Verify docs site renders correctly with new navigation structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)