### PR TITLE
cli: group login and register under auth parent command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,9 @@ For frontend-only development with hot reload: `make web-dev` (Vite dev server o
 
 Agent Vault requires two things before it becomes operational: a **master password** (encrypts credentials at rest via AES-256-GCM / Argon2id) and an **owner account** (first user with full admin privileges).
 
-- **Interactive startup**: When `agent-vault server` runs interactively on a fresh install, it prompts for master password, then daemonizes. Users self-register via `agent-vault register` or the `/register` web page.
+- **Interactive startup**: When `agent-vault server` runs interactively on a fresh install, it prompts for master password, then daemonizes. Users self-register via `agent-vault auth register` or the `/register` web page.
 - **Non-interactive startup**: When `AGENT_VAULT_MASTER_PASSWORD` env var is set (or `--password-stdin`), the server starts without prompts. All endpoints except `/health`, `POST /v1/auth/register`, and `POST /v1/auth/verify` respond normally once the server is up.
-- **Registration**: The first user to register via `agent-vault register` (or `POST /v1/auth/register`) becomes the owner, auto-active and auto-granted admin on the default vault. Subsequent users receive a 6-digit email verification code (15-min TTL) and must verify before their account is active.
+- **Registration**: The first user to register via `agent-vault auth register` (or `POST /v1/auth/register`) becomes the owner, auto-active and auto-granted admin on the default vault. Subsequent users receive a 6-digit email verification code (15-min TTL) and must verify before their account is active.
 - **Login**: Uses email + password or Google OAuth (owner or member account), not the master password. The master password is only used at server startup for encryption. Login rejects inactive (unverified) accounts.
 - **OAuth (Google)**: When `AGENT_VAULT_OAUTH_GOOGLE_CLIENT_ID` and `AGENT_VAULT_OAUTH_GOOGLE_CLIENT_SECRET` env vars are set, "Continue with Google" appears on login/register pages. OAuth uses PKCE (S256), CSRF state, and validates Google ID tokens via JWKS. No automatic account linking from unauthenticated contexts (security: prevents pre-hijack attacks). Users can connect/disconnect Google from account settings. First user must register with email/password. OAuth-only users can set a password from settings for CLI access.
 - **Auth methods**: Users can have password, OAuth (Google), or both. The `oauth_accounts` table tracks OAuth identities. The `handleAuthMe` response includes `has_password` (bool) and `oauth_providers` (string array).
@@ -43,14 +43,14 @@ Agent Vault requires two things before it becomes operational: a **master passwo
 
 - `agent-vault server` -- start the Agent Vault server (default port 14321; includes proxy endpoint at `/proxy/`)
   - `agent-vault server -d` -- start in detached (background) mode; prompts for master password + owner account first, then daemonizes
-  - `agent-vault server --password-stdin` -- read master password from stdin (for non-interactive/automated use); first user registers via `agent-vault register` or the `/register` web page
+  - `agent-vault server --password-stdin` -- read master password from stdin (for non-interactive/automated use); first user registers via `agent-vault auth register` or the `/register` web page
   - `agent-vault server stop` -- stop a running server (reads PID from `~/.agent-vault/agent-vault.pid`, sends SIGTERM)
   - Password resolution order: `AGENT_VAULT_MASTER_PASSWORD` env var, `--password-stdin`, interactive prompt. The env var is unset from the process immediately after reading.
   - `AGENT_VAULT_ADDR` env var: externally-reachable base URL (e.g. `https://agent-vault.example.com`). Used for generating links in emails, invites, and discovery. Falls back to `http://{host}:{port}` if unset.
   - OAuth (Google): configured via `AGENT_VAULT_OAUTH_GOOGLE_CLIENT_ID` and `AGENT_VAULT_OAUTH_GOOGLE_CLIENT_SECRET`. When both are set, Google OAuth is enabled. Callback URL: `{AGENT_VAULT_ADDR}/v1/auth/oauth/google/callback`.
   - SMTP notifications: configured via `AGENT_VAULT_SMTP_HOST`, `AGENT_VAULT_SMTP_PORT` (default 587), `AGENT_VAULT_SMTP_USERNAME`, `AGENT_VAULT_SMTP_PASSWORD`, `AGENT_VAULT_SMTP_FROM`, `AGENT_VAULT_SMTP_FROM_NAME` (default "Agent Vault"), `AGENT_VAULT_SMTP_TLS_MODE` (default "opportunistic"; values: opportunistic/required/none), `AGENT_VAULT_SMTP_TLS_SKIP_VERIFY` (default false). If `AGENT_VAULT_SMTP_HOST` is unset, notifications are silently disabled.
-- `agent-vault register [--address, --email, --password-stdin]` -- self-signup; first user to register becomes owner (auto-active, auto-granted admin on default vault)
-- `agent-vault login` -- authenticate with email and password (prompts interactively; use `--email` and `--password-stdin` for piped input)
+- `agent-vault auth register [--address, --email, --password-stdin]` -- self-signup; first user to register becomes owner (auto-active, auto-granted admin on default vault)
+- `agent-vault auth login` -- authenticate with email and password (prompts interactively; use `--email` and `--password-stdin` for piped input)
 - `agent-vault account [whoami|change-password|delete]` -- manage your own account
   - `agent-vault account whoami` -- show current user and session info
   - `agent-vault account change-password` -- change your own password (prompts interactively for current + new + confirm; use `--password-stdin` to read current and new passwords as two lines from stdin). Invalidates all existing sessions and issues a new one.
@@ -169,7 +169,7 @@ type Service struct {
 - `POST /v1/admin/proposals/{id}/reject` -- reject a proposal (requires vault access); accepts `{ "vault": "default", "reason": "..." }`
 - Proxy 403 responses include a `proposal_hint` field with the denied host and endpoint to create a proposal
 
-Proposal states: `pending`, `applied`, `rejected`, or `expired` (7-day TTL). Approval atomically merges services into the broker config, upserts/deletes credentials in one transaction. CLI proposal commands (`approve`, `reject`, `review`) communicate with the running server via these admin endpoints, they require an active login session (`agent-vault login`).
+Proposal states: `pending`, `applied`, `rejected`, or `expired` (7-day TTL). Approval atomically merges services into the broker config, upserts/deletes credentials in one transaction. CLI proposal commands (`approve`, `reject`, `review`) communicate with the running server via these admin endpoints, they require an active login session (`agent-vault auth login`).
 
 - `GET /v1/service-catalog` -- returns list of built-in service templates (no auth required)
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,14 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Authentication commands",
+}
+
+func init() {
+	authCmd.AddCommand(loginCmd)
+	authCmd.AddCommand(registerCmd)
+	rootCmd.AddCommand(authCmd)
+}

--- a/cmd/change_password.go
+++ b/cmd/change_password.go
@@ -94,7 +94,7 @@ var changePasswordCmd = &cobra.Command{
 			sess.Token = result.Token
 			if err := session.Save(sess); err != nil {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: password changed but failed to save new session: %v\n", err)
-				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "You may need to run 'agent-vault login' again.\n")
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "You may need to run 'agent-vault auth login' again.\n")
 				return nil
 			}
 		}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -25,10 +25,29 @@ func TestCommandsRegistered(t *testing.T) {
 		registered[c.Name()] = true
 	}
 
-	expected := []string{"server", "login", "register", "vault", "owner", "account"}
+	expected := []string{"server", "auth", "vault", "owner", "account"}
 	for _, name := range expected {
 		if !registered[name] {
 			t.Errorf("expected command %q to be registered, but it was not", name)
+		}
+	}
+}
+
+func TestAuthSubcommandsRegistered(t *testing.T) {
+	authCmd := findSubcommand(rootCmd, "auth")
+	if authCmd == nil {
+		t.Fatal("auth command not found")
+	}
+
+	registered := make(map[string]bool)
+	for _, c := range authCmd.Commands() {
+		registered[c.Name()] = true
+	}
+
+	expected := []string{"login", "register"}
+	for _, name := range expected {
+		if !registered[name] {
+			t.Errorf("expected auth subcommand %q to be registered, but it was not", name)
 		}
 	}
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -225,7 +225,7 @@ func ensureSession() (*session.ClientSession, error) {
 	}
 
 	if !isInteractive() {
-		return nil, fmt.Errorf("not logged in, run 'agent-vault login' first")
+		return nil, fmt.Errorf("not logged in, run 'agent-vault auth login' first")
 	}
 
 	fmt.Fprintln(os.Stderr, "\nNo active session. Let's get you connected.")

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -104,5 +104,4 @@ func init() {
 	loginCmd.Flags().String("address", DefaultAddress, "server address")
 	loginCmd.Flags().String("email", "", "account email address")
 	loginCmd.Flags().Bool("password-stdin", false, "read password from stdin (for non-interactive use)")
-	rootCmd.AddCommand(loginCmd)
 }

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -132,7 +132,7 @@ var registerCmd = &cobra.Command{
 			return fmt.Errorf("verification failed with status %d", verifyResp.StatusCode)
 		}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "%s Account verified. You can now log in with 'agent-vault login'.\n", successText("✓"))
+		fmt.Fprintf(cmd.OutOrStdout(), "%s Account verified. You can now log in with 'agent-vault auth login'.\n", successText("✓"))
 		return nil
 	},
 }
@@ -141,5 +141,4 @@ func init() {
 	registerCmd.Flags().String("address", DefaultAddress, "address of the running Agent Vault server")
 	registerCmd.Flags().String("email", "", "email address")
 	registerCmd.Flags().Bool("password-stdin", false, "read password from stdin")
-	rootCmd.AddCommand(registerCmd)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -39,7 +39,7 @@ Example:
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// 1. Load the admin session from agent-vault login.
+		// 1. Load the admin session from agent-vault auth login.
 		sess, err := ensureSession()
 		if err != nil {
 			return err

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -3,7 +3,7 @@ title: "Installation"
 description: "Install Agent Vault, start a server, and log in."
 ---
 
-Agent Vault ships as a single binary that acts as both the server and the CLI client. Install it once, then use `agent-vault server` to run a server and `agent-vault login` to interact with it.
+Agent Vault ships as a single binary that acts as both the server and the CLI client. Install it once, then use `agent-vault server` to run a server and `agent-vault auth login` to interact with it.
 
 ## Install
 
@@ -132,8 +132,8 @@ Any CLI command that needs authentication will walk you through registration and
 <Tabs>
   <Tab title="CLI">
     ```bash
-    agent-vault register
-    agent-vault login
+    agent-vault auth register
+    agent-vault auth login
     ```
   </Tab>
   <Tab title="Web UI">
@@ -141,7 +141,7 @@ Any CLI command that needs authentication will walk you through registration and
   </Tab>
 </Tabs>
 
-Subsequent users can self-register via `agent-vault register`, the web registration page, or be [invited to a vault](/learn/vaults#invite-users-to-a-vault) by a vault admin.
+Subsequent users can self-register via `agent-vault auth register`, the web registration page, or be [invited to a vault](/learn/vaults#invite-users-to-a-vault) by a vault admin.
 
 Once registered, you can manage Agent Vault through either the **web dashboard** or entirely via the **[CLI](/reference/cli)**. Both give you full access to [services](/learn/services), [credentials](/learn/credentials), [agents](/agents/overview), and [proposal](/learn/proposals) approvals.
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -52,9 +52,9 @@ description: "Complete reference for all Agent Vault CLI commands."
 ## Authentication
 
 <AccordionGroup>
-  <Accordion title="agent-vault register">
+  <Accordion title="agent-vault auth register">
     ```bash
-    agent-vault register [flags]
+    agent-vault auth register [flags]
     ```
 
     Self-signup for a new account. The first user to register becomes the instance owner, is auto-activated, and is granted admin on the default vault. Subsequent users receive a 6-digit email verification code.
@@ -66,9 +66,9 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `--password-stdin` | `false` | Read password from stdin |
   </Accordion>
 
-  <Accordion title="agent-vault login">
+  <Accordion title="agent-vault auth login">
     ```bash
-    agent-vault login [flags]
+    agent-vault auth login [flags]
     ```
 
     Authenticate with email and password. Prompts interactively by default. Rejects inactive (unverified) accounts.

--- a/docs/self-hosting/fly-io.mdx
+++ b/docs/self-hosting/fly-io.mdx
@@ -55,7 +55,7 @@ description: "Deploy Agent Vault to Fly.io with persistent storage"
 
   <Step title="Register the owner">
     ```bash
-    agent-vault register --address https://your-app.fly.dev
+    agent-vault auth register --address https://your-app.fly.dev
     ```
 
     The first user to register becomes the instance owner with full admin privileges, auto-granted admin on the default vault.

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -61,8 +61,8 @@ Any CLI command that needs authentication will walk you through registration and
 <Tabs>
   <Tab title="CLI">
     ```bash
-    agent-vault register
-    agent-vault login
+    agent-vault auth register
+    agent-vault auth login
     ```
   </Tab>
   <Tab title="Web UI">
@@ -70,7 +70,7 @@ Any CLI command that needs authentication will walk you through registration and
   </Tab>
 </Tabs>
 
-Subsequent users can self-register via `agent-vault register`, the web registration page, or be [invited to a vault](/learn/vaults#invite-users-to-a-vault) by a vault admin.
+Subsequent users can self-register via `agent-vault auth register`, the web registration page, or be [invited to a vault](/learn/vaults#invite-users-to-a-vault) by a vault admin.
 
 ## Upgrade
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -587,7 +587,7 @@ func (s *Server) requireInitialized(next http.HandlerFunc) http.HandlerFunc {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			_ = json.NewEncoder(w).Encode(map[string]string{
 				"error":   "not_initialized",
-				"message": "No owner account exists. Run 'agent-vault register' to create the first account.",
+				"message": "No owner account exists. Run 'agent-vault auth register' to create the first account.",
 			})
 			return
 		}
@@ -605,7 +605,7 @@ func (s *Server) Start() error {
 	go func() {
 		fmt.Printf("Agent Vault server listening on %s\n", s.baseURL)
 		if !s.initialized {
-			fmt.Printf("Run `agent-vault register` or visit %s to create the owner account\n", s.baseURL)
+			fmt.Printf("Run `agent-vault auth register` or visit %s to create the owner account\n", s.baseURL)
 		}
 		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			errCh <- err
@@ -1290,7 +1290,7 @@ func (s *Server) handleVaultInviteDetails(w http.ResponseWriter, r *http.Request
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"error": true, "error_title": "Already Accepted",
-			"error_message": "This invitation has already been accepted. You can log in using 'agent-vault login'.",
+			"error_message": "This invitation has already been accepted. You can log in using 'agent-vault auth login'.",
 		})
 		return
 	case "revoked":
@@ -3687,7 +3687,7 @@ func (s *Server) handleVaultInviteAccept(w http.ResponseWriter, r *http.Request)
 
 	msg := "Vault access granted."
 	if existing == nil {
-		msg = "Account created and vault access granted. You can now log in using 'agent-vault login'."
+		msg = "Account created and vault access granted. You can now log in using 'agent-vault auth login'."
 	}
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary
- Introduces a new `agent-vault auth` parent command that groups `login` and `register` as subcommands (`agent-vault auth login`, `agent-vault auth register`)
- Updates all user-facing strings, error messages, and documentation to reflect the new command paths
- Adds `TestAuthSubcommandsRegistered` test for the new command group

## Test plan
- [x] `go test ./...` passes
- [x] `go build` succeeds
- [x] `./agent-vault auth --help` shows `login` and `register` subcommands
- [x] Old top-level `./agent-vault login` returns unknown command error

🤖 Generated with [Claude Code](https://claude.com/claude-code)