### PR TITLE
fix: validate services_json parse in ProposalsTab

### DIFF
--- a/web/src/pages/vault/ProposalsTab.tsx
+++ b/web/src/pages/vault/ProposalsTab.tsx
@@ -395,7 +395,10 @@ function deriveProposalTitle(cs: Proposal): {
 } {
   let services: { action: string; host: string; description?: string }[] = [];
   try {
-    if (cs.services_json) services = JSON.parse(cs.services_json) || [];
+    if (cs.services_json) {
+      const parsed = JSON.parse(cs.services_json);
+      if (Array.isArray(parsed)) services = parsed;
+    }
   } catch {
     // ignore
   }


### PR DESCRIPTION
## Summary
- Adds `Array.isArray` guard after `JSON.parse(cs.services_json)` to prevent non-array values from being assigned to the services variable in `deriveProposalTitle`

## Test plan
- [ ] Verify proposals tab renders correctly with valid services JSON
- [ ] Verify no crash when `services_json` contains a non-array value

🤖 Generated with [Claude Code](https://claude.com/claude-code)