### PR TITLE
feat: add discover, catalog, proposal create commands and split agent skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Agent Vault requires two things before it becomes operational: a **master passwo
   - `agent-vault vault list` -- list vaults the current user has access to (owners see all vaults with `membership` field: `explicit` for joined, `implicit` for visible-but-not-joined)
   - `agent-vault vault delete <name>` -- delete a vault (vault admin or instance owner; cannot delete the default vault; use `--yes` to skip confirmation)
   - `agent-vault vault rename <old-name> <new-name>` -- rename a vault (vault admin or instance owner; cannot rename the default vault)
-  - `agent-vault vault init` -- bind the current directory to a vault by writing `agent-vault.json` (interactive picker; use `--vault` to skip picker). The file is meant to be committed so the whole team shares the vault binding. Vault resolution priority: `--vault` flag > `agent-vault.json` > user context > `"default"`.
+  - `agent-vault vault init` -- bind the current directory to a vault by writing `agent-vault.json` (interactive picker; use `--vault` to skip picker). The file is meant to be committed so the whole team shares the vault binding. Vault resolution priority: `--vault` flag > `AGENT_VAULT_VAULT` env var > `agent-vault.json` > user context > `"default"`.
   - `agent-vault vault user [invite|list|remove|set-role]` -- manage vault user access
     - `agent-vault vault user invite <email> [--vault <name>] [--role admin|member]` -- invite a user to a vault
     - `agent-vault vault user list [--vault <name>]` -- list vault users
@@ -90,9 +90,14 @@ Agent Vault requires two things before it becomes operational: a **master passwo
   - `agent-vault vault credential get <key>` -- print the decrypted value of a single credential to stdout (pipe-friendly, requires member+ role)
   - `agent-vault vault credential set <key=value> [...]` -- set one or more credentials
   - `agent-vault vault credential delete <key> [...]` -- delete one or more credentials
-- `agent-vault proposal [--vault] [list|show|approve|reject|review]` -- manage proposals (proposed service/credential changes)
+- `agent-vault proposal [--vault] [list|show|create|approve|reject|review]` -- manage proposals (proposed service/credential changes)
   - `agent-vault proposal list [--status pending]` -- list proposals for vault
   - `agent-vault proposal show <number>` -- show proposal details
+  - `agent-vault proposal create` -- create a proposal to request services or credentials. Supports two modes:
+    - Flag-driven: `--host`, `--auth-type`, `--token-key`/`--username-key`/`--password-key`/`--api-key-key`, `--credential KEY[=description]` (repeatable), `-m/--message`, `--user-message`. Credential slots have no value — the human provides it at approval time.
+    - JSON: `-f <file>` or `-f -` (stdin) for complex/multi-service proposals. `-m` and `--user-message` override JSON fields.
+    - `--json` flag outputs machine-readable JSON response with `{id, status, vault, approval_url}`.
+    - Auth: works with scoped sessions (via `AGENT_VAULT_SESSION_TOKEN` env var or `vault run`).
   - `agent-vault proposal approve <number> [KEY=VALUE ...]` -- approve and apply (requires active login session; prompts for missing credentials)
   - `agent-vault proposal reject <number> [--reason "..."]` -- reject a pending proposal (requires active login session)
   - `agent-vault proposal review` -- interactively walk through all pending proposals (approve, reject, skip, or quit each; requires active login session)
@@ -109,7 +114,9 @@ Agent Vault requires two things before it becomes operational: a **master passwo
   - `agent-vault vault agent rename <name> <new-name>` -- rename an agent
 - `agent-vault email test [--to <email>]` -- send a test email to verify SMTP configuration (owner-only; defaults to sending to the owner's own email)
 - `agent-vault reset [--yes]` -- permanently delete all data and reset the instance to a fresh state (owner-only; requires running server for role verification; auto-stops server before reset)
+- `agent-vault vault discover [--json]` -- show available services and credentials for the current vault. Requires a vault-scoped session (via `agent-vault vault run` or `AGENT_VAULT_SESSION_TOKEN` + `AGENT_VAULT_ADDR` env vars). `--json` for machine-readable output.
 - `agent-vault vault run [--addr] -- <agent>` -- wrap an agent process with Agent Vault access
+- `agent-vault catalog [--json] [--address <url>]` -- browse built-in service templates. No auth required. Address resolution: `--address` flag > `AGENT_VAULT_ADDR` env > session file > default.
 
 ## Proxy Endpoint
 
@@ -122,6 +129,19 @@ The server exposes a generic HTTP proxy at `/proxy/{target_host}/{path}[?query]`
 ## Discovery Endpoint
 
 `GET /discover` -- returns the list of brokerable services and available credential key names for the session's vault. Requires a scoped session token. Response includes vault name, proxy URL, services (host + optional description), and `available_credentials` (credential key names only, values are never exposed). Agents use `available_credentials` to reference existing credentials in proposals.
+
+## Agent Skills
+
+Agent Vault provides two skill files that teach agents how to interact with it:
+
+- `cmd/skill_cli.md` (`agent-vault-cli`) -- For agents launched via `vault run` that have the `agent-vault` binary on `$PATH`. Covers CLI commands (`discover`, `catalog`, `proposal create`, `credential get`) and the proxy URL pattern.
+- `cmd/skill_http.md` (`agent-vault-http`) -- For agents without the binary (invite-redeemed, remote, persistent). Covers HTTP endpoints only, including persistent agent mode (service token management).
+
+Both skills are embedded in the Go binary. `vault run` installs both to `~/.{claude,cursor,agents}/skills/agent-vault-{cli,http}/SKILL.md`. The server serves them at public endpoints:
+- `GET /v1/skills/cli` -- returns CLI skill as text/markdown
+- `GET /v1/skills/http` -- returns HTTP skill as text/markdown
+
+Invite redemption responses (`instructions_*.txt`) include compact, role-specific boot instructions with a pointer to `GET /v1/skills/http` for the full reference.
 
 ## Proposal API
 
@@ -315,7 +335,7 @@ docker run -it -p 14321:14321 -v agent-vault-data:/data infisical/agent-vault
 
 - After important changes, update this CLAUDE.md file if the new context would help future sessions (e.g. new commands, architectural decisions, changed patterns)
 - After notable changes, update README.md to keep user-facing documentation current
-- After notable changes, update `.claude/skills/agent-vault/SKILL.md` if the change affects the agent-facing API surface (e.g. new/changed endpoints, response fields, request constraints)
+- After notable changes, update both `cmd/skill_cli.md` and `cmd/skill_http.md` if the change affects the agent-facing API surface (e.g. new/changed endpoints, response fields, request constraints). Both skill files must be updated together.
 - When introducing new environment variables, update `.env.example` and relevant docs
 - Go module: `github.com/Infisical/agent-vault`
 - CLI framework: [spf13/cobra](https://github.com/spf13/cobra)

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var catalogCmd = &cobra.Command{
+	Use:   "catalog",
+	Short: "Browse built-in service templates",
+	Long:  `List the built-in service templates available for use in proposals. No authentication required.`,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		addr := resolveAddress(cmd)
+		jsonOut, _ := cmd.Flags().GetBool("json")
+
+		url := fmt.Sprintf("%s/v1/service-catalog", addr)
+		resp, err := http.Get(url)
+		if err != nil {
+			return fmt.Errorf("could not reach server at %s: %w", addr, err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("reading response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(respBody))
+		}
+
+		if jsonOut {
+			fmt.Fprintln(cmd.OutOrStdout(), string(respBody))
+			return nil
+		}
+
+		var data struct {
+			Services []struct {
+				ID                     string `json:"id"`
+				Name                   string `json:"name"`
+				Host                   string `json:"host"`
+				Description            string `json:"description"`
+				AuthType               string `json:"auth_type"`
+				SuggestedCredentialKey string `json:"suggested_credential_key"`
+			} `json:"services"`
+		}
+		if err := json.Unmarshal(respBody, &data); err != nil {
+			return fmt.Errorf("parsing response: %w", err)
+		}
+
+		w := cmd.OutOrStdout()
+		if len(data.Services) == 0 {
+			fmt.Fprintf(w, "%s\n", mutedText("No service templates available."))
+			return nil
+		}
+
+		t := newTable(w)
+		t.AppendHeader(table.Row{"ID", "NAME", "HOST", "AUTH TYPE", "SUGGESTED KEY"})
+		for _, svc := range data.Services {
+			t.AppendRow(table.Row{svc.ID, svc.Name, svc.Host, svc.AuthType, svc.SuggestedCredentialKey})
+		}
+		t.Render()
+		return nil
+	},
+}
+
+func init() {
+	catalogCmd.Flags().Bool("json", false, "output response as JSON")
+	catalogCmd.Flags().String("address", "", "server address (default: auto-detect)")
+	rootCmd.AddCommand(catalogCmd)
+}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -25,7 +25,7 @@ func TestCommandsRegistered(t *testing.T) {
 		registered[c.Name()] = true
 	}
 
-	expected := []string{"server", "auth", "vault", "owner", "account"}
+	expected := []string{"server", "auth", "vault", "owner", "account", "catalog"}
 	for _, name := range expected {
 		if !registered[name] {
 			t.Errorf("expected command %q to be registered, but it was not", name)
@@ -97,7 +97,7 @@ func TestVaultSubcommandsRegistered(t *testing.T) {
 		registered[c.Name()] = true
 	}
 
-	expected := []string{"create", "list", "rename", "use", "current", "init", "user", "credential", "service", "proposal", "agent"}
+	expected := []string{"create", "list", "rename", "use", "current", "init", "user", "credential", "service", "proposal", "agent", "discover"}
 	for _, name := range expected {
 		if !registered[name] {
 			t.Errorf("expected vault subcommand %q to be registered, but it was not", name)
@@ -338,7 +338,7 @@ func TestProposalSubcommandsRegistered(t *testing.T) {
 		registered[c.Name()] = true
 	}
 
-	expected := []string{"list", "show", "approve", "reject"}
+	expected := []string{"list", "show", "approve", "reject", "create"}
 	for _, name := range expected {
 		if !registered[name] {
 			t.Errorf("expected proposal subcommand %q to be registered, but it was not", name)
@@ -562,4 +562,135 @@ func TestResolveVaultWithProjectFile(t *testing.T) {
 			t.Errorf("expected %q, got %q", store.DefaultVault, got)
 		}
 	})
+}
+
+func TestResolveVaultWithEnvVar(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	t.Run("env var used when no flag", func(t *testing.T) {
+		dir := t.TempDir()
+		os.Chdir(dir)
+		t.Setenv("AGENT_VAULT_VAULT", "env-vault")
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("vault", "", "")
+		got := resolveVault(cmd)
+		if got != "env-vault" {
+			t.Errorf("expected %q, got %q", "env-vault", got)
+		}
+	})
+
+	t.Run("flag takes priority over env var", func(t *testing.T) {
+		dir := t.TempDir()
+		os.Chdir(dir)
+		t.Setenv("AGENT_VAULT_VAULT", "env-vault")
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("vault", "", "")
+		cmd.Flags().Set("vault", "flag-vault")
+		got := resolveVault(cmd)
+		if got != "flag-vault" {
+			t.Errorf("expected %q, got %q", "flag-vault", got)
+		}
+	})
+
+	t.Run("env var takes priority over project file", func(t *testing.T) {
+		dir := t.TempDir()
+		os.Chdir(dir)
+		os.WriteFile(ProjectConfigFile, []byte(`{"vault": "project-vault"}`), 0o600)
+		t.Setenv("AGENT_VAULT_VAULT", "env-vault")
+
+		cmd := &cobra.Command{}
+		cmd.Flags().String("vault", "", "")
+		got := resolveVault(cmd)
+		if got != "env-vault" {
+			t.Errorf("expected %q, got %q", "env-vault", got)
+		}
+	})
+}
+
+func TestResolveSessionFromEnvVars(t *testing.T) {
+	t.Run("returns session from env vars", func(t *testing.T) {
+		t.Setenv("AGENT_VAULT_SESSION_TOKEN", "test-token-123")
+		t.Setenv("AGENT_VAULT_ADDR", "http://localhost:9999")
+
+		sess, err := resolveSession()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sess.Token != "test-token-123" {
+			t.Errorf("expected token %q, got %q", "test-token-123", sess.Token)
+		}
+		if sess.Address != "http://localhost:9999" {
+			t.Errorf("expected address %q, got %q", "http://localhost:9999", sess.Address)
+		}
+	})
+
+	t.Run("trims trailing slash from address", func(t *testing.T) {
+		t.Setenv("AGENT_VAULT_SESSION_TOKEN", "test-token")
+		t.Setenv("AGENT_VAULT_ADDR", "http://localhost:9999/")
+
+		sess, err := resolveSession()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sess.Address != "http://localhost:9999" {
+			t.Errorf("expected address without trailing slash, got %q", sess.Address)
+		}
+	})
+}
+
+func TestProposalCreateFlagsRegistered(t *testing.T) {
+	vCmd := findSubcommand(rootCmd, "vault")
+	if vCmd == nil {
+		t.Fatal("vault command not found")
+	}
+	pCmd := findSubcommand(vCmd, "proposal")
+	if pCmd == nil {
+		t.Fatal("proposal command not found")
+	}
+	createCmd := findSubcommand(pCmd, "create")
+	if createCmd == nil {
+		t.Fatal("create command not found under proposal")
+	}
+
+	expectedFlags := []string{"file", "host", "auth-type", "token-key", "credential", "message", "user-message", "json", "description", "username-key", "password-key", "api-key-key", "api-key-header", "api-key-prefix"}
+	for _, name := range expectedFlags {
+		if createCmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected flag --%s on proposal create command", name)
+		}
+	}
+}
+
+func TestDiscoverFlagsRegistered(t *testing.T) {
+	vCmd := findSubcommand(rootCmd, "vault")
+	if vCmd == nil {
+		t.Fatal("vault command not found")
+	}
+	dCmd := findSubcommand(vCmd, "discover")
+	if dCmd == nil {
+		t.Fatal("discover command not found under vault")
+	}
+
+	if dCmd.Flags().Lookup("json") == nil {
+		t.Error("expected --json flag on discover command")
+	}
+}
+
+func TestCatalogFlagsRegistered(t *testing.T) {
+	catCmd := findSubcommand(rootCmd, "catalog")
+	if catCmd == nil {
+		t.Fatal("catalog command not found")
+	}
+
+	if catCmd.Flags().Lookup("json") == nil {
+		t.Error("expected --json flag on catalog command")
+	}
+	if catCmd.Flags().Lookup("address") == nil {
+		t.Error("expected --address flag on catalog command")
+	}
 }

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var discoverCmd = &cobra.Command{
+	Use:   "discover",
+	Short: "Show available services and credentials for the current vault",
+	Long: `Show the services and credentials available in the current vault.
+
+Requires a vault-scoped session (e.g. via agent-vault vault run or
+AGENT_VAULT_SESSION_TOKEN + AGENT_VAULT_ADDR environment variables).`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		sess, err := resolveSession()
+		if err != nil {
+			return err
+		}
+
+		jsonOut, _ := cmd.Flags().GetBool("json")
+
+		url := fmt.Sprintf("%s/discover", sess.Address)
+		respBody, err := doAdminRequestWithBody("GET", url, sess.Token, nil)
+		if err != nil {
+			return err
+		}
+
+		if jsonOut {
+			fmt.Fprintln(cmd.OutOrStdout(), string(respBody))
+			return nil
+		}
+
+		var resp struct {
+			Vault                string `json:"vault"`
+			ProxyURL             string `json:"proxy_url"`
+			Services             []struct {
+				Host        string `json:"host"`
+				Description string `json:"description"`
+			} `json:"services"`
+			AvailableCredentials []string `json:"available_credentials"`
+		}
+		if err := json.Unmarshal(respBody, &resp); err != nil {
+			return fmt.Errorf("parsing response: %w", err)
+		}
+
+		w := cmd.OutOrStdout()
+		fmt.Fprintf(w, "%s %s\n", fieldLabel("Vault:"), resp.Vault)
+		fmt.Fprintf(w, "%s %s\n", fieldLabel("Proxy:"), resp.ProxyURL)
+
+		if len(resp.Services) > 0 {
+			fmt.Fprintln(w)
+			fmt.Fprintf(w, "%s\n", boldText("Services"))
+			t := newTable(w)
+			t.AppendHeader(table.Row{"HOST", "DESCRIPTION"})
+			for _, svc := range resp.Services {
+				t.AppendRow(table.Row{svc.Host, svc.Description})
+			}
+			t.Render()
+		} else {
+			fmt.Fprintf(w, "\n%s\n", mutedText("No services configured."))
+		}
+
+		if len(resp.AvailableCredentials) > 0 {
+			fmt.Fprintln(w)
+			fmt.Fprintf(w, "%s\n", boldText("Available Credentials"))
+			for _, key := range resp.AvailableCredentials {
+				fmt.Fprintf(w, "  %s\n", key)
+			}
+		} else {
+			fmt.Fprintf(w, "\n%s\n", mutedText("No credentials stored."))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	discoverCmd.Flags().Bool("json", false, "output response as JSON")
+	vaultCmd.AddCommand(discoverCmd)
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -351,10 +351,13 @@ func loadProjectVault() string {
 	return cfg.Vault
 }
 
-// resolveVault returns the target vault using: --vault flag > project file > context file > "default".
+// resolveVault returns the target vault using: --vault flag > AGENT_VAULT_VAULT env > project file > context file > "default".
 func resolveVault(cmd *cobra.Command) string {
 	if name, _ := cmd.Flags().GetString("vault"); name != "" {
 		return name
+	}
+	if v := os.Getenv("AGENT_VAULT_VAULT"); v != "" {
+		return v
 	}
 	if pv := loadProjectVault(); pv != "" {
 		return pv
@@ -363,6 +366,30 @@ func resolveVault(cmd *cobra.Command) string {
 		return ctx
 	}
 	return store.DefaultVault
+}
+
+// resolveSession returns a client session from env vars (agent mode) or falls back to ensureSession (human mode).
+func resolveSession() (*session.ClientSession, error) {
+	token := os.Getenv("AGENT_VAULT_SESSION_TOKEN")
+	addr := os.Getenv("AGENT_VAULT_ADDR")
+	if token != "" && addr != "" {
+		return &session.ClientSession{Token: token, Address: strings.TrimRight(addr, "/")}, nil
+	}
+	return ensureSession()
+}
+
+// resolveAddress determines the server address from flags, env vars, or session.
+func resolveAddress(cmd *cobra.Command) string {
+	if addr, _ := cmd.Flags().GetString("address"); addr != "" {
+		return addr
+	}
+	if addr := os.Getenv("AGENT_VAULT_ADDR"); addr != "" {
+		return addr
+	}
+	if sess, err := session.Load(); err == nil && sess != nil {
+		return sess.Address
+	}
+	return DefaultAddress
 }
 
 // doAdminRequestWithBody makes an authenticated HTTP request to the server and returns the response body.

--- a/cmd/proposal_create.go
+++ b/cmd/proposal_create.go
@@ -1,0 +1,261 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Infisical/agent-vault/internal/broker"
+	"github.com/Infisical/agent-vault/internal/proposal"
+	"github.com/spf13/cobra"
+)
+
+// proposalCreateRequest mirrors the server's request shape for POST /v1/proposals.
+type proposalCreateRequest struct {
+	Services    []proposal.Service        `json:"services,omitempty"`
+	Credentials []proposal.CredentialSlot `json:"credentials,omitempty"`
+	Message     string                    `json:"message,omitempty"`
+	UserMessage string                    `json:"user_message,omitempty"`
+}
+
+var proposalCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a proposal to request services or credentials",
+	Long: `Create a proposal to request services or credentials for a vault.
+
+Flag-driven mode (common cases):
+
+  # Service + credential
+  agent-vault vault proposal create \
+    --host api.stripe.com --auth-type bearer --token-key STRIPE_KEY \
+    --credential STRIPE_KEY="Stripe API key" --message "Need Stripe access"
+
+  # Credential only (no host/service)
+  agent-vault vault proposal create \
+    --credential DB_PASSWORD="Database password" --message "Need DB access"
+
+JSON mode (complex/multi-service proposals):
+
+  agent-vault vault proposal create -f proposal.json
+  echo '{"services":[...],"credentials":[...]}' | agent-vault vault proposal create -f -`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		sess, err := resolveSession()
+		if err != nil {
+			return err
+		}
+
+		filePath, _ := cmd.Flags().GetString("file")
+		host, _ := cmd.Flags().GetString("host")
+		credentials, _ := cmd.Flags().GetStringArray("credential")
+		jsonOut, _ := cmd.Flags().GetBool("json")
+
+		// Validate mode: -f conflicts with flag-driven flags.
+		if filePath != "" && (host != "" || len(credentials) > 0) {
+			return fmt.Errorf("cannot mix -f/--file with --host or --credential flags")
+		}
+
+		var reqBody []byte
+
+		if filePath != "" {
+			// JSON mode.
+			reqBody, err = buildFromJSON(cmd, filePath)
+		} else if host != "" || len(credentials) > 0 {
+			// Flag-driven mode.
+			reqBody, err = buildFromFlags(cmd, host, credentials)
+		} else {
+			return fmt.Errorf("provide either --host/--credential flags or -f <file>\n\nExamples:\n  agent-vault vault proposal create --credential MY_KEY=\"description\" --message \"reason\"\n  agent-vault vault proposal create --host api.example.com --auth-type bearer --token-key MY_KEY --credential MY_KEY --message \"reason\"\n  agent-vault vault proposal create -f proposal.json")
+		}
+		if err != nil {
+			return err
+		}
+
+		url := fmt.Sprintf("%s/v1/proposals", sess.Address)
+		respBody, err := doAdminRequestWithBody("POST", url, sess.Token, reqBody)
+		if err != nil {
+			return err
+		}
+
+		if jsonOut {
+			fmt.Fprintln(cmd.OutOrStdout(), string(respBody))
+			return nil
+		}
+
+		var resp struct {
+			ID          int    `json:"id"`
+			Status      string `json:"status"`
+			Vault       string `json:"vault"`
+			ApprovalURL string `json:"approval_url"`
+		}
+		if err := json.Unmarshal(respBody, &resp); err != nil {
+			return fmt.Errorf("parsing response: %w", err)
+		}
+
+		w := cmd.OutOrStdout()
+		fmt.Fprintf(w, "%s Proposal #%d created in vault %q.\n", successText("✓"), resp.ID, resp.Vault)
+		if resp.ApprovalURL != "" {
+			fmt.Fprintf(w, "Approve at: %s\n", resp.ApprovalURL)
+		}
+		return nil
+	},
+}
+
+// buildFromJSON reads a JSON file or stdin and applies flag overrides for message/user_message.
+func buildFromJSON(cmd *cobra.Command, filePath string) ([]byte, error) {
+	var data []byte
+	var err error
+	if filePath == "-" {
+		data, err = readStdin()
+	} else {
+		data, err = os.ReadFile(filePath)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading input: %w", err)
+	}
+
+	m, _ := cmd.Flags().GetString("message")
+	um, _ := cmd.Flags().GetString("user-message")
+
+	// Fast path: no overrides, send raw bytes directly (preserves unknown fields).
+	if m == "" && um == "" {
+		if !json.Valid(data) {
+			return nil, fmt.Errorf("invalid JSON")
+		}
+		return data, nil
+	}
+
+	var req proposalCreateRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if m != "" {
+		req.Message = m
+	}
+	if um != "" {
+		req.UserMessage = um
+	}
+
+	return json.Marshal(req)
+}
+
+// buildFromFlags constructs a proposal request from CLI flags.
+func buildFromFlags(cmd *cobra.Command, host string, credentialFlags []string) ([]byte, error) {
+	req := proposalCreateRequest{}
+
+	// Parse credential flags: "KEY" or "KEY=description".
+	for _, c := range credentialFlags {
+		slot := proposal.CredentialSlot{Action: proposal.ActionSet}
+		if idx := strings.IndexByte(c, '='); idx >= 0 {
+			slot.Key = c[:idx]
+			slot.Description = c[idx+1:]
+		} else {
+			slot.Key = c
+		}
+		if slot.Key == "" {
+			return nil, fmt.Errorf("invalid --credential value %q: key cannot be empty", c)
+		}
+		req.Credentials = append(req.Credentials, slot)
+	}
+
+	// Build service if --host is provided.
+	if host != "" {
+		authType, _ := cmd.Flags().GetString("auth-type")
+		if authType == "" {
+			return nil, fmt.Errorf("--auth-type is required when --host is specified (supported: %s)", strings.Join(broker.SupportedAuthTypes, ", "))
+		}
+
+		auth, err := buildAuthFromFlags(cmd, authType)
+		if err != nil {
+			return nil, err
+		}
+
+		svc := proposal.Service{
+			Action: proposal.ActionSet,
+			Host:   host,
+			Auth:   auth,
+		}
+		if desc, _ := cmd.Flags().GetString("description"); desc != "" {
+			svc.Description = desc
+		}
+		req.Services = append(req.Services, svc)
+	} else {
+		// No host — auth flags should not be present.
+		authType, _ := cmd.Flags().GetString("auth-type")
+		if authType != "" {
+			return nil, fmt.Errorf("--auth-type requires --host to be specified")
+		}
+	}
+
+	if m, _ := cmd.Flags().GetString("message"); m != "" {
+		req.Message = m
+	}
+	if um, _ := cmd.Flags().GetString("user-message"); um != "" {
+		req.UserMessage = um
+	}
+
+	return json.Marshal(req)
+}
+
+// buildAuthFromFlags constructs a broker.Auth from the auth-related flags.
+func buildAuthFromFlags(cmd *cobra.Command, authType string) (*broker.Auth, error) {
+	a := &broker.Auth{Type: authType}
+
+	switch authType {
+	case "bearer":
+		tokenKey, _ := cmd.Flags().GetString("token-key")
+		if tokenKey == "" {
+			return nil, fmt.Errorf("--token-key is required for bearer auth")
+		}
+		a.Token = tokenKey
+
+	case "basic":
+		usernameKey, _ := cmd.Flags().GetString("username-key")
+		if usernameKey == "" {
+			return nil, fmt.Errorf("--username-key is required for basic auth")
+		}
+		a.Username = usernameKey
+		a.Password, _ = cmd.Flags().GetString("password-key")
+
+	case "api-key":
+		apiKeyKey, _ := cmd.Flags().GetString("api-key-key")
+		if apiKeyKey == "" {
+			return nil, fmt.Errorf("--api-key-key is required for api-key auth")
+		}
+		a.Key = apiKeyKey
+		a.Header, _ = cmd.Flags().GetString("api-key-header")
+		a.Prefix, _ = cmd.Flags().GetString("api-key-prefix")
+
+	case "custom":
+		return nil, fmt.Errorf("custom auth type requires JSON mode (-f); use flags for bearer, basic, or api-key")
+
+	default:
+		return nil, fmt.Errorf("unsupported auth type %q (supported: %s)", authType, strings.Join(broker.SupportedAuthTypes, ", "))
+	}
+
+	return a, nil
+}
+
+func init() {
+	// JSON mode.
+	proposalCreateCmd.Flags().StringP("file", "f", "", "path to JSON proposal file (use - for stdin)")
+
+	// Flag-driven mode.
+	proposalCreateCmd.Flags().String("host", "", "target service host (e.g. api.stripe.com)")
+	proposalCreateCmd.Flags().String("description", "", "service description")
+	proposalCreateCmd.Flags().String("auth-type", "", "auth type: bearer, basic, api-key")
+	proposalCreateCmd.Flags().String("token-key", "", "credential key for bearer auth")
+	proposalCreateCmd.Flags().String("username-key", "", "credential key for basic auth username")
+	proposalCreateCmd.Flags().String("password-key", "", "credential key for basic auth password")
+	proposalCreateCmd.Flags().String("api-key-key", "", "credential key for api-key auth")
+	proposalCreateCmd.Flags().String("api-key-header", "", "header name for api-key (default Authorization)")
+	proposalCreateCmd.Flags().String("api-key-prefix", "", "prefix for api-key value")
+	proposalCreateCmd.Flags().StringArray("credential", nil, "credential to request: KEY or KEY=description (repeatable)")
+
+	// Shared flags.
+	proposalCreateCmd.Flags().StringP("message", "m", "", "proposal message/reason")
+	proposalCreateCmd.Flags().String("user-message", "", "human-facing explanation for approval page")
+	proposalCreateCmd.Flags().Bool("json", false, "output response as JSON")
+
+	proposalCmd.AddCommand(proposalCreateCmd)
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -19,8 +19,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//go:embed skill_claude_code.md
-var skillClaudeCode string
+//go:embed skill_cli.md
+var skillCLI string
+
+//go:embed skill_http.md
+var skillHTTP string
 
 var runCmd = &cobra.Command{
 	Use:   "run [flags] -- <command> [args...]",
@@ -79,11 +82,11 @@ Example:
 		// 6. If the target command is a supported agent, offer to install the
 		//    Agent Vault skill (only when not already present).
 		if isClaudeCommand(args[0]) {
-			maybeInstallSkill("Claude Code", filepath.Join(".claude", "skills", "agent-vault", "SKILL.md"))
+			maybeInstallSkills("Claude Code", ".claude")
 		} else if isCursorCommand(args[0]) {
-			maybeInstallSkill("Cursor", filepath.Join(".cursor", "skills", "agent-vault", "SKILL.md"))
+			maybeInstallSkills("Cursor", ".cursor")
 		} else if isCodexCommand(args[0]) {
-			maybeInstallSkill("Codex", filepath.Join(".agents", "skills", "agent-vault", "SKILL.md"))
+			maybeInstallSkills("Codex", ".agents")
 		}
 
 		// 7. Confirm, then exec — replaces this process entirely so the child
@@ -112,22 +115,36 @@ func isCodexCommand(cmd string) bool {
 	return filepath.Base(cmd) == "codex"
 }
 
-// maybeInstallSkill installs the Agent Vault skill to ~/{relPath} if it
-// doesn't already exist, prompting the user for confirmation first.
-// agentName is used in user-facing messages (e.g. "Claude Code", "Cursor").
-func maybeInstallSkill(agentName, relPath string) {
+// maybeInstallSkills installs both Agent Vault skills (CLI and HTTP) under
+// ~/{baseDir}/skills/ if either is missing, prompting the user once for
+// confirmation. agentName is used in user-facing messages (e.g. "Claude Code").
+func maybeInstallSkills(agentName, baseDir string) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return
 	}
-	skillPath := filepath.Join(home, relPath)
 
-	// Already installed — nothing to do.
-	if _, err := os.Stat(skillPath); err == nil {
+	type skillEntry struct {
+		relPath string
+		content string
+	}
+	skills := []skillEntry{
+		{filepath.Join(baseDir, "skills", "agent-vault-cli", "SKILL.md"), skillCLI},
+		{filepath.Join(baseDir, "skills", "agent-vault-http", "SKILL.md"), skillHTTP},
+	}
+
+	// Check which skills need installing.
+	var missing []skillEntry
+	for _, s := range skills {
+		if _, err := os.Stat(filepath.Join(home, s.relPath)); err != nil {
+			missing = append(missing, s)
+		}
+	}
+	if len(missing) == 0 {
 		return
 	}
 
-	fmt.Fprintf(os.Stderr, "Install Agent Vault skill for %s at %s? [Y/n] ", agentName, skillPath)
+	fmt.Fprintf(os.Stderr, "Install Agent Vault skills for %s? [Y/n] ", agentName)
 	reader := bufio.NewReader(os.Stdin)
 	answer, err := reader.ReadString('\n')
 	if err != nil {
@@ -138,16 +155,19 @@ func maybeInstallSkill(agentName, relPath string) {
 		return
 	}
 
-	dir := filepath.Dir(skillPath)
-	if err := os.MkdirAll(dir, 0o750); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not create skill directory: %v\n", err)
-		return
+	for _, s := range missing {
+		fullPath := filepath.Join(home, s.relPath)
+		dir := filepath.Dir(fullPath)
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not create skill directory: %v\n", err)
+			continue
+		}
+		if err := os.WriteFile(fullPath, []byte(s.content), 0o600); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not write skill file: %v\n", err)
+			continue
+		}
 	}
-	if err := os.WriteFile(skillPath, []byte(skillClaudeCode), 0o600); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not write skill file: %v\n", err)
-		return
-	}
-	fmt.Fprintf(os.Stderr, "%s Installed Agent Vault skill for %s.\n", successText("agent-vault:"), agentName)
+	fmt.Fprintf(os.Stderr, "%s Installed Agent Vault skills for %s.\n", successText("agent-vault:"), agentName)
 }
 
 // resolveVaultForRun picks the vault for a run session. Priority:

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -91,6 +91,7 @@ var serverCmd = &cobra.Command{
 		notifier := notify.New(smtpCfg)
 		oauthProviders := loadOAuthProviders(baseURL)
 		srv := server.New(addr, db, masterKey.Key(), notifier, initialized, baseURL, oauthProviders)
+		srv.SetSkills(skillCLI, skillHTTP)
 		return srv.Start()
 	},
 }
@@ -303,6 +304,7 @@ func runDetachedChild(addr string) error {
 	notifier := notify.New(smtpCfg)
 	oauthProviders := loadOAuthProviders(baseURL)
 	srv := server.New(addr, db, key, notifier, initialized, baseURL, oauthProviders)
+	srv.SetSkills(skillCLI, skillHTTP)
 	return srv.Start()
 }
 

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -1,16 +1,17 @@
 ---
-name: agent-vault
+name: agent-vault-cli
 description: >-
-  Agent Vault: an authenticated HTTP proxy for external services (Linear,
-  GitHub, Stripe, Slack, Jira, etc.). Use when the task involves interacting
-  with any third-party API or service that requires credentials.
-compatibility: Requires a running Agent Vault server and AGENT_VAULT_SESSION_TOKEN environment variable
+  Agent Vault CLI: manage authenticated HTTP proxy access to external services
+  (Linear, GitHub, Stripe, Slack, Jira, etc.) using the agent-vault binary.
+  Use when the task involves interacting with any third-party API or service
+  that requires credentials.
+compatibility: Requires a running Agent Vault server, the agent-vault binary on $PATH, and AGENT_VAULT_SESSION_TOKEN environment variable
 metadata:
   author: dangtony98
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
-# Agent Vault
+# Agent Vault (CLI)
 
 You have access to Agent Vault, an HTTP proxy that attaches credentials to your outbound requests. You never see or handle credentials directly -- route authenticated requests through Agent Vault and it authenticates on your behalf.
 
@@ -20,12 +21,12 @@ You have access to Agent Vault, an HTTP proxy that attaches credentials to your 
 
 **Your workflow for ANY external service interaction:**
 1. Check that `AGENT_VAULT_SESSION_TOKEN` is set (it should be if you were launched via `agent-vault vault run`)
-2. Call `GET {AGENT_VAULT_ADDR}/discover` to see what services are available
+2. Run `agent-vault vault discover --json` to see what services are available
 3. If the service is listed, route your request through the Agent Vault proxy -- done
-4. If the service is NOT listed, propose access via a proposal (the user can approve and provide credentials)
+4. If the service is NOT listed, create a proposal via CLI (the user can approve and provide credentials)
 5. Only tell the user you cannot access a service if Agent Vault is not available at all (no session token)
 
-**Never say "I don't have access to X" without checking /discover first.** Agent Vault may already have credentials configured for the service you need.
+**Never say "I don't have access to X" without checking discover first.** Agent Vault may already have credentials configured for the service you need.
 
 **Not every HTTP request needs to go through Agent Vault.** Unauthenticated requests or requests to services not configured in Agent Vault should be made directly.
 
@@ -39,18 +40,19 @@ You have access to Agent Vault, an HTTP proxy that attaches credentials to your 
 
 ## Discover Available Services (Start Here)
 
-**Always call this first** to learn which services have credentials configured in Agent Vault:
+**Always run this first** to learn which services have credentials configured:
 
-```
-GET {AGENT_VAULT_ADDR}/discover
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+```bash
+agent-vault vault discover --json
 ```
 
 Response includes `vault`, `proxy_url`, `services` (host + description), and `available_credentials` (key names only, values are never exposed). Use `available_credentials` to reference existing credentials in proposals instead of creating duplicate slots.
 
+**Browse service templates:** `agent-vault catalog --json` lists built-in service templates with suggested credential keys and auth types. No auth needed.
+
 ## Making Requests Through Agent Vault
 
-For hosts returned by `/discover`, route requests through Agent Vault:
+For hosts returned by discover, route requests through Agent Vault's proxy:
 
 ```
 {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
@@ -67,11 +69,11 @@ Proposals are the primary way to exchange credentials with a human operator. Use
 - **Want to store a credential back** -- include the value in a credential slot and the human confirms it at approval.
 - **Need proxy access to a new host** -- propose a service with an `auth` config so Agent Vault can authenticate on your behalf.
 
-When you get a `403` for a host not in `/discover`, the response includes a `proposal_hint` with the denied host.
+When you get a `403` for a host not in discover, the response includes a `proposal_hint` with the denied host.
 
 ## Choosing the Right Auth Method
 
-**Before proposing a proposal for a new service, you MUST look up how that service authenticates API requests.** If you have internet access, fetch the service's API authentication documentation to determine the correct auth type. Do not guess -- incorrect auth wastes the operator's time and will fail at the proxy.
+**Before creating a proposal for a new service, you MUST look up how that service authenticates API requests.** If you have internet access, fetch the service's API authentication documentation to determine the correct auth type. Do not guess -- incorrect auth wastes the operator's time and will fail at the proxy.
 
 Agent Vault auth types:
 
@@ -86,17 +88,28 @@ Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic
 
 ### Creating a Proposal
 
-```
-POST {AGENT_VAULT_ADDR}/v1/proposals
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-Content-Type: application/json
+**Flag-driven mode (common cases):**
 
+```bash
+# Service + credential
+agent-vault vault proposal create \
+  --host api.stripe.com --auth-type bearer --token-key STRIPE_KEY \
+  --credential STRIPE_KEY="Stripe API key" \
+  -m "Need Stripe API key for billing feature" --json
+
+# Credential only (no host/service needed)
+agent-vault vault proposal create \
+  --credential DB_PASSWORD="Production database password" \
+  -m "Need database credentials" --json
+
+# Complex/multi-service (JSON mode)
+agent-vault vault proposal create -f - --json <<'EOF'
 {
   "services": [{"action": "set", "host": "api.stripe.com", "description": "Stripe API", "auth": {"type": "bearer", "token": "STRIPE_KEY"}}],
-  "credentials": [{"action": "set", "key": "STRIPE_KEY", "description": "Stripe API key", "obtain": "https://dashboard.stripe.com/apikeys", "obtain_instructions": "Developers -> API Keys -> Reveal test key"}],
-  "message": "Need Stripe API key for billing feature",
-  "user_message": "I need access to your Stripe account to build the checkout page."
+  "credentials": [{"action": "set", "key": "STRIPE_KEY", "description": "Stripe API key"}],
+  "message": "Need Stripe access"
 }
+EOF
 ```
 
 Key fields:
@@ -112,33 +125,22 @@ Key fields:
 2. Immediately start polling `GET {AGENT_VAULT_ADDR}/v1/proposals/{id}` -- do NOT wait for the user to say "go on" or confirm. Poll every 3s for the first 30s, then every 10s. Stop after 10 minutes (proposal may have expired).
 3. Once status is `applied`, automatically retry your original request and continue your task
 
-**Check status:** `GET {AGENT_VAULT_ADDR}/v1/proposals/{id}` -- returns `pending`, `applied`, `rejected`, or `expired`
+**Check status:** `GET {AGENT_VAULT_ADDR}/v1/proposals/{id}` with `Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}` -- returns `pending`, `applied`, `rejected`, or `expired`
 
-**List proposals:** `GET {AGENT_VAULT_ADDR}/v1/proposals?status=pending`
+## Reading Credentials
 
-## Persistent Agent Mode
+To read the decrypted value of a credential (requires member+ vault role):
 
-If you were registered as a persistent agent (via a persistent invite), you received two tokens:
-
-- **`av_agent_token`** (service token): Long-lived, for minting sessions only. Store permanently. Cannot be retrieved again.
-- **`av_session_token`**: Short-lived (24h), for all proxy/discover/proposal calls.
-
-When your session token expires (proxy returns 401), mint a new one:
-
-```
-POST {AGENT_VAULT_ADDR}/v1/agent/session
-Authorization: Bearer {av_agent_token}
+```bash
+agent-vault vault credential get <key>
 ```
 
-Returns: `av_session_token`, `av_vault`, `expires_at`. Do this automatically -- no human intervention needed.
-If minting fails with 401, your service token may have been rotated -- check with your operator.
-
-**Never** use the service token for proxy/discover/proposal calls -- only for `POST /v1/agent/session`.
+Prints the raw value to stdout (pipe-friendly). Useful for configuration tasks where you need to read a stored value.
 
 ## Error Handling
 
-- 401: Invalid or expired token -- check `AGENT_VAULT_SESSION_TOKEN` (or mint a new session for persistent agents)
-- 403: Host not allowed -- propose a proposal
+- 401: Invalid or expired token -- check `AGENT_VAULT_SESSION_TOKEN`
+- 403: Host not allowed -- create a proposal
 - 429: Too many pending proposals -- wait for review
 - 502: Missing credential or upstream unreachable, tell user a credential may need to be added
 
@@ -146,6 +148,6 @@ If minting fails with 401, your service token may have been rotated -- check wit
 
 - **Never** attempt to extract, log, or display credentials
 - **Never** hardcode tokens -- always read from `AGENT_VAULT_SESSION_TOKEN`
-- **Only** request hosts returned by `/discover` -- if a host isn't listed, propose a proposal
+- **Only** request hosts returned by discover -- if a host isn't listed, create a proposal
 - If you receive a `credential_not_found` error, inform the user which credential is missing
 - Do not modify or forge the `Authorization` header beyond using your session token

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -4,7 +4,8 @@ description: >-
   Agent Vault CLI: manage authenticated HTTP proxy access to external services
   (Linear, GitHub, Stripe, Slack, Jira, etc.) using the agent-vault binary.
   Use when the task involves interacting with any third-party API or service
-  that requires credentials.
+  that requires credentials, or when writing code that needs environment
+  variables for secrets/API keys.
 compatibility: Requires a running Agent Vault server, the agent-vault binary on $PATH, and AGENT_VAULT_SESSION_TOKEN environment variable
 metadata:
   author: dangtony98
@@ -126,6 +127,41 @@ Key fields:
 3. Once status is `applied`, automatically retry your original request and continue your task
 
 **Check status:** `GET {AGENT_VAULT_ADDR}/v1/proposals/{id}` with `Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}` -- returns `pending`, `applied`, `rejected`, or `expired`
+
+## Building Code That Needs Credentials
+
+When you are writing or modifying application code that requires secrets or API keys (e.g. `process.env.STRIPE_KEY`, `os.Getenv("DB_PASSWORD")`), use Agent Vault to ensure those credentials are tracked and available.
+
+**Workflow:**
+1. Write the code referencing the environment variable as normal (e.g. `process.env.STRIPE_KEY`)
+2. Run `agent-vault vault discover --json` and check `available_credentials` for the key
+3. If the key exists, you're done -- the credential is already stored in the vault
+4. If the key is missing, create a credential-only proposal so the human can provide the value:
+
+```bash
+agent-vault vault proposal create \
+  --credential STRIPE_KEY="Stripe secret key for payment processing" \
+  -m "Adding Stripe integration -- need API key" \
+  --user-message "The app needs a Stripe secret key to process payments. You can find it at https://dashboard.stripe.com/apikeys" \
+  --json
+```
+
+5. Present the `approval_url` to the user and poll until approved (same as service proposals)
+6. Update `.env.example` (or equivalent) to document the new variable
+
+**Multiple credentials at once:** If your code change introduces several env vars, batch them in one proposal:
+
+```bash
+agent-vault vault proposal create \
+  --credential DB_HOST="Database hostname" \
+  --credential DB_PASSWORD="Database password" \
+  -m "Adding database connection -- need credentials" --json
+```
+
+**Key points:**
+- Use credential-only proposals (no `--host`/`--auth-type`) when the credential is for the application, not for proxying through Agent Vault
+- Always check `available_credentials` first to avoid proposing duplicates
+- Include `obtain` URLs or `obtain_instructions` in JSON mode proposals to help the human find the credential
 
 ## Reading Credentials
 

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -4,7 +4,8 @@ description: >-
   Agent Vault HTTP: interact with Agent Vault's authenticated HTTP proxy for
   external services (Linear, GitHub, Stripe, Slack, Jira, etc.) using only
   HTTP requests. Use when the task involves any third-party API or service
-  that requires credentials.
+  that requires credentials, or when writing code that needs environment
+  variables for secrets/API keys.
 compatibility: Requires a running Agent Vault server and AGENT_VAULT_SESSION_TOKEN environment variable
 metadata:
   author: dangtony98
@@ -124,6 +125,48 @@ Key fields:
 **Check status:** `GET {AGENT_VAULT_ADDR}/v1/proposals/{id}` with `Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}` -- returns `pending`, `applied`, `rejected`, or `expired`
 
 **List proposals:** `GET {AGENT_VAULT_ADDR}/v1/proposals?status=pending`
+
+## Building Code That Needs Credentials
+
+When you are writing or modifying application code that requires secrets or API keys (e.g. `process.env.STRIPE_KEY`, `os.Getenv("DB_PASSWORD")`), use Agent Vault to ensure those credentials are tracked and available.
+
+**Workflow:**
+1. Write the code referencing the environment variable as normal (e.g. `process.env.STRIPE_KEY`)
+2. Call `GET {AGENT_VAULT_ADDR}/discover` and check `available_credentials` for the key
+3. If the key exists, you're done -- the credential is already stored in the vault
+4. If the key is missing, create a credential-only proposal so the human can provide the value:
+
+```
+POST {AGENT_VAULT_ADDR}/v1/proposals
+Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Content-Type: application/json
+
+{
+  "credentials": [{"action": "set", "key": "STRIPE_KEY", "description": "Stripe secret key for payment processing", "obtain": "https://dashboard.stripe.com/apikeys", "obtain_instructions": "Developers -> API Keys -> Reveal secret key"}],
+  "message": "Adding Stripe integration -- need API key",
+  "user_message": "The app needs a Stripe secret key to process payments."
+}
+```
+
+5. Present the `approval_url` to the user and poll until approved (same as service proposals)
+6. Update `.env.example` (or equivalent) to document the new variable
+
+**Multiple credentials at once:** Batch them in one proposal:
+
+```json
+{
+  "credentials": [
+    {"action": "set", "key": "DB_HOST", "description": "Database hostname"},
+    {"action": "set", "key": "DB_PASSWORD", "description": "Database password"}
+  ],
+  "message": "Adding database connection -- need credentials"
+}
+```
+
+**Key points:**
+- Use credential-only proposals (no `services` array) when the credential is for the application, not for proxying through Agent Vault
+- Always check `available_credentials` first to avoid proposing duplicates
+- Include `obtain` and `obtain_instructions` to help the human find the credential
 
 ## Persistent Agent Mode
 

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -1,0 +1,161 @@
+---
+name: agent-vault-http
+description: >-
+  Agent Vault HTTP: interact with Agent Vault's authenticated HTTP proxy for
+  external services (Linear, GitHub, Stripe, Slack, Jira, etc.) using only
+  HTTP requests. Use when the task involves any third-party API or service
+  that requires credentials.
+compatibility: Requires a running Agent Vault server and AGENT_VAULT_SESSION_TOKEN environment variable
+metadata:
+  author: dangtony98
+  version: "0.2.0"
+---
+
+# Agent Vault (HTTP)
+
+You have access to Agent Vault, an HTTP proxy that attaches credentials to your outbound requests. You never see or handle credentials directly -- route authenticated requests through Agent Vault and it authenticates on your behalf.
+
+## CRITICAL: Always Check Agent Vault First
+
+**Before telling the user you cannot access an external service, you MUST check Agent Vault.** This applies whenever a task involves any third-party service or API -- project management (Linear, Jira, Asana), source control (GitHub, GitLab), communication (Slack, Discord), payments (Stripe), databases, or any other authenticated service.
+
+**Your workflow for ANY external service interaction:**
+1. Check that `AGENT_VAULT_SESSION_TOKEN` is set
+2. Call `GET {AGENT_VAULT_ADDR}/discover` to see what services are available
+3. If the service is listed, route your request through the Agent Vault proxy -- done
+4. If the service is NOT listed, create a proposal (the user can approve and provide credentials)
+5. Only tell the user you cannot access a service if Agent Vault is not available at all (no session token)
+
+**Never say "I don't have access to X" without checking /discover first.** Agent Vault may already have credentials configured for the service you need.
+
+**Not every HTTP request needs to go through Agent Vault.** Unauthenticated requests or requests to services not configured in Agent Vault should be made directly.
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
+| `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault |
+| `AGENT_VAULT_VAULT` | Vault the session is scoped to |
+
+## Discover Available Services (Start Here)
+
+**Always call this first** to learn which services have credentials configured:
+
+```
+GET {AGENT_VAULT_ADDR}/discover
+Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+```
+
+Response includes `vault`, `proxy_url`, `services` (host + description), and `available_credentials` (key names only, values are never exposed). Use `available_credentials` to reference existing credentials in proposals instead of creating duplicate slots.
+
+**Browse service templates:**
+
+```
+GET {AGENT_VAULT_ADDR}/v1/service-catalog
+```
+
+Returns built-in service templates with suggested credential keys and auth types. No auth required.
+
+## Making Requests Through Agent Vault
+
+For hosts returned by `/discover`, route requests through Agent Vault's proxy:
+
+```
+{AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
+Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+```
+
+Agent Vault strips your auth header, injects the real credentials, and forwards the request over HTTPS.
+
+## Proposals -- Requesting and Storing Credentials
+
+Proposals are the primary way to exchange credentials with a human operator. Use them whenever you:
+
+- **Need a credential supplied by a human** -- create a proposal with a credential slot and the human will provide the value at approval time.
+- **Want to store a credential back** -- include the value in a credential slot and the human confirms it at approval.
+- **Need proxy access to a new host** -- propose a service with an `auth` config so Agent Vault can authenticate on your behalf.
+
+When you get a `403` for a host not in `/discover`, the response includes a `proposal_hint` with the denied host.
+
+## Choosing the Right Auth Method
+
+**Before creating a proposal for a new service, you MUST look up how that service authenticates API requests.** If you have internet access, fetch the service's API authentication documentation to determine the correct auth type. Do not guess -- incorrect auth wastes the operator's time and will fail at the proxy.
+
+Agent Vault auth types:
+
+```
+bearer    -- Authorization: Bearer <token>          {"auth": {"type": "bearer", "token": "SECRET_KEY"}}
+basic     -- HTTP Basic (user, optional password)    {"auth": {"type": "basic", "username": "API_KEY"}}
+api-key   -- key in a named header, optional prefix  {"auth": {"type": "api-key", "key": "SECRET", "header": "x-api-key"}}
+custom    -- freeform header templates               {"auth": {"type": "custom", "headers": {"X-Key": "{{ SECRET }}"}}}
+```
+
+Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic -- API key as username), Jira (basic -- email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
+
+### Creating a Proposal
+
+```
+POST {AGENT_VAULT_ADDR}/v1/proposals
+Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Content-Type: application/json
+
+{
+  "services": [{"action": "set", "host": "api.stripe.com", "description": "Stripe API", "auth": {"type": "bearer", "token": "STRIPE_KEY"}}],
+  "credentials": [{"action": "set", "key": "STRIPE_KEY", "description": "Stripe API key", "obtain": "https://dashboard.stripe.com/apikeys", "obtain_instructions": "Developers -> API Keys -> Reveal test key"}],
+  "message": "Need Stripe API key for billing feature",
+  "user_message": "I need access to your Stripe account to build the checkout page."
+}
+```
+
+Key fields:
+- `services[].action` -- `"set"` (upsert, needs `host` + `auth`) or `"delete"` (needs `host` only)
+- `services[].auth` -- authentication config. Types: `bearer` (`token`), `basic` (`username`, optional `password`), `api-key` (`key` + `header`, optional `prefix`), `custom` (`headers` map with `{{ KEY }}` templates)
+- `credentials[].action` -- `"set"` (omit `value` for human to supply; include `value` to store back) or `"delete"`
+- `credentials` -- only declare credentials not already in `available_credentials`. Every credential referenced in auth configs must resolve to a slot or existing credential (400 otherwise)
+- `message` -- developer-facing explanation; `user_message` -- shown on the browser approval page
+- `credentials[].obtain` -- URL where the human can get the credential; `obtain_instructions` -- steps to find it
+
+**After creating a proposal:**
+1. Present the `approval_url` to the user conversationally -- e.g. "I need access to your Stripe account. Click here to connect it: -> {approval_url}"
+2. Immediately start polling `GET {AGENT_VAULT_ADDR}/v1/proposals/{id}` -- do NOT wait for the user to say "go on" or confirm. Poll every 3s for the first 30s, then every 10s. Stop after 10 minutes (proposal may have expired).
+3. Once status is `applied`, automatically retry your original request and continue your task
+
+**Check status:** `GET {AGENT_VAULT_ADDR}/v1/proposals/{id}` with `Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}` -- returns `pending`, `applied`, `rejected`, or `expired`
+
+**List proposals:** `GET {AGENT_VAULT_ADDR}/v1/proposals?status=pending`
+
+## Persistent Agent Mode
+
+If you were registered as a persistent agent (via a persistent invite), you received two tokens:
+
+- **`av_agent_token`** (service token): Long-lived, for minting sessions only. Store permanently. Cannot be retrieved again.
+- **`av_session_token`**: Short-lived (24h), for all proxy/discover/proposal calls.
+
+When your session token expires (proxy returns 401), mint a new one:
+
+```
+POST {AGENT_VAULT_ADDR}/v1/agent/session
+Authorization: Bearer {av_agent_token}
+```
+
+Returns: `av_session_token`, `av_vault`, `expires_at`. Do this automatically -- no human intervention needed.
+If minting fails with 401, your service token may have been rotated -- check with your operator.
+
+**Never** use the service token for proxy/discover/proposal calls -- only for `POST /v1/agent/session`.
+
+## Error Handling
+
+- 401: Invalid or expired token -- check `AGENT_VAULT_SESSION_TOKEN` (or mint a new session for persistent agents)
+- 403: Host not allowed -- create a proposal
+- 429: Too many pending proposals -- wait for review
+- 502: Missing credential or upstream unreachable, tell user a credential may need to be added
+
+## Rules
+
+- **Never** attempt to extract, log, or display credentials
+- **Never** hardcode tokens -- always read from `AGENT_VAULT_SESSION_TOKEN`
+- **Never** use the service token for proxy/discover/proposal calls -- only for `POST /v1/agent/session`
+- **Only** request hosts returned by `/discover` -- if a host isn't listed, create a proposal
+- If you receive a `credential_not_found` error, inform the user which credential is missing
+- Do not modify or forge the `Authorization` header beyond using your session token

--- a/internal/server/instructions_admin.txt
+++ b/internal/server/instructions_admin.txt
@@ -8,158 +8,27 @@ Your vault role is **admin**. You have full vault access: proxy, discover, propo
 
 1. Store env vars from the redemption response: AGENT_VAULT_ADDR (server URL), AGENT_VAULT_SESSION_TOKEN (bearer token), AGENT_VAULT_VAULT (vault name)
 2. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN} — do this FIRST before any external service interaction
-3. For hosts in the response, route through the proxy. For all others, call directly.
+3. For hosts in the response, route through the proxy: {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}
 4. If a needed service isn't listed, raise a proposal — the user can approve and provide credentials.
 
-## Proxy
+## Admin Capabilities
 
-  {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+As an admin, you can also:
+- Set credentials: POST {AGENT_VAULT_ADDR}/v1/credentials with {"vault": "...", "credentials": {"KEY": "value"}}
+- Delete credentials: DELETE {AGENT_VAULT_ADDR}/v1/credentials with {"vault": "...", "keys": ["KEY"]}
+- Approve proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/approve with {"vault": "...", "credentials": {"KEY": "value"}}
+- Reject proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/reject with {"vault": "...", "reason": "..."}
+- Invite agents with any role: POST {AGENT_VAULT_ADDR}/v1/invites with {"vault": "...", "vault_role": "member|consumer|admin"}
+- Invite users: POST {AGENT_VAULT_ADDR}/v1/vaults/{name}/invites with {"email": "...", "role": "member|admin"}
 
-Agent Vault strips your auth header, attaches real credentials, and forwards over HTTPS.
+## Full Reference
 
-Example: GET {AGENT_VAULT_ADDR}/proxy/api.stripe.com/v1/charges?limit=10
+For the complete Agent Vault reference including auth types, proposal format, error handling, and behavioral rules, fetch:
 
-## Direct Credential Management
-
-You can set and delete credentials directly without a proposal.
-
-### Set Credentials
-
-  POST {AGENT_VAULT_ADDR}/v1/credentials
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {"vault": "default", "credentials": {"STRIPE_KEY": "sk_test_..."}}
-
-### Delete Credentials
-
-  DELETE {AGENT_VAULT_ADDR}/v1/credentials
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {"vault": "default", "keys": ["STRIPE_KEY"]}
-
-## Proposal Approval & Rejection
-
-You can approve or reject pending proposals.
-
-### Approve
-
-  POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/approve
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {"vault": "default", "credentials": {"KEY": "value"}}
-
-Provide values for any credentials the proposal requires.
-
-### Reject
-
-  POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/reject
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {"vault": "default", "reason": "Not needed"}
-
-## Vault Service Management
-
-You can view, set, and clear the vault's brokered services.
-
-### List Services
-
-  GET {AGENT_VAULT_ADDR}/v1/vaults/{name}/services
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-
-### Set Services
-
-  PUT {AGENT_VAULT_ADDR}/v1/vaults/{name}/services
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {"services": [{"host": "api.stripe.com", "description": "Stripe API", "auth": {"type": "bearer", "token": "STRIPE_KEY"}}]}
-
-### Clear Services
-
-  DELETE {AGENT_VAULT_ADDR}/v1/vaults/{name}/services
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-
-## Inviting Agents
-
-As an admin, you can invite agents with any role: consumer, member, or admin.
-
-  POST {AGENT_VAULT_ADDR}/v1/invites
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {"vault": "default", "vault_role": "member"}
-
-For persistent agents: {"vault": "default", "persistent": true, "agent_name": "my-bot", "vault_role": "member"}
-
-Roles: consumer (proxy + proposals only), member (+ credentials, approval, services), admin (+ invite users and agents with any role).
-
-## Inviting Users
-
-As an admin, you can invite human users to join the vault.
-
-  POST {AGENT_VAULT_ADDR}/v1/vaults/{name}/invites
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {"email": "user@example.com", "role": "member"}
-
-Roles: admin or member. The invitee receives an email (if SMTP is configured) with a link to accept.
-
-## Proposals — Requesting Access to New Services
-
-When you need a credential or proxy access to a host not in /discover, raise a proposal. A 403 response includes a proposal_hint with the denied host.
-
-IMPORTANT: Before raising a proposal, you MUST look up how the target service authenticates API requests. Check the service's API docs to determine the correct auth type. Do not guess — wrong auth wastes the operator's time and will fail at the proxy.
-
-### Auth Types
-
-  bearer    — Authorization: Bearer <token>          {"auth": {"type": "bearer", "token": "SECRET_KEY"}}
-  basic     — HTTP Basic (user, optional password)    {"auth": {"type": "basic", "username": "API_KEY"}}
-  api-key   — key in a named header, optional prefix  {"auth": {"type": "api-key", "key": "SECRET", "header": "x-api-key"}}
-  custom    — freeform header templates               {"auth": {"type": "custom", "headers": {"X-Key": "{{ SECRET }}"}}}
-
-Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic — API key as username), Jira (basic — email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
-
-### Creating a Proposal
-
-  POST {AGENT_VAULT_ADDR}/v1/proposals
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {
-    "services": [{"action": "set", "host": "api.stripe.com", "description": "Stripe API", "auth": {"type": "bearer", "token": "STRIPE_KEY"}}],
-    "credentials": [{"action": "set", "key": "STRIPE_KEY", "description": "Stripe credential key", "obtain": "https://dashboard.stripe.com/apikeys", "obtain_instructions": "Developers → API Keys → Reveal test key"}],
-    "message": "Need Stripe API key for billing feature",
-    "user_message": "I need access to your Stripe account to build the checkout page."
-  }
-
-Key fields:
-- services[].action: "set" (upsert, needs host + auth) or "delete" (needs host only)
-- credentials[].action: "set" (omit value for human to supply; include value to store back) or "delete"
-- credentials: only declare credentials not already in available_credentials from /discover
-- message: developer-facing explanation; user_message: shown on approval page
-- credentials[].obtain: URL where the human can get the credential; obtain_instructions: steps to find it
-
-Response includes approval_url. After creating:
-1. Present approval_url to the user conversationally
-2. Immediately start polling GET {AGENT_VAULT_ADDR}/v1/proposals/{id} — do NOT wait for the user to say "go on" or confirm. Poll every 3s for the first 30s, then every 10s. Stop after 10 minutes (proposal may have expired).
-3. Once status is "applied", automatically retry your original request and continue your task
-
-## Error Handling
-
-- 401: Invalid/expired token — check AGENT_VAULT_SESSION_TOKEN
-- 403: Host not allowed or insufficient role — raise a proposal or contact vault admin
-- 429: Too many pending proposals — wait for review
-- 502: Missing credential or upstream unreachable — tell user
+  GET {AGENT_VAULT_ADDR}/v1/skills/http
 
 ## Rules
 
 - Never attempt to extract, log, or display credentials
 - Never hardcode tokens — always use AGENT_VAULT_SESSION_TOKEN
 - Only proxy hosts returned by /discover — if not listed, raise a proposal
-- If you receive a credential_not_found error, inform the user which credential is missing

--- a/internal/server/instructions_consumer.txt
+++ b/internal/server/instructions_consumer.txt
@@ -8,68 +8,17 @@ Your vault role is **consumer**. You can proxy requests, discover services, and 
 
 1. Store env vars from the redemption response: AGENT_VAULT_ADDR (server URL), AGENT_VAULT_SESSION_TOKEN (bearer token), AGENT_VAULT_VAULT (vault name)
 2. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN} — do this FIRST before any external service interaction
-3. For hosts in the response, route through the proxy. For all others, call directly.
+3. For hosts in the response, route through the proxy: {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}
 4. If a needed service isn't listed, raise a proposal — the user can approve and provide credentials.
 
-## Proxy
+## Full Reference
 
-  {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+For the complete Agent Vault reference including auth types, proposal format, error handling, and behavioral rules, fetch:
 
-Agent Vault strips your auth header, attaches real credentials, and forwards over HTTPS.
-
-Example: GET {AGENT_VAULT_ADDR}/proxy/api.stripe.com/v1/charges?limit=10
-
-## Proposals — Requesting Access to New Services
-
-When you need a credential or proxy access to a host not in /discover, raise a proposal. A 403 response includes a proposal_hint with the denied host.
-
-IMPORTANT: Before raising a proposal, you MUST look up how the target service authenticates API requests. Check the service's API docs to determine the correct auth type. Do not guess — wrong auth wastes the operator's time and will fail at the proxy.
-
-### Auth Types
-
-  bearer    — Authorization: Bearer <token>          {"auth": {"type": "bearer", "token": "SECRET_KEY"}}
-  basic     — HTTP Basic (user, optional password)    {"auth": {"type": "basic", "username": "API_KEY"}}
-  api-key   — key in a named header, optional prefix  {"auth": {"type": "api-key", "key": "SECRET", "header": "x-api-key"}}
-  custom    — freeform header templates               {"auth": {"type": "custom", "headers": {"X-Key": "{{ SECRET }}"}}}
-
-Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic — API key as username), Jira (basic — email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
-
-### Creating a Proposal
-
-  POST {AGENT_VAULT_ADDR}/v1/proposals
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {
-    "services": [{"action": "set", "host": "api.stripe.com", "description": "Stripe API", "auth": {"type": "bearer", "token": "STRIPE_KEY"}}],
-    "credentials": [{"action": "set", "key": "STRIPE_KEY", "description": "Stripe credential key", "obtain": "https://dashboard.stripe.com/apikeys", "obtain_instructions": "Developers → API Keys → Reveal test key"}],
-    "message": "Need Stripe API key for billing feature",
-    "user_message": "I need access to your Stripe account to build the checkout page."
-  }
-
-Key fields:
-- services[].action: "set" (upsert, needs host + auth) or "delete" (needs host only)
-- credentials[].action: "set" (omit value for human to supply; include value to store back) or "delete"
-- credentials: only declare credentials not already in available_credentials from /discover
-- message: developer-facing explanation; user_message: shown on approval page
-- credentials[].obtain: URL where the human can get the credential; obtain_instructions: steps to find it
-
-Response includes approval_url. After creating:
-1. Present approval_url to the user conversationally
-2. Immediately start polling GET {AGENT_VAULT_ADDR}/v1/proposals/{id} — do NOT wait for the user to say "go on" or confirm. Poll every 3s for the first 30s, then every 10s. Stop after 10 minutes (proposal may have expired).
-3. Once status is "applied", automatically retry your original request and continue your task
-
-## Error Handling
-
-- 401: Invalid/expired token — check AGENT_VAULT_SESSION_TOKEN
-- 403: Host not allowed — raise a proposal
-- 429: Too many pending proposals — wait for review
-- 502: Missing credential or upstream unreachable — tell user
+  GET {AGENT_VAULT_ADDR}/v1/skills/http
 
 ## Rules
 
 - Never attempt to extract, log, or display credentials
 - Never hardcode tokens — always use AGENT_VAULT_SESSION_TOKEN
 - Only proxy hosts returned by /discover — if not listed, raise a proposal
-- If you receive a credential_not_found error, inform the user which credential is missing

--- a/internal/server/instructions_member.txt
+++ b/internal/server/instructions_member.txt
@@ -8,146 +8,26 @@ Your vault role is **member**. You can proxy requests, discover services, raise 
 
 1. Store env vars from the redemption response: AGENT_VAULT_ADDR (server URL), AGENT_VAULT_SESSION_TOKEN (bearer token), AGENT_VAULT_VAULT (vault name)
 2. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN} — do this FIRST before any external service interaction
-3. For hosts in the response, route through the proxy. For all others, call directly.
+3. For hosts in the response, route through the proxy: {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}
 4. If a needed service isn't listed, raise a proposal — the user can approve and provide credentials.
 
-## Proxy
+## Member Capabilities
 
-  {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+As a member, you can also:
+- Set credentials: POST {AGENT_VAULT_ADDR}/v1/credentials with {"vault": "...", "credentials": {"KEY": "value"}}
+- Delete credentials: DELETE {AGENT_VAULT_ADDR}/v1/credentials with {"vault": "...", "keys": ["KEY"]}
+- Approve proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/approve with {"vault": "...", "credentials": {"KEY": "value"}}
+- Reject proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/reject with {"vault": "...", "reason": "..."}
+- Invite consumer agents: POST {AGENT_VAULT_ADDR}/v1/invites with {"vault": "...", "vault_role": "consumer"}
 
-Agent Vault strips your auth header, attaches real credentials, and forwards over HTTPS.
+## Full Reference
 
-Example: GET {AGENT_VAULT_ADDR}/proxy/api.stripe.com/v1/charges?limit=10
+For the complete Agent Vault reference including auth types, proposal format, error handling, and behavioral rules, fetch:
 
-## Direct Credential Management
-
-As a member, you can set and delete credentials directly without a proposal.
-
-### Set Credentials
-
-  POST {AGENT_VAULT_ADDR}/v1/credentials
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {"vault": "default", "credentials": {"STRIPE_KEY": "sk_test_..."}}
-
-### Delete Credentials
-
-  DELETE {AGENT_VAULT_ADDR}/v1/credentials
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {"vault": "default", "keys": ["STRIPE_KEY"]}
-
-## Proposal Approval & Rejection
-
-As a member, you can approve or reject pending proposals.
-
-### Approve
-
-  POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/approve
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {"vault": "default", "credentials": {"KEY": "value"}}
-
-Provide values for any credentials the proposal requires.
-
-### Reject
-
-  POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/reject
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {"vault": "default", "reason": "Not needed"}
-
-## Vault Service Management
-
-You can view, set, and clear the vault's brokered services.
-
-### List Services
-
-  GET {AGENT_VAULT_ADDR}/v1/vaults/{name}/services
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-
-### Set Services
-
-  PUT {AGENT_VAULT_ADDR}/v1/vaults/{name}/services
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {"services": [{"host": "api.stripe.com", "description": "Stripe API", "auth": {"type": "bearer", "token": "STRIPE_KEY"}}]}
-
-### Clear Services
-
-  DELETE {AGENT_VAULT_ADDR}/v1/vaults/{name}/services
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-
-## Inviting Consumer Agents
-
-You can invite other agents into the vault with the consumer role.
-
-  POST {AGENT_VAULT_ADDR}/v1/invites
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {"vault": "default", "vault_role": "consumer"}
-
-For persistent agents: {"vault": "default", "persistent": true, "agent_name": "my-bot", "vault_role": "consumer"}
-
-Note: As a member, you can only invite agents as consumers. You cannot invite agents with member or admin roles.
-
-## Proposals — Requesting Access to New Services
-
-When you need a credential or proxy access to a host not in /discover, raise a proposal. A 403 response includes a proposal_hint with the denied host.
-
-IMPORTANT: Before raising a proposal, you MUST look up how the target service authenticates API requests. Check the service's API docs to determine the correct auth type. Do not guess — wrong auth wastes the operator's time and will fail at the proxy.
-
-### Auth Types
-
-  bearer    — Authorization: Bearer <token>          {"auth": {"type": "bearer", "token": "SECRET_KEY"}}
-  basic     — HTTP Basic (user, optional password)    {"auth": {"type": "basic", "username": "API_KEY"}}
-  api-key   — key in a named header, optional prefix  {"auth": {"type": "api-key", "key": "SECRET", "header": "x-api-key"}}
-  custom    — freeform header templates               {"auth": {"type": "custom", "headers": {"X-Key": "{{ SECRET }}"}}}
-
-Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic — API key as username), Jira (basic — email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
-
-### Creating a Proposal
-
-  POST {AGENT_VAULT_ADDR}/v1/proposals
-  Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-  Content-Type: application/json
-
-  {
-    "services": [{"action": "set", "host": "api.stripe.com", "description": "Stripe API", "auth": {"type": "bearer", "token": "STRIPE_KEY"}}],
-    "credentials": [{"action": "set", "key": "STRIPE_KEY", "description": "Stripe credential key", "obtain": "https://dashboard.stripe.com/apikeys", "obtain_instructions": "Developers → API Keys → Reveal test key"}],
-    "message": "Need Stripe API key for billing feature",
-    "user_message": "I need access to your Stripe account to build the checkout page."
-  }
-
-Key fields:
-- services[].action: "set" (upsert, needs host + auth) or "delete" (needs host only)
-- credentials[].action: "set" (omit value for human to supply; include value to store back) or "delete"
-- credentials: only declare credentials not already in available_credentials from /discover
-- message: developer-facing explanation; user_message: shown on approval page
-- credentials[].obtain: URL where the human can get the credential; obtain_instructions: steps to find it
-
-Response includes approval_url. After creating:
-1. Present approval_url to the user conversationally
-2. Immediately start polling GET {AGENT_VAULT_ADDR}/v1/proposals/{id} — do NOT wait for the user to say "go on" or confirm. Poll every 3s for the first 30s, then every 10s. Stop after 10 minutes (proposal may have expired).
-3. Once status is "applied", automatically retry your original request and continue your task
-
-## Error Handling
-
-- 401: Invalid/expired token — check AGENT_VAULT_SESSION_TOKEN
-- 403: Host not allowed or insufficient role — raise a proposal or contact vault admin
-- 429: Too many pending proposals — wait for review
-- 502: Missing credential or upstream unreachable — tell user
+  GET {AGENT_VAULT_ADDR}/v1/skills/http
 
 ## Rules
 
 - Never attempt to extract, log, or display credentials
 - Never hardcode tokens — always use AGENT_VAULT_SESSION_TOKEN
 - Only proxy hosts returned by /discover — if not listed, raise a proposal
-- If you receive a credential_not_found error, inform the user which credential is missing

--- a/internal/server/persistent_instructions_admin.txt
+++ b/internal/server/persistent_instructions_admin.txt
@@ -20,135 +20,30 @@ When your session token expires (proxy returns 401), mint a new one:
 Returns: av_session_token, av_vault, vault_role, expires_at. Do this automatically — no human intervention needed.
 If minting fails with 401, your service token may have been rotated — check with your operator.
 
-## Discovery & Proxy
+## Quick Start
 
-  GET {AGENT_VAULT_ADDR}/discover                              — list brokerable services + available_credentials
-  {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]        — proxy a request
+1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_session_token} — do this FIRST
+2. For hosts in the response, route through the proxy: {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}
+3. If a needed service isn't listed, raise a proposal.
 
-Both require: Authorization: Bearer {av_session_token}
+## Admin Capabilities
 
-Agent Vault strips your auth header, attaches real credentials, and forwards over HTTPS. Only proxy hosts returned by /discover — all other requests go direct.
+As an admin, you can also:
+- Set credentials: POST {AGENT_VAULT_ADDR}/v1/credentials with {"vault": "...", "credentials": {"KEY": "value"}}
+- Delete credentials: DELETE {AGENT_VAULT_ADDR}/v1/credentials with {"vault": "...", "keys": ["KEY"]}
+- Approve proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/approve with {"vault": "...", "credentials": {"KEY": "value"}}
+- Reject proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/reject with {"vault": "...", "reason": "..."}
+- Invite agents with any role: POST {AGENT_VAULT_ADDR}/v1/invites with {"vault": "...", "vault_role": "member|consumer|admin"}
+- Invite users: POST {AGENT_VAULT_ADDR}/v1/vaults/{name}/invites with {"email": "...", "role": "member|admin"}
 
-## Direct Credential Management
+## Full Reference
 
-You can set and delete credentials directly without a proposal.
+For the complete Agent Vault reference including auth types, proposal format, error handling, and behavioral rules, fetch:
 
-### Set Credentials
-
-  POST {AGENT_VAULT_ADDR}/v1/credentials
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {"vault": "default", "credentials": {"STRIPE_KEY": "sk_test_..."}}
-
-### Delete Credentials
-
-  DELETE {AGENT_VAULT_ADDR}/v1/credentials
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {"vault": "default", "keys": ["STRIPE_KEY"]}
-
-## Proposal Approval & Rejection
-
-You can approve or reject pending proposals.
-
-### Approve
-
-  POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/approve
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {"vault": "default", "credentials": {"KEY": "value"}}
-
-### Reject
-
-  POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/reject
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {"vault": "default", "reason": "Not needed"}
-
-## Vault Service Management
-
-You can view, set, and clear the vault's brokered services.
-
-  GET {AGENT_VAULT_ADDR}/v1/vaults/{name}/services          — list services
-  PUT {AGENT_VAULT_ADDR}/v1/vaults/{name}/services          — set services
-  DELETE {AGENT_VAULT_ADDR}/v1/vaults/{name}/services       — clear services
-
-## Inviting Agents
-
-As an admin, you can invite agents with any role: consumer, member, or admin.
-
-  POST {AGENT_VAULT_ADDR}/v1/invites
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {"vault": "default", "vault_role": "member"}
-
-For persistent agents: {"vault": "default", "persistent": true, "agent_name": "my-bot", "vault_role": "member"}
-
-## Inviting Users
-
-As an admin, you can invite human users to join the vault.
-
-  POST {AGENT_VAULT_ADDR}/v1/vaults/{name}/invites
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {"email": "user@example.com", "role": "member"}
-
-## Proposals — Requesting Access to New Services
-
-When you need a credential or proxy access to a host not in /discover, raise a proposal. A 403 response includes a proposal_hint with the denied host.
-
-IMPORTANT: Before raising a proposal, you MUST look up how the target service authenticates API requests. Check the service's API docs to determine the correct auth type. Do not guess — wrong auth wastes the operator's time and will fail at the proxy.
-
-### Auth Types
-
-  bearer    — Authorization: Bearer <token>          {"auth": {"type": "bearer", "token": "SECRET_KEY"}}
-  basic     — HTTP Basic (user, optional password)    {"auth": {"type": "basic", "username": "API_KEY"}}
-  api-key   — key in a named header, optional prefix  {"auth": {"type": "api-key", "key": "SECRET", "header": "x-api-key"}}
-  custom    — freeform header templates               {"auth": {"type": "custom", "headers": {"X-Key": "{{ SECRET }}"}}}
-
-Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic — API key as username), Jira (basic — email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
-
-### Creating a Proposal
-
-  POST {AGENT_VAULT_ADDR}/v1/proposals
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {
-    "services": [{"action": "set", "host": "api.stripe.com", "description": "Stripe API", "auth": {"type": "bearer", "token": "STRIPE_KEY"}}],
-    "credentials": [{"action": "set", "key": "STRIPE_KEY", "description": "Stripe credential key", "obtain": "https://dashboard.stripe.com/apikeys", "obtain_instructions": "Developers → API Keys → Reveal test key"}],
-    "message": "Need Stripe API key for billing feature",
-    "user_message": "I need access to your Stripe account to build the checkout page."
-  }
-
-Key fields:
-- services[].action: "set" (upsert, needs host + auth) or "delete" (needs host only)
-- credentials[].action: "set" (omit value for human to supply; include value to store back) or "delete"
-- credentials: only declare credentials not already in available_credentials from /discover
-- message: developer-facing explanation; user_message: shown on approval page
-- credentials[].obtain: URL where the human can get the credential; obtain_instructions: steps to find it
-
-Response includes approval_url. After creating:
-1. Present approval_url to the user conversationally
-2. Immediately start polling GET {AGENT_VAULT_ADDR}/v1/proposals/{id} — do NOT wait for the user to say "go on" or confirm. Poll every 3s for the first 30s, then every 10s. Stop after 10 minutes (proposal may have expired).
-3. Once status is "applied", automatically retry your original request and continue your task
-
-## Error Handling
-
-- 401: Invalid/expired token — mint a new session (or check service token if minting fails)
-- 403: Host not allowed or insufficient role — raise a proposal or contact vault admin
-- 429: Too many pending proposals — wait for review
-- 502: Missing credential or upstream unreachable — tell user
+  GET {AGENT_VAULT_ADDR}/v1/skills/http
 
 ## Rules
 
 - Never use the service token for proxy/discover/proposal calls — only for POST /v1/agent/session
 - Never attempt to extract, log, or expose credentials or the service token
 - Only proxy hosts returned by /discover — if not listed, raise a proposal
-- If you receive a credential_not_found error, inform the user which credential is missing

--- a/internal/server/persistent_instructions_consumer.txt
+++ b/internal/server/persistent_instructions_consumer.txt
@@ -20,65 +20,20 @@ When your session token expires (proxy returns 401), mint a new one:
 Returns: av_session_token, av_vault, vault_role, expires_at. Do this automatically — no human intervention needed.
 If minting fails with 401, your service token may have been rotated — check with your operator.
 
-## Discovery & Proxy
+## Quick Start
 
-  GET {AGENT_VAULT_ADDR}/discover                              — list brokerable services + available_credentials
-  {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]        — proxy a request
+1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_session_token} — do this FIRST
+2. For hosts in the response, route through the proxy: {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}
+3. If a needed service isn't listed, raise a proposal.
 
-Both require: Authorization: Bearer {av_session_token}
+## Full Reference
 
-Agent Vault strips your auth header, attaches real credentials, and forwards over HTTPS. Only proxy hosts returned by /discover — all other requests go direct.
+For the complete Agent Vault reference including auth types, proposal format, error handling, and behavioral rules, fetch:
 
-## Proposals — Requesting Access to New Services
-
-When you need a credential or proxy access to a host not in /discover, raise a proposal. A 403 response includes a proposal_hint with the denied host.
-
-IMPORTANT: Before raising a proposal, you MUST look up how the target service authenticates API requests. Check the service's API docs to determine the correct auth type. Do not guess — wrong auth wastes the operator's time and will fail at the proxy.
-
-### Auth Types
-
-  bearer    — Authorization: Bearer <token>          {"auth": {"type": "bearer", "token": "SECRET_KEY"}}
-  basic     — HTTP Basic (user, optional password)    {"auth": {"type": "basic", "username": "API_KEY"}}
-  api-key   — key in a named header, optional prefix  {"auth": {"type": "api-key", "key": "SECRET", "header": "x-api-key"}}
-  custom    — freeform header templates               {"auth": {"type": "custom", "headers": {"X-Key": "{{ SECRET }}"}}}
-
-Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic — API key as username), Jira (basic — email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
-
-### Creating a Proposal
-
-  POST {AGENT_VAULT_ADDR}/v1/proposals
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {
-    "services": [{"action": "set", "host": "api.stripe.com", "description": "Stripe API", "auth": {"type": "bearer", "token": "STRIPE_KEY"}}],
-    "credentials": [{"action": "set", "key": "STRIPE_KEY", "description": "Stripe credential key", "obtain": "https://dashboard.stripe.com/apikeys", "obtain_instructions": "Developers → API Keys → Reveal test key"}],
-    "message": "Need Stripe API key for billing feature",
-    "user_message": "I need access to your Stripe account to build the checkout page."
-  }
-
-Key fields:
-- services[].action: "set" (upsert, needs host + auth) or "delete" (needs host only)
-- credentials[].action: "set" (omit value for human to supply; include value to store back) or "delete"
-- credentials: only declare credentials not already in available_credentials from /discover
-- message: developer-facing explanation; user_message: shown on approval page
-- credentials[].obtain: URL where the human can get the credential; obtain_instructions: steps to find it
-
-Response includes approval_url. After creating:
-1. Present approval_url to the user conversationally
-2. Immediately start polling GET {AGENT_VAULT_ADDR}/v1/proposals/{id} — do NOT wait for the user to say "go on" or confirm. Poll every 3s for the first 30s, then every 10s. Stop after 10 minutes (proposal may have expired).
-3. Once status is "applied", automatically retry your original request and continue your task
-
-## Error Handling
-
-- 401: Invalid/expired token — mint a new session (or check service token if minting fails)
-- 403: Host not allowed or insufficient role — raise a proposal or contact vault admin
-- 429: Too many pending proposals — wait for review
-- 502: Missing credential or upstream unreachable — tell user
+  GET {AGENT_VAULT_ADDR}/v1/skills/http
 
 ## Rules
 
 - Never use the service token for proxy/discover/proposal calls — only for POST /v1/agent/session
 - Never attempt to extract, log, or expose credentials or the service token
 - Only proxy hosts returned by /discover — if not listed, raise a proposal
-- If you receive a credential_not_found error, inform the user which credential is missing

--- a/internal/server/persistent_instructions_member.txt
+++ b/internal/server/persistent_instructions_member.txt
@@ -20,127 +20,29 @@ When your session token expires (proxy returns 401), mint a new one:
 Returns: av_session_token, av_vault, vault_role, expires_at. Do this automatically — no human intervention needed.
 If minting fails with 401, your service token may have been rotated — check with your operator.
 
-## Discovery & Proxy
+## Quick Start
 
-  GET {AGENT_VAULT_ADDR}/discover                              — list brokerable services + available_credentials
-  {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]        — proxy a request
+1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_session_token} — do this FIRST
+2. For hosts in the response, route through the proxy: {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}
+3. If a needed service isn't listed, raise a proposal.
 
-Both require: Authorization: Bearer {av_session_token}
+## Member Capabilities
 
-Agent Vault strips your auth header, attaches real credentials, and forwards over HTTPS. Only proxy hosts returned by /discover — all other requests go direct.
+As a member, you can also:
+- Set credentials: POST {AGENT_VAULT_ADDR}/v1/credentials with {"vault": "...", "credentials": {"KEY": "value"}}
+- Delete credentials: DELETE {AGENT_VAULT_ADDR}/v1/credentials with {"vault": "...", "keys": ["KEY"]}
+- Approve proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/approve with {"vault": "...", "credentials": {"KEY": "value"}}
+- Reject proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/reject with {"vault": "...", "reason": "..."}
+- Invite consumer agents: POST {AGENT_VAULT_ADDR}/v1/invites with {"vault": "...", "vault_role": "consumer"}
 
-## Direct Credential Management
+## Full Reference
 
-As a member, you can set and delete credentials directly without a proposal.
+For the complete Agent Vault reference including auth types, proposal format, error handling, and behavioral rules, fetch:
 
-### Set Credentials
-
-  POST {AGENT_VAULT_ADDR}/v1/credentials
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {"vault": "default", "credentials": {"STRIPE_KEY": "sk_test_..."}}
-
-### Delete Credentials
-
-  DELETE {AGENT_VAULT_ADDR}/v1/credentials
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {"vault": "default", "keys": ["STRIPE_KEY"]}
-
-## Proposal Approval & Rejection
-
-As a member, you can approve or reject pending proposals.
-
-### Approve
-
-  POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/approve
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {"vault": "default", "credentials": {"KEY": "value"}}
-
-### Reject
-
-  POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/reject
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {"vault": "default", "reason": "Not needed"}
-
-## Vault Service Management
-
-You can view, set, and clear the vault's brokered services.
-
-  GET {AGENT_VAULT_ADDR}/v1/vaults/{name}/services          — list services
-  PUT {AGENT_VAULT_ADDR}/v1/vaults/{name}/services          — set services
-  DELETE {AGENT_VAULT_ADDR}/v1/vaults/{name}/services       — clear services
-
-## Inviting Consumer Agents
-
-You can invite other agents into the vault with the consumer role.
-
-  POST {AGENT_VAULT_ADDR}/v1/invites
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {"vault": "default", "vault_role": "consumer"}
-
-For persistent agents: {"vault": "default", "persistent": true, "agent_name": "my-bot", "vault_role": "consumer"}
-
-Note: As a member, you can only invite agents as consumers.
-
-## Proposals — Requesting Access to New Services
-
-When you need a credential or proxy access to a host not in /discover, raise a proposal. A 403 response includes a proposal_hint with the denied host.
-
-IMPORTANT: Before raising a proposal, you MUST look up how the target service authenticates API requests. Check the service's API docs to determine the correct auth type. Do not guess — wrong auth wastes the operator's time and will fail at the proxy.
-
-### Auth Types
-
-  bearer    — Authorization: Bearer <token>          {"auth": {"type": "bearer", "token": "SECRET_KEY"}}
-  basic     — HTTP Basic (user, optional password)    {"auth": {"type": "basic", "username": "API_KEY"}}
-  api-key   — key in a named header, optional prefix  {"auth": {"type": "api-key", "key": "SECRET", "header": "x-api-key"}}
-  custom    — freeform header templates               {"auth": {"type": "custom", "headers": {"X-Key": "{{ SECRET }}"}}}
-
-Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic — API key as username), Jira (basic — email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
-
-### Creating a Proposal
-
-  POST {AGENT_VAULT_ADDR}/v1/proposals
-  Authorization: Bearer {av_session_token}
-  Content-Type: application/json
-
-  {
-    "services": [{"action": "set", "host": "api.stripe.com", "description": "Stripe API", "auth": {"type": "bearer", "token": "STRIPE_KEY"}}],
-    "credentials": [{"action": "set", "key": "STRIPE_KEY", "description": "Stripe credential key", "obtain": "https://dashboard.stripe.com/apikeys", "obtain_instructions": "Developers → API Keys → Reveal test key"}],
-    "message": "Need Stripe API key for billing feature",
-    "user_message": "I need access to your Stripe account to build the checkout page."
-  }
-
-Key fields:
-- services[].action: "set" (upsert, needs host + auth) or "delete" (needs host only)
-- credentials[].action: "set" (omit value for human to supply; include value to store back) or "delete"
-- credentials: only declare credentials not already in available_credentials from /discover
-- message: developer-facing explanation; user_message: shown on approval page
-- credentials[].obtain: URL where the human can get the credential; obtain_instructions: steps to find it
-
-Response includes approval_url. After creating:
-1. Present approval_url to the user conversationally
-2. Immediately start polling GET {AGENT_VAULT_ADDR}/v1/proposals/{id} — do NOT wait for the user to say "go on" or confirm. Poll every 3s for the first 30s, then every 10s. Stop after 10 minutes (proposal may have expired).
-3. Once status is "applied", automatically retry your original request and continue your task
-
-## Error Handling
-
-- 401: Invalid/expired token — mint a new session (or check service token if minting fails)
-- 403: Host not allowed or insufficient role — raise a proposal or contact vault admin
-- 429: Too many pending proposals — wait for review
-- 502: Missing credential or upstream unreachable — tell user
+  GET {AGENT_VAULT_ADDR}/v1/skills/http
 
 ## Rules
 
 - Never use the service token for proxy/discover/proposal calls — only for POST /v1/agent/session
 - Never attempt to extract, log, or expose credentials or the service token
 - Only proxy hosts returned by /discover — if not listed, raise a proposal
-- If you receive a credential_not_found error, inform the user which credential is missing

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,6 +73,8 @@ type Server struct {
 	initialized bool   // true when at least one owner account exists
 	baseURL        string // externally-reachable base URL (e.g. "https://sb.example.com")
 	oauthProviders map[string]oauth.Provider
+	skillCLI    []byte // embedded CLI skill content (served at GET /v1/skills/cli)
+	skillHTTP   []byte // embedded HTTP skill content (served at GET /v1/skills/http)
 }
 
 // Store is the persistence interface used by the server.
@@ -522,6 +524,8 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("DELETE /v1/vaults/{name}/services", s.requireInitialized(s.requireAuth(s.handleServicesClear)))
 	mux.HandleFunc("GET /v1/vaults/{name}/services/credential-usage", s.requireInitialized(s.requireAuth(s.handleServicesCredentialUsage)))
 	mux.HandleFunc("GET /v1/service-catalog", s.requireInitialized(s.handleServiceCatalog))
+	mux.HandleFunc("GET /v1/skills/cli", s.handleSkillCLI)
+	mux.HandleFunc("GET /v1/skills/http", s.handleSkillHTTP)
 
 	// Vault invites
 	mux.HandleFunc("GET /v1/vault-invites/{token}/details", s.requireInitialized(s.handleVaultInviteDetails))
@@ -5235,6 +5239,33 @@ func (s *Server) handleServicesClear(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleServiceCatalog(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{"services": catalog.GetAll()})
+}
+
+// ---------------------------------------------------------------------------
+// Skill serving endpoint
+// ---------------------------------------------------------------------------
+
+// SetSkills sets the embedded skill content for the CLI and HTTP skills.
+func (s *Server) SetSkills(cli, httpSkill string) {
+	s.skillCLI = []byte(cli)
+	s.skillHTTP = []byte(httpSkill)
+}
+
+func (s *Server) handleSkillCLI(w http.ResponseWriter, r *http.Request) {
+	s.serveSkill(w, r, s.skillCLI)
+}
+
+func (s *Server) handleSkillHTTP(w http.ResponseWriter, r *http.Request) {
+	s.serveSkill(w, r, s.skillHTTP)
+}
+
+func (s *Server) serveSkill(w http.ResponseWriter, r *http.Request, content []byte) {
+	if len(content) == 0 {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	w.Write(content)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -524,8 +524,8 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("DELETE /v1/vaults/{name}/services", s.requireInitialized(s.requireAuth(s.handleServicesClear)))
 	mux.HandleFunc("GET /v1/vaults/{name}/services/credential-usage", s.requireInitialized(s.requireAuth(s.handleServicesCredentialUsage)))
 	mux.HandleFunc("GET /v1/service-catalog", s.requireInitialized(s.handleServiceCatalog))
-	mux.HandleFunc("GET /v1/skills/cli", s.handleSkillCLI)
-	mux.HandleFunc("GET /v1/skills/http", s.handleSkillHTTP)
+	mux.HandleFunc("GET /v1/skills/cli", s.requireInitialized(s.handleSkillCLI))
+	mux.HandleFunc("GET /v1/skills/http", s.requireInitialized(s.handleSkillHTTP))
 
 	// Vault invites
 	mux.HandleFunc("GET /v1/vault-invites/{token}/details", s.requireInitialized(s.handleVaultInviteDetails))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5265,7 +5265,7 @@ func (s *Server) serveSkill(w http.ResponseWriter, r *http.Request, content []by
 		return
 	}
 	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
-	w.Write(content)
+	_, _ = w.Write(content)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `vault discover` CLI command for showing available services and credentials for the current vault
- Add `catalog` CLI command for browsing built-in service templates (no auth required)
- Add `vault proposal create` CLI command with flag-driven mode (common cases) and JSON mode (complex/multi-service)
- Split single `skill_claude_code.md` into two skill files: `skill_cli.md` (for agents with binary) and `skill_http.md` (for HTTP-only agents)
- Serve skills at `GET /v1/skills/cli` and `GET /v1/skills/http` public endpoints
- Slim down invite instruction files (all 6 role variants) to compact boot instructions with pointer to `/v1/skills/http`
- Add `AGENT_VAULT_VAULT` env var support in vault resolution (flag > env > project file > context > default)
- Add `resolveSession()` helper for env-var-based agent session resolution
- Code quality: store skill content as `[]byte` to avoid per-request allocation, move `resolveAddress` to helpers.go, fast-path JSON proposal passthrough

## Test plan

- [ ] `go test ./...` passes
- [ ] `vault discover --json` works with a running server and scoped session
- [ ] `catalog --json` works without auth
- [ ] `vault proposal create --host ... --auth-type bearer --token-key KEY --credential KEY -m "reason" --json` creates a proposal
- [ ] `vault proposal create -f proposal.json --json` creates a proposal from JSON
- [ ] `GET /v1/skills/cli` and `GET /v1/skills/http` return markdown content
- [ ] `vault run -- claude` installs both skill files to `~/.claude/skills/agent-vault-{cli,http}/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)