### PR TITLE
deps: bump vite from 6.4.1 to 6.4.2 (security)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,7 +17,7 @@
         "@vitejs/plugin-react": "^4.4.1",
         "tailwindcss": "^4.2.2",
         "typescript": "^5.8.3",
-        "vite": "^6.3.2"
+        "vite": "^6.4.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2536,9 +2536,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,6 @@
     "@vitejs/plugin-react": "^4.4.1",
     "tailwindcss": "^4.2.2",
     "typescript": "^5.8.3",
-    "vite": "^6.3.2"
+    "vite": "^6.4.2"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps `vite` from 6.4.1 to 6.4.2 to fix two security vulnerabilities:
  - **CVE-2026-39363** (High): Arbitrary file read via Vite dev server WebSocket — `fetchModule` bypasses `server.fs` restrictions
  - **CVE-2026-39365** (Medium): Path traversal in optimized deps `.map` handling

## Test plan
- [x] `make build` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)