### PR TITLE
cli: add `vault init` command for project-level vault binding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,12 @@ Agent Vault requires two things before it becomes operational: a **master passwo
   - `agent-vault account whoami` -- show current user and session info
   - `agent-vault account change-password` -- change your own password (prompts interactively for current + new + confirm; use `--password-stdin` to read current and new passwords as two lines from stdin). Invalidates all existing sessions and issues a new one.
   - `agent-vault account delete` -- permanently delete your own account (owners cannot delete themselves; transfer ownership first)
-- `agent-vault vault [create|list|delete|rename]` -- manage vaults (default vault is seeded automatically)
+- `agent-vault vault [create|list|delete|rename|init]` -- manage vaults (default vault is seeded automatically)
   - `agent-vault vault create <name>` -- create a new vault
   - `agent-vault vault list` -- list vaults the current user has access to (owners see all vaults with `membership` field: `explicit` for joined, `implicit` for visible-but-not-joined)
   - `agent-vault vault delete <name>` -- delete a vault (vault admin or instance owner; cannot delete the default vault; use `--yes` to skip confirmation)
   - `agent-vault vault rename <old-name> <new-name>` -- rename a vault (vault admin or instance owner; cannot rename the default vault)
+  - `agent-vault vault init` -- bind the current directory to a vault by writing `agent-vault.json` (interactive picker; use `--vault` to skip picker). The file is meant to be committed so the whole team shares the vault binding. Vault resolution priority: `--vault` flag > `agent-vault.json` > user context > `"default"`.
   - `agent-vault vault user [invite|list|remove|set-role]` -- manage vault user access
     - `agent-vault vault user invite <email> [--vault <name>] [--role admin|member]` -- invite a user to a vault
     - `agent-vault vault user list [--vault <name>]` -- list vault users

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -473,7 +473,7 @@ func TestLoadProjectVault(t *testing.T) {
 	t.Run("valid file returns vault name", func(t *testing.T) {
 		dir := t.TempDir()
 		os.Chdir(dir)
-		os.WriteFile(ProjectConfigFile, []byte(`{"vault": "staging"}`), 0o644)
+		os.WriteFile(ProjectConfigFile, []byte(`{"vault": "staging"}`), 0o600)
 		if got := loadProjectVault(); got != "staging" {
 			t.Errorf("expected %q, got %q", "staging", got)
 		}
@@ -482,7 +482,7 @@ func TestLoadProjectVault(t *testing.T) {
 	t.Run("malformed JSON returns empty", func(t *testing.T) {
 		dir := t.TempDir()
 		os.Chdir(dir)
-		os.WriteFile(ProjectConfigFile, []byte(`not json`), 0o644)
+		os.WriteFile(ProjectConfigFile, []byte(`not json`), 0o600)
 		if got := loadProjectVault(); got != "" {
 			t.Errorf("expected empty, got %q", got)
 		}
@@ -491,7 +491,7 @@ func TestLoadProjectVault(t *testing.T) {
 	t.Run("empty vault field returns empty", func(t *testing.T) {
 		dir := t.TempDir()
 		os.Chdir(dir)
-		os.WriteFile(ProjectConfigFile, []byte(`{"vault": ""}`), 0o644)
+		os.WriteFile(ProjectConfigFile, []byte(`{"vault": ""}`), 0o600)
 		if got := loadProjectVault(); got != "" {
 			t.Errorf("expected empty, got %q", got)
 		}
@@ -508,7 +508,7 @@ func TestResolveVaultWithProjectFile(t *testing.T) {
 	t.Run("project file used when no flag", func(t *testing.T) {
 		dir := t.TempDir()
 		os.Chdir(dir)
-		os.WriteFile(ProjectConfigFile, []byte(`{"vault": "team-vault"}`), 0o644)
+		os.WriteFile(ProjectConfigFile, []byte(`{"vault": "team-vault"}`), 0o600)
 
 		cmd := &cobra.Command{}
 		cmd.Flags().String("vault", "", "")
@@ -521,7 +521,7 @@ func TestResolveVaultWithProjectFile(t *testing.T) {
 	t.Run("flag takes priority over project file", func(t *testing.T) {
 		dir := t.TempDir()
 		os.Chdir(dir)
-		os.WriteFile(ProjectConfigFile, []byte(`{"vault": "team-vault"}`), 0o644)
+		os.WriteFile(ProjectConfigFile, []byte(`{"vault": "team-vault"}`), 0o600)
 
 		cmd := &cobra.Command{}
 		cmd.Flags().String("vault", "", "")

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -78,7 +78,7 @@ func TestVaultSubcommandsRegistered(t *testing.T) {
 		registered[c.Name()] = true
 	}
 
-	expected := []string{"create", "list", "rename", "use", "current", "user", "credentials", "service", "proposal", "agent"}
+	expected := []string{"create", "list", "rename", "use", "current", "init", "user", "credentials", "service", "proposal", "agent"}
 	for _, name := range expected {
 		if !registered[name] {
 			t.Errorf("expected vault subcommand %q to be registered, but it was not", name)
@@ -452,4 +452,95 @@ func TestInviteCreateDirectFlags(t *testing.T) {
 	if f.DefValue != "" {
 		t.Errorf("expected --label default to be empty, got %q", f.DefValue)
 	}
+}
+
+func TestLoadProjectVault(t *testing.T) {
+	// Run in a temp directory so we don't affect the real working directory.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	t.Run("missing file returns empty", func(t *testing.T) {
+		dir := t.TempDir()
+		os.Chdir(dir)
+		if got := loadProjectVault(); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("valid file returns vault name", func(t *testing.T) {
+		dir := t.TempDir()
+		os.Chdir(dir)
+		os.WriteFile(ProjectConfigFile, []byte(`{"vault": "staging"}`), 0o644)
+		if got := loadProjectVault(); got != "staging" {
+			t.Errorf("expected %q, got %q", "staging", got)
+		}
+	})
+
+	t.Run("malformed JSON returns empty", func(t *testing.T) {
+		dir := t.TempDir()
+		os.Chdir(dir)
+		os.WriteFile(ProjectConfigFile, []byte(`not json`), 0o644)
+		if got := loadProjectVault(); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("empty vault field returns empty", func(t *testing.T) {
+		dir := t.TempDir()
+		os.Chdir(dir)
+		os.WriteFile(ProjectConfigFile, []byte(`{"vault": ""}`), 0o644)
+		if got := loadProjectVault(); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+}
+
+func TestResolveVaultWithProjectFile(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	t.Run("project file used when no flag", func(t *testing.T) {
+		dir := t.TempDir()
+		os.Chdir(dir)
+		os.WriteFile(ProjectConfigFile, []byte(`{"vault": "team-vault"}`), 0o644)
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("vault", "", "")
+		got := resolveVault(cmd)
+		if got != "team-vault" {
+			t.Errorf("expected %q, got %q", "team-vault", got)
+		}
+	})
+
+	t.Run("flag takes priority over project file", func(t *testing.T) {
+		dir := t.TempDir()
+		os.Chdir(dir)
+		os.WriteFile(ProjectConfigFile, []byte(`{"vault": "team-vault"}`), 0o644)
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("vault", "", "")
+		cmd.Flags().Set("vault", "explicit")
+		got := resolveVault(cmd)
+		if got != "explicit" {
+			t.Errorf("expected %q, got %q", "explicit", got)
+		}
+	})
+
+	t.Run("falls back to default when no file", func(t *testing.T) {
+		dir := t.TempDir()
+		os.Chdir(dir)
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("vault", "", "")
+		got := resolveVault(cmd)
+		if got != store.DefaultVault {
+			t.Errorf("expected %q, got %q", store.DefaultVault, got)
+		}
+	})
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -332,10 +332,32 @@ func ensureSession() (*session.ClientSession, error) {
 	return sess, nil
 }
 
-// resolveVault returns the target vault using: --vault flag > context file > "default".
+// ProjectConfigFile is the name of the project-level vault binding file.
+const ProjectConfigFile = "agent-vault.json"
+
+// loadProjectVault reads agent-vault.json from the working directory.
+// Returns the vault name or "" if the file doesn't exist or is invalid.
+func loadProjectVault() string {
+	data, err := os.ReadFile(ProjectConfigFile)
+	if err != nil {
+		return ""
+	}
+	var cfg struct {
+		Vault string `json:"vault"`
+	}
+	if json.Unmarshal(data, &cfg) != nil {
+		return ""
+	}
+	return cfg.Vault
+}
+
+// resolveVault returns the target vault using: --vault flag > project file > context file > "default".
 func resolveVault(cmd *cobra.Command) string {
 	if name, _ := cmd.Flags().GetString("vault"); name != "" {
 		return name
+	}
+	if pv := loadProjectVault(); pv != "" {
+		return pv
 	}
 	if ctx := session.LoadVaultContext(); ctx != "" {
 		return ctx

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -150,11 +150,15 @@ func maybeInstallSkill(agentName, relPath string) {
 }
 
 // resolveVaultForRun picks the vault for a run session. Priority:
-// --vault flag > vault context > interactive select (if multiple) > "default".
+// --vault flag > project file > vault context > interactive select (if multiple) > "default".
 func resolveVaultForRun(cmd *cobra.Command, addr, token string) (string, error) {
 	// Explicit --vault flag takes priority.
 	if name, _ := cmd.Flags().GetString("vault"); name != "" {
 		return name, nil
+	}
+	// Project-level agent-vault.json is next.
+	if pv := loadProjectVault(); pv != "" {
+		return pv, nil
 	}
 	// Vault context (set by a previous command) is next.
 	if ctx := session.LoadVaultContext(); ctx != "" {

--- a/cmd/vault_init.go
+++ b/cmd/vault_init.go
@@ -62,7 +62,7 @@ var vaultInitCmd = &cobra.Command{
 		}
 		data = append(data, '\n')
 
-		if err := os.WriteFile(ProjectConfigFile, data, 0o644); err != nil {
+		if err := os.WriteFile(ProjectConfigFile, data, 0o600); err != nil {
 			return fmt.Errorf("writing %s: %w", ProjectConfigFile, err)
 		}
 

--- a/cmd/vault_init.go
+++ b/cmd/vault_init.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+)
+
+var vaultInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Bind the current directory to a vault (writes agent-vault.json)",
+	Long:  "Writes an agent-vault.json file in the current directory so all team members automatically target the same vault. The file is meant to be committed to version control.",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := ensureSession()
+		if err != nil {
+			return err
+		}
+
+		// If --vault flag is provided, use it directly; otherwise interactive pick.
+		vaultName, _ := cmd.Flags().GetString("vault")
+		if vaultName == "" {
+			vaultName, err = selectVault(client)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Check for existing file and confirm overwrite.
+		if data, err := os.ReadFile(ProjectConfigFile); err == nil {
+			var existing struct {
+				Vault string `json:"vault"`
+			}
+			if json.Unmarshal(data, &existing) == nil && existing.Vault != "" {
+				fmt.Fprintf(os.Stderr, "Current binding: vault %q\n", existing.Vault)
+				if existing.Vault == vaultName {
+					fmt.Fprintln(os.Stderr, "Already bound to this vault, nothing to do.")
+					return nil
+				}
+				var ok bool
+				if err := huh.NewConfirm().
+					Title(fmt.Sprintf("Overwrite with vault %q?", vaultName)).
+					Affirmative("Yes").
+					Negative("No").
+					Value(&ok).
+					Run(); err != nil {
+					return err
+				}
+				if !ok {
+					return nil
+				}
+			}
+		}
+
+		cfg := map[string]string{"vault": vaultName}
+		data, err := json.MarshalIndent(cfg, "", "  ")
+		if err != nil {
+			return err
+		}
+		data = append(data, '\n')
+
+		if err := os.WriteFile(ProjectConfigFile, data, 0o644); err != nil {
+			return fmt.Errorf("writing %s: %w", ProjectConfigFile, err)
+		}
+
+		fmt.Fprintf(os.Stderr, "%s Wrote %s (vault: %s)\n", successText("✓"), ProjectConfigFile, vaultName)
+		fmt.Fprintln(os.Stderr, "Commit this file so your team shares the vault binding.")
+		return nil
+	},
+}
+
+func init() {
+	vaultCmd.AddCommand(vaultInitCmd)
+}

--- a/docs/learn/vaults.mdx
+++ b/docs/learn/vaults.mdx
@@ -26,6 +26,18 @@ agent-vault vault list
 
 Vault names must be **unique** across the Agent Vault instance and use **slug format**: lowercase letters, numbers, and hyphens only.
 
+## Bind a project to a vault
+
+Run `vault init` inside your project directory to create an `agent-vault.json` file that binds the project to a specific vault:
+
+```bash
+agent-vault vault init
+```
+
+This file is meant to be committed to version control. When present, all team members and agents running in that directory will automatically target the bound vault without needing `--vault` flags or per-user context.
+
+Vault resolution priority: `--vault` flag > `agent-vault.json` > user context > `"default"`.
+
 ## Invite agents to a vault
 
 <Tabs>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -167,6 +167,18 @@ description: "Complete reference for all Agent Vault CLI commands."
 
     Show the active vault.
   </Accordion>
+
+  <Accordion title="agent-vault vault init">
+    ```bash
+    agent-vault vault init [flags]
+    ```
+
+    Bind the current directory to a vault by writing an `agent-vault.json` file. This file is meant to be committed to version control so the whole team shares the vault binding.
+
+    When present, `agent-vault.json` is used in vault resolution between the `--vault` flag and the user context: `--vault` flag > `agent-vault.json` > user context > `"default"`.
+
+    Uses an interactive picker if multiple vaults are available. Use `--vault` to skip the picker.
+  </Accordion>
 </AccordionGroup>
 
 ## Vault users


### PR DESCRIPTION
## Summary
- Adds `agent-vault vault init` command that writes an `agent-vault.json` file in the current directory, binding the project to a specific vault
- Updates vault resolution in `resolveVault` and `resolveVaultForRun` to check for `agent-vault.json` between the `--vault` flag and user context
- The file is meant to be committed to version control so the whole team shares the vault binding

## Test plan
- [x] `make test` passes (new tests for `loadProjectVault` and `resolveVault` with project file)
- [ ] Manual: run `agent-vault vault init` with a running server, verify `agent-vault.json` is written
- [ ] Manual: run a vault-scoped command in a directory with `agent-vault.json` and confirm it picks up the project vault
- [ ] Manual: verify `--vault` flag still takes priority over `agent-vault.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)