### PR TITLE
feat: add resend verification code endpoint and UI

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -455,6 +455,7 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("GET /v1/status", s.handleStatus)
 	mux.HandleFunc("POST /v1/auth/register", limitBody(s.handleRegister))
 	mux.HandleFunc("POST /v1/auth/verify", limitBody(s.handleVerify))
+	mux.HandleFunc("POST /v1/auth/resend-verification", limitBody(s.handleResendVerification))
 	mux.HandleFunc("POST /v1/auth/forgot-password", limitBody(s.handleForgotPassword))
 	mux.HandleFunc("POST /v1/auth/reset-password", limitBody(s.handleResetPassword))
 
@@ -680,6 +681,46 @@ func (l *verifyRateLimiter) reset(email string) {
 	delete(l.attempts, email)
 }
 
+var errTooManyPendingCodes = errors.New("too many pending verification codes")
+
+// generateAndSendVerificationCode creates a new 6-digit verification code for
+// the given email and sends it via email (or logs to stderr if SMTP is not configured).
+func (s *Server) generateAndSendVerificationCode(ctx context.Context, email string) (bool, error) {
+	// Rate limit verification codes per email.
+	pendingCount, err := s.store.CountPendingEmailVerifications(ctx, email)
+	if err != nil {
+		return false, fmt.Errorf("failed to count pending verifications: %w", err)
+	}
+	if pendingCount >= maxPendingVerifications {
+		return false, errTooManyPendingCodes
+	}
+
+	// Generate 6-digit verification code (uniform distribution via rejection sampling).
+	codeInt, _ := crand.Int(crand.Reader, big.NewInt(1_000_000))
+	code := fmt.Sprintf("%06d", codeInt.Int64())
+
+	_, err = s.store.CreateEmailVerification(ctx, email, code, time.Now().Add(emailVerificationTTL))
+	if err != nil {
+		return false, fmt.Errorf("failed to create verification: %w", err)
+	}
+
+	// Send verification code via email or log to stderr.
+	emailSent := false
+	if s.notifier.Enabled() {
+		body := strings.Replace(verificationCodeEmailHTML, "{{CODE}}", html.EscapeString(code), 1)
+		if err := s.notifier.SendHTMLMail([]string{email}, "Agent Vault verification code", body); err != nil {
+			fmt.Fprintf(os.Stderr, "[agent-vault] Failed to send verification email to %s: %v\n", email, err)
+			fmt.Fprintf(os.Stderr, "[agent-vault] Email verification code for %s: %s\n", email, code)
+		} else {
+			emailSent = true
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "[agent-vault] Email verification code for %s: %s\n", email, code)
+	}
+
+	return emailSent, nil
+}
+
 func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Email    string `json:"email"`
@@ -749,34 +790,14 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Rate limit verification codes.
-		pendingCount, _ := s.store.CountPendingEmailVerifications(ctx, req.Email)
-		if pendingCount >= maxPendingVerifications {
+		emailSent, err := s.generateAndSendVerificationCode(ctx, req.Email)
+		if errors.Is(err, errTooManyPendingCodes) {
 			jsonError(w, http.StatusTooManyRequests, "Too many pending verification codes")
 			return
 		}
-
-		// Generate 6-digit verification code.
-		codeInt, _ := crand.Int(crand.Reader, big.NewInt(1_000_000))
-		code := fmt.Sprintf("%06d", codeInt.Int64())
-
-		_, err = s.store.CreateEmailVerification(ctx, req.Email, code, time.Now().Add(emailVerificationTTL))
 		if err != nil {
 			jsonError(w, http.StatusInternalServerError, "Failed to create verification")
 			return
-		}
-
-		emailSent := false
-		if s.notifier.Enabled() {
-			body := strings.Replace(verificationCodeEmailHTML, "{{CODE}}", html.EscapeString(code), 1)
-			if err := s.notifier.SendHTMLMail([]string{req.Email}, "Agent Vault verification code", body); err != nil {
-				fmt.Fprintf(os.Stderr, "[agent-vault] Failed to send verification email to %s: %v\n", req.Email, err)
-				fmt.Fprintf(os.Stderr, "[agent-vault] Email verification code for %s: %s\n", req.Email, code)
-			} else {
-				emailSent = true
-			}
-		} else {
-			fmt.Fprintf(os.Stderr, "[agent-vault] Email verification code for %s: %s\n", req.Email, code)
 		}
 
 		msg := "Account updated. Ask your Agent Vault instance owner for the verification code."
@@ -844,35 +865,14 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Rate limit verification codes.
-	pendingCount, _ := s.store.CountPendingEmailVerifications(ctx, req.Email)
-	if pendingCount >= maxPendingVerifications {
+	emailSent, err := s.generateAndSendVerificationCode(ctx, req.Email)
+	if errors.Is(err, errTooManyPendingCodes) {
 		jsonError(w, http.StatusTooManyRequests, "Too many pending verification codes")
 		return
 	}
-
-	// Generate 6-digit verification code (uniform distribution via rejection sampling).
-	codeInt, _ := crand.Int(crand.Reader, big.NewInt(1_000_000))
-	code := fmt.Sprintf("%06d", codeInt.Int64())
-
-	_, err = s.store.CreateEmailVerification(ctx, req.Email, code, time.Now().Add(emailVerificationTTL))
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create verification")
 		return
-	}
-
-	// Send verification code via email or log to stderr.
-	emailSent := false
-	if s.notifier.Enabled() {
-		body := strings.Replace(verificationCodeEmailHTML, "{{CODE}}", html.EscapeString(code), 1)
-		if err := s.notifier.SendHTMLMail([]string{req.Email}, "Agent Vault verification code", body); err != nil {
-			fmt.Fprintf(os.Stderr, "[agent-vault] Failed to send verification email to %s: %v\n", req.Email, err)
-			fmt.Fprintf(os.Stderr, "[agent-vault] Email verification code for %s: %s\n", req.Email, code)
-		} else {
-			emailSent = true
-		}
-	} else {
-		fmt.Fprintf(os.Stderr, "[agent-vault] Email verification code for %s: %s\n", req.Email, code)
 	}
 
 	msg := "Account created. Ask your Agent Vault instance owner for the verification code."
@@ -957,6 +957,49 @@ func (s *Server) handleVerify(w http.ResponseWriter, r *http.Request) {
 		"authenticated": true,
 		"message":       "Account verified.",
 	})
+}
+
+func (s *Server) handleResendVerification(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Email string `json:"email"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Email == "" {
+		jsonError(w, http.StatusBadRequest, "Email is required")
+		return
+	}
+
+	// Rate limit by IP.
+	ip := clientIP(r)
+	if !resendVerifyLimiter.allow(ip) {
+		jsonError(w, http.StatusTooManyRequests, "Too many requests, try again later")
+		return
+	}
+
+	ctx := r.Context()
+
+	// Uniform response to prevent email enumeration.
+	uniformResponse := func(emailSent bool) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"message":    "If an unverified account exists for this email, a new verification code has been sent.",
+			"email_sent": emailSent,
+		})
+	}
+
+	user, err := s.store.GetUserByEmail(ctx, req.Email)
+	if err != nil || user == nil || user.IsActive {
+		uniformResponse(false)
+		return
+	}
+
+	emailSent, err := s.generateAndSendVerificationCode(ctx, req.Email)
+	if err != nil {
+		// Don't reveal whether the email exists — return uniform response.
+		uniformResponse(false)
+		return
+	}
+
+	uniformResponse(emailSent)
 }
 
 const passwordResetTTL = 15 * time.Minute
@@ -1542,6 +1585,7 @@ var (
 	loginEmailLimiter = newSlidingWindowLimiter(loginRateWindow, loginRateMax, 10000)
 	registerLimiter          = newSlidingWindowLimiter(loginRateWindow, 5, 10000) // 5 registrations per IP per 5 min
 	forgotPasswordLimiter    = newSlidingWindowLimiter(loginRateWindow, 5, 10000) // 5 forgot-password requests per IP per 5 min
+	resendVerifyLimiter      = newSlidingWindowLimiter(loginRateWindow, 5, 10000) // 5 resend-verification requests per IP per 5 min
 	vaultInviteAcceptLimiter = newSlidingWindowLimiter(loginRateWindow, 10, 10000) // 10 invite accepts per IP per 5 min
 	resetVerifyLimiter    = &verifyRateLimiter{attempts: make(map[string]int), maxKeys: maxVerifyKeys}
 )

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4166,3 +4166,123 @@ func TestDirectSessionWithLabel(t *testing.T) {
 		t.Fatalf("expected label 'testing stripe', got %q", storedSess.Label)
 	}
 }
+
+// setupMockStoreWithInactiveUser creates a mock store with an inactive (unverified) user.
+func setupMockStoreWithInactiveUser(t *testing.T, email, password string) *mockStore {
+	t.Helper()
+	ms := setupMockStoreWithUser(t, email, password)
+	// Demote the user to inactive member; add a separate owner so count > 1.
+	ms.users[email].IsActive = false
+	ms.users[email].Role = "member"
+	ms.users["owner@test.com"] = &store.User{
+		ID: "owner-id", Email: "owner@test.com",
+		Role: "owner", IsActive: true,
+	}
+	return ms
+}
+
+func TestResendVerificationSuccess(t *testing.T) {
+	ms := setupMockStoreWithInactiveUser(t, "test@example.com", "password123")
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	body := `{"email":"test@example.com"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/resend-verification", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+	if resp["message"] == nil {
+		t.Fatal("expected message in response")
+	}
+
+	// Verify a new verification code was created.
+	if len(ms.emailVerifications) != 1 {
+		t.Fatalf("expected 1 email verification, got %d", len(ms.emailVerifications))
+	}
+}
+
+func TestResendVerificationUnknownEmail(t *testing.T) {
+	ms := setupMockStoreWithInactiveUser(t, "test@example.com", "password123")
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	// Unknown email — should return 200 (uniform response, no enumeration).
+	body := `{"email":"unknown@example.com"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/resend-verification", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// No verification code should have been created.
+	if len(ms.emailVerifications) != 0 {
+		t.Fatalf("expected 0 email verifications, got %d", len(ms.emailVerifications))
+	}
+}
+
+func TestResendVerificationActiveUser(t *testing.T) {
+	ms := setupMockStoreWithUser(t, "admin@test.com", "password123")
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	// Active user — should return 200 (uniform response, no enumeration).
+	body := `{"email":"admin@test.com"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/resend-verification", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// No verification code should have been created.
+	if len(ms.emailVerifications) != 0 {
+		t.Fatalf("expected 0 email verifications, got %d", len(ms.emailVerifications))
+	}
+}
+
+func TestResendVerificationEmptyEmail(t *testing.T) {
+	srv := New("127.0.0.1:0", newMockStore(), make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	body := `{"email":""}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/resend-verification", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestResendVerificationTooManyPending(t *testing.T) {
+	ms := setupMockStoreWithInactiveUser(t, "test@example.com", "password123")
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	// Pre-fill 3 pending verifications to hit the limit.
+	for i := 0; i < 3; i++ {
+		ms.emailVerifications = append(ms.emailVerifications, &store.EmailVerification{
+			ID: i + 1, Email: "test@example.com", Code: fmt.Sprintf("%06d", i),
+			Status: "pending", CreatedAt: time.Now(), ExpiresAt: time.Now().Add(15 * time.Minute),
+		})
+	}
+
+	body := `{"email":"test@example.com"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/resend-verification", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	// Too many pending codes — uniform 200 (don't reveal account exists).
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// No new verification should have been created.
+	if len(ms.emailVerifications) != 3 {
+		t.Fatalf("expected 3 email verifications, got %d", len(ms.emailVerifications))
+	}
+}

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, type FormEvent } from "react";
+import { useState, useRef, useEffect, type FormEvent } from "react";
 import { Link, useLoaderData, useNavigate } from "@tanstack/react-router";
 import { apiFetch } from "../lib/api";
 import Navbar from "../components/Navbar";
@@ -75,6 +75,7 @@ function RegisterForm({ isFirstUser }: { isFirstUser: boolean }) {
   const [submitting, setSubmitting] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
   const [emailSent, setEmailSent] = useState(false);
+  const [resendCooldown, setResendCooldown] = useState(0);
 
   const emailRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
@@ -175,6 +176,34 @@ function RegisterForm({ isFirstUser }: { isFirstUser: boolean }) {
     }
   }
 
+  useEffect(() => {
+    if (resendCooldown <= 0) return;
+    const timer = setTimeout(() => setResendCooldown((c) => c - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [resendCooldown]);
+
+  async function handleResend() {
+    if (resendCooldown > 0) return;
+    setFormError("");
+
+    try {
+      const resp = await apiFetch("/v1/auth/resend-verification", {
+        method: "POST",
+        body: JSON.stringify({ email: email.trim() }),
+      });
+      const data = await resp.json();
+
+      if (!resp.ok) {
+        setFormError(data.error || "Failed to resend code.");
+        return;
+      }
+
+      setResendCooldown(60);
+    } catch {
+      setFormError("Network error. Please try again.");
+    }
+  }
+
   if (step === "done") {
     return (
       <div className="flex flex-col items-center text-center">
@@ -244,6 +273,23 @@ function RegisterForm({ isFirstUser }: { isFirstUser: boolean }) {
             {submitting === "verify" ? "Verifying\u2026" : "Verify & Activate"}
           </Button>
         </form>
+
+        <p className="text-center text-sm text-text-muted mt-4">
+          {resendCooldown > 0 ? (
+            <span className="text-text-dim">Code sent. Resend in {resendCooldown}s</span>
+          ) : (
+            <>
+              Didn't receive a code?{" "}
+              <button
+                type="button"
+                onClick={handleResend}
+                className="text-primary font-medium hover:underline bg-transparent border-none cursor-pointer p-0 text-sm"
+              >
+                Resend code
+              </button>
+            </>
+          )}
+        </p>
       </>
     );
   }


### PR DESCRIPTION
## Summary
- Adds `POST /v1/auth/resend-verification` endpoint with IP-based rate limiting (5 req/5 min) and email enumeration protection (uniform 200 responses)
- Adds frontend "Resend code" button with 60-second cooldown timer on the email verification step
- Extracts duplicated code-generation + email-sending logic from `handleRegister` into a shared `generateAndSendVerificationCode` helper (also fixes a silently discarded error on `CountPendingEmailVerifications`)

## Test plan
- [x] `make build` succeeds
- [x] `make test` passes (5 new tests: success, unknown email, active user, empty email, too many pending)
- [ ] Manual: register a new user, verify the "Resend code" link appears, click it, confirm cooldown timer shows
- [ ] Manual: verify the resent code works to activate the account
- [ ] Manual: verify rate limiting returns 429 after 5 rapid resend requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)