### PR TITLE
feat: service template picker with verified auth configs

### DIFF
--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -2,12 +2,16 @@ package catalog
 
 // Template represents a preconfigured service template in the catalog.
 type Template struct {
-	ID                    string `json:"id"`
-	Name                  string `json:"name"`
-	Host                  string `json:"host"`
-	Description           string `json:"description"`
-	AuthType              string `json:"auth_type"`
-	SuggestedCredentialKey string `json:"suggested_credential_key"`
+	ID                     string            `json:"id"`
+	Name                   string            `json:"name"`
+	Host                   string            `json:"host"`
+	Description            string            `json:"description"`
+	AuthType               string            `json:"auth_type"`
+	SuggestedCredentialKey string            `json:"suggested_credential_key"`
+	AuthHeader             string            `json:"auth_header,omitempty"`
+	AuthPrefix             string            `json:"auth_prefix,omitempty"`
+	SuggestedPasswordKey   string            `json:"suggested_password_key,omitempty"`
+	AuthHeaders            map[string]string `json:"auth_headers,omitempty"`
 }
 
 // catalog is the built-in list of common service templates.
@@ -15,23 +19,23 @@ var catalog = []Template{
 	{ID: "stripe", Name: "Stripe", Host: "api.stripe.com", Description: "Payment processing API", AuthType: "bearer", SuggestedCredentialKey: "STRIPE_KEY"},
 	{ID: "github", Name: "GitHub", Host: "api.github.com", Description: "GitHub REST API", AuthType: "bearer", SuggestedCredentialKey: "GITHUB_TOKEN"},
 	{ID: "openai", Name: "OpenAI", Host: "api.openai.com", Description: "OpenAI / ChatGPT API", AuthType: "bearer", SuggestedCredentialKey: "OPENAI_API_KEY"},
-	{ID: "anthropic", Name: "Anthropic", Host: "api.anthropic.com", Description: "Claude API", AuthType: "api-key", SuggestedCredentialKey: "ANTHROPIC_API_KEY"},
+	{ID: "anthropic", Name: "Anthropic", Host: "api.anthropic.com", Description: "Claude API", AuthType: "api-key", SuggestedCredentialKey: "ANTHROPIC_API_KEY", AuthHeader: "x-api-key"},
 	{ID: "slack", Name: "Slack", Host: "slack.com", Description: "Slack Web API", AuthType: "bearer", SuggestedCredentialKey: "SLACK_TOKEN"},
-	{ID: "twilio", Name: "Twilio", Host: "api.twilio.com", Description: "Communication APIs (SMS, voice, email)", AuthType: "basic", SuggestedCredentialKey: "TWILIO_AUTH_TOKEN"},
+	{ID: "twilio", Name: "Twilio", Host: "api.twilio.com", Description: "Communication APIs (SMS, voice, email)", AuthType: "basic", SuggestedCredentialKey: "TWILIO_ACCOUNT_SID", SuggestedPasswordKey: "TWILIO_AUTH_TOKEN"},
 	{ID: "sendgrid", Name: "SendGrid", Host: "api.sendgrid.com", Description: "Email delivery API", AuthType: "bearer", SuggestedCredentialKey: "SENDGRID_API_KEY"},
 	{ID: "aws-s3", Name: "AWS S3", Host: "s3.amazonaws.com", Description: "Amazon S3 object storage", AuthType: "custom", SuggestedCredentialKey: "AWS_SECRET_ACCESS_KEY"},
 	{ID: "cloudflare", Name: "Cloudflare", Host: "api.cloudflare.com", Description: "Cloudflare API", AuthType: "bearer", SuggestedCredentialKey: "CLOUDFLARE_API_TOKEN"},
-	{ID: "datadog", Name: "Datadog", Host: "api.datadoghq.com", Description: "Monitoring and analytics", AuthType: "api-key", SuggestedCredentialKey: "DATADOG_API_KEY"},
-	{ID: "pagerduty", Name: "PagerDuty", Host: "api.pagerduty.com", Description: "Incident management", AuthType: "bearer", SuggestedCredentialKey: "PAGERDUTY_TOKEN"},
+	{ID: "datadog", Name: "Datadog", Host: "api.datadoghq.com", Description: "Monitoring and analytics", AuthType: "custom", SuggestedCredentialKey: "DATADOG_API_KEY", AuthHeaders: map[string]string{"DD-API-KEY": "{{ DATADOG_API_KEY }}", "DD-APPLICATION-KEY": "{{ DATADOG_APP_KEY }}"}},
+	{ID: "pagerduty", Name: "PagerDuty", Host: "api.pagerduty.com", Description: "Incident management", AuthType: "api-key", SuggestedCredentialKey: "PAGERDUTY_TOKEN", AuthHeader: "Authorization", AuthPrefix: "Token token="},
 	{ID: "linear", Name: "Linear", Host: "api.linear.app", Description: "Project management and issue tracking", AuthType: "bearer", SuggestedCredentialKey: "LINEAR_API_KEY"},
-	{ID: "jira", Name: "Jira", Host: "*.atlassian.net", Description: "Atlassian Jira project tracking", AuthType: "basic", SuggestedCredentialKey: "JIRA_API_TOKEN"},
+	{ID: "jira", Name: "Jira", Host: "*.atlassian.net", Description: "Atlassian Jira project tracking", AuthType: "basic", SuggestedCredentialKey: "JIRA_EMAIL", SuggestedPasswordKey: "JIRA_API_TOKEN"},
 	{ID: "notion", Name: "Notion", Host: "api.notion.com", Description: "Notion workspace API", AuthType: "bearer", SuggestedCredentialKey: "NOTION_TOKEN"},
 	{ID: "vercel", Name: "Vercel", Host: "api.vercel.com", Description: "Vercel deployment platform", AuthType: "bearer", SuggestedCredentialKey: "VERCEL_TOKEN"},
 	{ID: "supabase", Name: "Supabase", Host: "*.supabase.co", Description: "Supabase backend-as-a-service", AuthType: "bearer", SuggestedCredentialKey: "SUPABASE_KEY"},
 	{ID: "resend", Name: "Resend", Host: "api.resend.com", Description: "Email API for developers", AuthType: "bearer", SuggestedCredentialKey: "RESEND_API_KEY"},
-	{ID: "postmark", Name: "Postmark", Host: "api.postmarkapp.com", Description: "Transactional email service", AuthType: "api-key", SuggestedCredentialKey: "POSTMARK_SERVER_TOKEN"},
+	{ID: "postmark", Name: "Postmark", Host: "api.postmarkapp.com", Description: "Transactional email service", AuthType: "api-key", SuggestedCredentialKey: "POSTMARK_SERVER_TOKEN", AuthHeader: "X-Postmark-Server-Token"},
 	{ID: "sentry", Name: "Sentry", Host: "sentry.io", Description: "Error tracking and performance monitoring", AuthType: "bearer", SuggestedCredentialKey: "SENTRY_AUTH_TOKEN"},
-	{ID: "shopify", Name: "Shopify", Host: "*.myshopify.com", Description: "Shopify e-commerce API", AuthType: "api-key", SuggestedCredentialKey: "SHOPIFY_ACCESS_TOKEN"},
+	{ID: "shopify", Name: "Shopify", Host: "*.myshopify.com", Description: "Shopify e-commerce API", AuthType: "api-key", SuggestedCredentialKey: "SHOPIFY_ACCESS_TOKEN", AuthHeader: "X-Shopify-Access-Token"},
 }
 
 // GetAll returns all available service templates.

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -237,6 +237,21 @@ export default function ServicesTab() {
   );
 }
 
+/* -- Service template type -- */
+
+interface ServiceTemplate {
+  id: string;
+  name: string;
+  host: string;
+  description: string;
+  auth_type: string;
+  suggested_credential_key: string;
+  auth_header?: string;
+  auth_prefix?: string;
+  suggested_password_key?: string;
+  auth_headers?: Record<string, string>;
+}
+
 /* -- Add / Edit modal -- */
 
 function ServiceModal({
@@ -253,6 +268,25 @@ function ServiceModal({
   const [host, setHost] = useState(initial?.host ?? "");
   const [description, setDescription] = useState(initial?.description ?? "");
   const [authType, setAuthType] = useState(initial?.auth?.type ?? "bearer");
+
+  // Template picker state (only for add mode)
+  const isAddMode = !initial;
+  const [templates, setTemplates] = useState<ServiceTemplate[]>([]);
+  const [templateSearch, setTemplateSearch] = useState("");
+
+  useEffect(() => {
+    if (!isAddMode) return;
+    fetch("/v1/service-catalog")
+      .then((r) => r.ok ? r.json() : null)
+      .then((data) => { if (data?.services) setTemplates(data.services); })
+      .catch(() => {});
+  }, [isAddMode]);
+
+  const filteredTemplates = templates.filter((t) => {
+    if (!templateSearch.trim()) return true;
+    const q = templateSearch.toLowerCase();
+    return t.name.toLowerCase().includes(q) || t.host.toLowerCase().includes(q) || t.description.toLowerCase().includes(q);
+  });
 
   // Bearer fields
   const [token, setToken] = useState(initial?.auth?.token ?? "");
@@ -338,6 +372,87 @@ function ServiceModal({
     }
   }
 
+  // In add mode, start on the template picker step; skip straight to form for edit
+  const [step, setStep] = useState<"pick" | "form">(isAddMode ? "pick" : "form");
+  const [selectedTemplate, setSelectedTemplate] = useState<ServiceTemplate | null>(null);
+
+  function applyTemplateAndContinue(t: ServiceTemplate) {
+    setHost(t.host);
+    setDescription(t.description);
+    setAuthType(t.auth_type);
+    switch (t.auth_type) {
+      case "bearer": setToken(t.suggested_credential_key); break;
+      case "basic":
+        setUsername(t.suggested_credential_key);
+        if (t.suggested_password_key) setPassword(t.suggested_password_key);
+        break;
+      case "api-key":
+        setApiKey(t.suggested_credential_key);
+        if (t.auth_header) setApiKeyHeader(t.auth_header);
+        if (t.auth_prefix) setApiKeyPrefix(t.auth_prefix);
+        break;
+      case "custom":
+        setCustomHeaders(
+          t.auth_headers && Object.keys(t.auth_headers).length > 0
+            ? Object.entries(t.auth_headers).map(([name, value]) => ({ name, value }))
+            : [{ name: "", value: "" }]
+        );
+        break;
+    }
+    setSelectedTemplate(t);
+    setStep("form");
+  }
+
+  /* -- Template picker step -- */
+  if (step === "pick") {
+    return (
+      <Modal
+        open
+        onClose={onClose}
+        title="Add Service"
+        description="Choose a service template or configure one from scratch."
+        footer={
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+        }
+      >
+        <div className="space-y-3">
+          <Input
+            placeholder="Search services..."
+            value={templateSearch}
+            onChange={(e) => setTemplateSearch(e.target.value)}
+            autoFocus
+          />
+          <div className="grid grid-cols-2 gap-2 max-h-[320px] overflow-y-auto">
+            {/* Custom service card — always first */}
+            <button
+              onClick={() => setStep("form")}
+              className="flex flex-col items-start gap-0.5 px-3 py-2.5 rounded-lg border border-dashed border-border bg-transparent hover:border-border-focus hover:bg-surface-hover text-left transition-colors"
+            >
+              <span className="text-sm font-medium text-text">Custom service</span>
+              <span className="text-xs text-text-muted">Configure manually</span>
+            </button>
+            {filteredTemplates.map((t) => (
+              <button
+                key={t.id}
+                onClick={() => applyTemplateAndContinue(t)}
+                className="flex flex-col items-start gap-0.5 px-3 py-2.5 rounded-lg border border-border bg-surface-raised hover:border-border-focus hover:bg-surface-hover text-left transition-colors"
+              >
+                <span className="text-sm font-medium text-text">{t.name}</span>
+                <span className="text-xs text-text-muted">{t.host}</span>
+              </button>
+            ))}
+            {filteredTemplates.length === 0 && (
+              <p className="text-sm text-text-muted py-3 text-center">No templates match your search.</p>
+            )}
+          </div>
+        </div>
+      </Modal>
+    );
+  }
+
+  /* -- Form step -- */
   return (
     <Modal
       open
@@ -346,9 +461,15 @@ function ServiceModal({
       description="Services define which hosts are proxied and how credentials are injected."
       footer={
         <>
-          <Button variant="secondary" onClick={onClose}>
-            Cancel
-          </Button>
+          {isAddMode ? (
+            <Button variant="secondary" onClick={() => { setStep("pick"); setSelectedTemplate(null); }}>
+              Back
+            </Button>
+          ) : (
+            <Button variant="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+          )}
           <Button
             onClick={handleSubmit}
             disabled={!canSubmit}
@@ -360,6 +481,13 @@ function ServiceModal({
       }
     >
       <div className="space-y-4">
+        {selectedTemplate && (
+          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-surface-hover border border-border text-sm">
+            <span className="text-text-muted">Template:</span>
+            <span className="font-medium text-text">{selectedTemplate.name}</span>
+          </div>
+        )}
+
         <FormField label="Host Pattern">
           <Input
             placeholder="e.g. api.stripe.com"


### PR DESCRIPTION
## Summary
- Extend catalog `Template` struct with optional auth detail fields (`auth_header`, `auth_prefix`, `suggested_password_key`, `auth_headers`) so templates can pre-fill the full service configuration form
- Update 8 service templates with verified auth methods: Anthropic, Twilio, Datadog, PagerDuty, Jira, Postmark, Shopify
- Add template picker UI to the "Add Service" modal with search/filter, two-step wizard (pick → configure), and back navigation
- Frontend `applyTemplateAndContinue` now maps all new fields (header, prefix, password key, custom headers) to form state

## Test plan
- [ ] `go build ./...` and `go test ./...` pass
- [ ] `GET /v1/service-catalog` returns new fields for updated templates, omits them for unchanged ones
- [ ] Pick Anthropic template → header field pre-fills with `x-api-key`
- [ ] Pick Twilio template → username pre-fills with `TWILIO_ACCOUNT_SID`, password with `TWILIO_AUTH_TOKEN`
- [ ] Pick Datadog template → custom headers pre-fill with `DD-API-KEY` and `DD-APPLICATION-KEY`
- [ ] Pick PagerDuty template → api-key header = `Authorization`, prefix = `Token token=`
- [ ] Switching between templates resets stale form state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)