### PR TITLE
feat: inline setup for all authenticated CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ sudo mv agent-vault /usr/local/bin/
 ```bash
 # Start the server (runs on localhost:14321 by default; use --host and --port to change)
 agent-vault server -d
-agent-vault register
-agent-vault login
 
 # Run with your agent
 agent-vault vault run -- claude    # Claude Code
@@ -75,7 +73,7 @@ agent-vault vault run -- codex     # Codex
 agent-vault vault agent invite create
 ```
 
-`agent-vault vault run` wraps your agent process with a scoped session — no tokens to manage. Alternatively, `agent-vault vault agent invite create` prints an invite prompt you can paste into any agent's chat to connect it.
+Any command that needs authentication will walk you through setup automatically — just run it and follow the prompts. `agent-vault vault run` wraps your agent process with a scoped session — no tokens to manage. Alternatively, `agent-vault vault agent invite create` prints an invite prompt you can paste into any agent's chat to connect it.
 
 Once connected, ask the agent to call any external API. It will discover available services, [propose access](https://docs.agent-vault.dev/first-proposal) for anything missing, and give you a browser link to approve.
 

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -17,7 +17,7 @@ var accountDeleteCmd = &cobra.Command{
 	Short: "Permanently delete your account",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -18,7 +18,7 @@ var agentListCmd = &cobra.Command{
 	Short: "List registered agents",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -66,7 +66,7 @@ var agentInfoCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -113,7 +113,7 @@ var agentRevokeCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ var agentRotateCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -173,7 +173,7 @@ var agentRenameCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 		newName := args[1]
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -207,7 +207,7 @@ var agentSetRoleCmd = &cobra.Command{
 			return fmt.Errorf("--role must be one of: consumer, member, admin")
 		}
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/change_password.go
+++ b/cmd/change_password.go
@@ -17,7 +17,7 @@ var changePasswordCmd = &cobra.Command{
 	Short: "Change your account password",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -20,7 +20,7 @@ var credentialsListCmd = &cobra.Command{
 	Short: "List credential keys in a vault",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -60,7 +60,7 @@ var credentialsSetCmd = &cobra.Command{
 	Short: "Set one or more credentials",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -109,7 +109,7 @@ var credentialsDeleteCmd = &cobra.Command{
 	Short: "Delete one or more credentials",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/email.go
+++ b/cmd/email.go
@@ -18,7 +18,7 @@ var emailTestCmd = &cobra.Command{
 	Long:  `Send a test email to verify that SMTP is configured correctly on the server. Only owners can use this command.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -20,18 +20,6 @@ import (
 	"golang.org/x/term"
 )
 
-// loadSession loads the client session or returns an error prompting login.
-func loadSession() (*session.ClientSession, error) {
-	sess, err := session.Load()
-	if err != nil {
-		return nil, fmt.Errorf("loading session: %w", err)
-	}
-	if sess == nil {
-		return nil, fmt.Errorf("not logged in, run 'agent-vault login' first")
-	}
-	return sess, nil
-}
-
 const (
 	hostingLocal       = "local"
 	hostingSelfHosting = "self-hosting"

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -7,13 +7,17 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"syscall"
 	"time"
 
+	"github.com/charmbracelet/huh"
+	"github.com/Infisical/agent-vault/internal/auth"
 	"github.com/Infisical/agent-vault/internal/pidfile"
 	"github.com/Infisical/agent-vault/internal/session"
 	"github.com/Infisical/agent-vault/internal/store"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // loadSession loads the client session or returns an error prompting login.
@@ -25,6 +29,318 @@ func loadSession() (*session.ClientSession, error) {
 	if sess == nil {
 		return nil, fmt.Errorf("not logged in, run 'agent-vault login' first")
 	}
+	return sess, nil
+}
+
+const (
+	hostingLocal       = "local"
+	hostingSelfHosting = "self-hosting"
+)
+
+// httpClient is used for setup-flow HTTP calls with a reasonable timeout.
+var httpClient = &http.Client{Timeout: 10 * time.Second}
+
+// selectAddress prompts the user to pick a hosting option interactively.
+// Returns the server address to use.
+func selectAddress() (string, error) {
+	var choice string
+	err := huh.NewSelect[string]().
+		Title("Select your hosting option:").
+		Options(
+			huh.NewOption(fmt.Sprintf("Agent Vault (%s:%d)", DefaultHost, DefaultPort), hostingLocal),
+			huh.NewOption("Self-Hosting or Dedicated Instance", hostingSelfHosting),
+		).
+		Value(&choice).
+		Run()
+	if err != nil {
+		return "", fmt.Errorf("hosting selection: %w", err)
+	}
+
+	if choice == hostingLocal {
+		return DefaultAddress, nil
+	}
+
+	var address string
+	err = huh.NewInput().
+		Title("Enter your server address:").
+		Placeholder("https://my-agent-vault.example.com").
+		Value(&address).
+		Validate(func(s string) error {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				return fmt.Errorf("address cannot be empty")
+			}
+			if !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
+				return fmt.Errorf("address must start with http:// or https://")
+			}
+			return nil
+		}).
+		Run()
+	if err != nil {
+		return "", fmt.Errorf("address input: %w", err)
+	}
+
+	return strings.TrimRight(strings.TrimSpace(address), "/"), nil
+}
+
+// isInteractive returns true if stdin is a terminal.
+func isInteractive() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// serverStatus holds the parsed /v1/status response.
+type serverStatus struct {
+	Initialized    bool `json:"initialized"`
+	NeedsFirstUser bool `json:"needs_first_user"`
+}
+
+// checkServerStatus queries the server's public status endpoint.
+func checkServerStatus(address string) (*serverStatus, error) {
+	resp, err := httpClient.Get(address + "/v1/status")
+	if err != nil {
+		return nil, fmt.Errorf("could not reach server at %s: %w", address, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server at %s returned status %d", address, resp.StatusCode)
+	}
+
+	var status serverStatus
+	if err := json.NewDecoder(resp.Body).Decode(&status); err != nil {
+		return nil, fmt.Errorf("parsing server status: %w", err)
+	}
+	return &status, nil
+}
+
+// registerResult holds the parsed register API response.
+type registerResult struct {
+	Email                string `json:"email"`
+	Role                 string `json:"role"`
+	RequiresVerification bool   `json:"requires_verification"`
+	EmailSent            bool   `json:"email_sent"`
+	Message              string `json:"message"`
+}
+
+// doRegister posts credentials to /v1/auth/register and returns the result.
+func doRegister(address, email, password string) (*registerResult, error) {
+	body, err := json.Marshal(map[string]string{
+		"email":    email,
+		"password": password,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Post(address+"/v1/auth/register", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("could not reach server at %s: %w", address, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result struct {
+		registerResult
+		Error string `json:"error"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&result)
+
+	if resp.StatusCode >= 400 {
+		if result.Error != "" {
+			return nil, fmt.Errorf("%s", result.Error)
+		}
+		return nil, fmt.Errorf("registration failed with status %d", resp.StatusCode)
+	}
+
+	return &result.registerResult, nil
+}
+
+// doLogin posts credentials to /v1/auth/login, saves the session on success, and returns it.
+func doLogin(address, email, password string) (*session.ClientSession, error) {
+	body, err := json.Marshal(map[string]string{"email": email, "password": password})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Post(address+"/v1/auth/login", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("could not reach server at %s: %w", address, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("invalid email or password")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&errResp)
+		if errResp.Error != "" {
+			return nil, fmt.Errorf("login failed: %s", errResp.Error)
+		}
+		return nil, fmt.Errorf("login failed with status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Token     string `json:"token"`
+		ExpiresAt string `json:"expires_at"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+
+	sess := &session.ClientSession{
+		Token:   result.Token,
+		Address: address,
+	}
+	if err := session.Save(sess); err != nil {
+		return nil, fmt.Errorf("saving session: %w", err)
+	}
+	return sess, nil
+}
+
+// interactiveReadEmail prompts for an email address on stderr and reads from stdin.
+func interactiveReadEmail() (string, error) {
+	return auth.PromptEmail("Email: ")
+}
+
+// interactiveReadPassword prompts for a password using hidden input.
+func interactiveReadPassword() (string, error) {
+	pw, err := auth.PromptPassword("Password: ")
+	if err != nil {
+		return "", err
+	}
+	return string(pw), nil
+}
+
+// interactiveReadPasswordWithConfirm prompts for a password with confirmation and enforces minimum length.
+func interactiveReadPasswordWithConfirm() (string, error) {
+	pw, err := auth.PromptNewPassword("Password: ", "Confirm password: ")
+	if err != nil {
+		return "", err
+	}
+	if len(pw) < 8 {
+		return "", fmt.Errorf("password must be at least 8 characters")
+	}
+	return string(pw), nil
+}
+
+// ensureSession loads the client session, or interactively guides the user through setup if no session exists and a TTY is available.
+func ensureSession() (*session.ClientSession, error) {
+	sess, err := session.Load()
+	if err != nil {
+		return nil, fmt.Errorf("loading session: %w", err)
+	}
+	if sess != nil {
+		return sess, nil
+	}
+
+	if !isInteractive() {
+		return nil, fmt.Errorf("not logged in, run 'agent-vault login' first")
+	}
+
+	fmt.Fprintln(os.Stderr, "\nNo active session. Let's get you connected.")
+
+	address, err := selectAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	status, err := checkServerStatus(address)
+	if err != nil {
+		return nil, err
+	}
+
+	if status.NeedsFirstUser {
+		fmt.Fprintln(os.Stderr, "\nThis server needs its first user (owner account).")
+
+		email, err := interactiveReadEmail()
+		if err != nil {
+			return nil, err
+		}
+		password, err := interactiveReadPasswordWithConfirm()
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := doRegister(address, email, password); err != nil {
+			return nil, fmt.Errorf("registration failed: %w", err)
+		}
+		fmt.Fprintln(os.Stderr, successText("✓")+" Owner account created. Logging in...")
+
+		sess, err := doLogin(address, email, password)
+		if err != nil {
+			return nil, fmt.Errorf("auto-login failed: %w", err)
+		}
+		fmt.Fprintln(os.Stderr, successText("✓")+" Login successful.\n")
+		return sess, nil
+	}
+
+	// Server has existing users — prompt to log in or register.
+	const choiceLogin = "login"
+	const choiceRegister = "register"
+	var choice string
+	err = huh.NewSelect[string]().
+		Title("This server already has users. What would you like to do?").
+		Options(
+			huh.NewOption("Log in to existing account", choiceLogin),
+			huh.NewOption("Create a new account", choiceRegister),
+		).
+		Value(&choice).
+		Run()
+	if err != nil {
+		return nil, fmt.Errorf("action selection: %w", err)
+	}
+
+	if choice == choiceRegister {
+		email, err := interactiveReadEmail()
+		if err != nil {
+			return nil, err
+		}
+		password, err := interactiveReadPasswordWithConfirm()
+		if err != nil {
+			return nil, err
+		}
+
+		result, err := doRegister(address, email, password)
+		if err != nil {
+			return nil, fmt.Errorf("registration failed: %w", err)
+		}
+
+		if result.RequiresVerification {
+			if result.EmailSent {
+				fmt.Fprintln(os.Stderr, successText("✓")+" Account created. Check your email for a verification code.")
+			} else {
+				fmt.Fprintln(os.Stderr, successText("✓")+" Account created. Ask your instance owner for the verification code.")
+			}
+			return nil, fmt.Errorf("account requires verification before login; verify your account then re-run this command")
+		}
+
+		fmt.Fprintln(os.Stderr, successText("✓")+" "+result.Message)
+		sess, err := doLogin(address, email, password)
+		if err != nil {
+			return nil, fmt.Errorf("auto-login failed: %w", err)
+		}
+		fmt.Fprintln(os.Stderr, successText("✓")+" Login successful.\n")
+		return sess, nil
+	}
+
+	// Login flow.
+	email, err := interactiveReadEmail()
+	if err != nil {
+		return nil, err
+	}
+	password, err := interactiveReadPassword()
+	if err != nil {
+		return nil, err
+	}
+
+	sess, err = doLogin(address, email, password)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintln(os.Stderr, successText("✓")+" Login successful.\n")
 	return sess, nil
 }
 

--- a/cmd/invite.go
+++ b/cmd/invite.go
@@ -55,7 +55,7 @@ var inviteCreateCmd = &cobra.Command{
 			return fmt.Errorf("--session-ttl must be at least 5 minutes")
 		}
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -189,7 +189,7 @@ var inviteListCmd = &cobra.Command{
 		vault := resolveVault(cmd)
 		status, _ := cmd.Flags().GetString("status")
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -255,7 +255,7 @@ var inviteRevokeCmd = &cobra.Command{
 		vault := resolveVault(cmd)
 		suffix := args[0]
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -2,67 +2,13 @@ package cmd
 
 import (
 	"bufio"
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"strings"
 
-	"github.com/charmbracelet/huh"
-	"github.com/Infisical/agent-vault/internal/session"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
-
-const (
-	hostingLocal       = "local"
-	hostingSelfHosting = "self-hosting"
-	defaultAddress     = DefaultAddress
-)
-
-// selectAddress prompts the user to pick a hosting option interactively.
-// Returns the server address to use.
-func selectAddress() (string, error) {
-	var choice string
-	err := huh.NewSelect[string]().
-		Title("Select your hosting option:").
-		Options(
-			huh.NewOption(fmt.Sprintf("Agent Vault (%s:%d)", DefaultHost, DefaultPort), hostingLocal),
-			huh.NewOption("Self-Hosting or Dedicated Instance", hostingSelfHosting),
-		).
-		Value(&choice).
-		Run()
-	if err != nil {
-		return "", fmt.Errorf("hosting selection: %w", err)
-	}
-
-	if choice == hostingLocal {
-		return defaultAddress, nil
-	}
-
-	var address string
-	err = huh.NewInput().
-		Title("Enter your server address:").
-		Placeholder("https://my-agent-vault.example.com").
-		Value(&address).
-		Validate(func(s string) error {
-			s = strings.TrimSpace(s)
-			if s == "" {
-				return fmt.Errorf("address cannot be empty")
-			}
-			if !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
-				return fmt.Errorf("address must start with http:// or https://")
-			}
-			return nil
-		}).
-		Run()
-	if err != nil {
-		return "", fmt.Errorf("address input: %w", err)
-	}
-
-	return strings.TrimRight(strings.TrimSpace(address), "/"), nil
-}
 
 // readLoginEmail reads the email either from --email flag or by prompting interactively.
 func readLoginEmail(cmd *cobra.Command) (string, error) {
@@ -125,7 +71,7 @@ var loginCmd = &cobra.Command{
 			address, _ = cmd.Flags().GetString("address")
 		} else if fromStdin {
 			// Non-interactive mode: use the default address.
-			address = defaultAddress
+			address = DefaultAddress
 		} else {
 			// Interactive mode: show hosting selection.
 			addr, err := selectAddress()
@@ -145,45 +91,8 @@ var loginCmd = &cobra.Command{
 			return err
 		}
 
-		body, err := json.Marshal(map[string]string{"email": email, "password": password})
-		if err != nil {
+		if _, err := doLogin(address, email, password); err != nil {
 			return err
-		}
-
-		resp, err := http.Post(address+"/v1/auth/login", "application/json", bytes.NewReader(body))
-		if err != nil {
-			return fmt.Errorf("could not reach server at %s: %w", address, err)
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		if resp.StatusCode == http.StatusUnauthorized {
-			return fmt.Errorf("invalid email or password")
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			var errResp struct {
-				Error string `json:"error"`
-			}
-			_ = json.NewDecoder(resp.Body).Decode(&errResp)
-			if errResp.Error != "" {
-				return fmt.Errorf("login failed: %s", errResp.Error)
-			}
-			return fmt.Errorf("login failed with status %d", resp.StatusCode)
-		}
-
-		var result struct {
-			Token     string `json:"token"`
-			ExpiresAt string `json:"expires_at"`
-		}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return fmt.Errorf("parsing response: %w", err)
-		}
-
-		if err := session.Save(&session.ClientSession{
-			Token:   result.Token,
-			Address: address,
-		}); err != nil {
-			return fmt.Errorf("saving session: %w", err)
 		}
 
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), successText("✓")+" Login successful.")

--- a/cmd/owner_vault.go
+++ b/cmd/owner_vault.go
@@ -19,7 +19,7 @@ var ownerVaultListCmd = &cobra.Command{
 	Short: "List all vaults across the instance (owner only)",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -67,7 +67,7 @@ var ownerVaultRemoveCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ var ownerVaultJoinCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -24,7 +24,7 @@ var policyGetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vault := resolveVault(cmd)
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -97,7 +97,7 @@ var policySetCmd = &cobra.Command{
 			return fmt.Errorf("invalid policy: %w", err)
 		}
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -144,7 +144,7 @@ var policyClearCmd = &cobra.Command{
 			}
 		}
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/policy_interactive.go
+++ b/cmd/policy_interactive.go
@@ -30,7 +30,7 @@ func runInteractivePolicySet(cmd *cobra.Command) error {
 		return err
 	}
 
-	sess, err := loadSession()
+	sess, err := ensureSession()
 	if err != nil {
 		return err
 	}

--- a/cmd/proposal.go
+++ b/cmd/proposal.go
@@ -146,12 +146,7 @@ func collectCredentialValues(cmd *cobra.Command, cs *store.Proposal, credentialO
 }
 
 // sendApproveRequest sends a proposal approval to the running server via HTTP.
-func sendApproveRequest(vault string, id int, credentials map[string]string) error {
-	sess, err := loadSession()
-	if err != nil {
-		return err
-	}
-
+func sendApproveRequest(sess *session.ClientSession, vault string, id int, credentials map[string]string) error {
 	body, err := json.Marshal(map[string]interface{}{
 		"vault":       vault,
 		"credentials": credentials,
@@ -165,12 +160,7 @@ func sendApproveRequest(vault string, id int, credentials map[string]string) err
 }
 
 // sendRejectRequest sends a proposal rejection to the running server via HTTP.
-func sendRejectRequest(vault string, id int, reason string) error {
-	sess, err := loadSession()
-	if err != nil {
-		return err
-	}
-
+func sendRejectRequest(sess *session.ClientSession, vault string, id int, reason string) error {
 	body, err := json.Marshal(map[string]interface{}{
 		"vault": vault,
 		"reason":    reason,
@@ -255,7 +245,7 @@ var proposalListCmd = &cobra.Command{
 		vault := resolveVault(cmd)
 		status, _ := cmd.Flags().GetString("status")
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -313,7 +303,7 @@ var proposalShowCmd = &cobra.Command{
 			return fmt.Errorf("invalid proposal number: %s", args[0])
 		}
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -351,7 +341,7 @@ var proposalApproveCmd = &cobra.Command{
 			credentialOverrides[arg[:idx]] = arg[idx+1:]
 		}
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -391,7 +381,7 @@ var proposalApproveCmd = &cobra.Command{
 		}
 
 		// Send approval to the running server.
-		if err := sendApproveRequest(vault, id, credentials); err != nil {
+		if err := sendApproveRequest(sess, vault, id, credentials); err != nil {
 			return err
 		}
 
@@ -413,7 +403,12 @@ var proposalRejectCmd = &cobra.Command{
 			return fmt.Errorf("invalid proposal number: %s", args[0])
 		}
 
-		if err := sendRejectRequest(vault, id, reason); err != nil {
+		sess, err := ensureSession()
+		if err != nil {
+			return err
+		}
+
+		if err := sendRejectRequest(sess, vault, id, reason); err != nil {
 			return err
 		}
 
@@ -433,7 +428,7 @@ var proposalReviewCmd = &cobra.Command{
 
 		vault := resolveVault(cmd)
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -512,7 +507,7 @@ var proposalReviewCmd = &cobra.Command{
 					continue
 				}
 
-				if err := sendApproveRequest(vault, fresh.ID, credentials); err != nil {
+				if err := sendApproveRequest(sess, vault, fresh.ID, credentials); err != nil {
 					fmt.Fprintf(cmd.OutOrStderr(), "Error approving proposal #%d: %v\n", fresh.ID, err)
 					skipped = append(skipped, fresh.ID)
 				} else {
@@ -530,7 +525,7 @@ var proposalReviewCmd = &cobra.Command{
 					return err
 				}
 
-				if err := sendRejectRequest(vault, fresh.ID, reason); err != nil {
+				if err := sendRejectRequest(sess, vault, fresh.ID, reason); err != nil {
 					fmt.Fprintf(cmd.OutOrStderr(), "Error rejecting proposal #%d: %v\n", fresh.ID, err)
 					skipped = append(skipped, fresh.ID)
 				} else {

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -76,36 +76,9 @@ var registerCmd = &cobra.Command{
 			return fmt.Errorf("password must be at least 8 characters")
 		}
 
-		// Send register request.
-		body, err := json.Marshal(map[string]string{
-			"email":    email,
-			"password": password,
-		})
+		result, err := doRegister(address, email, password)
 		if err != nil {
 			return err
-		}
-
-		resp, err := http.Post(address+"/v1/auth/register", "application/json", bytes.NewReader(body))
-		if err != nil {
-			return fmt.Errorf("could not reach server at %s: %w", address, err)
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		var result struct {
-			Email                string `json:"email"`
-			Role                 string `json:"role"`
-			RequiresVerification bool   `json:"requires_verification"`
-			EmailSent            bool   `json:"email_sent"`
-			Message              string `json:"message"`
-			Error                string `json:"error"`
-		}
-		_ = json.NewDecoder(resp.Body).Decode(&result)
-
-		if resp.StatusCode >= 400 {
-			if result.Error != "" {
-				return fmt.Errorf("%s", result.Error)
-			}
-			return fmt.Errorf("registration failed with status %d", resp.StatusCode)
 		}
 
 		if !result.RequiresVerification {

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -26,7 +26,7 @@ it will be stopped automatically before the reset.`,
 		yes, _ := cmd.Flags().GetBool("yes")
 
 		// 1. Load session
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -40,7 +40,7 @@ Example:
 	DisableFlagsInUseLine: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// 1. Load the admin session from agent-vault login.
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -18,7 +18,7 @@ var settingsGetCmd = &cobra.Command{
 	Short: "Show instance settings",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ var settingsSetCmd = &cobra.Command{
 	Short: "Update instance settings",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -19,7 +19,7 @@ var userListCmd = &cobra.Command{
 	Short: "List all users (owner only)",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -66,7 +66,7 @@ var userInfoCmd = &cobra.Command{
 	Short: "View user info (owner or self)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -108,7 +108,7 @@ var userRemoveCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		email := args[0]
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ var userSetRoleCmd = &cobra.Command{
 			return fmt.Errorf("--role is required (owner or member)")
 		}
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/vaults.go
+++ b/cmd/vaults.go
@@ -26,7 +26,7 @@ var vaultCreateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -60,7 +60,7 @@ var vaultListCmd = &cobra.Command{
 	Short: "List vaults",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -149,7 +149,7 @@ var vaultUserInviteCmd = &cobra.Command{
 		vaultName := resolveVault(cmd)
 		role, _ := cmd.Flags().GetString("role")
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -190,7 +190,7 @@ var vaultUserListCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vaultName := resolveVault(cmd)
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -234,7 +234,7 @@ var vaultUserRemoveCmd = &cobra.Command{
 		email := args[0]
 		vaultName := resolveVault(cmd)
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -261,7 +261,7 @@ var vaultUserSetRoleCmd = &cobra.Command{
 			return fmt.Errorf("--role is required (admin or member)")
 		}
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -284,7 +284,7 @@ var vaultRenameCmd = &cobra.Command{
 		oldName := args[0]
 		newName := args[1]
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
@@ -331,7 +331,7 @@ var vaultDeleteCmd = &cobra.Command{
 			}
 		}
 
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -13,7 +13,7 @@ var whoamiCmd = &cobra.Command{
 	Short: "Show current user and session info",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := loadSession()
+		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}

--- a/docs/first-proposal.mdx
+++ b/docs/first-proposal.mdx
@@ -9,13 +9,9 @@ When an agent needs access to a service that isn't configured yet, it creates a 
 
 - A running Agent Vault server with an account ([see installation guide](/installation))
 
-## 1. Log in
+## 1. Create an agent invite
 
-```bash
-agent-vault login
-```
-
-## 2. Create an agent invite
+If you haven't logged in yet, you'll be guided through setup automatically.
 
 <Tabs>
   <Tab title="CLI">
@@ -30,11 +26,11 @@ agent-vault login
   </Tab>
 </Tabs>
 
-## 3. Paste the prompt into your agent
+## 2. Paste the prompt into your agent
 
 Open your agent (Claude Code, Cursor, or any supported agent) and paste the invite prompt. The agent redeems the invite automatically and receives a session token scoped to your vault.
 
-## 4. Give the agent a task
+## 3. Give the agent a task
 
 Ask the agent to do something that requires an external API:
 
@@ -44,7 +40,7 @@ Ask the agent to do something that requires an external API:
 
 > "Check my Cloudflare DNS records"
 
-## 5. Approve the proposal
+## 4. Approve the proposal
 
 Here's what happens — with zero pre-configuration:
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -127,6 +127,8 @@ agent-vault server stop
 
 The first user to register becomes the instance [owner](/learn/permissions#instance-roles) with full admin privileges and is automatically granted [admin](/learn/permissions#vault-roles) on the default [vault](/learn/vaults).
 
+Any CLI command that needs authentication will walk you through registration and login automatically — just run the command you want and follow the prompts. You can also register explicitly:
+
 <Tabs>
   <Tab title="CLI">
     ```bash

--- a/docs/quickstart/claude-code.mdx
+++ b/docs/quickstart/claude-code.mdx
@@ -10,13 +10,7 @@ description: "Learn how to connect Claude Code to Agent Vault so it can make aut
 
 ## Quick start
 
-Log in to your Agent Vault instance:
-
-```bash
-agent-vault login
-```
-
-Then launch Claude Code with `vault run`. It wraps Claude Code with a vault-scoped session and installs the Agent Vault skill so Claude knows how to proxy requests and raise proposals automatically.
+Launch Claude Code with `vault run`. It wraps Claude Code with a vault-scoped session and installs the Agent Vault skill so Claude knows how to proxy requests and raise proposals automatically. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault run -- claude

--- a/docs/quickstart/codex.mdx
+++ b/docs/quickstart/codex.mdx
@@ -10,13 +10,7 @@ description: "Learn how to connect Codex to Agent Vault so it can make authentic
 
 ## Quick start
 
-Log in to your Agent Vault instance:
-
-```bash
-agent-vault login
-```
-
-Then launch Codex with `vault run`. It wraps Codex with a vault-scoped session and installs the Agent Vault skill so Codex knows how to proxy requests and raise proposals automatically.
+Launch Codex with `vault run`. It wraps Codex with a vault-scoped session and installs the Agent Vault skill so Codex knows how to proxy requests and raise proposals automatically. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault run -- codex

--- a/docs/quickstart/cursor.mdx
+++ b/docs/quickstart/cursor.mdx
@@ -10,13 +10,7 @@ description: "Learn how to connect Cursor to Agent Vault so it can make authenti
 
 ## Quick start
 
-Log in to your Agent Vault instance:
-
-```bash
-agent-vault login
-```
-
-Then launch Cursor with `vault run`. It wraps Cursor with a vault-scoped session and installs the Agent Vault skill so Cursor knows how to proxy requests and raise proposals automatically.
+Launch Cursor with `vault run`. It wraps Cursor with a vault-scoped session and installs the Agent Vault skill so Cursor knows how to proxy requests and raise proposals automatically. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault run -- agent

--- a/docs/quickstart/custom-agent.mdx
+++ b/docs/quickstart/custom-agent.mdx
@@ -10,13 +10,7 @@ description: "Connect any HTTP-capable agent or script to Agent Vault using envi
 
 ## Quick start
 
-Log in to your Agent Vault instance:
-
-```bash
-agent-vault login
-```
-
-Create a direct-connect session to get the environment variables your agent needs:
+Create a direct-connect session to get the environment variables your agent needs. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault agent invite create --direct

--- a/docs/quickstart/hermes-agent.mdx
+++ b/docs/quickstart/hermes-agent.mdx
@@ -10,13 +10,9 @@ To get the most out of this guide, you'll need to:
 - A deployed Agent Vault instance ([see installation guide](/installation))
 - Have [Hermes Agent](https://hermesagent.dev/) installed
 
-## 1. Log in
+## 1. Create an agent invite
 
-```bash
-agent-vault login
-```
-
-## 2. Create an agent invite
+If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault agent invite create
@@ -24,11 +20,11 @@ agent-vault vault agent invite create
 
 This generates a one-time onboarding prompt and copies it to your clipboard.
 
-## 3. Paste the prompt into Hermes Agent
+## 2. Paste the prompt into Hermes Agent
 
 Open Hermes Agent's chat and paste the invite prompt. Hermes Agent redeems the invite automatically and receives a session token scoped to your vault.
 
-## 4. Start using it
+## 3. Start using it
 
 Ask Hermes Agent to do something that requires an external API:
 

--- a/docs/quickstart/nanoclaw.mdx
+++ b/docs/quickstart/nanoclaw.mdx
@@ -10,13 +10,9 @@ To get the most out of this guide, you'll need to:
 - A deployed Agent Vault instance ([see installation guide](/installation))
 - Have [NanoClaw](https://nanoclaw.dev/) installed
 
-## 1. Log in
+## 1. Create an agent invite
 
-```bash
-agent-vault login
-```
-
-## 2. Create an agent invite
+If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault agent invite create
@@ -24,11 +20,11 @@ agent-vault vault agent invite create
 
 This generates a one-time onboarding prompt and copies it to your clipboard.
 
-## 3. Paste the prompt into NanoClaw
+## 2. Paste the prompt into NanoClaw
 
 Open NanoClaw's chat and paste the invite prompt. NanoClaw redeems the invite automatically and receives a session token scoped to your vault.
 
-## 4. Start using it
+## 3. Start using it
 
 Ask NanoClaw to do something that requires an external API:
 

--- a/docs/quickstart/openclaw.mdx
+++ b/docs/quickstart/openclaw.mdx
@@ -10,13 +10,9 @@ To get the most out of this guide, you'll need to:
 - A deployed Agent Vault instance ([see installation guide](/installation))
 - Have [OpenClaw](https://openclaw.ai) installed
 
-## 1. Log in
+## 1. Create an agent invite
 
-```bash
-agent-vault login
-```
-
-## 2. Create an agent invite
+If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault agent invite create
@@ -24,11 +20,11 @@ agent-vault vault agent invite create
 
 This generates a one-time onboarding prompt and copies it to your clipboard.
 
-## 3. Paste the prompt into OpenClaw
+## 2. Paste the prompt into OpenClaw
 
 Open OpenClaw's chat and paste the invite prompt. OpenClaw redeems the invite automatically and receives a session token scoped to your vault.
 
-## 4. Start using it
+## 3. Start using it
 
 Ask OpenClaw to do something that requires an external API:
 

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -56,6 +56,8 @@ agent-vault server stop
 
 The first user to register becomes the instance [owner](/learn/permissions#instance-roles) with full admin privileges and is automatically granted [admin](/learn/permissions#vault-roles) on the default [vault](/learn/vaults).
 
+Any CLI command that needs authentication will walk you through registration and login automatically — just run the command you want and follow the prompts. You can also register explicitly:
+
 <Tabs>
   <Tab title="CLI">
     ```bash


### PR DESCRIPTION
## Summary
- When any authenticated CLI command detects no active session in an interactive terminal, it now guides the user through server address selection, registration or login, then continues executing the original command
- Non-interactive callers (CI, piped input) get the same fast error as before
- Extracted `doLogin()`, `doRegister()`, `checkServerStatus()` as reusable helpers; reuses `auth.PromptEmail`/`auth.PromptPassword` from `internal/auth`
- Updated README and all 10 quickstart/setup docs to remove the explicit `agent-vault login` step

## Test plan
- [ ] `make test` passes (verified locally)
- [ ] Delete `~/.agent-vault/session.json`, run `agent-vault vault list` — should trigger inline setup flow
- [ ] With a fresh server (no users), run `agent-vault policy get` — should prompt to create owner account, register, login, then show policy
- [ ] With an existing server, run `agent-vault credentials list` — should prompt login vs register
- [ ] Pipe input (`echo | agent-vault vault list`) — should fail with old error, not hang
- [ ] `agent-vault login` and `agent-vault register` still work identically as standalone commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)