### PR TITLE
feat: instance-level user invites with vault pre-assignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,11 +61,15 @@ Agent Vault requires two things before it becomes operational: a **master passwo
   - `agent-vault vault delete <name>` -- delete a vault (vault admin or instance owner; cannot delete the default vault; use `--yes` to skip confirmation)
   - `agent-vault vault rename <old-name> <new-name>` -- rename a vault (vault admin or instance owner; cannot rename the default vault)
   - `agent-vault vault init` -- bind the current directory to a vault by writing `agent-vault.json` (interactive picker; use `--vault` to skip picker). The file is meant to be committed so the whole team shares the vault binding. Vault resolution priority: `--vault` flag > `AGENT_VAULT_VAULT` env var > `agent-vault.json` > user context > `"default"`.
-  - `agent-vault vault user [invite|list|remove|set-role]` -- manage vault user access
-    - `agent-vault vault user invite <email> [--vault <name>] [--role admin|member]` -- invite a user to a vault
-    - `agent-vault vault user list [--vault <name>]` -- list vault users
+  - `agent-vault vault user [add|list|remove|set-role]` -- manage vault user access
+    - `agent-vault vault user add <email> [--vault <name>] [--role admin|member]` -- add an existing instance user to a vault (direct grant, no invite needed)
+    - `agent-vault vault user list [--vault <name>]` -- list vault users (includes pending invite pre-assignments with "pending" status)
     - `agent-vault vault user remove <email> [--vault <name>]` -- remove a user from a vault
     - `agent-vault vault user set-role <email> --role admin|member [--vault <name>]` -- change a user's vault role
+- `agent-vault user invite` -- instance-level user invite commands (any authenticated user)
+  - `agent-vault user invite <email> [--vault <name>:<role> ...]` -- invite a user to the Agent Vault instance with optional vault pre-assignments (repeatable --vault flag, format: `name:role`, role defaults to `member`)
+  - `agent-vault user invite list [--status pending]` -- list user invites
+  - `agent-vault user invite revoke <token_suffix>` -- revoke a pending invite
 - `agent-vault users` -- list all users in the instance (any authenticated user; owners see vault memberships, members see email/role/created)
 - `agent-vault owner user [list|info|remove|set-role]` -- manage users (owner only, except `info` for self)
   - `agent-vault owner user list` -- list all users
@@ -291,17 +295,21 @@ Agent Vault uses two independent permission axes:
 
 The first user to register is always an instance owner and is automatically invited as vault admin on the default vault. User deletion removes the user and their vault grants but leaves vaults intact. Orphaned vaults (no remaining members) can be recovered by an instance owner joining them.
 
-### Vault Invite API
+### User Invite API
 
-Vault-scoped invites let vault admins onboard human users. The invitee receives an email with a link to a browser-based acceptance page. For new users, they set their password on acceptance; for existing users, the vault grant is applied immediately on acceptance.
+Instance-level invites let any authenticated user invite people to Agent Vault. Invites optionally pre-assign vault access (vault admins can pre-assign their vaults; owners can pre-assign any vault). The invitee receives an email with a link to a browser-based acceptance page. For new users, they set their password on acceptance; for existing users, the invite is accepted immediately and pre-assigned vault grants are applied.
 
-- `POST /v1/vaults/{name}/invites` -- vault admin creates an invite; body: `{"email": "...", "role": "admin|member"}`. Sends HTML email if SMTP configured; always returns `invite_link` in response. 48-hour TTL, max 50 pending.
-- `GET /v1/vaults/{name}/invites` -- list invites for vault (vault admin only)
-- `DELETE /v1/vaults/{name}/invites/{token}` -- revoke a pending invite (vault admin only)
-- `GET /vault-invite/{token}` -- serves the browser acceptance page (no auth, token is credential)
-- `POST /v1/vault-invites/{token}/accept` -- accept invite (no auth); body: `{"password": "..."}` for new users, empty for existing users. Validates token, creates account if needed, grants vault membership.
+- `POST /v1/users/invites` -- any authenticated user creates an invite; body: `{"email": "...", "vaults": [{"vault_name": "...", "vault_role": "admin|member"}]}`. Vaults array is optional. Sends HTML email if SMTP configured; always returns `invite_link` in response. 48-hour TTL, max 50 pending.
+- `GET /v1/users/invites?status=pending` -- list invites (owners see all; others see invites they created or with pre-assignments to vaults they admin)
+- `DELETE /v1/users/invites/{token}` -- revoke a pending invite
+- `GET /v1/users/invites/{token}/details` -- public, token-based details for the acceptance page
+- `POST /v1/users/invites/{token}/accept` -- accept invite (no auth); body: `{"password": "..."}` for new users, empty for existing users. Creates account if needed, applies pre-assigned vault grants.
+- `GET /invite/{token}` -- serves the browser acceptance page (no auth, token is credential)
 
-Invite states: `pending`, `accepted`, `expired`, or `revoked`. Token format: `av_uinv_` + 64 hex chars. Duplicate pending invites for the same email+vault are blocked.
+Adding existing users to vaults is a direct grant (no invite needed):
+- `POST /v1/vaults/{name}/users` -- vault admin adds an existing instance user; body: `{"email": "...", "role": "admin|member"}`. User must exist (404 if not), must not already have access (409 if so).
+
+Invite states: `pending`, `accepted`, `expired`, or `revoked`. Token format: `av_uinv_` + 64 hex chars. Duplicate pending invites for the same email are blocked.
 
 ### User Management API
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -25,7 +25,7 @@ func TestCommandsRegistered(t *testing.T) {
 		registered[c.Name()] = true
 	}
 
-	expected := []string{"server", "auth", "vault", "owner", "account", "catalog"}
+	expected := []string{"server", "auth", "vault", "owner", "account", "catalog", "user"}
 	for _, name := range expected {
 		if !registered[name] {
 			t.Errorf("expected command %q to be registered, but it was not", name)
@@ -667,6 +667,58 @@ func TestDiscoverFlagsRegistered(t *testing.T) {
 
 	if dCmd.Flags().Lookup("json") == nil {
 		t.Error("expected --json flag on discover command")
+	}
+}
+
+func TestUserInviteSubcommandsRegistered(t *testing.T) {
+	uCmd := findSubcommand(rootCmd, "user")
+	if uCmd == nil {
+		t.Fatal("user command not found")
+	}
+	invCmd := findSubcommand(uCmd, "invite")
+	if invCmd == nil {
+		t.Fatal("invite command not found under user")
+	}
+
+	registered := make(map[string]bool)
+	for _, c := range invCmd.Commands() {
+		registered[c.Name()] = true
+	}
+
+	expected := []string{"list", "revoke"}
+	for _, name := range expected {
+		if !registered[name] {
+			t.Errorf("expected user invite subcommand %q to be registered, but it was not", name)
+		}
+	}
+
+	// Verify --vault flag on invite command
+	f := invCmd.Flags().Lookup("vault")
+	if f == nil {
+		t.Fatal("expected --vault flag on user invite command")
+	}
+}
+
+func TestVaultUserAddSubcommandRegistered(t *testing.T) {
+	vCmd := findSubcommand(rootCmd, "vault")
+	if vCmd == nil {
+		t.Fatal("vault command not found")
+	}
+	userCmd := findSubcommand(vCmd, "user")
+	if userCmd == nil {
+		t.Fatal("user command not found under vault")
+	}
+
+	registered := make(map[string]bool)
+	for _, c := range userCmd.Commands() {
+		registered[c.Name()] = true
+	}
+
+	if !registered["add"] {
+		t.Error("expected vault user subcommand \"add\" to be registered, but it was not")
+	}
+	if !registered["list"] {
+		t.Error("expected vault user subcommand \"list\" to be registered, but it was not")
 	}
 }
 

--- a/cmd/user_invite.go
+++ b/cmd/user_invite.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+// topUserCmd is the top-level "user" command (distinct from the owner-scoped userCmd).
+var topUserCmd = &cobra.Command{
+	Use:   "user",
+	Short: "User commands (invites)",
+}
+
+var userInviteCmd = &cobra.Command{
+	Use:   "invite <email>",
+	Short: "Invite a user to the instance",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		email := args[0]
+
+		sess, err := ensureSession()
+		if err != nil {
+			return err
+		}
+
+		vaultFlags, _ := cmd.Flags().GetStringArray("vault")
+
+		type vaultEntry struct {
+			VaultName string `json:"vault_name"`
+			VaultRole string `json:"vault_role"`
+		}
+
+		var vaults []vaultEntry
+		for _, v := range vaultFlags {
+			name, role, _ := strings.Cut(v, ":")
+			if role == "" {
+				role = "member"
+			}
+			vaults = append(vaults, vaultEntry{VaultName: name, VaultRole: role})
+		}
+
+		payload := map[string]any{
+			"email": email,
+		}
+		if len(vaults) > 0 {
+			payload["vaults"] = vaults
+		}
+
+		body, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+
+		reqURL := fmt.Sprintf("%s/v1/users/invites", sess.Address)
+		respBody, err := doAdminRequestWithBody("POST", reqURL, sess.Token, body)
+		if err != nil {
+			return err
+		}
+
+		var resp struct {
+			Email     string `json:"email"`
+			EmailSent bool   `json:"email_sent"`
+			InviteLink string `json:"invite_link"`
+		}
+		_ = json.Unmarshal(respBody, &resp)
+
+		if resp.EmailSent {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s Invitation sent to %s\n", successText("✓"), resp.Email)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s Invite created for %s\n", successText("✓"), resp.Email)
+			fmt.Fprintf(cmd.OutOrStdout(), "  Share this link: %s\n", resp.InviteLink)
+		}
+		return nil
+	},
+}
+
+var userInviteListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List user invites",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sess, err := ensureSession()
+		if err != nil {
+			return err
+		}
+
+		status, _ := cmd.Flags().GetString("status")
+		reqURL := fmt.Sprintf("%s/v1/users/invites", sess.Address)
+		if status != "" {
+			reqURL += "?status=" + status
+		}
+
+		respBody, err := doAdminRequestWithBody("GET", reqURL, sess.Token, nil)
+		if err != nil {
+			return err
+		}
+
+		var resp struct {
+			Invites []struct {
+				Email     string `json:"email"`
+				Status    string `json:"status"`
+				CreatedBy string `json:"created_by"`
+				CreatedAt string `json:"created_at"`
+				ExpiresAt string `json:"expires_at"`
+				Vaults    []struct {
+					VaultName string `json:"vault_name"`
+					VaultRole string `json:"vault_role"`
+				} `json:"vaults"`
+			} `json:"invites"`
+		}
+		if err := json.Unmarshal(respBody, &resp); err != nil {
+			return fmt.Errorf("parsing response: %w", err)
+		}
+
+		if len(resp.Invites) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No invites found.")
+			return nil
+		}
+
+		t := newTable(cmd.OutOrStdout())
+		t.AppendHeader(table.Row{"EMAIL", "STATUS", "VAULTS", "INVITED BY", "CREATED", "EXPIRES"})
+		for _, inv := range resp.Invites {
+			var vaultParts []string
+			for _, v := range inv.Vaults {
+				vaultParts = append(vaultParts, fmt.Sprintf("%s:%s", v.VaultName, v.VaultRole))
+			}
+			vaults := strings.Join(vaultParts, ", ")
+			if vaults == "" {
+				vaults = "-"
+			}
+			created := inv.CreatedAt
+			if parsed, err := time.Parse(time.RFC3339, inv.CreatedAt); err == nil {
+				created = parsed.Format("2006-01-02 15:04")
+			}
+			expires := inv.ExpiresAt
+			if parsed, err := time.Parse(time.RFC3339, inv.ExpiresAt); err == nil {
+				expires = parsed.Format("2006-01-02 15:04")
+			}
+			t.AppendRow(table.Row{inv.Email, inv.Status, vaults, inv.CreatedBy, created, expires})
+		}
+		t.Render()
+		return nil
+	},
+}
+
+var userInviteRevokeCmd = &cobra.Command{
+	Use:   "revoke <token_suffix>",
+	Short: "Revoke a pending invite",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tokenSuffix := args[0]
+
+		sess, err := ensureSession()
+		if err != nil {
+			return err
+		}
+
+		reqURL := fmt.Sprintf("%s/v1/users/invites/%s", sess.Address, tokenSuffix)
+		if err := doAdminRequest("DELETE", reqURL, sess.Token, nil); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "%s Invite revoked\n", successText("✓"))
+		return nil
+	},
+}
+
+func init() {
+	userInviteCmd.Flags().StringArray("vault", nil, "vault pre-assignment (format: name:role, role defaults to member)")
+	userInviteListCmd.Flags().String("status", "", "filter by status (pending, accepted, expired, revoked)")
+
+	userInviteCmd.AddCommand(userInviteListCmd, userInviteRevokeCmd)
+	topUserCmd.AddCommand(userInviteCmd)
+	rootCmd.AddCommand(topUserCmd)
+}

--- a/cmd/vaults.go
+++ b/cmd/vaults.go
@@ -140,9 +140,9 @@ var vaultUserCmd = &cobra.Command{
 	Short: "Manage vault users",
 }
 
-var vaultUserInviteCmd = &cobra.Command{
-	Use:   "invite <email>",
-	Short: "Invite a user to this vault",
+var vaultUserAddCmd = &cobra.Command{
+	Use:   "add <email>",
+	Short: "Add an existing instance user to this vault",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		email := args[0]
@@ -162,23 +162,12 @@ var vaultUserInviteCmd = &cobra.Command{
 			return err
 		}
 
-		reqURL := fmt.Sprintf("%s/v1/vaults/%s/invites", sess.Address, vaultName)
-		respBody, err := doAdminRequestWithBody("POST", reqURL, sess.Token, body)
-		if err != nil {
+		reqURL := fmt.Sprintf("%s/v1/vaults/%s/users", sess.Address, vaultName)
+		if _, err := doAdminRequestWithBody("POST", reqURL, sess.Token, body); err != nil {
 			return err
 		}
 
-		var result struct {
-			EmailSent  bool   `json:"email_sent"`
-			InviteLink string `json:"invite_link"`
-		}
-		_ = json.Unmarshal(respBody, &result)
-
-		if result.EmailSent {
-			fmt.Fprintf(cmd.OutOrStdout(), "%s Invitation sent to %s (vault: %s, role: %s)\n", successText("✓"), email, vaultName, role)
-		} else {
-			fmt.Fprintf(cmd.OutOrStdout(), "%s Invitation created. Share this link:\n  %s\n", successText("✓"), result.InviteLink)
-		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s Added %s to vault %s (role: %s)\n", successText("✓"), email, vaultName, role)
 		return nil
 	},
 }
@@ -203,8 +192,9 @@ var vaultUserListCmd = &cobra.Command{
 
 		var resp struct {
 			Users []struct {
-				Email string `json:"email"`
-				Role  string `json:"role"`
+				Email  string `json:"email"`
+				Role   string `json:"role"`
+				Status string `json:"status"`
 			} `json:"users"`
 		}
 		if err := json.Unmarshal(respBody, &resp); err != nil {
@@ -217,9 +207,9 @@ var vaultUserListCmd = &cobra.Command{
 		}
 
 		t := newTable(cmd.OutOrStdout())
-		t.AppendHeader(table.Row{"EMAIL", "ROLE"})
+		t.AppendHeader(table.Row{"EMAIL", "STATUS", "ROLE"})
 		for _, m := range resp.Users {
-			t.AppendRow(table.Row{m.Email, m.Role})
+			t.AppendRow(table.Row{m.Email, m.Status, m.Role})
 		}
 		t.Render()
 		return nil
@@ -358,10 +348,10 @@ func init() {
 	vaultCmd.AddCommand(vaultUseCmd)
 	vaultCmd.AddCommand(vaultCurrentCmd)
 
-	vaultUserInviteCmd.Flags().String("role", "member", "role to grant (admin or member)")
+	vaultUserAddCmd.Flags().String("role", "member", "role to grant (admin or member)")
 	vaultUserSetRoleCmd.Flags().String("role", "", "role to set (admin or member)")
 
-	vaultUserCmd.AddCommand(vaultUserInviteCmd, vaultUserListCmd, vaultUserRemoveCmd, vaultUserSetRoleCmd)
+	vaultUserCmd.AddCommand(vaultUserAddCmd, vaultUserListCmd, vaultUserRemoveCmd, vaultUserSetRoleCmd)
 	vaultCmd.AddCommand(vaultUserCmd)
 
 	rootCmd.AddCommand(vaultCmd)

--- a/internal/server/instructions_admin.txt
+++ b/internal/server/instructions_admin.txt
@@ -19,7 +19,7 @@ As an admin, you can also:
 - Approve proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/approve with {"vault": "...", "credentials": {"KEY": "value"}}
 - Reject proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/reject with {"vault": "...", "reason": "..."}
 - Invite agents with any role: POST {AGENT_VAULT_ADDR}/v1/invites with {"vault": "...", "vault_role": "member|proxy|admin"}
-- Invite users: POST {AGENT_VAULT_ADDR}/v1/vaults/{name}/invites with {"email": "...", "role": "member|admin"}
+- Invite users: POST {AGENT_VAULT_ADDR}/v1/users/invites with {"email": "...", "vaults": [{"vault_name": "...", "vault_role": "member|admin"}]}
 
 ## Full Reference
 

--- a/internal/server/invite_email.html
+++ b/internal/server/invite_email.html
@@ -34,7 +34,7 @@
           </tr>
           <tr><td colspan="2" style="height:10px;"></td></tr>
           <tr>
-            <td style="font-family:'Anonymous Pro',Consolas,monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:#8b949e;">Vault</td>
+            <td style="font-family:'Anonymous Pro',Consolas,monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:#8b949e;">Vaults</td>
             <td align="right" style="font-family:'Anonymous Pro',Consolas,monospace;font-size:13px;color:#E7F256;">{{VAULTS}}</td>
           </tr>
           <tr><td colspan="2" style="height:10px;"></td></tr>

--- a/internal/server/persistent_instructions_admin.txt
+++ b/internal/server/persistent_instructions_admin.txt
@@ -22,7 +22,7 @@ As an admin, you can also:
 - Approve proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/approve with {"vault": "...", "credentials": {"KEY": "value"}}
 - Reject proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/reject with {"vault": "...", "reason": "..."}
 - Invite agents with any role: POST {AGENT_VAULT_ADDR}/v1/invites with {"vault": "...", "vault_role": "member|proxy|admin"}
-- Invite users: POST {AGENT_VAULT_ADDR}/v1/vaults/{name}/invites with {"email": "...", "role": "member|admin"}
+- Invite users: POST {AGENT_VAULT_ADDR}/v1/users/invites with {"email": "...", "vaults": [{"vault_name": "...", "vault_role": "member|admin"}]}
 
 ## Full Reference
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -148,15 +148,16 @@ type Store interface {
 	CountPendingInvites(ctx context.Context, vaultID string) (int, error)
 	ExpirePendingInvites(ctx context.Context, before time.Time) (int, error)
 
-	// Vault invites
-	CreateVaultInvite(ctx context.Context, email, vaultID, vaultRole, createdBy string, expiresAt time.Time) (*store.VaultInvite, error)
-	GetVaultInviteByToken(ctx context.Context, token string) (*store.VaultInvite, error)
-	GetPendingVaultInviteByEmailAndVault(ctx context.Context, email, vaultID string) (*store.VaultInvite, error)
-	ListVaultInvites(ctx context.Context, vaultID, status string) ([]store.VaultInvite, error)
-	AcceptVaultInvite(ctx context.Context, token string) error
-	RevokeVaultInvite(ctx context.Context, token, vaultID string) error
-	UpdateVaultInviteRole(ctx context.Context, token, vaultID, newRole string) error
-	CountPendingVaultInvites(ctx context.Context, vaultID string) (int, error)
+	// User invites (instance-level)
+	CreateUserInvite(ctx context.Context, email, createdBy string, expiresAt time.Time, vaults []store.UserInviteVault) (*store.UserInvite, error)
+	GetUserInviteByToken(ctx context.Context, token string) (*store.UserInvite, error)
+	GetPendingUserInviteByEmail(ctx context.Context, email string) (*store.UserInvite, error)
+	ListUserInvites(ctx context.Context, status string) ([]store.UserInvite, error)
+	ListUserInvitesByVault(ctx context.Context, vaultID, status string) ([]store.UserInvite, error)
+	AcceptUserInvite(ctx context.Context, token string) error
+	RevokeUserInvite(ctx context.Context, token string) error
+	UpdateUserInviteVaults(ctx context.Context, token string, vaults []store.UserInviteVault) error
+	CountPendingUserInvites(ctx context.Context) (int, error)
 
 	// Email verification
 	CreateEmailVerification(ctx context.Context, email, code string, expiresAt time.Time) (*store.EmailVerification, error)
@@ -250,6 +251,22 @@ func (s *Server) requireOwner(w http.ResponseWriter, r *http.Request) (*store.Us
 	if user.Role != "owner" {
 		jsonError(w, http.StatusForbidden, "Owner role required")
 		return nil, fmt.Errorf("not owner")
+	}
+	return user, nil
+}
+
+// requireUser checks that the request is from a logged-in user (any role).
+// Writes a 403 and returns a non-nil error if the check fails.
+func (s *Server) requireUser(w http.ResponseWriter, r *http.Request) (*store.User, error) {
+	sess := sessionFromContext(r.Context())
+	if sess == nil || sess.UserID == "" {
+		jsonError(w, http.StatusForbidden, "User session required")
+		return nil, fmt.Errorf("no user session")
+	}
+	user, err := s.userFromSession(r.Context(), sess)
+	if err != nil || user == nil {
+		jsonError(w, http.StatusForbidden, "User session required")
+		return nil, fmt.Errorf("user not found")
 	}
 	return user, nil
 }
@@ -531,19 +548,17 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("GET /v1/skills/cli", s.requireInitialized(s.handleSkillCLI))
 	mux.HandleFunc("GET /v1/skills/http", s.requireInitialized(s.handleSkillHTTP))
 
-	// Vault invites
-	mux.HandleFunc("GET /v1/vault-invites/{token}/details", s.requireInitialized(s.handleVaultInviteDetails))
-	mux.HandleFunc("POST /v1/vault-invites/{token}/accept", s.requireInitialized(limitBody(s.handleVaultInviteAccept)))
-
-	// Vault invite management (vault admin)
-	mux.HandleFunc("POST /v1/vaults/{name}/invites", s.requireInitialized(s.requireAuth(limitBody(s.handleVaultInviteCreate))))
-	mux.HandleFunc("GET /v1/vaults/{name}/invites", s.requireInitialized(s.requireAuth(s.handleVaultInviteList)))
-	mux.HandleFunc("DELETE /v1/vaults/{name}/invites/{token}", s.requireInitialized(s.requireAuth(s.handleVaultInviteRevoke)))
-	mux.HandleFunc("POST /v1/vaults/{name}/invites/{token}/reinvite", s.requireInitialized(s.requireAuth(limitBody(s.handleVaultInviteReinvite))))
-	mux.HandleFunc("PATCH /v1/vaults/{name}/invites/{token}", s.requireInitialized(s.requireAuth(limitBody(s.handleVaultInviteUpdate))))
+	// Instance-level user invites
+	mux.HandleFunc("POST /v1/users/invites", s.requireInitialized(s.requireAuth(limitBody(s.handleUserInviteCreate))))
+	mux.HandleFunc("GET /v1/users/invites", s.requireInitialized(s.requireAuth(s.handleUserInviteList)))
+	mux.HandleFunc("DELETE /v1/users/invites/{token}", s.requireInitialized(s.requireAuth(s.handleUserInviteRevoke)))
+	mux.HandleFunc("POST /v1/users/invites/{token}/reinvite", s.requireInitialized(s.requireAuth(limitBody(s.handleUserInviteReinvite))))
+	mux.HandleFunc("GET /v1/users/invites/{token}/details", s.requireInitialized(s.handleUserInviteDetails))
+	mux.HandleFunc("POST /v1/users/invites/{token}/accept", s.requireInitialized(limitBody(s.handleUserInviteAccept)))
 
 	// Vault user management (vault admin)
 	mux.HandleFunc("GET /v1/vaults/{name}/users", s.requireInitialized(s.requireAuth(s.handleVaultUserList)))
+	mux.HandleFunc("POST /v1/vaults/{name}/users", s.requireInitialized(s.requireAuth(limitBody(s.handleVaultUserAdd))))
 	mux.HandleFunc("DELETE /v1/vaults/{name}/users/{email}", s.requireInitialized(s.requireAuth(s.handleVaultUserRemove)))
 	mux.HandleFunc("POST /v1/vaults/{name}/users/{email}/role", s.requireInitialized(s.requireAuth(limitBody(s.handleVaultUserSetRole))))
 
@@ -576,7 +591,7 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("GET /register", s.handleSPA)
 	mux.HandleFunc("GET /vaults/{$}", s.handleSPA)
 	mux.HandleFunc("GET /vaults/{name...}", s.handleSPA)
-	mux.HandleFunc("GET /vault-invite/{token...}", s.handleSPA)
+	mux.HandleFunc("GET /invite/{token...}", s.handleSPA)
 	mux.HandleFunc("GET /approve/{id...}", s.handleSPA)
 	mux.HandleFunc("GET /manage/{path...}", s.handleSPA)
 	mux.HandleFunc("GET /change-password", s.handleSPA)
@@ -1282,12 +1297,12 @@ func (s *Server) handleVaultContext(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleVaultInviteDetails returns vault invite details as JSON (token-based, no auth).
-func (s *Server) handleVaultInviteDetails(w http.ResponseWriter, r *http.Request) {
+// handleUserInviteDetails returns instance-level invite details as JSON (token-based, no auth).
+func (s *Server) handleUserInviteDetails(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	token := r.PathValue("token")
 
-	inv, err := s.store.GetVaultInviteByToken(ctx, token)
+	inv, err := s.store.GetUserInviteByToken(ctx, token)
 	if err != nil || inv == nil {
 		jsonError(w, http.StatusNotFound, "Invite not found")
 		return
@@ -1298,21 +1313,21 @@ func (s *Server) handleVaultInviteDetails(w http.ResponseWriter, r *http.Request
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"error": true, "error_title": "Already Accepted",
-			"error_message": "This invitation has already been accepted. You can log in using 'agent-vault auth login'.",
+			"error_message": "This invitation has already been accepted. You can log in.",
 		})
 		return
 	case "revoked":
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"error": true, "error_title": "Invite Revoked",
-			"error_message": "This invitation was revoked. Please ask the vault admin for a new one.",
+			"error_message": "This invitation was revoked. Please ask for a new one.",
 		})
 		return
 	case "expired":
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"error": true, "error_title": "Invite Expired",
-			"error_message": "This invitation has expired. Please ask the vault admin for a new one.",
+			"error_message": "This invitation has expired. Please ask for a new one.",
 		})
 		return
 	}
@@ -1321,15 +1336,9 @@ func (s *Server) handleVaultInviteDetails(w http.ResponseWriter, r *http.Request
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"error": true, "error_title": "Invite Expired",
-			"error_message": "This invitation has expired. Please ask the vault admin for a new one.",
+			"error_message": "This invitation has expired. Please ask for a new one.",
 		})
 		return
-	}
-
-	vault, _ := s.store.GetVaultByID(ctx, inv.VaultID)
-	vaultName := ""
-	if vault != nil {
-		vaultName = vault.Name
 	}
 
 	existing, _ := s.store.GetUserByEmail(ctx, inv.Email)
@@ -1337,10 +1346,8 @@ func (s *Server) handleVaultInviteDetails(w http.ResponseWriter, r *http.Request
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"token":         inv.Token,
 		"email":         inv.Email,
-		"vault_name":    vaultName,
-		"vault_role":    inv.VaultRole,
+		"vaults":        vaultsToJSON(inv.Vaults),
 		"needs_account": needsAccount,
 	})
 }
@@ -1596,7 +1603,7 @@ var (
 	registerLimiter          = newSlidingWindowLimiter(loginRateWindow, 5, 10000) // 5 registrations per IP per 5 min
 	forgotPasswordLimiter    = newSlidingWindowLimiter(loginRateWindow, 5, 10000) // 5 forgot-password requests per IP per 5 min
 	resendVerifyLimiter      = newSlidingWindowLimiter(loginRateWindow, 5, 10000) // 5 resend-verification requests per IP per 5 min
-	vaultInviteAcceptLimiter = newSlidingWindowLimiter(loginRateWindow, 10, 10000) // 10 invite accepts per IP per 5 min
+	userInviteAcceptLimiter = newSlidingWindowLimiter(loginRateWindow, 10, 10000) // 10 invite accepts per IP per 5 min
 	resetVerifyLimiter    = &verifyRateLimiter{attempts: make(map[string]int), maxKeys: maxVerifyKeys}
 )
 
@@ -3622,28 +3629,72 @@ func (s *Server) handleEmailTest(w http.ResponseWriter, r *http.Request) {
 
 // --- Vault Invite Endpoints ---
 
-const vaultInviteTTL = 48 * time.Hour
-const maxPendingVaultInvites = 50
+const userInviteTTL = 48 * time.Hour
+const maxPendingUserInvites = 100
 
-func (s *Server) handleVaultInviteCreate(w http.ResponseWriter, r *http.Request) {
-	vaultName := r.PathValue("name")
-	ctx := r.Context()
+// userInviteVaultJSON is the JSON response shape for vault pre-assignments on invites.
+type userInviteVaultJSON struct {
+	VaultName string `json:"vault_name"`
+	VaultRole string `json:"vault_role"`
+}
 
-	vault, err := s.store.GetVault(ctx, vaultName)
-	if err != nil || vault == nil {
-		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", vaultName))
-		return
+func vaultsToJSON(vaults []store.UserInviteVault) []userInviteVaultJSON {
+	items := make([]userInviteVaultJSON, len(vaults))
+	for i, v := range vaults {
+		items[i] = userInviteVaultJSON{VaultName: v.VaultName, VaultRole: v.VaultRole}
+	}
+	return items
+}
+
+// sendUserInviteEmail sends the invite email. Returns true if sent.
+// On send failure, writes a JSON response directly and returns false.
+func (s *Server) sendUserInviteEmail(w http.ResponseWriter, recipientEmail, inviterEmail, inviteLink, subject string, vaults []store.UserInviteVault, expiresAt time.Time) bool {
+	if !s.notifier.Enabled() {
+		return false
+	}
+	vaultNames := make([]string, len(vaults))
+	for i, v := range vaults {
+		vaultNames[i] = v.VaultName
+	}
+	vaultsStr := "No vaults pre-assigned"
+	if len(vaultNames) > 0 {
+		vaultsStr = strings.Join(vaultNames, ", ")
 	}
 
-	// Vault user invites require admin role (user vault admin or admin agent).
-	user, err := s.requireVaultAdminSession(w, r, vault.ID)
+	emailHTML := userInviteEmailHTML
+	emailHTML = strings.ReplaceAll(emailHTML, "{{INVITER_EMAIL}}", html.EscapeString(inviterEmail))
+	emailHTML = strings.ReplaceAll(emailHTML, "{{VAULTS}}", html.EscapeString(vaultsStr))
+	emailHTML = strings.ReplaceAll(emailHTML, "{{INVITE_LINK}}", html.EscapeString(inviteLink))
+
+	if err := s.notifier.SendHTMLMail([]string{recipientEmail}, subject, emailHTML); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"email":       recipientEmail,
+			"invite_link": inviteLink,
+			"email_sent":  false,
+			"email_error": fmt.Sprintf("failed to send email: %v", err),
+			"expires_at":  expiresAt.Format(time.RFC3339),
+		})
+		return false
+	}
+	return true
+}
+
+func (s *Server) handleUserInviteCreate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	user, err := s.requireUser(w, r)
 	if err != nil {
 		return
 	}
 
 	var req struct {
-		Email string `json:"email"`
-		Role  string `json:"role"`
+		Email  string `json:"email"`
+		Vaults []struct {
+			VaultName string `json:"vault_name"`
+			VaultRole string `json:"vault_role"`
+		} `json:"vaults"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, http.StatusBadRequest, "Invalid request body")
@@ -3653,27 +3704,17 @@ func (s *Server) handleVaultInviteCreate(w http.ResponseWriter, r *http.Request)
 		jsonError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if req.Role == "" {
-		req.Role = "member"
-	}
-	if req.Role != "admin" && req.Role != "member" {
-		jsonError(w, http.StatusBadRequest, "Role must be 'admin' or 'member'")
-		return
-	}
 
-	// Check for existing pending invite for this email+vault.
-	if pending, _ := s.store.GetPendingVaultInviteByEmailAndVault(ctx, req.Email, vault.ID); pending != nil {
-		jsonError(w, http.StatusConflict, fmt.Sprintf("A pending invite already exists for %q in vault %q", req.Email, vaultName))
-		return
-	}
-
-	// Check if user already has access to this vault.
+	// Check if user already exists in the instance.
 	if existing, _ := s.store.GetUserByEmail(ctx, req.Email); existing != nil {
-		has, _ := s.store.HasVaultAccess(ctx, existing.ID, vault.ID)
-		if has {
-			jsonError(w, http.StatusConflict, fmt.Sprintf("User %q already has access to vault %q", req.Email, vaultName))
-			return
-		}
+		jsonError(w, http.StatusConflict, fmt.Sprintf("User %q already has an account. Use vault user management to add them to a vault.", req.Email))
+		return
+	}
+
+	// Check for existing pending invite for this email.
+	if pending, _ := s.store.GetPendingUserInviteByEmail(ctx, req.Email); pending != nil {
+		jsonError(w, http.StatusConflict, fmt.Sprintf("A pending invite already exists for %q", req.Email))
+		return
 	}
 
 	// Check allowed email domains.
@@ -3683,62 +3724,58 @@ func (s *Server) handleVaultInviteCreate(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Check pending invite limit.
-	count, err := s.store.CountPendingVaultInvites(ctx, vault.ID)
+	count, err := s.store.CountPendingUserInvites(ctx)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to count pending invites")
 		return
 	}
-	if count >= maxPendingVaultInvites {
-		jsonError(w, http.StatusTooManyRequests, "Too many pending vault invites")
+	if count >= maxPendingUserInvites {
+		jsonError(w, http.StatusTooManyRequests, "Too many pending invites")
 		return
 	}
 
-	createdBy := "agent"
-	inviterLabel := "an agent"
-	if user != nil {
-		createdBy = user.ID
-		inviterLabel = user.Email
+	// Resolve and validate vault pre-assignments.
+	var vaults []store.UserInviteVault
+	for _, v := range req.Vaults {
+		if v.VaultRole == "" {
+			v.VaultRole = "member"
+		}
+		if v.VaultRole != "admin" && v.VaultRole != "member" {
+			jsonError(w, http.StatusBadRequest, fmt.Sprintf("Vault role must be 'admin' or 'member', got %q", v.VaultRole))
+			return
+		}
+		vault, err := s.store.GetVault(ctx, v.VaultName)
+		if err != nil || vault == nil {
+			jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", v.VaultName))
+			return
+		}
+		// Non-owners must be admin of each pre-assigned vault.
+		if user.Role != "owner" {
+			role, _ := s.store.GetVaultRole(ctx, user.ID, vault.ID)
+			if role != "admin" {
+				jsonError(w, http.StatusForbidden, fmt.Sprintf("You must be an admin of vault %q to pre-assign it", v.VaultName))
+				return
+			}
+		}
+		vaults = append(vaults, store.UserInviteVault{VaultID: vault.ID, VaultName: vault.Name, VaultRole: v.VaultRole})
 	}
 
-	inv, err := s.store.CreateVaultInvite(ctx, req.Email, vault.ID, req.Role, createdBy, time.Now().Add(vaultInviteTTL))
+	inv, err := s.store.CreateUserInvite(ctx, req.Email, user.ID, time.Now().Add(userInviteTTL), vaults)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create invite")
 		return
 	}
 
-	baseURL := s.baseURL
-	inviteLink := baseURL + "/vault-invite/" + inv.Token
+	inviteLink := s.baseURL + "/invite/" + inv.Token
 
-	// Send email if SMTP is configured.
-	emailSent := false
-	if s.notifier.Enabled() {
-		emailHTML := userInviteEmailHTML
-		emailHTML = strings.ReplaceAll(emailHTML, "{{INVITER_EMAIL}}", html.EscapeString(inviterLabel))
-		emailHTML = strings.ReplaceAll(emailHTML, "{{VAULTS}}", html.EscapeString(vaultName))
-		emailHTML = strings.ReplaceAll(emailHTML, "{{INVITE_LINK}}", html.EscapeString(inviteLink))
-
-		if err := s.notifier.SendHTMLMail(
-			[]string{req.Email},
-			fmt.Sprintf("You've been invited to vault %q on Agent Vault", vaultName),
-			emailHTML,
-		); err != nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"email":       req.Email,
-				"invite_link": inviteLink,
-				"email_sent":  false,
-				"email_error": fmt.Sprintf("failed to send email: %v", err),
-				"expires_at":  inv.ExpiresAt.Format(time.RFC3339),
-			})
-			return
-		}
-		emailSent = true
+	emailSent := s.sendUserInviteEmail(w, req.Email, user.Email, inviteLink, "You've been invited to Agent Vault", vaults, inv.ExpiresAt)
+	if !emailSent && s.notifier.Enabled() {
+		return // error response already written by sendUserInviteEmail
 	}
 
 	resp := map[string]interface{}{
 		"email":      req.Email,
-		"role":       req.Role,
+		"vaults":     vaultsToJSON(vaults),
 		"email_sent": emailSent,
 		"expires_at": inv.ExpiresAt.Format(time.RFC3339),
 	}
@@ -3773,9 +3810,9 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 }
 
 
-func (s *Server) handleVaultInviteAccept(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleUserInviteAccept(w http.ResponseWriter, r *http.Request) {
 	ip := clientIP(r)
-	if !vaultInviteAcceptLimiter.allow(ip) {
+	if !userInviteAcceptLimiter.allow(ip) {
 		jsonError(w, http.StatusTooManyRequests, "Too many requests. Please try again later.")
 		return
 	}
@@ -3789,7 +3826,7 @@ func (s *Server) handleVaultInviteAccept(w http.ResponseWriter, r *http.Request)
 	// Body may be empty for existing users.
 	_ = json.NewDecoder(r.Body).Decode(&req)
 
-	inv, err := s.store.GetVaultInviteByToken(ctx, token)
+	inv, err := s.store.GetUserInviteByToken(ctx, token)
 	if err != nil || inv == nil {
 		jsonError(w, http.StatusNotFound, "Invite not found")
 		return
@@ -3815,8 +3852,7 @@ func (s *Server) handleVaultInviteAccept(w http.ResponseWriter, r *http.Request)
 	// Does the invitee already have an account?
 	existing, _ := s.store.GetUserByEmail(ctx, inv.Email)
 
-	// For new users, validate password and domain BEFORE claiming the invite
-	// so the invite isn't burned on a validation failure.
+	// For new users, validate password and domain BEFORE claiming the invite.
 	if existing == nil {
 		if msg := s.checkEmailDomain(ctx, inv.Email); msg != "" {
 			jsonError(w, http.StatusForbidden, msg)
@@ -3829,9 +3865,7 @@ func (s *Server) handleVaultInviteAccept(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Atomically claim the invite (prevents double-spend race).
-	// AcceptVaultInvite uses UPDATE ... WHERE status='pending', so only
-	// the first concurrent request succeeds.
-	if err := s.store.AcceptVaultInvite(ctx, token); err != nil {
+	if err := s.store.AcceptUserInvite(ctx, token); err != nil {
 		jsonError(w, http.StatusGone, "This invite has already been accepted")
 		return
 	}
@@ -3839,12 +3873,8 @@ func (s *Server) handleVaultInviteAccept(w http.ResponseWriter, r *http.Request)
 	var user *store.User
 
 	if existing != nil {
-		// Existing user — just grant vault role, no password needed.
 		user = existing
 	} else {
-
-		// New user — password already validated above.
-
 		hash, salt, kdfP, err := auth.HashUserPassword([]byte(req.Password))
 		if err != nil {
 			jsonError(w, http.StatusInternalServerError, "Failed to hash password")
@@ -3864,15 +3894,20 @@ func (s *Server) handleVaultInviteAccept(w http.ResponseWriter, r *http.Request)
 		user = newUser
 	}
 
-	// Grant vault access with the invited role.
-	if err := s.store.GrantVaultRole(ctx, user.ID, inv.VaultID, inv.VaultRole); err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to grant vault access")
-		return
+	// Grant pre-assigned vault access.
+	for _, v := range inv.Vaults {
+		if err := s.store.GrantVaultRole(ctx, user.ID, v.VaultID, v.VaultRole); err != nil {
+			jsonError(w, http.StatusInternalServerError, "Failed to grant vault access")
+			return
+		}
 	}
 
-	msg := "Vault access granted."
-	if existing == nil {
-		msg = "Account created and vault access granted. You can now log in using 'agent-vault auth login'."
+	msg := "Account created."
+	if existing != nil {
+		msg = "Invite accepted."
+	}
+	if len(inv.Vaults) > 0 {
+		msg += " Vault access granted."
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -3882,68 +3917,107 @@ func (s *Server) handleVaultInviteAccept(w http.ResponseWriter, r *http.Request)
 	})
 }
 
-func (s *Server) handleVaultInviteList(w http.ResponseWriter, r *http.Request) {
-	vaultName := r.PathValue("name")
+func (s *Server) handleUserInviteList(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	vault, err := s.store.GetVault(ctx, vaultName)
-	if err != nil || vault == nil {
-		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", vaultName))
-		return
-	}
-
-	if _, err := s.requireVaultAdminSession(w, r, vault.ID); err != nil {
+	user, err := s.requireUser(w, r)
+	if err != nil {
 		return
 	}
 
 	status := r.URL.Query().Get("status")
-	invites, err := s.store.ListVaultInvites(ctx, vault.ID, status)
+	invites, err := s.store.ListUserInvites(ctx, status)
 	if err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to list vault invites")
+		jsonError(w, http.StatusInternalServerError, "Failed to list invites")
 		return
 	}
 
-	type inviteItem struct {
-		Email     string `json:"email"`
-		Token     string `json:"token"`
-		Status    string `json:"status"`
-		Role      string `json:"role"`
-		ExpiresAt string `json:"expires_at"`
-		CreatedAt string `json:"created_at"`
+	// Non-owners only see invites they created or invites with pre-assignments to vaults they admin.
+	if user.Role != "owner" {
+		userGrants, _ := s.store.ListUserGrants(ctx, user.ID)
+		adminVaultIDs := map[string]bool{}
+		for _, g := range userGrants {
+			if g.Role == "admin" {
+				adminVaultIDs[g.VaultID] = true
+			}
+		}
+
+		var filtered []store.UserInvite
+		for _, inv := range invites {
+			if inv.CreatedBy == user.ID {
+				filtered = append(filtered, inv)
+				continue
+			}
+			for _, v := range inv.Vaults {
+				if adminVaultIDs[v.VaultID] {
+					filtered = append(filtered, inv)
+					break
+				}
+			}
+		}
+		invites = filtered
 	}
 
-	items := make([]inviteItem, len(invites))
-	for i, inv := range invites {
-		items[i] = inviteItem{
+	type inviteItem struct {
+		Email     string                `json:"email"`
+		Token     string                `json:"token"`
+		Status    string                `json:"status"`
+		CreatedBy string                `json:"created_by"`
+		Vaults    []userInviteVaultJSON `json:"vaults"`
+		ExpiresAt string                `json:"expires_at"`
+		CreatedAt string                `json:"created_at"`
+	}
+
+	items := make([]inviteItem, 0, len(invites))
+	for _, inv := range invites {
+		items = append(items, inviteItem{
 			Email:     inv.Email,
 			Token:     inv.Token,
 			Status:    inv.Status,
-			Role:      inv.VaultRole,
+			CreatedBy: inv.CreatedBy,
+			Vaults:    vaultsToJSON(inv.Vaults),
 			ExpiresAt: inv.ExpiresAt.Format(time.RFC3339),
 			CreatedAt: inv.CreatedAt.Format(time.RFC3339),
-		}
+		})
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{"invites": items})
 }
 
-func (s *Server) handleVaultInviteRevoke(w http.ResponseWriter, r *http.Request) {
-	vaultName := r.PathValue("name")
+func (s *Server) handleUserInviteRevoke(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	vault, err := s.store.GetVault(ctx, vaultName)
-	if err != nil || vault == nil {
-		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", vaultName))
-		return
-	}
-
-	if _, err := s.requireVaultAdminSession(w, r, vault.ID); err != nil {
+	user, err := s.requireUser(w, r)
+	if err != nil {
 		return
 	}
 
 	token := r.PathValue("token")
-	if err := s.store.RevokeVaultInvite(ctx, token, vault.ID); err != nil {
+
+	inv, err := s.store.GetUserInviteByToken(ctx, token)
+	if err != nil || inv == nil || inv.Status != "pending" {
+		jsonError(w, http.StatusNotFound, "Invite not found or not pending")
+		return
+	}
+
+	// Authorization: creator, owner, or admin of a pre-assigned vault
+	allowed := inv.CreatedBy == user.Email || user.Role == "owner"
+	if !allowed {
+		for _, v := range inv.Vaults {
+			role, _ := s.store.GetVaultRole(ctx, user.ID, v.VaultID)
+			if role == "admin" {
+				allowed = true
+				break
+			}
+		}
+	}
+	if !allowed {
+		jsonError(w, http.StatusForbidden, "You don't have permission to revoke this invite")
+		return
+	}
+
+	if err := s.store.RevokeUserInvite(ctx, token); err != nil {
 		jsonError(w, http.StatusNotFound, "Invite not found or not pending")
 		return
 	}
@@ -3952,39 +4026,20 @@ func (s *Server) handleVaultInviteRevoke(w http.ResponseWriter, r *http.Request)
 	json.NewEncoder(w).Encode(map[string]string{"message": "Invite revoked"})
 }
 
-// handleVaultInviteReinvite revokes an existing pending invite and creates a
-// new one for the same email/role, generating a fresh token and link.
-func (s *Server) handleVaultInviteReinvite(w http.ResponseWriter, r *http.Request) {
-	vaultName := r.PathValue("name")
+// handleUserInviteReinvite revokes an existing pending invite and creates a
+// new one for the same email/vault assignments, generating a fresh token and link.
+func (s *Server) handleUserInviteReinvite(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	vault, err := s.store.GetVault(ctx, vaultName)
-	if err != nil || vault == nil {
-		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", vaultName))
-		return
-	}
-
-	user, err := s.requireVaultAdminSession(w, r, vault.ID)
+	user, err := s.requireUser(w, r)
 	if err != nil {
 		return
 	}
 
-	createdBy := "agent"
-	inviterLabel := "an agent"
-	if user != nil {
-		createdBy = user.ID
-		inviterLabel = user.Email
-	}
-
 	token := r.PathValue("token")
 
-	// Look up the existing invite to get email and role.
-	existing, err := s.store.GetVaultInviteByToken(ctx, token)
+	existing, err := s.store.GetUserInviteByToken(ctx, token)
 	if err != nil || existing == nil {
-		jsonError(w, http.StatusNotFound, "Invite not found")
-		return
-	}
-	if existing.VaultID != vault.ID {
 		jsonError(w, http.StatusNotFound, "Invite not found")
 		return
 	}
@@ -3994,52 +4049,27 @@ func (s *Server) handleVaultInviteReinvite(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Revoke the old invite.
-	if err := s.store.RevokeVaultInvite(ctx, token, vault.ID); err != nil {
+	if err := s.store.RevokeUserInvite(ctx, token); err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to revoke old invite")
 		return
 	}
 
-	// Create a new invite with the same email and role.
-	inv, err := s.store.CreateVaultInvite(ctx, existing.Email, vault.ID, existing.VaultRole, createdBy, time.Now().Add(vaultInviteTTL))
+	// Create a new invite with the same email and vault assignments.
+	inv, err := s.store.CreateUserInvite(ctx, existing.Email, user.ID, time.Now().Add(userInviteTTL), existing.Vaults)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create new invite")
 		return
 	}
 
-	inviteLink := s.baseURL + "/vault-invite/" + inv.Token
+	inviteLink := s.baseURL + "/invite/" + inv.Token
 
-	// Send email if SMTP is configured.
-	emailSent := false
-	if s.notifier.Enabled() {
-		emailHTML := userInviteEmailHTML
-		emailHTML = strings.ReplaceAll(emailHTML, "{{INVITER_EMAIL}}", html.EscapeString(inviterLabel))
-		emailHTML = strings.ReplaceAll(emailHTML, "{{VAULTS}}", html.EscapeString(vaultName))
-		emailHTML = strings.ReplaceAll(emailHTML, "{{INVITE_LINK}}", html.EscapeString(inviteLink))
-
-		if err := s.notifier.SendHTMLMail(
-			[]string{existing.Email},
-			fmt.Sprintf("You've been re-invited to vault %q on Agent Vault", vaultName),
-			emailHTML,
-		); err != nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusCreated)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"email":       existing.Email,
-				"token":       inv.Token,
-				"invite_link": inviteLink,
-				"email_sent":  false,
-				"email_error": fmt.Sprintf("failed to send email: %v", err),
-				"expires_at":  inv.ExpiresAt.Format(time.RFC3339),
-			})
-			return
-		}
-		emailSent = true
+	emailSent := s.sendUserInviteEmail(w, existing.Email, user.Email, inviteLink, "You've been re-invited to Agent Vault", existing.Vaults, inv.ExpiresAt)
+	if !emailSent && s.notifier.Enabled() {
+		return // error response already written by sendUserInviteEmail
 	}
 
 	resp := map[string]interface{}{
 		"email":      existing.Email,
-		"token":      inv.Token,
-		"role":       existing.VaultRole,
 		"email_sent": emailSent,
 		"expires_at": inv.ExpiresAt.Format(time.RFC3339),
 	}
@@ -4050,44 +4080,6 @@ func (s *Server) handleVaultInviteReinvite(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(resp)
-}
-
-// handleVaultInviteUpdate updates a pending invite's role in place.
-func (s *Server) handleVaultInviteUpdate(w http.ResponseWriter, r *http.Request) {
-	vaultName := r.PathValue("name")
-	ctx := r.Context()
-
-	vault, err := s.store.GetVault(ctx, vaultName)
-	if err != nil || vault == nil {
-		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", vaultName))
-		return
-	}
-
-	if _, err := s.requireVaultAdminSession(w, r, vault.ID); err != nil {
-		return
-	}
-
-	token := r.PathValue("token")
-
-	var req struct {
-		Role string `json:"role"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		jsonError(w, http.StatusBadRequest, "Invalid request body")
-		return
-	}
-	if req.Role != "admin" && req.Role != "member" {
-		jsonError(w, http.StatusBadRequest, "Role must be 'admin' or 'member'")
-		return
-	}
-
-	if err := s.store.UpdateVaultInviteRole(ctx, token, vault.ID, req.Role); err != nil {
-		jsonError(w, http.StatusNotFound, "Invite not found or not pending")
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"role": req.Role})
 }
 
 // --- Vault User Endpoints ---
@@ -4113,8 +4105,9 @@ func (s *Server) handleVaultUserList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type userItem struct {
-		Email string `json:"email"`
-		Role  string `json:"role"`
+		Email  string `json:"email"`
+		Role   string `json:"role"`
+		Status string `json:"status"`
 	}
 
 	var users []userItem
@@ -4123,11 +4116,82 @@ func (s *Server) handleVaultUserList(w http.ResponseWriter, r *http.Request) {
 		if err != nil || u == nil {
 			continue
 		}
-		users = append(users, userItem{Email: u.Email, Role: g.Role})
+		users = append(users, userItem{Email: u.Email, Role: g.Role, Status: "active"})
+	}
+
+	// Include pending invite entries for this vault.
+	pendingInvites, _ := s.store.ListUserInvitesByVault(ctx, vault.ID, "pending")
+	for _, inv := range pendingInvites {
+		for _, v := range inv.Vaults {
+			if v.VaultID == vault.ID {
+				users = append(users, userItem{Email: inv.Email, Role: v.VaultRole, Status: "pending"})
+				break
+			}
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{"users": users})
+}
+
+// handleVaultUserAdd adds an existing instance user to a vault directly.
+func (s *Server) handleVaultUserAdd(w http.ResponseWriter, r *http.Request) {
+	vaultName := r.PathValue("name")
+	ctx := r.Context()
+
+	vault, err := s.store.GetVault(ctx, vaultName)
+	if err != nil || vault == nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", vaultName))
+		return
+	}
+
+	if _, err := s.requireVaultAdminSession(w, r, vault.ID); err != nil {
+		return
+	}
+
+	var req struct {
+		Email string `json:"email"`
+		Role  string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	if err := auth.ValidateEmail(req.Email); err != nil {
+		jsonError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.Role == "" {
+		req.Role = "member"
+	}
+	if req.Role != "admin" && req.Role != "member" {
+		jsonError(w, http.StatusBadRequest, "Role must be 'admin' or 'member'")
+		return
+	}
+
+	target, err := s.store.GetUserByEmail(ctx, req.Email)
+	if err != nil || target == nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("User %q not found in this instance", req.Email))
+		return
+	}
+
+	has, _ := s.store.HasVaultAccess(ctx, target.ID, vault.ID)
+	if has {
+		jsonError(w, http.StatusConflict, fmt.Sprintf("User %q already has access to vault %q", req.Email, vaultName))
+		return
+	}
+
+	if err := s.store.GrantVaultRole(ctx, target.ID, vault.ID, req.Role); err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to grant vault access")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"email": req.Email,
+		"role":  req.Role,
+	})
 }
 
 func (s *Server) handleVaultUserRemove(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -33,7 +33,7 @@ type mockStore struct {
 	invites            map[string]*store.Invite              // keyed by token
 	users              map[string]*store.User                // keyed by email
 	grants             map[string]map[string]string          // keyed by userID -> vaultID -> role
-	vaultInvites       map[string]*store.VaultInvite         // keyed by token
+	userInvites        map[string]*store.UserInvite           // keyed by token
 	emailVerifications []*store.EmailVerification
 	passwordResets     []*store.PasswordReset
 	agents             map[string]*store.Agent               // keyed by name
@@ -49,7 +49,7 @@ func newMockStore() *mockStore {
 		brokerConfigs: make(map[string]*store.BrokerConfig),
 		invites:       make(map[string]*store.Invite),
 		users:         make(map[string]*store.User),
-		vaultInvites:  make(map[string]*store.VaultInvite),
+		userInvites:   make(map[string]*store.UserInvite),
 		agents:        make(map[string]*store.Agent),
 		settings:      make(map[string]string),
 	}
@@ -593,54 +593,69 @@ func (m *mockStore) SetMasterKeyRecord(_ context.Context, record *store.MasterKe
 	return nil
 }
 
-// --- Vault Invite mock methods ---
+// --- User Invite mock methods ---
 
-func (m *mockStore) CreateVaultInvite(_ context.Context, email, vaultID, vaultRole, createdBy string, expiresAt time.Time) (*store.VaultInvite, error) {
-	token := "av_vinv_testtoken_" + email
-	inv := &store.VaultInvite{
-		ID:        len(m.vaultInvites) + 1,
+func (m *mockStore) CreateUserInvite(_ context.Context, email, createdBy string, expiresAt time.Time, vaults []store.UserInviteVault) (*store.UserInvite, error) {
+	token := "av_uinv_testtoken_" + email
+	inv := &store.UserInvite{
+		ID:        len(m.userInvites) + 1,
 		Token:     token,
 		Email:     email,
-		VaultID:   vaultID,
-		VaultRole: vaultRole,
 		Status:    "pending",
 		CreatedBy: createdBy,
 		CreatedAt: time.Now(),
 		ExpiresAt: expiresAt,
+		Vaults:    vaults,
 	}
-	m.vaultInvites[token] = inv
+	m.userInvites[token] = inv
 	return inv, nil
 }
 
-func (m *mockStore) GetVaultInviteByToken(_ context.Context, token string) (*store.VaultInvite, error) {
-	inv, ok := m.vaultInvites[token]
+func (m *mockStore) GetUserInviteByToken(_ context.Context, token string) (*store.UserInvite, error) {
+	inv, ok := m.userInvites[token]
 	if !ok {
-		return nil, fmt.Errorf("vault invite not found")
+		return nil, fmt.Errorf("user invite not found")
 	}
 	return inv, nil
 }
 
-func (m *mockStore) GetPendingVaultInviteByEmailAndVault(_ context.Context, email, vaultID string) (*store.VaultInvite, error) {
-	for _, inv := range m.vaultInvites {
-		if inv.Email == email && inv.VaultID == vaultID && inv.Status == "pending" && time.Now().Before(inv.ExpiresAt) {
+func (m *mockStore) GetPendingUserInviteByEmail(_ context.Context, email string) (*store.UserInvite, error) {
+	for _, inv := range m.userInvites {
+		if inv.Email == email && inv.Status == "pending" && time.Now().Before(inv.ExpiresAt) {
 			return inv, nil
 		}
 	}
 	return nil, nil
 }
 
-func (m *mockStore) ListVaultInvites(_ context.Context, vaultID, status string) ([]store.VaultInvite, error) {
-	var result []store.VaultInvite
-	for _, inv := range m.vaultInvites {
-		if inv.VaultID == vaultID && (status == "" || inv.Status == status) {
+func (m *mockStore) ListUserInvites(_ context.Context, status string) ([]store.UserInvite, error) {
+	var result []store.UserInvite
+	for _, inv := range m.userInvites {
+		if status == "" || inv.Status == status {
 			result = append(result, *inv)
 		}
 	}
 	return result, nil
 }
 
-func (m *mockStore) AcceptVaultInvite(_ context.Context, token string) error {
-	inv, ok := m.vaultInvites[token]
+func (m *mockStore) ListUserInvitesByVault(_ context.Context, vaultID, status string) ([]store.UserInvite, error) {
+	var result []store.UserInvite
+	for _, inv := range m.userInvites {
+		if status != "" && inv.Status != status {
+			continue
+		}
+		for _, v := range inv.Vaults {
+			if v.VaultID == vaultID {
+				result = append(result, *inv)
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStore) AcceptUserInvite(_ context.Context, token string) error {
+	inv, ok := m.userInvites[token]
 	if !ok || inv.Status != "pending" {
 		return fmt.Errorf("not found or not pending")
 	}
@@ -650,28 +665,28 @@ func (m *mockStore) AcceptVaultInvite(_ context.Context, token string) error {
 	return nil
 }
 
-func (m *mockStore) RevokeVaultInvite(_ context.Context, token, vaultID string) error {
-	inv, ok := m.vaultInvites[token]
-	if !ok || inv.Status != "pending" || inv.VaultID != vaultID {
+func (m *mockStore) RevokeUserInvite(_ context.Context, token string) error {
+	inv, ok := m.userInvites[token]
+	if !ok || inv.Status != "pending" {
 		return fmt.Errorf("not found or not pending")
 	}
 	inv.Status = "revoked"
 	return nil
 }
 
-func (m *mockStore) UpdateVaultInviteRole(_ context.Context, token, vaultID, newRole string) error {
-	inv, ok := m.vaultInvites[token]
-	if !ok || inv.Status != "pending" || inv.VaultID != vaultID {
+func (m *mockStore) UpdateUserInviteVaults(_ context.Context, token string, vaults []store.UserInviteVault) error {
+	inv, ok := m.userInvites[token]
+	if !ok || inv.Status != "pending" {
 		return fmt.Errorf("not found or not pending")
 	}
-	inv.VaultRole = newRole
+	inv.Vaults = vaults
 	return nil
 }
 
-func (m *mockStore) CountPendingVaultInvites(_ context.Context, vaultID string) (int, error) {
+func (m *mockStore) CountPendingUserInvites(_ context.Context) (int, error) {
 	count := 0
-	for _, inv := range m.vaultInvites {
-		if inv.VaultID == vaultID && inv.Status == "pending" {
+	for _, inv := range m.userInvites {
+		if inv.Status == "pending" {
 			count++
 		}
 	}
@@ -4214,13 +4229,13 @@ func TestOwnerVaultJoinNotFound(t *testing.T) {
 	}
 }
 
-func TestVaultInviteCreateBlockedByAllowedDomains(t *testing.T) {
+func TestUserInviteCreateBlockedByAllowedDomains(t *testing.T) {
 	ms, token := setupMockStoreWithSession(t)
 	ms.settings[settingAllowedDomains] = `["acme.com"]`
 	srv := New(":0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
 
-	body := `{"email":"user@gmail.com","role":"member"}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/vaults/default/invites", strings.NewReader(body))
+	body := `{"email":"user@gmail.com"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/invites", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)
@@ -4230,13 +4245,13 @@ func TestVaultInviteCreateBlockedByAllowedDomains(t *testing.T) {
 	}
 }
 
-func TestVaultInviteCreateAllowedDomain(t *testing.T) {
+func TestUserInviteCreateAllowedDomain(t *testing.T) {
 	ms, token := setupMockStoreWithSession(t)
 	ms.settings[settingAllowedDomains] = `["acme.com"]`
 	srv := New(":0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
 
-	body := `{"email":"user@acme.com","role":"member"}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/vaults/default/invites", strings.NewReader(body))
+	body := `{"email":"user@acme.com"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/invites", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)
@@ -4246,13 +4261,13 @@ func TestVaultInviteCreateAllowedDomain(t *testing.T) {
 	}
 }
 
-func TestVaultInviteCreateNoDomainRestrictions(t *testing.T) {
+func TestUserInviteCreateNoDomainRestrictions(t *testing.T) {
 	ms, token := setupMockStoreWithSession(t)
 	// No domain restrictions set
 	srv := New(":0", ms, make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
 
-	body := `{"email":"user@gmail.com","role":"member"}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/vaults/default/invites", strings.NewReader(body))
+	body := `{"email":"user@gmail.com"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/invites", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)

--- a/internal/store/migrations/034_instance_user_invites.sql
+++ b/internal/store/migrations/034_instance_user_invites.sql
@@ -1,0 +1,27 @@
+-- Replace vault-scoped user invites with instance-level user invites.
+-- Invites now bring users into the instance, with optional vault pre-assignment.
+
+DROP TABLE IF EXISTS vault_invites;
+
+CREATE TABLE user_invites (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    token_hash  TEXT    NOT NULL UNIQUE,
+    email       TEXT    NOT NULL,
+    status      TEXT    NOT NULL DEFAULT 'pending'
+                CHECK(status IN ('pending','accepted','expired','revoked')),
+    created_by  TEXT    NOT NULL,
+    created_at  TEXT    NOT NULL DEFAULT (datetime('now')),
+    expires_at  TEXT    NOT NULL,
+    accepted_at TEXT
+);
+CREATE INDEX idx_user_invites_token_hash ON user_invites(token_hash);
+CREATE INDEX idx_user_invites_email_status ON user_invites(email, status);
+
+CREATE TABLE user_invite_vaults (
+    user_invite_id  INTEGER NOT NULL REFERENCES user_invites(id) ON DELETE CASCADE,
+    vault_id        TEXT    NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+    vault_role      TEXT    NOT NULL DEFAULT 'member'
+                    CHECK(vault_role IN ('admin', 'member')),
+    PRIMARY KEY (user_invite_id, vault_id)
+);
+CREATE INDEX idx_user_invite_vaults_vault ON user_invite_vaults(vault_id);

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1639,7 +1639,7 @@ func (s *SQLiteStore) loadUserInviteVaultsBatch(ctx context.Context, invites []U
 		placeholders = append(placeholders, '?')
 	}
 
-	rows, err := s.db.QueryContext(ctx,
+	rows, err := s.db.QueryContext(ctx, //nolint:gosec // placeholders are only '?' and ','
 		`SELECT uiv.user_invite_id, uiv.vault_id, v.name, uiv.vault_role
 		 FROM user_invite_vaults uiv
 		 JOIN vaults v ON v.id = uiv.vault_id

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1356,7 +1356,7 @@ func scanInviteRow(rows *sql.Rows) (*Invite, error) {
 
 // --- Vault Invites ---
 
-func newVaultInviteToken() string {
+func newUserInviteToken() string {
 	var b [32]byte
 	if _, err := io.ReadFull(rand.Reader, b[:]); err != nil {
 		panic("crypto/rand: " + err.Error())
@@ -1364,93 +1364,175 @@ func newVaultInviteToken() string {
 	return "av_uinv_" + hex.EncodeToString(b[:])
 }
 
-func (s *SQLiteStore) CreateVaultInvite(ctx context.Context, email, vaultID, vaultRole, createdBy string, expiresAt time.Time) (*VaultInvite, error) {
+func (s *SQLiteStore) CreateUserInvite(ctx context.Context, email, createdBy string, expiresAt time.Time, vaults []UserInviteVault) (*UserInvite, error) {
 	now := time.Now().UTC()
-	token := newVaultInviteToken()
+	token := newUserInviteToken()
+	nowStr := now.Format(time.DateTime)
+	expiresStr := expiresAt.UTC().Format(time.DateTime)
 
-	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO vault_invites (token_hash, email, vault_id, vault_role, created_by, created_at, expires_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		hashToken(token), email, vaultID, vaultRole, createdBy, now.Format(time.DateTime), expiresAt.UTC().Format(time.DateTime),
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.ExecContext(ctx,
+		`INSERT INTO user_invites (token_hash, email, created_by, created_at, expires_at)
+		 VALUES (?, ?, ?, ?, ?)`,
+		hashToken(token), email, createdBy, nowStr, expiresStr,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("inserting vault invite: %w", err)
+		return nil, fmt.Errorf("inserting user invite: %w", err)
 	}
 
-	return &VaultInvite{
+	inviteID, _ := res.LastInsertId()
+
+	for _, v := range vaults {
+		_, err := tx.ExecContext(ctx,
+			`INSERT INTO user_invite_vaults (user_invite_id, vault_id, vault_role)
+			 VALUES (?, ?, ?)`,
+			inviteID, v.VaultID, v.VaultRole,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("inserting user invite vault: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+
+	return &UserInvite{
+		ID:        int(inviteID),
 		Token:     token,
 		Email:     email,
-		VaultID:   vaultID,
-		VaultRole: vaultRole,
 		Status:    "pending",
 		CreatedBy: createdBy,
 		CreatedAt: now,
 		ExpiresAt: expiresAt.UTC(),
+		Vaults:    vaults,
 	}, nil
 }
 
-func (s *SQLiteStore) GetVaultInviteByToken(ctx context.Context, token string) (*VaultInvite, error) {
+func (s *SQLiteStore) GetUserInviteByToken(ctx context.Context, token string) (*UserInvite, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, '' as token, email, vault_id, vault_role, status, created_by,
-		        created_at, expires_at, accepted_at
-		 FROM vault_invites WHERE token_hash = ?`, hashToken(token),
+		`SELECT id, email, status, created_by, created_at, expires_at, accepted_at
+		 FROM user_invites WHERE token_hash = ?`, hashToken(token),
 	)
-	return scanVaultInvite(row)
+	inv, err := scanUserInvite(row)
+	if err != nil {
+		return nil, err
+	}
+	vaults, err := s.loadUserInviteVaults(ctx, inv.ID)
+	if err != nil {
+		return nil, err
+	}
+	inv.Vaults = vaults
+	return inv, nil
 }
 
-func (s *SQLiteStore) GetPendingVaultInviteByEmailAndVault(ctx context.Context, email, vaultID string) (*VaultInvite, error) {
+func (s *SQLiteStore) GetPendingUserInviteByEmail(ctx context.Context, email string) (*UserInvite, error) {
 	nowStr := time.Now().UTC().Format(time.DateTime)
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, '' as token, email, vault_id, vault_role, status, created_by,
-		        created_at, expires_at, accepted_at
-		 FROM vault_invites WHERE email = ? AND vault_id = ? AND status = 'pending' AND expires_at > ?
-		 ORDER BY created_at DESC LIMIT 1`, email, vaultID, nowStr,
+		`SELECT id, email, status, created_by, created_at, expires_at, accepted_at
+		 FROM user_invites WHERE email = ? AND status = 'pending' AND expires_at > ?
+		 ORDER BY created_at DESC LIMIT 1`, email, nowStr,
 	)
-	return scanVaultInvite(row)
+	inv, err := scanUserInvite(row)
+	if err != nil {
+		return nil, err
+	}
+	vaults, err := s.loadUserInviteVaults(ctx, inv.ID)
+	if err != nil {
+		return nil, err
+	}
+	inv.Vaults = vaults
+	return inv, nil
 }
 
-func (s *SQLiteStore) ListVaultInvites(ctx context.Context, vaultID, status string) ([]VaultInvite, error) {
+func (s *SQLiteStore) ListUserInvites(ctx context.Context, status string) ([]UserInvite, error) {
 	var rows *sql.Rows
 	var err error
 	if status != "" {
 		rows, err = s.db.QueryContext(ctx,
-			`SELECT id, '' as token, email, vault_id, vault_role, status, created_by,
-			        created_at, expires_at, accepted_at
-			 FROM vault_invites WHERE vault_id = ? AND status = ? ORDER BY created_at DESC`, vaultID, status,
+			`SELECT id, email, status, created_by, created_at, expires_at, accepted_at
+			 FROM user_invites WHERE status = ? ORDER BY created_at DESC`, status,
 		)
 	} else {
 		rows, err = s.db.QueryContext(ctx,
-			`SELECT id, '' as token, email, vault_id, vault_role, status, created_by,
-			        created_at, expires_at, accepted_at
-			 FROM vault_invites WHERE vault_id = ? ORDER BY created_at DESC`, vaultID,
+			`SELECT id, email, status, created_by, created_at, expires_at, accepted_at
+			 FROM user_invites ORDER BY created_at DESC`,
 		)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("listing vault invites: %w", err)
+		return nil, fmt.Errorf("listing user invites: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	var invites []VaultInvite
+	var invites []UserInvite
 	for rows.Next() {
-		inv, err := scanVaultInviteRow(rows)
+		inv, err := scanUserInviteRow(rows)
 		if err != nil {
 			return nil, err
 		}
 		invites = append(invites, *inv)
 	}
-	return invites, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if err := s.loadUserInviteVaultsBatch(ctx, invites); err != nil {
+		return nil, err
+	}
+	return invites, nil
 }
 
-func (s *SQLiteStore) AcceptVaultInvite(ctx context.Context, token string) error {
+func (s *SQLiteStore) ListUserInvitesByVault(ctx context.Context, vaultID, status string) ([]UserInvite, error) {
+	query := `SELECT ui.id, ui.email, ui.status, ui.created_by, ui.created_at, ui.expires_at, ui.accepted_at
+		 FROM user_invites ui
+		 JOIN user_invite_vaults uiv ON ui.id = uiv.user_invite_id
+		 WHERE uiv.vault_id = ?`
+	args := []any{vaultID}
+	if status != "" {
+		query += ` AND ui.status = ?`
+		args = append(args, status)
+	}
+	query += ` ORDER BY ui.created_at DESC`
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing user invites by vault: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var invites []UserInvite
+	for rows.Next() {
+		inv, err := scanUserInviteRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		invites = append(invites, *inv)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if err := s.loadUserInviteVaultsBatch(ctx, invites); err != nil {
+		return nil, err
+	}
+	return invites, nil
+}
+
+func (s *SQLiteStore) AcceptUserInvite(ctx context.Context, token string) error {
 	nowStr := time.Now().UTC().Format(time.DateTime)
 
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE vault_invites SET status = 'accepted', accepted_at = ?
+		`UPDATE user_invites SET status = 'accepted', accepted_at = ?
 		 WHERE token_hash = ? AND status = 'pending' AND expires_at > ?`,
 		nowStr, hashToken(token), nowStr,
 	)
 	if err != nil {
-		return fmt.Errorf("accepting vault invite: %w", err)
+		return fmt.Errorf("accepting user invite: %w", err)
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
@@ -1459,14 +1541,14 @@ func (s *SQLiteStore) AcceptVaultInvite(ctx context.Context, token string) error
 	return nil
 }
 
-func (s *SQLiteStore) RevokeVaultInvite(ctx context.Context, token, vaultID string) error {
+func (s *SQLiteStore) RevokeUserInvite(ctx context.Context, token string) error {
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE vault_invites SET status = 'revoked'
-		 WHERE token_hash = ? AND vault_id = ? AND status = 'pending'`,
-		hashToken(token), vaultID,
+		`UPDATE user_invites SET status = 'revoked'
+		 WHERE token_hash = ? AND status = 'pending'`,
+		hashToken(token),
 	)
 	if err != nil {
-		return fmt.Errorf("revoking vault invite: %w", err)
+		return fmt.Errorf("revoking user invite: %w", err)
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
@@ -1475,37 +1557,124 @@ func (s *SQLiteStore) RevokeVaultInvite(ctx context.Context, token, vaultID stri
 	return nil
 }
 
-func (s *SQLiteStore) UpdateVaultInviteRole(ctx context.Context, token, vaultID, newRole string) error {
-	res, err := s.db.ExecContext(ctx,
-		`UPDATE vault_invites SET vault_role = ?
-		 WHERE token_hash = ? AND vault_id = ? AND status = 'pending'`,
-		newRole, hashToken(token), vaultID,
-	)
+func (s *SQLiteStore) UpdateUserInviteVaults(ctx context.Context, token string, vaults []UserInviteVault) error {
+	// Look up invite ID by token hash
+	var inviteID int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id FROM user_invites WHERE token_hash = ? AND status = 'pending'`,
+		hashToken(token),
+	).Scan(&inviteID)
 	if err != nil {
-		return fmt.Errorf("updating vault invite role: %w", err)
+		return fmt.Errorf("finding user invite: %w", err)
 	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return sql.ErrNoRows
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
 	}
-	return nil
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `DELETE FROM user_invite_vaults WHERE user_invite_id = ?`, inviteID)
+	if err != nil {
+		return fmt.Errorf("clearing user invite vaults: %w", err)
+	}
+
+	for _, v := range vaults {
+		_, err := tx.ExecContext(ctx,
+			`INSERT INTO user_invite_vaults (user_invite_id, vault_id, vault_role) VALUES (?, ?, ?)`,
+			inviteID, v.VaultID, v.VaultRole,
+		)
+		if err != nil {
+			return fmt.Errorf("inserting user invite vault: %w", err)
+		}
+	}
+
+	return tx.Commit()
 }
 
-func (s *SQLiteStore) CountPendingVaultInvites(ctx context.Context, vaultID string) (int, error) {
+func (s *SQLiteStore) CountPendingUserInvites(ctx context.Context) (int, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM vault_invites WHERE vault_id = ? AND status = 'pending'",
-		vaultID,
+		"SELECT COUNT(*) FROM user_invites WHERE status = 'pending'",
 	).Scan(&count)
 	return count, err
 }
 
-func scanVaultInvite(row *sql.Row) (*VaultInvite, error) {
-	var inv VaultInvite
+// loadUserInviteVaults fetches the vault pre-assignments for a user invite.
+func (s *SQLiteStore) loadUserInviteVaults(ctx context.Context, inviteID int) ([]UserInviteVault, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT uiv.vault_id, v.name, uiv.vault_role
+		 FROM user_invite_vaults uiv
+		 JOIN vaults v ON v.id = uiv.vault_id
+		 WHERE uiv.user_invite_id = ?`, inviteID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("loading user invite vaults: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var vaults []UserInviteVault
+	for rows.Next() {
+		var v UserInviteVault
+		if err := rows.Scan(&v.VaultID, &v.VaultName, &v.VaultRole); err != nil {
+			return nil, err
+		}
+		vaults = append(vaults, v)
+	}
+	return vaults, rows.Err()
+}
+
+func (s *SQLiteStore) loadUserInviteVaultsBatch(ctx context.Context, invites []UserInvite) error {
+	if len(invites) == 0 {
+		return nil
+	}
+
+	ids := make([]any, len(invites))
+	placeholders := make([]byte, 0, len(invites)*2-1)
+	for i, inv := range invites {
+		ids[i] = inv.ID
+		if i > 0 {
+			placeholders = append(placeholders, ',')
+		}
+		placeholders = append(placeholders, '?')
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT uiv.user_invite_id, uiv.vault_id, v.name, uiv.vault_role
+		 FROM user_invite_vaults uiv
+		 JOIN vaults v ON v.id = uiv.vault_id
+		 WHERE uiv.user_invite_id IN (`+string(placeholders)+`)`, ids...,
+	)
+	if err != nil {
+		return fmt.Errorf("loading user invite vaults batch: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	byID := make(map[int][]UserInviteVault, len(invites))
+	for rows.Next() {
+		var inviteID int
+		var v UserInviteVault
+		if err := rows.Scan(&inviteID, &v.VaultID, &v.VaultName, &v.VaultRole); err != nil {
+			return err
+		}
+		byID[inviteID] = append(byID[inviteID], v)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for i := range invites {
+		invites[i].Vaults = byID[invites[i].ID]
+	}
+	return nil
+}
+
+func scanUserInvite(row *sql.Row) (*UserInvite, error) {
+	var inv UserInvite
 	var createdAt, expiresAt string
 	var acceptedAt sql.NullString
 
-	if err := row.Scan(&inv.ID, &inv.Token, &inv.Email, &inv.VaultID, &inv.VaultRole, &inv.Status,
+	if err := row.Scan(&inv.ID, &inv.Email, &inv.Status,
 		&inv.CreatedBy, &createdAt, &expiresAt, &acceptedAt); err != nil {
 		return nil, err
 	}
@@ -1519,12 +1688,12 @@ func scanVaultInvite(row *sql.Row) (*VaultInvite, error) {
 	return &inv, nil
 }
 
-func scanVaultInviteRow(rows *sql.Rows) (*VaultInvite, error) {
-	var inv VaultInvite
+func scanUserInviteRow(rows *sql.Rows) (*UserInvite, error) {
+	var inv UserInvite
 	var createdAt, expiresAt string
 	var acceptedAt sql.NullString
 
-	if err := rows.Scan(&inv.ID, &inv.Token, &inv.Email, &inv.VaultID, &inv.VaultRole, &inv.Status,
+	if err := rows.Scan(&inv.ID, &inv.Email, &inv.Status,
 		&inv.CreatedBy, &createdAt, &expiresAt, &acceptedAt); err != nil {
 		return nil, err
 	}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"syscall"
 	"time"
 
@@ -1630,21 +1631,12 @@ func (s *SQLiteStore) loadUserInviteVaultsBatch(ctx context.Context, invites []U
 	}
 
 	ids := make([]any, len(invites))
-	placeholders := make([]byte, 0, len(invites)*2-1)
 	for i, inv := range invites {
 		ids[i] = inv.ID
-		if i > 0 {
-			placeholders = append(placeholders, ',')
-		}
-		placeholders = append(placeholders, '?')
 	}
 
-	rows, err := s.db.QueryContext(ctx, //nolint:gosec // placeholders are only '?' and ','
-		`SELECT uiv.user_invite_id, uiv.vault_id, v.name, uiv.vault_role
-		 FROM user_invite_vaults uiv
-		 JOIN vaults v ON v.id = uiv.vault_id
-		 WHERE uiv.user_invite_id IN (`+string(placeholders)+`)`, ids...,
-	)
+	query := "SELECT uiv.user_invite_id, uiv.vault_id, v.name, uiv.vault_role FROM user_invite_vaults uiv JOIN vaults v ON v.id = uiv.vault_id WHERE uiv.user_invite_id IN (" + strings.Repeat("?,", len(ids)-1) + "?)" //nolint:gosec // only '?' placeholders
+	rows, err := s.db.QueryContext(ctx, query, ids...)
 	if err != nil {
 		return fmt.Errorf("loading user invite vaults batch: %w", err)
 	}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -28,8 +28,8 @@ func TestOpenAndMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("querying schema_migrations: %v", err)
 	}
-	if version != 33 {
-		t.Fatalf("expected migration version 33, got %d", version)
+	if version != 34 {
+		t.Fatalf("expected migration version 34, got %d", version)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -152,20 +152,25 @@ type Agent struct {
 	RevokedAt          *time.Time
 }
 
-// VaultInvite represents an invitation for a user to join a specific vault
-// with a given role. If the user doesn't have an account, they create one
-// during acceptance.
-type VaultInvite struct {
+// UserInvite represents an instance-level invitation for a new user.
+// Invites bring users into the instance, with optional vault pre-assignment.
+type UserInvite struct {
 	ID         int
-	Token      string
+	Token      string // only populated on creation (not stored in DB)
 	Email      string
-	VaultID    string
-	VaultRole  string // "admin" or "member"
 	Status     string // pending, accepted, expired, revoked
 	CreatedBy  string // user ID of the inviter
 	CreatedAt  time.Time
 	ExpiresAt  time.Time
 	AcceptedAt *time.Time
+	Vaults     []UserInviteVault // pre-assigned vault access
+}
+
+// UserInviteVault represents a pre-assigned vault grant on a user invite.
+type UserInviteVault struct {
+	VaultID   string
+	VaultName string // populated via JOIN on reads
+	VaultRole string // "admin" or "member"
 }
 
 // EmailVerification holds a verification code for self-signup email confirmation.
@@ -294,15 +299,16 @@ type Store interface {
 	CountPendingInvites(ctx context.Context, vaultID string) (int, error)
 	ExpirePendingInvites(ctx context.Context, before time.Time) (int, error)
 
-	// Vault invites
-	CreateVaultInvite(ctx context.Context, email, vaultID, vaultRole, createdBy string, expiresAt time.Time) (*VaultInvite, error)
-	GetVaultInviteByToken(ctx context.Context, token string) (*VaultInvite, error)
-	GetPendingVaultInviteByEmailAndVault(ctx context.Context, email, vaultID string) (*VaultInvite, error)
-	ListVaultInvites(ctx context.Context, vaultID, status string) ([]VaultInvite, error)
-	AcceptVaultInvite(ctx context.Context, token string) error
-	RevokeVaultInvite(ctx context.Context, token, vaultID string) error
-	UpdateVaultInviteRole(ctx context.Context, token, vaultID, newRole string) error
-	CountPendingVaultInvites(ctx context.Context, vaultID string) (int, error)
+	// User invites (instance-level)
+	CreateUserInvite(ctx context.Context, email, createdBy string, expiresAt time.Time, vaults []UserInviteVault) (*UserInvite, error)
+	GetUserInviteByToken(ctx context.Context, token string) (*UserInvite, error)
+	GetPendingUserInviteByEmail(ctx context.Context, email string) (*UserInvite, error)
+	ListUserInvites(ctx context.Context, status string) ([]UserInvite, error)
+	ListUserInvitesByVault(ctx context.Context, vaultID, status string) ([]UserInvite, error)
+	AcceptUserInvite(ctx context.Context, token string) error
+	RevokeUserInvite(ctx context.Context, token string) error
+	UpdateUserInviteVaults(ctx context.Context, token string, vaults []UserInviteVault) error
+	CountPendingUserInvites(ctx context.Context) (int, error)
 
 	// Email verification
 	CreateEmailVerification(ctx context.Context, email, code string, expiresAt time.Time) (*EmailVerification, error)

--- a/web/src/pages/UserInvite.tsx
+++ b/web/src/pages/UserInvite.tsx
@@ -7,19 +7,24 @@ import { DomainNotice } from "../components/DomainNotice";
 import { apiFetch } from "../lib/api";
 import { OAuthSection } from "../components/GoogleButton";
 
-interface VaultInviteData {
+interface InviteVault {
+  vault_name: string;
+  vault_role: string;
+}
+
+interface UserInviteData {
   token?: string;
   email?: string;
-  vault_name?: string;
-  vault_role?: string;
+  vaults?: InviteVault[];
   needs_account?: boolean;
+  status?: string;
   error?: boolean;
   error_title?: string;
   error_message?: string;
 }
 
-export default function VaultInvite() {
-  const invite = useLoaderData({ from: "/vault-invite/$token" }) as VaultInviteData | null;
+export default function UserInvite() {
+  const invite = useLoaderData({ from: "/invite/$token" }) as UserInviteData | null;
 
   return (
     <div className="min-h-screen w-full flex flex-col bg-bg">
@@ -33,7 +38,7 @@ export default function VaultInvite() {
               <div className="bg-surface rounded-2xl w-full max-w-[480px] p-10 shadow-[0_1px_3px_rgba(0,0,0,0.08),0_8px_24px_rgba(0,0,0,0.04)]">
                 <ErrorSection
                   title={invite?.error_title ?? "Invite Unavailable"}
-                  message={invite?.error_message ?? "This invite link is no longer valid. Please ask your vault administrator for a new invitation."}
+                  message={invite?.error_message ?? "This invite link is no longer valid. Please ask for a new invitation."}
                 />
               </div>
             )
@@ -43,15 +48,13 @@ export default function VaultInvite() {
                 <NewUserForm
                   token={invite.token!}
                   email={invite.email!}
-                  vaultName={invite.vault_name!}
-                  vaultRole={invite.vault_role!}
+                  vaults={invite.vaults ?? []}
                 />
               ) : (
                 <ExistingUserForm
                   token={invite.token!}
                   email={invite.email!}
-                  vaultName={invite.vault_name!}
-                  vaultRole={invite.vault_role!}
+                  vaults={invite.vaults ?? []}
                 />
               )}
             </div>
@@ -76,7 +79,7 @@ function AlreadyAccepted() {
           </div>
           <h2 className="text-2xl font-semibold text-text mb-2">Already Accepted</h2>
           <p className="text-text-muted text-[15px] mb-8">
-            This invitation has already been accepted. You can log in to access your vault.
+            This invitation has already been accepted. You can log in to access your account.
           </p>
           <Link
             to="/login"
@@ -110,20 +113,23 @@ function ErrorSection({ title, message }: { title: string; message: string }) {
   );
 }
 
-function InviteDetails({ vaultName, vaultRole }: { vaultName: string; vaultRole: string }) {
+function InviteDetails({ vaults }: { vaults: InviteVault[] }) {
+  if (vaults.length === 0) return null;
+
   return (
     <div className="bg-bg border border-border rounded-lg p-4 mb-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <div className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-1">Vault</div>
-          <div className="text-sm text-text font-medium">{vaultName}</div>
-        </div>
-        <div className="text-right">
-          <div className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-1">Role</div>
-          <span className="inline-block px-2.5 py-0.5 bg-primary/10 text-primary text-xs font-semibold rounded-full capitalize">
-            {vaultRole}
-          </span>
-        </div>
+      <div className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+        Vault Access
+      </div>
+      <div className="space-y-2">
+        {vaults.map((v) => (
+          <div key={v.vault_name} className="flex items-center justify-between">
+            <span className="text-sm text-text font-medium">{v.vault_name}</span>
+            <span className="inline-block px-2.5 py-0.5 bg-primary/10 text-primary text-xs font-semibold rounded-full capitalize">
+              {v.vault_role}
+            </span>
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -132,13 +138,11 @@ function InviteDetails({ vaultName, vaultRole }: { vaultName: string; vaultRole:
 function ExistingUserForm({
   token,
   email,
-  vaultName,
-  vaultRole,
+  vaults,
 }: {
   token: string;
   email: string;
-  vaultName: string;
-  vaultRole: string;
+  vaults: InviteVault[];
 }) {
   const [view, setView] = useState<"confirm" | "success">("confirm");
   const [formError, setFormError] = useState("");
@@ -149,7 +153,7 @@ function ExistingUserForm({
     setSubmitting(true);
 
     try {
-      const resp = await apiFetch(`/v1/vault-invites/${token}/accept`, {
+      const resp = await apiFetch(`/v1/users/invites/${token}/accept`, {
         method: "POST",
         body: JSON.stringify({}),
       });
@@ -178,7 +182,10 @@ function ExistingUserForm({
         </div>
         <h2 className="text-2xl font-semibold text-text mb-2">Invite Accepted</h2>
         <p className="text-text-muted text-[15px] mb-8">
-          You now have <strong className="text-text">{vaultRole}</strong> access to vault <strong className="text-text">{vaultName}</strong>.
+          You've joined Agent Vault.
+          {vaults.length > 0 && (
+            <> You have access to {vaults.map((v) => v.vault_name).join(", ")}.</>
+          )}
         </p>
         <a
           href="/login"
@@ -197,13 +204,13 @@ function ExistingUserForm({
   return (
     <>
       <h2 className="text-[28px] font-semibold mb-2 tracking-tight text-text">
-        Accept Vault Invitation
+        Join Agent Vault
       </h2>
       <p className="text-text-muted text-[15px] mb-6">
-        You've been invited to join a vault as <strong className="text-text">{email}</strong>.
+        You've been invited to join as <strong className="text-text">{email}</strong>.
       </p>
 
-      <InviteDetails vaultName={vaultName} vaultRole={vaultRole} />
+      <InviteDetails vaults={vaults} />
 
       {formError && <ErrorBanner message={formError} className="mb-4" />}
 
@@ -222,13 +229,11 @@ function ExistingUserForm({
 function NewUserForm({
   token,
   email,
-  vaultName,
-  vaultRole,
+  vaults,
 }: {
   token: string;
   email: string;
-  vaultName: string;
-  vaultRole: string;
+  vaults: InviteVault[];
 }) {
   const [view, setView] = useState<"form" | "success">("form");
   const [password, setPassword] = useState("");
@@ -266,7 +271,7 @@ function NewUserForm({
     setSubmitting(true);
 
     try {
-      const resp = await apiFetch(`/v1/vault-invites/${token}/accept`, {
+      const resp = await apiFetch(`/v1/users/invites/${token}/accept`, {
         method: "POST",
         body: JSON.stringify({ password }),
       });
@@ -295,7 +300,10 @@ function NewUserForm({
         </div>
         <h2 className="text-2xl font-semibold text-text mb-2">Account Created</h2>
         <p className="text-text-muted text-[15px] mb-8">
-          Your account is ready with <strong className="text-text">{vaultRole}</strong> access to vault <strong className="text-text">{vaultName}</strong>.
+          Your account is ready.
+          {vaults.length > 0 && (
+            <> You have access to {vaults.map((v) => v.vault_name).join(", ")}.</>
+          )}
         </p>
         <a
           href="/login"
@@ -314,17 +322,17 @@ function NewUserForm({
   return (
     <>
       <h2 className="text-[28px] font-semibold mb-2 tracking-tight text-text">
-        Accept Vault Invitation
+        Join Agent Vault
       </h2>
       <p className="text-text-muted text-[15px] mb-6">
-        Create an account to join vault <strong className="text-text">{vaultName}</strong> as <strong className="text-text">{vaultRole}</strong>.
+        Create an account to join Agent Vault.
       </p>
 
-      <InviteDetails vaultName={vaultName} vaultRole={vaultRole} />
+      <InviteDetails vaults={vaults} />
 
       <DomainNotice className="mb-4" />
 
-      <OAuthSection redirect={`/vault-invite/${token}`} />
+      <OAuthSection redirect={`/invite/${token}`} />
 
       <form onSubmit={handleSubmit} autoComplete="off">
         <div className="mb-6">
@@ -414,4 +422,3 @@ function NewUserForm({
     </>
   );
 }
-

--- a/web/src/pages/home/AllUsersTab.tsx
+++ b/web/src/pages/home/AllUsersTab.tsx
@@ -4,13 +4,27 @@ import { LoadingSpinner, ErrorBanner, timeAgo } from "../../components/shared";
 import DataTable, { type Column } from "../../components/DataTable";
 import DropdownMenu from "../../components/DropdownMenu";
 import ConfirmDeleteModal from "../../components/ConfirmDeleteModal";
+import Modal from "../../components/Modal";
+import Button from "../../components/Button";
+import Input from "../../components/Input";
+import FormField from "../../components/FormField";
+import CopyButton from "../../components/CopyButton";
+import { apiFetch } from "../../lib/api";
 import type { AuthContext } from "../../router";
 
 interface PublicUser {
   email: string;
   role: string;
+  status: "active" | "pending";
   vaults?: string[];
   created_at: string;
+  invite_token?: string;
+}
+
+interface VaultOption {
+  id: string;
+  name: string;
+  role: string;
 }
 
 function RowActions({
@@ -25,6 +39,17 @@ function RowActions({
   onRemove: (user: PublicUser) => void;
 }) {
   if (user.email === currentEmail) return null;
+
+  if (user.status === "pending") {
+    return (
+      <DropdownMenu
+        width={192}
+        items={[
+          { label: "Revoke invite", onClick: () => onRemove(user), variant: "danger" },
+        ]}
+      />
+    );
+  }
 
   const isOwner = user.role === "owner";
 
@@ -66,14 +91,37 @@ export default function AllUsersTab() {
 
   const fetchUsers = useCallback(async () => {
     try {
-      const resp = await fetch("/v1/users");
-      if (!resp.ok) {
-        const data = await resp.json();
+      const [usersResp, invResp] = await Promise.all([
+        fetch("/v1/users"),
+        fetch("/v1/users/invites?status=pending"),
+      ]);
+
+      if (!usersResp.ok) {
+        const data = await usersResp.json();
         setError(data.error || "Failed to load users.");
         return;
       }
-      const data = await resp.json();
-      setUsers(data.users ?? []);
+      const data = await usersResp.json();
+      const activeUsers: PublicUser[] = (data.users ?? []).map(
+        (u: PublicUser) => ({ ...u, status: "active" as const })
+      );
+
+      let pendingUsers: PublicUser[] = [];
+      if (invResp.ok) {
+        const invData = await invResp.json();
+        pendingUsers = (invData.invites ?? []).map(
+          (inv: { email: string; token: string; created_at: string; vaults?: { vault_name: string }[] }) => ({
+            email: inv.email,
+            role: "member",
+            status: "pending" as const,
+            vaults: inv.vaults?.map((v: { vault_name: string }) => v.vault_name) ?? [],
+            created_at: inv.created_at,
+            invite_token: inv.token,
+          })
+        );
+      }
+
+      setUsers([...activeUsers, ...pendingUsers]);
     } catch {
       setError("Network error.");
     } finally {
@@ -87,6 +135,20 @@ export default function AllUsersTab() {
 
   async function handleDeleteUser() {
     if (!deleteTarget) return;
+    if (deleteTarget.status === "pending") {
+      if (!deleteTarget.invite_token) return;
+      const resp = await fetch(
+        `/v1/users/invites/${encodeURIComponent(deleteTarget.invite_token)}`,
+        { method: "DELETE" }
+      );
+      if (!resp.ok) {
+        const data = await resp.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to revoke invite");
+      }
+      setDeleteTarget(null);
+      fetchUsers();
+      return;
+    }
     const resp = await fetch(
       `/v1/admin/users/${encodeURIComponent(deleteTarget.email)}`,
       { method: "DELETE" }
@@ -105,6 +167,19 @@ export default function AllUsersTab() {
         key: "email",
         header: "Email",
         render: (u) => <span className="text-sm text-text">{u.email}</span>,
+      },
+      {
+        key: "status",
+        header: "Status",
+        render: (u) => (
+          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+            u.status === "pending"
+              ? "bg-yellow-500/10 text-yellow-500"
+              : "bg-green-500/10 text-green-500"
+          }`}>
+            {u.status === "pending" ? "Pending" : "Active"}
+          </span>
+        ),
       },
       {
         key: "role",
@@ -165,6 +240,7 @@ export default function AllUsersTab() {
             All users across the instance.
           </p>
         </div>
+        <InviteUserButton onInvited={fetchUsers} isOwner={auth.is_owner} />
       </div>
 
       {loading ? (
@@ -175,13 +251,13 @@ export default function AllUsersTab() {
         <DataTable
           columns={columns}
           data={users}
-          rowKey={(u) => u.email}
+          rowKey={(u) => u.email + u.status}
           emptyTitle="No users"
           emptyDescription="No users have registered yet."
         />
       )}
 
-      {auth.is_owner && (
+      {auth.is_owner && deleteTarget?.status !== "pending" && (
         <ConfirmDeleteModal
           open={deleteTarget !== null}
           onClose={() => setDeleteTarget(null)}
@@ -194,5 +270,244 @@ export default function AllUsersTab() {
         />
       )}
     </div>
+  );
+}
+
+interface VaultAssignment {
+  vault_name: string;
+  vault_role: "member" | "admin";
+}
+
+function InviteUserButton({
+  onInvited,
+  isOwner,
+}: {
+  onInvited: () => void;
+  isOwner: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [vaultAssignments, setVaultAssignments] = useState<VaultAssignment[]>([]);
+  const [availableVaults, setAvailableVaults] = useState<VaultOption[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [inviteLink, setInviteLink] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    // Fetch vaults the user can assign
+    fetch("/v1/vaults")
+      .then((r) => r.json())
+      .then((data) => {
+        const vaults = (data.vaults ?? []).filter(
+          (v: VaultOption) => isOwner || v.role === "admin"
+        );
+        setAvailableVaults(vaults);
+      })
+      .catch(() => {});
+  }, [open, isOwner]);
+
+  function close() {
+    setOpen(false);
+    setEmail("");
+    setVaultAssignments([]);
+    setError("");
+    setInviteLink("");
+  }
+
+  function addVault() {
+    const assignedNames = new Set(vaultAssignments.map((a) => a.vault_name));
+    const next = availableVaults.find((v) => !assignedNames.has(v.name));
+    if (next) {
+      setVaultAssignments([...vaultAssignments, { vault_name: next.name, vault_role: "member" }]);
+    }
+  }
+
+  function removeVault(idx: number) {
+    setVaultAssignments(vaultAssignments.filter((_, i) => i !== idx));
+  }
+
+  function updateVault(idx: number, field: "vault_name" | "vault_role", value: string) {
+    const updated = [...vaultAssignments];
+    updated[idx] = { ...updated[idx], [field]: value };
+    setVaultAssignments(updated);
+  }
+
+  async function handleInvite() {
+    if (!email.trim()) return;
+    setSubmitting(true);
+    setError("");
+    try {
+      const payload: Record<string, unknown> = { email: email.trim() };
+      if (vaultAssignments.length > 0) {
+        payload.vaults = vaultAssignments;
+      }
+      const resp = await apiFetch("/v1/users/invites", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      const data = await resp.json();
+      if (resp.ok) {
+        onInvited();
+        if (data.email_sent) {
+          close();
+        } else {
+          setInviteLink(data.invite_link || "");
+        }
+      } else {
+        setError(data.error || "Failed to send invite.");
+      }
+    } catch {
+      setError("Network error.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const assignedNames = new Set(vaultAssignments.map((a) => a.vault_name));
+  const canAddMore = availableVaults.some((v) => !assignedNames.has(v.name));
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>
+        <svg
+          className="w-4 h-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+          <circle cx="8.5" cy="7" r="4" />
+          <line x1="20" y1="8" x2="20" y2="14" />
+          <line x1="23" y1="11" x2="17" y2="11" />
+        </svg>
+        Invite user
+      </Button>
+
+      <Modal
+        open={open}
+        onClose={close}
+        title={inviteLink ? "Invite Created" : "Invite User"}
+        description={inviteLink ? "Share this link to grant access." : "Invite a user to Agent Vault."}
+        footer={
+          inviteLink ? (
+            <Button onClick={close}>Done</Button>
+          ) : (
+            <>
+              <Button variant="secondary" onClick={close}>Cancel</Button>
+              <Button
+                onClick={handleInvite}
+                disabled={!email.trim()}
+                loading={submitting}
+              >
+                Send invite
+              </Button>
+            </>
+          )
+        }
+      >
+        {inviteLink ? (
+          <div className="space-y-4">
+            <p className="text-sm text-text-muted">
+              Email delivery is not configured. Share this link with{" "}
+              <span className="font-medium text-text">{email}</span> so
+              they can accept the invite.
+            </p>
+            <div className="flex items-center gap-2">
+              <Input
+                readOnly
+                value={inviteLink}
+                className="flex-1 px-4 py-3 bg-bg border border-border rounded-lg text-text text-sm font-mono outline-none select-all"
+                onFocus={(e) => e.target.select()}
+              />
+              <CopyButton value={inviteLink} />
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <FormField label="Email">
+              <Input
+                type="email"
+                placeholder="name@company.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleInvite();
+                }}
+                autoFocus
+              />
+            </FormField>
+
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <label className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+                  Vault access (optional)
+                </label>
+                {canAddMore && (
+                  <button
+                    type="button"
+                    onClick={addVault}
+                    className="text-xs text-primary hover:underline"
+                  >
+                    + Add vault
+                  </button>
+                )}
+              </div>
+              {vaultAssignments.length === 0 ? (
+                <p className="text-sm text-text-muted">
+                  No vaults pre-assigned. User will join the instance without vault access.
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {vaultAssignments.map((assignment, idx) => (
+                    <div key={idx} className="flex items-center gap-2">
+                      <select
+                        value={assignment.vault_name}
+                        onChange={(e) => updateVault(idx, "vault_name", e.target.value)}
+                        className="flex-1 px-3 py-2 bg-surface border border-border rounded-lg text-text text-sm outline-none"
+                      >
+                        {availableVaults.map((v) => (
+                          <option
+                            key={v.name}
+                            value={v.name}
+                            disabled={assignedNames.has(v.name) && v.name !== assignment.vault_name}
+                          >
+                            {v.name}
+                          </option>
+                        ))}
+                      </select>
+                      <select
+                        value={assignment.vault_role}
+                        onChange={(e) => updateVault(idx, "vault_role", e.target.value)}
+                        className="w-28 px-3 py-2 bg-surface border border-border rounded-lg text-text text-sm outline-none"
+                      >
+                        <option value="member">Member</option>
+                        <option value="admin">Admin</option>
+                      </select>
+                      <button
+                        type="button"
+                        onClick={() => removeVault(idx)}
+                        className="text-text-muted hover:text-danger p-1"
+                        title="Remove"
+                      >
+                        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <line x1="18" y1="6" x2="6" y2="18" />
+                          <line x1="6" y1="6" x2="18" y2="18" />
+                        </svg>
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {error && <ErrorBanner message={error} />}
+          </div>
+        )}
+      </Modal>
+    </>
   );
 }

--- a/web/src/pages/vault/UsersTab.tsx
+++ b/web/src/pages/vault/UsersTab.tsx
@@ -9,17 +9,14 @@ import DataTable, { type Column } from "../../components/DataTable";
 import Modal from "../../components/Modal";
 import DropdownMenu, { type DropdownMenuItem } from "../../components/DropdownMenu";
 import Button from "../../components/Button";
-import Input from "../../components/Input";
 import Select from "../../components/Select";
 import FormField from "../../components/FormField";
-import CopyButton from "../../components/CopyButton";
 import { apiFetch } from "../../lib/api";
 
 interface VaultUser {
   email: string;
   role: string;
   status: "active" | "pending";
-  invite_token?: string;
 }
 
 function RowActions({
@@ -27,37 +24,24 @@ function RowActions({
   vaultName,
   currentEmail,
   onDone,
-  onReinviteLink,
 }: {
   user: VaultUser;
   vaultName: string;
   currentEmail: string;
   onDone: () => void;
-  onReinviteLink: (email: string, link: string) => void;
 }) {
   if (user.email === currentEmail) return null;
 
   const newRole = user.role === "admin" ? "member" : "admin";
 
   async function handleChangeRole() {
-    let resp: Response;
-    if (user.status === "pending" && user.invite_token) {
-      resp = await apiFetch(
-        `/v1/vaults/${encodeURIComponent(vaultName)}/invites/${encodeURIComponent(user.invite_token)}`,
-        {
-          method: "PATCH",
-          body: JSON.stringify({ role: newRole }),
-        }
-      );
-    } else {
-      resp = await apiFetch(
-        `/v1/vaults/${encodeURIComponent(vaultName)}/users/${encodeURIComponent(user.email)}/role`,
-        {
-          method: "POST",
-          body: JSON.stringify({ role: newRole }),
-        }
-      );
-    }
+    const resp = await apiFetch(
+      `/v1/vaults/${encodeURIComponent(vaultName)}/users/${encodeURIComponent(user.email)}/role`,
+      {
+        method: "POST",
+        body: JSON.stringify({ role: newRole }),
+      }
+    );
     if (!resp.ok) {
       const data = await resp.json().catch(() => ({}));
       alert(data.error || "Failed to change role");
@@ -67,18 +51,10 @@ function RowActions({
   }
 
   async function handleRemove() {
-    let resp: Response;
-    if (user.status === "pending" && user.invite_token) {
-      resp = await fetch(
-        `/v1/vaults/${encodeURIComponent(vaultName)}/invites/${encodeURIComponent(user.invite_token)}`,
-        { method: "DELETE" }
-      );
-    } else {
-      resp = await fetch(
-        `/v1/vaults/${encodeURIComponent(vaultName)}/users/${encodeURIComponent(user.email)}`,
-        { method: "DELETE" }
-      );
-    }
+    const resp = await fetch(
+      `/v1/vaults/${encodeURIComponent(vaultName)}/users/${encodeURIComponent(user.email)}`,
+      { method: "DELETE" }
+    );
     if (!resp.ok) {
       const data = await resp.json().catch(() => ({}));
       alert(data.error || "Failed to remove user");
@@ -87,27 +63,10 @@ function RowActions({
     onDone();
   }
 
-  async function handleReinvite() {
-    const resp = await fetch(
-      `/v1/vaults/${encodeURIComponent(vaultName)}/invites/${encodeURIComponent(user.invite_token!)}/reinvite`,
-      { method: "POST" }
-    );
-    if (resp.ok) {
-      const data = await resp.json();
-      onDone();
-      if (!data.email_sent && data.invite_link) {
-        onReinviteLink(user.email, data.invite_link);
-      }
-    }
-  }
-
   const items: DropdownMenuItem[] = [
     { label: `Make ${newRole}`, onClick: handleChangeRole },
-    ...(user.status === "pending" && user.invite_token
-      ? [{ label: "Reinvite", onClick: handleReinvite }]
-      : []),
     {
-      label: user.status === "pending" ? "Delete" : "Remove",
+      label: "Remove",
       onClick: handleRemove,
       variant: "danger" as const,
     },
@@ -121,10 +80,6 @@ export default function UsersTab() {
   const [users, setUsers] = useState<VaultUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [reinviteLink, setReinviteLink] = useState<{
-    email: string;
-    link: string;
-  } | null>(null);
 
   const columns: Column<VaultUser>[] = [
     {
@@ -156,9 +111,6 @@ export default function UsersTab() {
                 vaultName={vaultName}
                 currentEmail={currentEmail}
                 onDone={fetchUsers}
-                onReinviteLink={(email, link) =>
-                  setReinviteLink({ email, link })
-                }
               />
             ),
           },
@@ -172,42 +124,16 @@ export default function UsersTab() {
 
   async function fetchUsers() {
     try {
-      const usersResp = await fetch(
+      const resp = await fetch(
         `/v1/vaults/${encodeURIComponent(vaultName)}/users`
       );
-      if (!usersResp.ok) {
-        const data = await usersResp.json();
+      if (!resp.ok) {
+        const data = await resp.json();
         setError(data.error || "Failed to load users.");
         return;
       }
-      const usersData = await usersResp.json();
-      const activeUsers: VaultUser[] = (usersData.users ?? []).map(
-        (u: { email: string; role: string }) => ({
-          ...u,
-          status: "active" as const,
-        })
-      );
-
-      // Fetch pending invites if admin
-      let pendingUsers: VaultUser[] = [];
-      if (vaultRole === "admin") {
-        const invResp = await fetch(
-          `/v1/vaults/${encodeURIComponent(vaultName)}/invites?status=pending`
-        );
-        if (invResp.ok) {
-          const invData = await invResp.json();
-          pendingUsers = (invData.invites ?? []).map(
-            (inv: { email: string; role: string; token: string }) => ({
-              email: inv.email,
-              role: inv.role,
-              status: "pending" as const,
-              invite_token: inv.token,
-            })
-          );
-        }
-      }
-
-      setUsers([...activeUsers, ...pendingUsers]);
+      const data = await resp.json();
+      setUsers(data.users ?? []);
     } catch {
       setError("Network error.");
     } finally {
@@ -227,7 +153,7 @@ export default function UsersTab() {
           </p>
         </div>
         {vaultRole === "admin" && (
-          <InviteUserButton vaultName={vaultName} onInvited={fetchUsers} />
+          <AddUserButton vaultName={vaultName} vaultUsers={users} onAdded={fetchUsers} />
         )}
       </div>
 
@@ -241,88 +167,71 @@ export default function UsersTab() {
           data={users}
           rowKey={(u) => u.email}
           emptyTitle="No users"
-          emptyDescription="Invite people to give them access to this vault."
+          emptyDescription="Add existing instance users to give them access to this vault."
         />
       )}
-
-      <Modal
-        open={!!reinviteLink}
-        onClose={() => setReinviteLink(null)}
-        title="Invite Link"
-        description="Share this link to grant vault access."
-        footer={
-          <Button onClick={() => setReinviteLink(null)}>Done</Button>
-        }
-      >
-        {reinviteLink && (
-          <div className="space-y-4">
-            <p className="text-sm text-text-muted">
-              Email delivery is not configured. Share this link with{" "}
-              <span className="font-medium text-text">
-                {reinviteLink.email}
-              </span>{" "}
-              so they can accept the invite.
-            </p>
-            <div className="flex items-center gap-2">
-              <Input
-                readOnly
-                value={reinviteLink.link}
-                className="flex-1 px-4 py-3 bg-bg border border-border rounded-lg text-text text-sm font-mono outline-none select-all"
-                onFocus={(e) => e.target.select()}
-              />
-              <CopyButton value={reinviteLink.link} />
-            </div>
-          </div>
-        )}
-      </Modal>
     </div>
   );
 }
 
-function InviteUserButton({
+interface InstanceUser {
+  email: string;
+  role: string;
+}
+
+function AddUserButton({
   vaultName,
-  onInvited,
+  vaultUsers,
+  onAdded,
 }: {
   vaultName: string;
-  onInvited: () => void;
+  vaultUsers: VaultUser[];
+  onAdded: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<"member" | "admin">("member");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
-  const [inviteLink, setInviteLink] = useState("");
+  const [instanceUsers, setInstanceUsers] = useState<InstanceUser[]>([]);
+
+  useEffect(() => {
+    if (!open) return;
+    fetch("/v1/users")
+      .then((r) => r.json())
+      .then((data) => setInstanceUsers(data.users ?? []))
+      .catch(() => {});
+  }, [open]);
+
+  const availableUsers = instanceUsers.filter(
+    (u) => !vaultUsers.some((vu) => vu.email === u.email)
+  );
 
   function close() {
     setOpen(false);
     setEmail("");
     setRole("member");
     setError("");
-    setInviteLink("");
   }
 
-  async function handleInvite() {
-    if (!email.trim()) return;
+  async function handleAdd() {
+    if (!email) return;
     setSubmitting(true);
     setError("");
     try {
       const resp = await apiFetch(
-        `/v1/vaults/${encodeURIComponent(vaultName)}/invites`,
+        `/v1/vaults/${encodeURIComponent(vaultName)}/users`,
         {
           method: "POST",
-          body: JSON.stringify({ email: email.trim(), role }),
+          body: JSON.stringify({ email, role }),
         }
       );
-      const data = await resp.json();
       if (resp.ok) {
-        onInvited();
-        if (data.email_sent) {
-          close();
-        } else {
-          setInviteLink(data.invite_link || "");
-        }
+        onAdded();
+        close();
       } else {
-        setError(data.error || "Failed to send invite.");
+        const data = await resp.json();
+        setError(data.error || "Failed to add user.");
       }
     } catch {
       setError("Network error.");
@@ -348,79 +257,62 @@ function InviteUserButton({
           <line x1="20" y1="8" x2="20" y2="14" />
           <line x1="23" y1="11" x2="17" y2="11" />
         </svg>
-        Invite user
+        Add user
       </Button>
 
       <Modal
         open={open}
         onClose={close}
-        title={inviteLink ? "Invite Created" : "Invite User"}
-        description={inviteLink ? "Share this link to grant vault access." : "Grant a user access to this vault."}
+        title="Add User to Vault"
+        description="Grant an existing instance user access to this vault."
         footer={
-          inviteLink ? (
-            <Button onClick={close}>Done</Button>
-          ) : (
-            <>
-              <Button variant="secondary" onClick={close}>Cancel</Button>
-              <Button
-                onClick={handleInvite}
-                disabled={!email.trim()}
-                loading={submitting}
-              >
-                Send invite
-              </Button>
-            </>
-          )
+          <>
+            <Button variant="secondary" onClick={close}>Cancel</Button>
+            <Button
+              onClick={handleAdd}
+              disabled={!email}
+              loading={submitting}
+            >
+              Add user
+            </Button>
+          </>
         }
       >
-        {inviteLink ? (
-          <div className="space-y-4">
-            <p className="text-sm text-text-muted">
-              Email delivery is not configured. Share this link with{" "}
-              <span className="font-medium text-text">{email}</span> so
-              they can accept the invite.
-            </p>
-            <div className="flex items-center gap-2">
-              <Input
-                readOnly
-                value={inviteLink}
-                className="flex-1 px-4 py-3 bg-bg border border-border rounded-lg text-text text-sm font-mono outline-none select-all"
-                onFocus={(e) => e.target.select()}
-              />
-              <CopyButton value={inviteLink} />
-            </div>
-          </div>
-        ) : (
-          <div className="space-y-4">
-            <FormField label="Email">
-              <Input
-                type="email"
-                placeholder="name@company.com"
+        <div className="space-y-4">
+          <FormField label="User">
+            {availableUsers.length === 0 ? (
+              <p className="text-sm text-text-muted py-2">
+                All instance users already have access to this vault.
+              </p>
+            ) : (
+              <Select
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleInvite();
-                }}
                 autoFocus
-              />
-            </FormField>
-            <FormField
-              label="Role"
-              helperText={<>{role === "member"
-                ? "Manage credentials, use proxy, approve proposals, and manage services."
-                : "All member permissions, plus invite users and agents with any role."} <a href="https://docs.agent-vault.dev/learn/permissions#vault-roles" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Learn more</a></>}
-            >
-              <Select
-                value={role}
-                onChange={(e) => setRole(e.target.value as "member" | "admin")}
               >
-                <option value="member">Member</option>
-                <option value="admin">Admin</option>
+                <option value="" disabled>Select a user...</option>
+                {availableUsers.map((u) => (
+                  <option key={u.email} value={u.email}>{u.email}</option>
+                ))}
               </Select>
-            </FormField>
-            {error && <ErrorBanner message={error} />}
-          </div>
-        )}
+            )}
+          </FormField>
+          <FormField
+            label="Role"
+            helperText={<>{role === "member"
+              ? "Manage credentials, use proxy, approve proposals, and manage services."
+              : "All member permissions, plus invite users and agents with any role."} <a href="https://docs.agent-vault.dev/learn/permissions#vault-roles" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Learn more</a></>}
+          >
+            <Select
+              value={role}
+              onChange={(e) => setRole(e.target.value as "member" | "admin")}
+            >
+              <option value="member">Member</option>
+              <option value="admin">Admin</option>
+            </Select>
+          </FormField>
+          {error && <ErrorBanner message={error} />}
+        </div>
       </Modal>
     </>
   );

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -12,7 +12,7 @@ import ForgotPassword from "./pages/ForgotPassword";
 import VaultsLayout from "./components/VaultsLayout";
 import VaultsListTab from "./pages/home/VaultsListTab";
 import AllUsersTab from "./pages/home/AllUsersTab";
-import VaultInvite from "./pages/VaultInvite";
+import UserInvite from "./pages/UserInvite";
 import ProposalApprove from "./pages/ProposalApprove";
 import VaultLayout from "./components/VaultLayout";
 import ProposalsTab from "./pages/vault/ProposalsTab";
@@ -102,13 +102,15 @@ const forgotPasswordRoute = createRoute({
   component: ForgotPassword,
 });
 
-const vaultInviteRoute = createRoute({
+const userInviteRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/vault-invite/$token",
+  path: "/invite/$token",
   loader: async ({ params }) => {
-    const resp = await apiFetch(`/v1/vault-invites/${params.token}/details`);
+    const resp = await apiFetch(`/v1/users/invites/${params.token}/details`);
     if (resp.ok) {
-      return resp.json();
+      const data = await resp.json();
+      data.token = params.token;
+      return data;
     }
     // Return error shape the component expects
     const data = await resp.json().catch(() => ({}));
@@ -118,7 +120,7 @@ const vaultInviteRoute = createRoute({
       error_message: data.error || "This invite link is no longer valid.",
     };
   },
-  component: VaultInvite,
+  component: UserInvite,
 });
 
 const proposalApproveRoute = createRoute({
@@ -336,7 +338,7 @@ const routeTree = rootRoute.addChildren([
   loginRoute,
   registerRoute,
   forgotPasswordRoute,
-  vaultInviteRoute,
+  userInviteRoute,
   proposalApproveRoute,
   oauthCallbackRoute,
   authLayoutRoute.addChildren([


### PR DESCRIPTION
## Summary

- Restructure user invites from vault-scoped to instance-level. Any authenticated user can invite someone to the Agent Vault instance with optional vault pre-assignments.
- Adding existing users to vaults is now a direct grant via `POST /v1/vaults/{name}/users` (no invite needed).
- Vault Users tab "Add user" modal now shows a dropdown of instance users instead of a free-text email input.

### Changes

**Database**: Migration 034 drops `vault_invites`, creates `user_invites` + `user_invite_vaults` junction table.

**API**: New endpoints `POST/GET/DELETE /v1/users/invites`, `GET /v1/users/invites/{token}/details`, `POST /v1/users/invites/{token}/accept`, `POST /v1/vaults/{name}/users`. Old `/v1/vaults/{name}/invites` endpoints removed.

**CLI**: New `agent-vault user invite` command group. Replaced `vault user invite` with `vault user add`.

**Frontend**: Invite modal with vault picker on AllUsersTab, user dropdown selector on vault AddUser modal, renamed VaultInvite → UserInvite page (`/invite/$token`).

**Quality fixes**: Batch vault loading (N+1 fix), authorization on invite revoke, extracted `sendUserInviteEmail` helper, consolidated vault JSON response types, updated agent instruction docs.

## Test plan

- [x] `go build ./...` compiles
- [x] `npx tsc --noEmit` passes
- [x] `go test ./...` passes (all packages)
- [ ] Manual E2E: owner sends invite, invitee accepts via browser, verify vault pre-assignments applied
- [ ] Manual: vault admin adds existing user via dropdown in vault Users tab
- [ ] Manual: non-creator member cannot revoke another user's invite

🤖 Generated with [Claude Code](https://claude.com/claude-code)