### PR TITLE
refactor: normalize CLI subcommand names to singular nouns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,11 +71,11 @@ Agent Vault requires two things before it becomes operational: a **master passwo
   - `agent-vault owner user info [email]` -- view user info (own info if no email given)
   - `agent-vault owner user remove <email>` -- remove a user
   - `agent-vault owner user set-role <email> --role owner|member` -- change instance-level role (last owner cannot be demoted)
-- `agent-vault owner settings [get|set]` -- manage instance settings (owner only)
-  - `agent-vault owner settings get` -- show current settings (invite_only, allowed_email_domains)
-  - `agent-vault owner settings set --invite-only` -- enable invite-only registration (only vault invites can create accounts)
-  - `agent-vault owner settings set --invite-only=false` -- disable invite-only registration
-  - `agent-vault owner settings set --allowed-domains acme.com,acme.org` -- restrict signups to specific domains (empty to clear)
+- `agent-vault owner config [get|set]` -- manage instance settings (owner only)
+  - `agent-vault owner config get` -- show current settings (invite_only, allowed_email_domains)
+  - `agent-vault owner config set --invite-only` -- enable invite-only registration (only vault invites can create accounts)
+  - `agent-vault owner config set --invite-only=false` -- disable invite-only registration
+  - `agent-vault owner config set --allowed-domains acme.com,acme.org` -- restrict signups to specific domains (empty to clear)
 - `agent-vault owner vault [list|join|remove]` -- manage all vaults across the instance (owner only)
   - `agent-vault owner vault list` -- list all vaults
   - `agent-vault owner vault join <name>` -- join a vault as admin (for recovering orphaned vaults)
@@ -85,11 +85,11 @@ Agent Vault requires two things before it becomes operational: a **master passwo
   - `agent-vault service set` -- interactive service builder (prompts for services, auth config, credentials; requires TTY)
   - `agent-vault service set -f <file>` -- replace services from YAML file
   - `agent-vault service clear` -- remove all services (prompts for confirmation; use `--yes` to skip)
-- `agent-vault vault credentials [list|get|set|delete]` -- manage credentials (alias: `creds`)
-  - `agent-vault vault credentials list [--reveal]` -- list credential keys; with `--reveal`, shows decrypted values in a KEY+VALUE table (requires member+ role)
-  - `agent-vault vault credentials get <key>` -- print the decrypted value of a single credential to stdout (pipe-friendly, requires member+ role)
-  - `agent-vault vault credentials set <key=value> [...]` -- set one or more credentials
-  - `agent-vault vault credentials delete <key> [...]` -- delete one or more credentials
+- `agent-vault vault credential [list|get|set|delete]` -- manage credentials (alias: `creds`)
+  - `agent-vault vault credential list [--reveal]` -- list credential keys; with `--reveal`, shows decrypted values in a KEY+VALUE table (requires member+ role)
+  - `agent-vault vault credential get <key>` -- print the decrypted value of a single credential to stdout (pipe-friendly, requires member+ role)
+  - `agent-vault vault credential set <key=value> [...]` -- set one or more credentials
+  - `agent-vault vault credential delete <key> [...]` -- delete one or more credentials
 - `agent-vault proposal [--vault] [list|show|approve|reject|review]` -- manage proposals (proposed service/credential changes)
   - `agent-vault proposal list [--status pending]` -- list proposals for vault
   - `agent-vault proposal show <number>` -- show proposal details

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -97,7 +97,7 @@ func TestVaultSubcommandsRegistered(t *testing.T) {
 		registered[c.Name()] = true
 	}
 
-	expected := []string{"create", "list", "rename", "use", "current", "init", "user", "credentials", "service", "proposal", "agent"}
+	expected := []string{"create", "list", "rename", "use", "current", "init", "user", "credential", "service", "proposal", "agent"}
 	for _, name := range expected {
 		if !registered[name] {
 			t.Errorf("expected vault subcommand %q to be registered, but it was not", name)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -8,12 +8,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var settingsCmd = &cobra.Command{
-	Use:   "settings",
+var configCmd = &cobra.Command{
+	Use:   "config",
 	Short: "Manage instance settings (owner only)",
 }
 
-var settingsGetCmd = &cobra.Command{
+var configGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Show instance settings",
 	Args:  cobra.NoArgs,
@@ -53,7 +53,7 @@ var settingsGetCmd = &cobra.Command{
 	},
 }
 
-var settingsSetCmd = &cobra.Command{
+var configSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Update instance settings",
 	Args:  cobra.NoArgs,
@@ -127,9 +127,9 @@ var settingsSetCmd = &cobra.Command{
 }
 
 func init() {
-	settingsSetCmd.Flags().Bool("invite-only", false, "enable invite-only mode (only vault invites can create accounts)")
-	settingsSetCmd.Flags().String("allowed-domains", "", "comma-separated list of allowed email domains (empty to clear)")
-	settingsCmd.AddCommand(settingsGetCmd)
-	settingsCmd.AddCommand(settingsSetCmd)
-	ownerCmd.AddCommand(settingsCmd)
+	configSetCmd.Flags().Bool("invite-only", false, "enable invite-only mode (only vault invites can create accounts)")
+	configSetCmd.Flags().String("allowed-domains", "", "comma-separated list of allowed email domains (empty to clear)")
+	configCmd.AddCommand(configGetCmd)
+	configCmd.AddCommand(configSetCmd)
+	ownerCmd.AddCommand(configCmd)
 }

--- a/cmd/credential.go
+++ b/cmd/credential.go
@@ -10,13 +10,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var credentialsCmd = &cobra.Command{
-	Use:     "credentials",
+var credentialCmd = &cobra.Command{
+	Use:     "credential",
 	Aliases: []string{"creds"},
 	Short:   "Manage credentials",
 }
 
-var credentialsListCmd = &cobra.Command{
+var credentialListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List credential keys in a vault",
 	Args:  cobra.NoArgs,
@@ -71,7 +71,7 @@ var credentialsListCmd = &cobra.Command{
 	},
 }
 
-var credentialsGetCmd = &cobra.Command{
+var credentialGetCmd = &cobra.Command{
 	Use:   "get <key>",
 	Short: "Get the decrypted value of a credential",
 	Args:  cobra.ExactArgs(1),
@@ -110,7 +110,7 @@ var credentialsGetCmd = &cobra.Command{
 	},
 }
 
-var credentialsSetCmd = &cobra.Command{
+var credentialSetCmd = &cobra.Command{
 	Use:   "set <key=value> [key2=value2 ...]",
 	Short: "Set one or more credentials",
 	Args:  cobra.MinimumNArgs(1),
@@ -159,7 +159,7 @@ var credentialsSetCmd = &cobra.Command{
 	},
 }
 
-var credentialsDeleteCmd = &cobra.Command{
+var credentialDeleteCmd = &cobra.Command{
 	Use:   "delete <key> [key2 ...]",
 	Short: "Delete one or more credentials",
 	Args:  cobra.MinimumNArgs(1),
@@ -200,10 +200,10 @@ var credentialsDeleteCmd = &cobra.Command{
 }
 
 func init() {
-	credentialsListCmd.Flags().Bool("reveal", false, "Show decrypted credential values (requires member+ role)")
-	credentialsCmd.AddCommand(credentialsListCmd)
-	credentialsCmd.AddCommand(credentialsGetCmd)
-	credentialsCmd.AddCommand(credentialsSetCmd)
-	credentialsCmd.AddCommand(credentialsDeleteCmd)
-	vaultCmd.AddCommand(credentialsCmd)
+	credentialListCmd.Flags().Bool("reveal", false, "Show decrypted credential values (requires member+ role)")
+	credentialCmd.AddCommand(credentialListCmd)
+	credentialCmd.AddCommand(credentialGetCmd)
+	credentialCmd.AddCommand(credentialSetCmd)
+	credentialCmd.AddCommand(credentialDeleteCmd)
+	vaultCmd.AddCommand(credentialCmd)
 }


### PR DESCRIPTION
## Summary
- Rename `credentials` → `credential` (keeps `creds` as convenience alias)
- Rename `settings` → `config`
- Aligns all grouping commands with singular noun convention (`git branch`, `docker container`, `npm config`)

## Test plan
- [x] `make test` passes
- [ ] `./agent-vault vault credential --help` shows subcommands
- [ ] `./agent-vault vault creds --help` works (alias)
- [ ] `./agent-vault owner config --help` shows subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)