### PR TITLE
feat: add --role flag to vault run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -57,7 +57,8 @@ Example:
 		}
 
 		// 3. Request a vault-scoped session token from the server.
-		scopedToken, err := requestScopedSession(addr, sess.Token, vault)
+		role, _ := cmd.Flags().GetString("role")
+		scopedToken, err := requestScopedSession(addr, sess.Token, vault, role)
 		if err != nil {
 			return err
 		}
@@ -231,8 +232,12 @@ func fetchUserVaults(addr, token string) ([]string, error) {
 
 // requestScopedSession calls the server to create a vault-scoped session
 // and returns the scoped token.
-func requestScopedSession(addr, adminToken, vault string) (string, error) {
-	reqBody, err := json.Marshal(map[string]string{"vault": vault})
+func requestScopedSession(addr, adminToken, vault, role string) (string, error) {
+	body := map[string]string{"vault": vault}
+	if role != "" {
+		body["vault_role"] = role
+	}
+	reqBody, err := json.Marshal(body)
 	if err != nil {
 		return "", err
 	}
@@ -272,6 +277,7 @@ func requestScopedSession(addr, adminToken, vault string) (string, error) {
 
 func init() {
 	runCmd.Flags().String("address", "", "Agent Vault server address (defaults to session address)")
+	runCmd.Flags().String("role", "", "Vault role for the agent session (consumer, member, admin; default: member)")
 
 	vaultCmd.AddCommand(runCmd)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1823,7 +1823,8 @@ func (s *Server) optionalAuth(next http.HandlerFunc) http.HandlerFunc {
 }
 
 type scopedSessionRequest struct {
-	Vault string `json:"vault"`
+	Vault     string `json:"vault"`
+	VaultRole string `json:"vault_role"`
 }
 
 type scopedSessionResponse struct {
@@ -1851,7 +1852,19 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sess, err := s.store.CreateScopedSession(ctx, ns.ID, "consumer", "", time.Now().Add(sessionTTL))
+	// Default to "member" if no role specified; cap to caller's own role.
+	requestedRole := req.VaultRole
+	if requestedRole == "" {
+		requestedRole = "member"
+	}
+	parentSess := sessionFromContext(ctx)
+	cappedRole, errMsg := s.capRequestedRole(ctx, parentSess, ns.ID, requestedRole)
+	if errMsg != "" {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, errMsg), http.StatusForbidden)
+		return
+	}
+
+	sess, err := s.store.CreateScopedSession(ctx, ns.ID, cappedRole, "", time.Now().Add(sessionTTL))
 	if err != nil {
 		http.Error(w, `{"error":"Failed to create scoped session"}`, http.StatusInternalServerError)
 		return
@@ -1864,13 +1877,15 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// capRequestedRole enforces role-capping rules: consumers cannot mint sessions,
-// members can only mint consumer sessions, admins can mint any role.
-// Returns the (possibly capped) role, or an error string if the caller lacks permission.
+// capRequestedRole enforces role-capping rules: the requested role cannot
+// exceed the caller's own vault role. Consumers cannot mint sessions at all.
+// Returns the validated role, or an error string if the caller lacks permission.
 func (s *Server) capRequestedRole(ctx context.Context, sess *store.Session, vaultID, requestedRole string) (string, string) {
 	if requestedRole == "" {
 		requestedRole = "consumer"
 	}
+
+	var callerRole string
 
 	if sess.VaultID != "" {
 		// Scoped session (agent or temp invite).
@@ -1880,29 +1895,26 @@ func (s *Server) capRequestedRole(ctx context.Context, sess *store.Session, vaul
 		if !agentRoleSatisfies(sess.VaultRole, "member") {
 			return "", "Member role required"
 		}
-		// Members can only mint consumer sessions.
-		if sess.VaultRole == "member" && requestedRole != "consumer" {
-			requestedRole = "consumer"
+		callerRole = sess.VaultRole
+	} else {
+		// User session: require vault access.
+		user, err := s.userFromSession(ctx, sess)
+		if err != nil || user == nil {
+			return "", "Invalid session"
 		}
-		return requestedRole, ""
+		has, err := s.store.HasVaultAccess(ctx, user.ID, vaultID)
+		if err != nil || !has {
+			return "", "No access to this vault"
+		}
+		role, err2 := s.store.GetVaultRole(ctx, user.ID, vaultID)
+		if err2 != nil {
+			return "", "Failed to check vault role"
+		}
+		callerRole = role
 	}
 
-	// User session: require vault access.
-	user, err := s.userFromSession(ctx, sess)
-	if err != nil || user == nil {
-		return "", "Invalid session"
-	}
-	has, err := s.store.HasVaultAccess(ctx, user.ID, vaultID)
-	if err != nil || !has {
-		return "", "No access to this vault"
-	}
-	// User vault members can only mint consumer sessions.
-	role, err2 := s.store.GetVaultRole(ctx, user.ID, vaultID)
-	if err2 != nil {
-		return "", "Failed to check vault role"
-	}
-	if role != "admin" && requestedRole != "consumer" {
-		requestedRole = "consumer"
+	if !agentRoleSatisfies(callerRole, requestedRole) {
+		return "", fmt.Sprintf("Your vault role (%s) cannot mint sessions with role %s", callerRole, requestedRole)
 	}
 	return requestedRole, ""
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1363,13 +1363,111 @@ func TestScopedSessionSuccess(t *testing.T) {
 	if resp.ExpiresAt == "" {
 		t.Fatal("expected non-empty expires_at")
 	}
-	// Verify the scoped session was stored with vault_id
+	// Verify the scoped session was stored with vault_id and default role "member".
 	scopedSess := ms.sessions[resp.Token]
 	if scopedSess == nil {
 		t.Fatal("scoped session not found in store")
 	}
 	if scopedSess.VaultID != "root-ns-id" {
 		t.Fatalf("expected vault_id root-ns-id, got %q", scopedSess.VaultID)
+	}
+	if scopedSess.VaultRole != "member" {
+		t.Fatalf("expected vault_role member, got %q", scopedSess.VaultRole)
+	}
+}
+
+func TestScopedSessionExplicitRole(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	body := `{"vault":"default","vault_role":"admin"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/scoped", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp scopedSessionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	scopedSess := ms.sessions[resp.Token]
+	if scopedSess == nil {
+		t.Fatal("scoped session not found in store")
+	}
+	if scopedSess.VaultRole != "admin" {
+		t.Fatalf("expected vault_role admin, got %q", scopedSess.VaultRole)
+	}
+}
+
+func TestScopedSessionRoleRejected(t *testing.T) {
+	// Create a member-role user (not admin) to verify role escalation is rejected.
+	ms := newMockStore()
+	ms.users["member@test.com"] = &store.User{
+		ID: "member-user-id", Email: "member@test.com",
+		Role: "member", IsActive: true,
+	}
+	ms.GrantVaultRole(context.Background(), "member-user-id", "root-ns-id", "member")
+	sess, err := ms.CreateSession(context.Background(), "member-user-id", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	// Member requests admin — should be rejected.
+	body := `{"vault":"default","vault_role":"admin"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/scoped", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+sess.ID)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestScopedSessionMemberGetsMember(t *testing.T) {
+	// A vault member requesting member role should succeed.
+	ms := newMockStore()
+	ms.users["member@test.com"] = &store.User{
+		ID: "member-user-id", Email: "member@test.com",
+		Role: "member", IsActive: true,
+	}
+	ms.GrantVaultRole(context.Background(), "member-user-id", "root-ns-id", "member")
+	sess, err := ms.CreateSession(context.Background(), "member-user-id", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+
+	body := `{"vault":"default","vault_role":"member"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/scoped", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+sess.ID)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp scopedSessionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	scopedSess := ms.sessions[resp.Token]
+	if scopedSess == nil {
+		t.Fatal("scoped session not found in store")
+	}
+	if scopedSess.VaultRole != "member" {
+		t.Fatalf("expected vault_role member, got %q", scopedSess.VaultRole)
 	}
 }
 
@@ -4200,7 +4298,7 @@ func TestDirectSessionDefaultsVaultAndRole(t *testing.T) {
 	}
 }
 
-func TestDirectSessionRoleCapping(t *testing.T) {
+func TestDirectSessionRoleRejected(t *testing.T) {
 	// Create a member user (non-admin) with vault access
 	ms := newMockStore()
 	ms.users["member@test.com"] = &store.User{
@@ -4215,7 +4313,7 @@ func TestDirectSessionRoleCapping(t *testing.T) {
 
 	srv := New("127.0.0.1:0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
 
-	// Request admin role — should be capped to consumer
+	// Request admin role — should be rejected, not silently capped.
 	body := `{"vault":"default","vault_role":"admin"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/direct", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+sess.ID)
@@ -4223,16 +4321,8 @@ func TestDirectSessionRoleCapping(t *testing.T) {
 
 	srv.httpServer.Handler.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	var resp directSessionResponse
-	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if resp.VaultRole != "consumer" {
-		t.Fatalf("expected role capped to consumer, got %q", resp.VaultRole)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- `vault run` now defaults to `member` role instead of `consumer`, matching the intent that agents started this way have useful access
- Added `--role` flag to `vault run` so callers can explicitly set the session role (`consumer`, `member`, `admin`)
- `capRequestedRole` now rejects role escalation with a clear 403 error instead of silently capping — affects both `/v1/sessions/scoped` and `/v1/sessions/direct`

## Test plan
- [x] `TestScopedSessionSuccess` — default role is now `member`
- [x] `TestScopedSessionExplicitRole` — admin can request admin
- [x] `TestScopedSessionRoleRejected` — member requesting admin gets 403
- [x] `TestScopedSessionMemberGetsMember` — member requesting member succeeds
- [x] `TestDirectSessionRoleRejected` — direct session also rejects escalation
- [ ] Manual: `agent-vault vault run -- claude` starts with member session
- [ ] Manual: `agent-vault vault run --role consumer -- claude` starts with consumer session

🤖 Generated with [Claude Code](https://claude.com/claude-code)