### PR TITLE
feat: instance-level agents with multi-vault access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,17 +106,20 @@ Agent Vault requires two things before it becomes operational: a **master passwo
   - `agent-vault proposal approve <number> [KEY=VALUE ...]` -- approve and apply (requires active login session; prompts for missing credentials)
   - `agent-vault proposal reject <number> [--reason "..."]` -- reject a pending proposal (requires active login session)
   - `agent-vault proposal review` -- interactively walk through all pending proposals (approve, reject, skip, or quit each; requires active login session)
-- `agent-vault vault agent [invite|list|info|revoke|rotate|rename]` -- manage agents and invite links
-  - `agent-vault vault agent invite create [--ttl 15m] [--role proxy|member|admin]` -- create a one-time invite and print the onboarding prompt (copies to clipboard; default role: proxy)
-  - `agent-vault vault agent invite create --name <agent-name> [--role proxy|member|admin] [--ttl <duration>]` -- create a persistent (named) agent invite (agent gets a session token with configurable expiry)
-  - `agent-vault vault agent invite create --direct [--role proxy|member|admin] [--ttl 24h] [--label "my agent"]` -- mint a scoped session token immediately, skipping the invite ceremony; outputs env vars to paste into the agent's environment
-  - `agent-vault vault agent invite list [--status pending]` -- list invites for vault
-  - `agent-vault vault agent invite revoke <token_suffix>` -- revoke a pending invite by last 8+ chars of token
-  - `agent-vault vault agent list [--vault default]` -- list registered agents
-  - `agent-vault vault agent info <name>` -- show agent details (vault, status, active sessions)
-  - `agent-vault vault agent revoke <name>` -- revoke an agent (deletes all sessions)
-  - `agent-vault vault agent rotate <name>` -- create a rotation invite to re-issue an agent's session
-  - `agent-vault vault agent rename <name> <new-name>` -- rename an agent
+- `agent-vault agent [invite|list|info|revoke|rotate|rename]` -- instance-level agent management
+  - `agent-vault agent invite <name> [--vault name:role ...]` -- invite an agent to the instance with optional vault pre-assignments (repeatable --vault flag, format: `name:role`, role defaults to `proxy`)
+  - `agent-vault agent invite list [--status pending]` -- list agent invites
+  - `agent-vault agent invite revoke <token_suffix>` -- revoke a pending agent invite
+  - `agent-vault agent list` -- list all agents
+  - `agent-vault agent info <name>` -- show agent details (vaults, status, active sessions)
+  - `agent-vault agent revoke <name>` -- revoke an agent (deletes all sessions)
+  - `agent-vault agent rotate <name>` -- create a rotation invite to re-issue an agent's session
+  - `agent-vault agent rename <name> <new-name>` -- rename an agent
+- `agent-vault vault agent [list|add|remove|set-role]` -- manage vault-level agent access
+  - `agent-vault vault agent list` -- list agents in the current vault
+  - `agent-vault vault agent add <name> [--role proxy|member|admin]` -- add an existing instance agent to the vault
+  - `agent-vault vault agent remove <name>` -- remove an agent from the vault
+  - `agent-vault vault agent set-role <name> --role proxy|member|admin` -- change an agent's vault role
 - `agent-vault email test [--to <email>]` -- send a test email to verify SMTP configuration (owner-only; defaults to sending to the owner's own email)
 - `agent-vault reset [--yes]` -- permanently delete all data and reset the instance to a fresh state (owner-only; requires running server for role verification; auto-stops server before reset)
 - `agent-vault vault discover [--json]` -- show available services and credentials for the current vault. Requires a vault-scoped session (via `agent-vault vault run` or `AGENT_VAULT_SESSION_TOKEN` + `AGENT_VAULT_ADDR` env vars). `--json` for machine-readable output.
@@ -140,7 +143,7 @@ The server exposes a generic HTTP proxy at `/proxy/{target_host}/{path}[?query]`
 Agent Vault provides two skill files that teach agents how to interact with it:
 
 - `cmd/skill_cli.md` (`agent-vault-cli`) -- For agents launched via `vault run` that have the `agent-vault` binary on `$PATH`. Covers CLI commands (`discover`, `catalog`, `proposal create`, `credential get`) and the proxy URL pattern.
-- `cmd/skill_http.md` (`agent-vault-http`) -- For agents without the binary (invite-redeemed, remote, persistent). Covers HTTP endpoints only, including persistent agent mode.
+- `cmd/skill_http.md` (`agent-vault-http`) -- For agents without the binary (invite-redeemed, remote, instance-level). Covers HTTP endpoints only, including instance-level agent sessions and X-Vault header.
 
 Both skills are embedded in the Go binary. `vault run` installs both to `~/.{claude,cursor,agents}/skills/agent-vault-{cli,http}/SKILL.md`. The server serves them at public endpoints:
 - `GET /v1/skills/cli` -- returns CLI skill as text/markdown
@@ -242,45 +245,41 @@ The `instance_settings` table is a generic key-value store. Settings are stored 
 
 OAuth state table (`oauth_states`) stores SHA-256 hashed state params, PKCE code_verifiers, mode (login/connect), and optional user_id. Expired states are cleaned up alongside proposal/invite expiry.
 
-## Invite API
+## Agent Invite API
 
-Invites let a human onboard any agent (including cloud-hosted agents like Devin or chat-based agents) by pasting a short prompt into the agent's chat. The agent redeems the invite via a single GET request (no auth required) and receives a session token plus full usage instructions.
+Agent invites let a human onboard any agent (including cloud-hosted agents like Devin or chat-based agents) by pasting a short prompt into the agent's chat. The agent redeems the invite via a POST request and receives an instance-level session token plus full usage instructions.
 
-- `GET /invite/{token}` -- redeem a temporary invite (no auth required; the token itself is the credential). Returns session token, proxy URL, services, and embedded usage instructions. Single-use: token is burned on redemption. Returns 405 for persistent invites (must use POST).
-- `POST /invite/{token}` -- redeem a persistent invite. Body: `{"name": "agent-name"}` (optional if name was pre-set). Returns `av_session_token`, agent name, services, and persistent agent instructions. Also used for rotation invite redemption (body ignored, new session issued).
-- `GET /v1/invites?vault=default&status=pending` -- list invites (admin session required)
-- `DELETE /v1/invites/{token}` -- revoke a pending invite (admin session required)
+- `POST /v1/agents/invites` -- create an agent invite (any authenticated user). Body: `{"name": "my-agent", "vaults": [{"vault_name": "default", "vault_role": "proxy"}]}`. Name is required. Vault pre-assignments are optional.
+- `GET /v1/agents/invites[?status=pending]` -- list agent invites
+- `DELETE /v1/agents/invites/{token}` -- revoke a pending agent invite
+- `POST /invite/{token}` -- redeem an agent invite. Body: `{}`. Returns `av_session_token`, agent name, vault list, and usage instructions. Creates an instance-level agent session (vault_id = NULL). Also used for rotation invite redemption.
 
-Invite states: `pending`, `redeemed`, `expired`, or `revoked`. Token format: `av_inv_` + 64 hex chars. Max 10 pending invites per vault. Default TTL: 15 minutes.
+Invite states: `pending`, `redeemed`, `expired`, or `revoked`. Token format: `av_inv_` + 64 hex chars. Default TTL: 15 minutes.
 
-## Direct Connect Sessions
+## Instance-Level Agent API
 
-Direct connect skips the invite ceremony entirely. Instead of creating an invite link for an agent to redeem, it uses the caller's login session to mint a scoped session token immediately. The output is a set of env vars (`AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, `AGENT_VAULT_VAULT`) that can be pasted directly into any agent's environment.
-
-- `POST /v1/sessions/direct` -- mint a scoped session token (requires user or agent session with at least member role on the vault)
-  - Request: `{"vault": "default", "vault_role": "proxy", "ttl_seconds": 86400, "label": "my agent"}`
-  - Defaults: vault=`"default"`, vault_role=`"proxy"`, ttl_seconds=`86400` (24h)
-  - TTL bounds: min 5 minutes (300s), max 7 days (604800s)
-  - Label: optional, max 128 characters
-  - Response: `{"av_addr", "av_session_token", "av_vault", "vault_role", "proxy_url", "services", "instructions", "expires_at"}`
-
-**Role capping**: The minted session's role is capped to the caller's own vault role. Members can only mint `proxy` sessions; admins can mint any role (`proxy`, `member`, `admin`). Proxy-role agents cannot mint sessions at all.
-
-## Persistent Agent API
-
-Persistent agents have named identities with session tokens that can be configured with no expiry (or a specific TTL). This is for agents that need ongoing access without human intervention.
+Agents are instance-level entities (like users) with multi-vault access via `agent_vault_grants`. Agent sessions are instance-level (vault_id = NULL) and select vaults per-request via the `X-Vault` header.
 
 - **Agent names**: globally unique, 3-64 chars, lowercase alphanumeric + hyphens.
 - **Session token**: `av_sess_` + 64 hex chars, hashed with SHA-256. Configurable expiry (including no expiry).
-- **Rotation**: `POST /v1/admin/agents/{name}/rotate` creates a rotation invite. The operator pastes the prompt into the agent's chat. The agent POSTs to the invite URL and receives a new session token. Old sessions are invalidated at redemption time (not at invite creation).
+- **Multi-vault**: Agents can be granted access to multiple vaults with independent roles per vault.
+- **X-Vault header**: Instance-level agent sessions must include `X-Vault: {vault_name}` on all vault-scoped requests (proxy, discover, proposals, credentials).
+- **Rotation**: `POST /v1/agents/{name}/rotate` creates a rotation invite. The operator pastes the prompt into the agent's chat. The agent POSTs to the invite URL and receives a new session token. Old sessions are invalidated at redemption time (not at invite creation).
 
-### Agent Admin Endpoints (owner-only)
+### Instance-Level Agent Endpoints
 
-- `GET /v1/admin/agents[?vault=...]` -- list agents
-- `GET /v1/admin/agents/{name}` -- get agent details (vault, status, active session count)
-- `DELETE /v1/admin/agents/{name}` -- revoke agent + cascade delete sessions
-- `POST /v1/admin/agents/{name}/rotate` -- create rotation invite, returns invite URL + prompt
-- `POST /v1/admin/agents/{name}/rename` -- rename agent; body: `{"name": "new-name"}`
+- `GET /v1/agents` -- list all agents (any authenticated user)
+- `GET /v1/agents/{name}` -- get agent details (vaults, status, active session count)
+- `DELETE /v1/agents/{name}` -- revoke agent + cascade delete sessions
+- `POST /v1/agents/{name}/rotate` -- create rotation invite, returns invite URL + prompt
+- `POST /v1/agents/{name}/rename` -- rename agent; body: `{"name": "new-name"}`
+
+### Vault-Level Agent Endpoints
+
+- `GET /v1/vaults/{name}/agents` -- list agents in a vault
+- `POST /v1/vaults/{name}/agents` -- add an existing agent to a vault; body: `{"name": "my-agent", "role": "proxy"}`
+- `DELETE /v1/vaults/{name}/agents/{agentName}` -- remove agent from vault
+- `POST /v1/vaults/{name}/agents/{agentName}/role` -- change vault role; body: `{"role": "member"}`
 
 ## Multi-User Permission Model
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ agent-vault vault run -- agent     # Cursor
 agent-vault vault run -- codex     # Codex
 
 # Or create an invite for any agent
-agent-vault vault agent invite create
+agent-vault agent invite my-agent
 ```
 
-Any command that needs authentication will walk you through setup automatically — just run it and follow the prompts. `agent-vault vault run` wraps your agent process with a scoped session — no tokens to manage. Alternatively, `agent-vault vault agent invite create` prints an invite prompt you can paste into any agent's chat to connect it.
+Any command that needs authentication will walk you through setup automatically — just run it and follow the prompts. `agent-vault vault run` wraps your agent process with a scoped session — no tokens to manage. Alternatively, `agent-vault agent invite` prints an invite prompt you can paste into any agent's chat to connect it.
 
 Once connected, ask the agent to call any external API. It will discover available services, [propose access](https://docs.agent-vault.dev/first-proposal) for anything missing, and give you a browser link to approve.
 

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -4,19 +4,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 )
 
-var agentCmd = &cobra.Command{
+// topAgentCmd is the top-level "agent" command for instance-level agent management.
+var topAgentCmd = &cobra.Command{
 	Use:   "agent",
-	Short: "Manage agents",
+	Short: "Manage agents (instance-level)",
 }
 
 var agentListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List registered agents",
+	Short: "List all agents",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sess, err := ensureSession()
@@ -24,9 +26,7 @@ var agentListCmd = &cobra.Command{
 			return err
 		}
 
-		vault := resolveVault(cmd)
-		reqURL := sess.Address + "/v1/admin/agents?vault=" + url.QueryEscape(vault)
-
+		reqURL := sess.Address + "/v1/agents"
 		respBody, err := doAdminRequestWithBody("GET", reqURL, sess.Token, nil)
 		if err != nil {
 			return err
@@ -34,12 +34,13 @@ var agentListCmd = &cobra.Command{
 
 		var result struct {
 			Agents []struct {
-				Name      string  `json:"name"`
-				VaultID   string  `json:"vault_id"`
-				VaultRole string  `json:"vault_role"`
-				Status    string  `json:"status"`
-				CreatedAt string  `json:"created_at"`
-				RevokedAt *string `json:"revoked_at,omitempty"`
+				Name      string `json:"name"`
+				Status    string `json:"status"`
+				CreatedAt string `json:"created_at"`
+				Vaults    []struct {
+					VaultName string `json:"vault_name"`
+					VaultRole string `json:"vault_role"`
+				} `json:"vaults"`
 			} `json:"agents"`
 		}
 		if err := json.Unmarshal(respBody, &result); err != nil {
@@ -52,9 +53,17 @@ var agentListCmd = &cobra.Command{
 		}
 
 		t := newTable(cmd.OutOrStdout())
-		t.AppendHeader(table.Row{"NAME", "ROLE", "STATUS", "VAULT", "CREATED"})
+		t.AppendHeader(table.Row{"NAME", "STATUS", "VAULTS", "CREATED"})
 		for _, ag := range result.Agents {
-			t.AppendRow(table.Row{ag.Name, ag.VaultRole, statusBadge(ag.Status), ag.VaultID, ag.CreatedAt})
+			var vaultParts []string
+			for _, v := range ag.Vaults {
+				vaultParts = append(vaultParts, fmt.Sprintf("%s:%s", v.VaultName, v.VaultRole))
+			}
+			vaults := strings.Join(vaultParts, ", ")
+			if vaults == "" {
+				vaults = "-"
+			}
+			t.AppendRow(table.Row{ag.Name, statusBadge(ag.Status), vaults, ag.CreatedAt})
 		}
 		t.Render()
 		return nil
@@ -72,22 +81,24 @@ var agentInfoCmd = &cobra.Command{
 			return err
 		}
 
-		reqURL := sess.Address + "/v1/admin/agents/" + url.PathEscape(name)
+		reqURL := sess.Address + "/v1/agents/" + url.PathEscape(name)
 		respBody, err := doAdminRequestWithBody("GET", reqURL, sess.Token, nil)
 		if err != nil {
 			return err
 		}
 
 		var info struct {
-			Name           string  `json:"name"`
-			Vault          string  `json:"vault"`
-			VaultRole      string  `json:"vault_role"`
-			Status         string  `json:"status"`
-			CreatedBy      string  `json:"created_by"`
-			CreatedAt      string  `json:"created_at"`
-			UpdatedAt      string  `json:"updated_at"`
+			Name           string `json:"name"`
+			Status         string `json:"status"`
+			CreatedBy      string `json:"created_by"`
+			CreatedAt      string `json:"created_at"`
+			UpdatedAt      string `json:"updated_at"`
 			RevokedAt      *string `json:"revoked_at,omitempty"`
 			ActiveSessions int     `json:"active_sessions"`
+			Vaults         []struct {
+				VaultName string `json:"vault_name"`
+				VaultRole string `json:"vault_role"`
+			} `json:"vaults"`
 		}
 		if err := json.Unmarshal(respBody, &info); err != nil {
 			return fmt.Errorf("parsing response: %w", err)
@@ -95,8 +106,6 @@ var agentInfoCmd = &cobra.Command{
 
 		w := cmd.OutOrStdout()
 		_, _ = fmt.Fprintf(w, "%s\n", boldText("Agent: "+info.Name))
-		_, _ = fmt.Fprintf(w, "%s %s\n", fieldLabel("Vault:"), info.Vault)
-		_, _ = fmt.Fprintf(w, "%s %s\n", fieldLabel("Role:"), info.VaultRole)
 		_, _ = fmt.Fprintf(w, "%s %s\n", fieldLabel("Status:"), statusBadge(info.Status))
 		_, _ = fmt.Fprintf(w, "%s %s\n", fieldLabel("Created:"), info.CreatedAt)
 		_, _ = fmt.Fprintf(w, "%s %s\n", fieldLabel("Updated:"), info.UpdatedAt)
@@ -104,6 +113,14 @@ var agentInfoCmd = &cobra.Command{
 			_, _ = fmt.Fprintf(w, "%s %s\n", fieldLabel("Revoked:"), *info.RevokedAt)
 		}
 		_, _ = fmt.Fprintf(w, "%s %d\n", fieldLabel("Active sessions:"), info.ActiveSessions)
+		if len(info.Vaults) > 0 {
+			_, _ = fmt.Fprintf(w, "%s\n", fieldLabel("Vaults:"))
+			for _, v := range info.Vaults {
+				_, _ = fmt.Fprintf(w, "  - %s (%s)\n", v.VaultName, v.VaultRole)
+			}
+		} else {
+			_, _ = fmt.Fprintf(w, "%s none\n", fieldLabel("Vaults:"))
+		}
 		return nil
 	},
 }
@@ -119,7 +136,7 @@ var agentRevokeCmd = &cobra.Command{
 			return err
 		}
 
-		reqURL := sess.Address + "/v1/admin/agents/" + url.PathEscape(name)
+		reqURL := sess.Address + "/v1/agents/" + url.PathEscape(name)
 		if err := doAdminRequest("DELETE", reqURL, sess.Token, nil); err != nil {
 			return err
 		}
@@ -140,7 +157,7 @@ var agentRotateCmd = &cobra.Command{
 			return err
 		}
 
-		reqURL := sess.Address + "/v1/admin/agents/" + url.PathEscape(name) + "/rotate"
+		reqURL := sess.Address + "/v1/agents/" + url.PathEscape(name) + "/rotate"
 		respBody, err := doAdminRequestWithBody("POST", reqURL, sess.Token, []byte("{}"))
 		if err != nil {
 			return err
@@ -184,7 +201,7 @@ var agentRenameCmd = &cobra.Command{
 			return err
 		}
 
-		reqURL := sess.Address + "/v1/admin/agents/" + url.PathEscape(name) + "/rename"
+		reqURL := sess.Address + "/v1/agents/" + url.PathEscape(name) + "/rename"
 		if err := doAdminRequest("POST", reqURL, sess.Token, body); err != nil {
 			return err
 		}
@@ -194,12 +211,118 @@ var agentRenameCmd = &cobra.Command{
 	},
 }
 
-var agentSetRoleCmd = &cobra.Command{
-	Use:   "set-role <name>",
-	Short: "Set an agent's vault role",
+// --- Vault-level agent commands (under "vault agent") ---
+
+var vaultAgentCmd = &cobra.Command{
+	Use:   "agent",
+	Short: "Manage vault agent access",
+}
+
+var vaultAgentListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List agents in a vault",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		vault := resolveVault(cmd)
+		sess, err := ensureSession()
+		if err != nil {
+			return err
+		}
+
+		reqURL := sess.Address + "/v1/vaults/" + url.PathEscape(vault) + "/agents"
+		respBody, err := doAdminRequestWithBody("GET", reqURL, sess.Token, nil)
+		if err != nil {
+			return err
+		}
+
+		var result struct {
+			Agents []struct {
+				Name      string `json:"name"`
+				VaultRole string `json:"vault_role"`
+				Status    string `json:"status"`
+			} `json:"agents"`
+		}
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			return fmt.Errorf("parsing response: %w", err)
+		}
+
+		if len(result.Agents) == 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No agents in vault %q.\n", vault)
+			return nil
+		}
+
+		t := newTable(cmd.OutOrStdout())
+		t.AppendHeader(table.Row{"NAME", "ROLE", "STATUS"})
+		for _, ag := range result.Agents {
+			t.AppendRow(table.Row{ag.Name, ag.VaultRole, statusBadge(ag.Status)})
+		}
+		t.Render()
+		return nil
+	},
+}
+
+var vaultAgentAddCmd = &cobra.Command{
+	Use:   "add <name>",
+	Short: "Add an existing agent to this vault",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		name := args[0]
+		agentName := args[0]
+		vault := resolveVault(cmd)
+		role, _ := cmd.Flags().GetString("role")
+		if role == "" {
+			role = "proxy"
+		}
+
+		sess, err := ensureSession()
+		if err != nil {
+			return err
+		}
+
+		body, err := json.Marshal(map[string]string{"name": agentName, "role": role})
+		if err != nil {
+			return err
+		}
+
+		reqURL := sess.Address + "/v1/vaults/" + url.PathEscape(vault) + "/agents"
+		if err := doAdminRequest("POST", reqURL, sess.Token, body); err != nil {
+			return err
+		}
+
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Agent %q added to vault %q with role %q.\n", successText("✓"), agentName, vault, role)
+		return nil
+	},
+}
+
+var vaultAgentRemoveCmd = &cobra.Command{
+	Use:   "remove <name>",
+	Short: "Remove an agent from this vault",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		agentName := args[0]
+		vault := resolveVault(cmd)
+
+		sess, err := ensureSession()
+		if err != nil {
+			return err
+		}
+
+		reqURL := sess.Address + "/v1/vaults/" + url.PathEscape(vault) + "/agents/" + url.PathEscape(agentName)
+		if err := doAdminRequest("DELETE", reqURL, sess.Token, nil); err != nil {
+			return err
+		}
+
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Agent %q removed from vault %q.\n", successText("✓"), agentName, vault)
+		return nil
+	},
+}
+
+var vaultAgentSetRoleCmd = &cobra.Command{
+	Use:   "set-role <name>",
+	Short: "Change an agent's vault role",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		agentName := args[0]
+		vault := resolveVault(cmd)
 		role, _ := cmd.Flags().GetString("role")
 		if role == "" {
 			return fmt.Errorf("--role is required (proxy, member, admin)")
@@ -218,24 +341,32 @@ var agentSetRoleCmd = &cobra.Command{
 			return err
 		}
 
-		reqURL := sess.Address + "/v1/admin/agents/" + url.PathEscape(name) + "/vault-role"
+		reqURL := sess.Address + "/v1/vaults/" + url.PathEscape(vault) + "/agents/" + url.PathEscape(agentName) + "/role"
 		if err := doAdminRequest("POST", reqURL, sess.Token, body); err != nil {
 			return err
 		}
 
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Agent %q role set to %q.\n", successText("✓"), name, role)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Agent %q role in vault %q set to %q.\n", successText("✓"), agentName, vault, role)
 		return nil
 	},
 }
 
 func init() {
-	agentSetRoleCmd.Flags().String("role", "", "vault role (proxy, member, admin)")
+	vaultAgentAddCmd.Flags().String("role", "proxy", "vault role (proxy, member, admin)")
+	vaultAgentSetRoleCmd.Flags().String("role", "", "vault role (proxy, member, admin)")
 
-	agentCmd.AddCommand(agentListCmd)
-	agentCmd.AddCommand(agentInfoCmd)
-	agentCmd.AddCommand(agentRevokeCmd)
-	agentCmd.AddCommand(agentRotateCmd)
-	agentCmd.AddCommand(agentRenameCmd)
-	agentCmd.AddCommand(agentSetRoleCmd)
-	vaultCmd.AddCommand(agentCmd)
+	// Instance-level agent commands: agent-vault agent [list|info|revoke|rotate|rename]
+	topAgentCmd.AddCommand(agentListCmd)
+	topAgentCmd.AddCommand(agentInfoCmd)
+	topAgentCmd.AddCommand(agentRevokeCmd)
+	topAgentCmd.AddCommand(agentRotateCmd)
+	topAgentCmd.AddCommand(agentRenameCmd)
+	rootCmd.AddCommand(topAgentCmd)
+
+	// Vault-level agent commands: agent-vault vault agent [list|add|remove|set-role]
+	vaultAgentCmd.AddCommand(vaultAgentListCmd)
+	vaultAgentCmd.AddCommand(vaultAgentAddCmd)
+	vaultAgentCmd.AddCommand(vaultAgentRemoveCmd)
+	vaultAgentCmd.AddCommand(vaultAgentSetRoleCmd)
+	vaultCmd.AddCommand(vaultAgentCmd)
 }

--- a/cmd/agent_invite.go
+++ b/cmd/agent_invite.go
@@ -1,0 +1,193 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var agentInviteCmd = &cobra.Command{
+	Use:   "invite <name>",
+	Short: "Invite an agent to the instance",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		agentName := args[0]
+		inviteTTL, _ := cmd.Flags().GetDuration("invite-ttl")
+		vaultFlags, _ := cmd.Flags().GetStringArray("vault")
+		tokenOnly, _ := cmd.Flags().GetBool("token-only")
+
+		sess, err := ensureSession()
+		if err != nil {
+			return err
+		}
+
+		addr := sess.Address
+		if flagAddr, _ := cmd.Flags().GetString("address"); flagAddr != "" {
+			addr = flagAddr
+		}
+
+		type vaultEntry struct {
+			VaultName string `json:"vault_name"`
+			VaultRole string `json:"vault_role"`
+		}
+
+		var vaults []vaultEntry
+		for _, v := range vaultFlags {
+			name, role, _ := strings.Cut(v, ":")
+			if role == "" {
+				role = "proxy"
+			}
+			vaults = append(vaults, vaultEntry{VaultName: name, VaultRole: role})
+		}
+
+		payload := map[string]any{
+			"name":        agentName,
+			"ttl_seconds": int(inviteTTL.Seconds()),
+		}
+		if len(vaults) > 0 {
+			payload["vaults"] = vaults
+		}
+
+		body, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+
+		reqURL := fmt.Sprintf("%s/v1/agents/invites", sess.Address)
+		respBody, err := doAdminRequestWithBody("POST", reqURL, sess.Token, body)
+		if err != nil {
+			return err
+		}
+
+		var resp struct {
+			Token     string `json:"token"`
+			ExpiresAt string `json:"expires_at"`
+		}
+		if err := json.Unmarshal(respBody, &resp); err != nil {
+			return fmt.Errorf("parsing response: %w", err)
+		}
+
+		inviteURL := addr + "/invite/" + resp.Token
+
+		if tokenOnly {
+			fmt.Fprint(cmd.OutOrStdout(), resp.Token)
+			return nil
+		}
+
+		prompt := buildAgentInvitePrompt(inviteURL, inviteTTL)
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Agent invite created for %q (expires in %s).\n", agentName, formatDuration(inviteTTL))
+		fmt.Fprintf(cmd.OutOrStdout(), "Paste the following into your agent:\n\n")
+		fmt.Fprintf(cmd.OutOrStdout(), "---\n\n%s\n---\n", prompt)
+		if err := copyToClipboard(prompt); err == nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "\n(Copied to clipboard)\n")
+		}
+		return nil
+	},
+}
+
+var agentInviteListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List agent invites",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sess, err := ensureSession()
+		if err != nil {
+			return err
+		}
+
+		status, _ := cmd.Flags().GetString("status")
+		reqURL := fmt.Sprintf("%s/v1/agents/invites", sess.Address)
+		if status != "" {
+			reqURL += "?status=" + status
+		}
+
+		respBody, err := doAdminRequestWithBody("GET", reqURL, sess.Token, nil)
+		if err != nil {
+			return err
+		}
+
+		var resp struct {
+			Invites []struct {
+				AgentName string `json:"agent_name"`
+				Status    string `json:"status"`
+				CreatedBy string `json:"created_by"`
+				CreatedAt string `json:"created_at"`
+				ExpiresAt string `json:"expires_at"`
+				Vaults    []struct {
+					VaultName string `json:"vault_name"`
+					VaultRole string `json:"vault_role"`
+				} `json:"vaults"`
+			} `json:"invites"`
+		}
+		if err := json.Unmarshal(respBody, &resp); err != nil {
+			return fmt.Errorf("parsing response: %w", err)
+		}
+
+		if len(resp.Invites) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No agent invites found.")
+			return nil
+		}
+
+		t := newTable(cmd.OutOrStdout())
+		t.AppendHeader(table.Row{"NAME", "STATUS", "VAULTS", "INVITED BY", "CREATED", "EXPIRES"})
+		for _, inv := range resp.Invites {
+			var vaultParts []string
+			for _, v := range inv.Vaults {
+				vaultParts = append(vaultParts, fmt.Sprintf("%s:%s", v.VaultName, v.VaultRole))
+			}
+			vaults := strings.Join(vaultParts, ", ")
+			if vaults == "" {
+				vaults = "-"
+			}
+			created := inv.CreatedAt
+			if parsed, err := time.Parse(time.RFC3339, inv.CreatedAt); err == nil {
+				created = parsed.Format("2006-01-02 15:04")
+			}
+			expires := inv.ExpiresAt
+			if parsed, err := time.Parse(time.RFC3339, inv.ExpiresAt); err == nil {
+				expires = parsed.Format("2006-01-02 15:04")
+			}
+			t.AppendRow(table.Row{inv.AgentName, inv.Status, vaults, inv.CreatedBy, created, expires})
+		}
+		t.Render()
+		return nil
+	},
+}
+
+var agentInviteRevokeCmd = &cobra.Command{
+	Use:   "revoke <token_suffix>",
+	Short: "Revoke a pending agent invite",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tokenSuffix := args[0]
+
+		sess, err := ensureSession()
+		if err != nil {
+			return err
+		}
+
+		reqURL := fmt.Sprintf("%s/v1/agents/invites/%s", sess.Address, tokenSuffix)
+		if err := doAdminRequest("DELETE", reqURL, sess.Token, nil); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "%s Agent invite revoked\n", successText("✓"))
+		return nil
+	},
+}
+
+func init() {
+	agentInviteCmd.Flags().Duration("invite-ttl", 15*time.Minute, "invite link expiration time")
+	agentInviteCmd.Flags().StringArray("vault", nil, "vault pre-assignment (format: name:role, role defaults to proxy)")
+	agentInviteCmd.Flags().String("address", "", "Agent Vault server address (default: from session)")
+	agentInviteCmd.Flags().Bool("token-only", false, "output only the raw invite token (for programmatic use)")
+	agentInviteListCmd.Flags().String("status", "", "filter by status (pending, redeemed, expired, revoked)")
+
+	agentInviteCmd.AddCommand(agentInviteListCmd, agentInviteRevokeCmd)
+	topAgentCmd.AddCommand(agentInviteCmd)
+}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -25,7 +25,7 @@ func TestCommandsRegistered(t *testing.T) {
 		registered[c.Name()] = true
 	}
 
-	expected := []string{"server", "auth", "vault", "owner", "account", "catalog", "user"}
+	expected := []string{"server", "auth", "vault", "owner", "account", "catalog", "user", "agent"}
 	for _, name := range expected {
 		if !registered[name] {
 			t.Errorf("expected command %q to be registered, but it was not", name)
@@ -97,7 +97,7 @@ func TestVaultSubcommandsRegistered(t *testing.T) {
 		registered[c.Name()] = true
 	}
 
-	expected := []string{"create", "list", "rename", "use", "current", "init", "user", "credential", "service", "proposal", "agent", "discover"}
+	expected := []string{"create", "list", "rename", "use", "current", "init", "user", "credential", "service", "proposal", "agent", "discover", "delete"}
 	for _, name := range expected {
 		if !registered[name] {
 			t.Errorf("expected vault subcommand %q to be registered, but it was not", name)
@@ -347,6 +347,7 @@ func TestProposalSubcommandsRegistered(t *testing.T) {
 }
 
 func TestAgentSubcommandsRegistered(t *testing.T) {
+	// Vault-level agent commands: list, add, remove, set-role
 	vCmd := findSubcommand(rootCmd, "vault")
 	if vCmd == nil {
 		t.Fatal("vault command not found")
@@ -361,7 +362,27 @@ func TestAgentSubcommandsRegistered(t *testing.T) {
 		registered[c.Name()] = true
 	}
 
-	expected := []string{"invite", "list", "info", "revoke", "rotate", "rename"}
+	expected := []string{"list", "add", "remove", "set-role"}
+	for _, name := range expected {
+		if !registered[name] {
+			t.Errorf("expected vault agent subcommand %q to be registered, but it was not", name)
+		}
+	}
+}
+
+func TestTopAgentSubcommandsRegistered(t *testing.T) {
+	// Instance-level agent commands: list, info, revoke, rotate, rename, invite
+	agCmd := findSubcommand(rootCmd, "agent")
+	if agCmd == nil {
+		t.Fatal("agent command not found")
+	}
+
+	registered := make(map[string]bool)
+	for _, c := range agCmd.Commands() {
+		registered[c.Name()] = true
+	}
+
+	expected := []string{"list", "info", "revoke", "rotate", "rename", "invite"}
 	for _, name := range expected {
 		if !registered[name] {
 			t.Errorf("expected agent subcommand %q to be registered, but it was not", name)
@@ -369,97 +390,33 @@ func TestAgentSubcommandsRegistered(t *testing.T) {
 	}
 }
 
-func TestInviteCreateFlags(t *testing.T) {
-	// Find vault > agent > invite > create command.
-	vCmd := findSubcommand(rootCmd, "vault")
-	if vCmd == nil {
-		t.Fatal("vault command not found")
-	}
-	agCmd := findSubcommand(vCmd, "agent")
+func TestAgentInviteSubcommandsRegistered(t *testing.T) {
+	agCmd := findSubcommand(rootCmd, "agent")
 	if agCmd == nil {
-		t.Fatal("agent command not found under vault")
+		t.Fatal("agent command not found")
 	}
-
-	var invCmd *cobra.Command
-	for _, c := range agCmd.Commands() {
-		if c.Name() == "invite" {
-			invCmd = c
-			break
-		}
-	}
+	invCmd := findSubcommand(agCmd, "invite")
 	if invCmd == nil {
 		t.Fatal("invite command not found under agent")
 	}
 
-	var createCmd *cobra.Command
+	registered := make(map[string]bool)
 	for _, c := range invCmd.Commands() {
-		if c.Name() == "create" {
-			createCmd = c
-			break
+		registered[c.Name()] = true
+	}
+
+	expected := []string{"list", "revoke"}
+	for _, name := range expected {
+		if !registered[name] {
+			t.Errorf("expected agent invite subcommand %q to be registered, but it was not", name)
 		}
 	}
-	if createCmd == nil {
-		t.Fatal("create command not found under invite")
-	}
 
-	// Verify --name flag exists.
-	f := createCmd.Flags().Lookup("name")
+	// Verify --vault flag on invite command
+	f := invCmd.Flags().Lookup("vault")
 	if f == nil {
-		t.Fatal("expected --name flag on invite create command")
+		t.Fatal("expected --vault flag on agent invite command")
 	}
-	if f.DefValue != "" {
-		t.Errorf("expected --name default to be empty, got %q", f.DefValue)
-	}
-
-	// Verify --ttl flag exists.
-	f = createCmd.Flags().Lookup("ttl")
-	if f == nil {
-		t.Fatal("expected --ttl flag on invite create command")
-	}
-}
-
-func TestInviteCreateDirectFlags(t *testing.T) {
-	// Find vault > agent > invite > create command.
-	vCmd := findSubcommand(rootCmd, "vault")
-	if vCmd == nil {
-		t.Fatal("vault command not found")
-	}
-	agCmd := findSubcommand(vCmd, "agent")
-	if agCmd == nil {
-		t.Fatal("agent command not found under vault")
-	}
-
-	var invCmd *cobra.Command
-	for _, c := range agCmd.Commands() {
-		if c.Name() == "invite" {
-			invCmd = c
-			break
-		}
-	}
-	if invCmd == nil {
-		t.Fatal("invite command not found under agent")
-	}
-
-	var createCmd *cobra.Command
-	for _, c := range invCmd.Commands() {
-		if c.Name() == "create" {
-			createCmd = c
-			break
-		}
-	}
-	if createCmd == nil {
-		t.Fatal("create command not found under invite")
-	}
-
-	// Verify --direct flag exists.
-	f := createCmd.Flags().Lookup("direct")
-	if f == nil {
-		t.Fatal("expected --direct flag on invite create command")
-	}
-	if f.DefValue != "false" {
-		t.Errorf("expected --direct default to be false, got %q", f.DefValue)
-	}
-
 }
 
 func TestLoadProjectVault(t *testing.T) {

--- a/cmd/invite.go
+++ b/cmd/invite.go
@@ -1,326 +1,14 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os/exec"
 	"runtime"
 	"strings"
 	"time"
-	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/spf13/cobra"
 )
 
-var inviteCmd = &cobra.Command{
-	Use:   "invite",
-	Short: "Manage invite links for agent onboarding",
-}
-
-var inviteCreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create an invite link and print the onboarding prompt",
-	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vault := resolveVault(cmd)
-		inviteTTL, _ := cmd.Flags().GetDuration("invite-ttl")
-		direct, _ := cmd.Flags().GetBool("direct")
-		agentName, _ := cmd.Flags().GetString("name")
-		vaultRole, _ := cmd.Flags().GetString("role")
-		ttl, _ := cmd.Flags().GetDuration("ttl")
-		hasTTL := cmd.Flags().Changed("ttl")
-
-		if direct && agentName != "" {
-			return fmt.Errorf("--direct and --name are mutually exclusive")
-		}
-		if vaultRole != "" && vaultRole != "proxy" && vaultRole != "member" && vaultRole != "admin" {
-			return fmt.Errorf("--role must be one of: proxy, member, admin")
-		}
-		if hasTTL && ttl > 7*24*time.Hour {
-			return fmt.Errorf("--ttl cannot exceed 7 days")
-		}
-		if hasTTL && ttl < 5*time.Minute {
-			return fmt.Errorf("--ttl must be at least 5 minutes")
-		}
-
-		sess, err := ensureSession()
-		if err != nil {
-			return err
-		}
-
-		addr := sess.Address
-		if flagAddr, _ := cmd.Flags().GetString("address"); flagAddr != "" {
-			addr = flagAddr
-		}
-
-		// Direct connect: mint credentials immediately.
-		if direct {
-			reqBody := map[string]interface{}{
-				"vault": vault,
-			}
-			if hasTTL {
-				reqBody["ttl_seconds"] = int(ttl.Seconds())
-			}
-			if vaultRole != "" {
-				reqBody["vault_role"] = vaultRole
-			}
-			body, err := json.Marshal(reqBody)
-			if err != nil {
-				return err
-			}
-
-			url := fmt.Sprintf("%s/v1/sessions/direct", addr)
-			respBody, err := doAdminRequestWithBody("POST", url, sess.Token, body)
-			if err != nil {
-				return err
-			}
-
-			var resp struct {
-				AVAddr         string `json:"av_addr"`
-				AVSessionToken string `json:"av_session_token"`
-				AVVault        string `json:"av_vault"`
-				VaultRole      string `json:"vault_role"`
-				ExpiresAt      string `json:"expires_at"`
-			}
-			if err := json.Unmarshal(respBody, &resp); err != nil {
-				return fmt.Errorf("parsing response: %w", err)
-			}
-
-			envBlock := fmt.Sprintf("export AGENT_VAULT_ADDR=%q\nexport AGENT_VAULT_SESSION_TOKEN=%q\nexport AGENT_VAULT_VAULT=%q",
-				resp.AVAddr, resp.AVSessionToken, resp.AVVault)
-
-			if hasTTL {
-				fmt.Fprintf(cmd.OutOrStdout(), "Direct connect session created (role: %s, expires in %s).\n\n", resp.VaultRole, formatDuration(ttl))
-			} else {
-				fmt.Fprintf(cmd.OutOrStdout(), "Direct connect session created (role: %s, no expiry).\n\n", resp.VaultRole)
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "---\n\n%s\n\n---\n", envBlock)
-			if err := copyToClipboard(envBlock); err == nil {
-				fmt.Fprintf(cmd.OutOrStdout(), "\n(Copied to clipboard)\n")
-			}
-			return nil
-		}
-
-		// Invite flow: create an invite link for the agent to redeem.
-		isPersistent := agentName != ""
-		reqBody := map[string]interface{}{
-			"vault":       vault,
-			"persistent":  isPersistent,
-			"ttl_seconds": int(inviteTTL.Seconds()),
-			"agent_name":  agentName,
-		}
-		if vaultRole != "" {
-			reqBody["vault_role"] = vaultRole
-		}
-		if hasTTL {
-			reqBody["session_ttl_seconds"] = int(ttl.Seconds())
-		}
-		body, err := json.Marshal(reqBody)
-		if err != nil {
-			return err
-		}
-
-		url := fmt.Sprintf("%s/v1/invites", sess.Address)
-		respBody, err := doAdminRequestWithBody("POST", url, sess.Token, body)
-		if err != nil {
-			return err
-		}
-
-		var resp struct {
-			Token      string `json:"token"`
-			Persistent bool   `json:"persistent"`
-			ExpiresAt  string `json:"expires_at"`
-		}
-		if err := json.Unmarshal(respBody, &resp); err != nil {
-			return fmt.Errorf("parsing response: %w", err)
-		}
-
-		inviteURL := addr + "/invite/" + resp.Token
-
-		if isPersistent {
-			prompt := buildPersistentInvitePrompt(inviteURL, inviteTTL, agentName)
-			fmt.Fprintf(cmd.OutOrStdout(), "Agent invite created (expires in %s).\n", formatDuration(inviteTTL))
-			fmt.Fprintf(cmd.OutOrStdout(), "Paste the following into your agent:\n\n")
-			fmt.Fprintf(cmd.OutOrStdout(), "---\n\n%s\n---\n", prompt)
-			if err := copyToClipboard(prompt); err == nil {
-				fmt.Fprintf(cmd.OutOrStdout(), "\n(Copied to clipboard)\n")
-			}
-			return nil
-		}
-
-		prompt := buildInvitePrompt(inviteURL, inviteTTL)
-		expiryNote := "no expiry"
-		if hasTTL {
-			expiryNote = "session expires in " + formatDuration(ttl)
-		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Invite created (%s).\n", expiryNote)
-		fmt.Fprintf(cmd.OutOrStdout(), "Paste the following into your agent:\n\n")
-		fmt.Fprintf(cmd.OutOrStdout(), "---\n\n%s\n---\n", prompt)
-		if err := copyToClipboard(prompt); err == nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "\n(Copied to clipboard)\n")
-		}
-		return nil
-	},
-}
-
-var inviteListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List invites for a vault",
-	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vault := resolveVault(cmd)
-		status, _ := cmd.Flags().GetString("status")
-
-		sess, err := ensureSession()
-		if err != nil {
-			return err
-		}
-
-		url := fmt.Sprintf("%s/v1/invites?vault=%s", sess.Address, vault)
-		if status != "" {
-			url += "&status=" + status
-		}
-		respBody, err := doAdminRequestWithBody("GET", url, sess.Token, nil)
-		if err != nil {
-			return err
-		}
-
-		var invites []struct {
-			Token     string `json:"token"`
-			Status    string `json:"status"`
-			CreatedAt string `json:"created_at"`
-			ExpiresAt string `json:"expires_at"`
-		}
-		if err := json.Unmarshal(respBody, &invites); err != nil {
-			return fmt.Errorf("parsing response: %w", err)
-		}
-
-		if len(invites) == 0 {
-			fmt.Fprintf(cmd.OutOrStdout(), "No invites found in vault %q.\n", vault)
-			return nil
-		}
-
-		t := newTable(cmd.OutOrStdout())
-		t.AppendHeader(table.Row{"TOKEN", "STATUS", "CREATED", "EXPIRES"})
-		for _, inv := range invites {
-			// Show last 8 chars for display.
-			suffix := inv.Token
-			if len(suffix) > 8 {
-				suffix = inv.Token[len(inv.Token)-8:]
-			}
-			created := inv.CreatedAt
-			if parsed, err := time.Parse(time.RFC3339, inv.CreatedAt); err == nil {
-				created = parsed.Format("2006-01-02 15:04")
-			}
-			expires := inv.ExpiresAt
-			if parsed, err := time.Parse(time.RFC3339, inv.ExpiresAt); err == nil {
-				expires = parsed.Format("2006-01-02 15:04")
-			}
-			t.AppendRow(table.Row{
-				"..." + suffix,
-				statusBadge(inv.Status),
-				created,
-				expires,
-			})
-		}
-		t.Render()
-		return nil
-	},
-}
-
-var inviteRevokeCmd = &cobra.Command{
-	Use:   "revoke <token_suffix>",
-	Short: "Revoke a pending invite",
-	Long:  "Revoke a pending invite by the last 8 (or more) characters of its token.",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		vault := resolveVault(cmd)
-		suffix := args[0]
-
-		sess, err := ensureSession()
-		if err != nil {
-			return err
-		}
-
-		// Fetch pending invites (admin session gets full tokens).
-		url := fmt.Sprintf("%s/v1/invites?vault=%s&status=pending", sess.Address, vault)
-		respBody, err := doAdminRequestWithBody("GET", url, sess.Token, nil)
-		if err != nil {
-			return err
-		}
-
-		var invites []struct {
-			Token string `json:"token"`
-		}
-		if err := json.Unmarshal(respBody, &invites); err != nil {
-			return fmt.Errorf("parsing response: %w", err)
-		}
-
-		// Suffix match.
-		var matches []string
-		for _, inv := range invites {
-			if strings.HasSuffix(inv.Token, suffix) {
-				matches = append(matches, inv.Token)
-			}
-		}
-
-		switch len(matches) {
-		case 0:
-			return fmt.Errorf("no pending invite found matching suffix %q", suffix)
-		case 1:
-			// Unique match — proceed.
-		default:
-			return fmt.Errorf("ambiguous suffix %q matches %d invites — provide more characters", suffix, len(matches))
-		}
-
-		revokeURL := fmt.Sprintf("%s/v1/invites/%s", sess.Address, matches[0])
-		if err := doAdminRequest("DELETE", revokeURL, sess.Token, nil); err != nil {
-			return err
-		}
-
-		fmt.Fprintf(cmd.OutOrStdout(), "Invite ...%s revoked.\n", suffix)
-		return nil
-	},
-}
-
-func buildPersistentInvitePrompt(inviteURL string, ttl time.Duration, agentName string) string {
-	bodyExample := "{}"
-	if agentName == "" {
-		bodyExample = `{"name": "your-agent-name"}`
-	}
-
-	nameNote := ""
-	if agentName == "" {
-		nameNote = "\nYou must provide a name for yourself in the request body. Choose a short, descriptive name (lowercase, hyphens allowed, 3-64 chars).\n"
-	}
-
-	return fmt.Sprintf(`You are being invited to register as a persistent agent with Agent Vault, a local HTTP proxy that lets you call external APIs without seeing credentials.
-%s
-To accept this invite, make the following HTTP request:
-
-POST %s
-Content-Type: application/json
-
-%s
-
-The response contains your session token and usage instructions.
-
-This invite expires in %s and can only be used once.
-`, nameNote, inviteURL, bodyExample, formatDuration(ttl))
-}
-
-func buildInvitePrompt(inviteURL string, ttl time.Duration) string {
-	return fmt.Sprintf(`You are being invited to use Agent Vault, a local HTTP proxy that lets you call external APIs (Stripe, GitHub, etc.) without seeing the underlying credentials.
-
-To accept this invite, make the following HTTP request:
-
-GET %s
-
-The response contains your session token and usage instructions. Do this before making any external API calls.
-
-This invite expires in %s and can only be used once.
-`, inviteURL, formatDuration(ttl))
-}
-
+// formatDuration formats a duration as a human-readable string (e.g. "15m", "2h").
 func formatDuration(d time.Duration) string {
 	if d >= time.Hour {
 		return fmt.Sprintf("%.0fh", d.Hours())
@@ -328,13 +16,13 @@ func formatDuration(d time.Duration) string {
 	return fmt.Sprintf("%.0fm", d.Minutes())
 }
 
+// copyToClipboard copies text to the system clipboard.
 func copyToClipboard(text string) error {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
 		cmd = exec.Command("pbcopy")
 	case "linux":
-		// Try xclip first, fall back to xsel.
 		if _, err := exec.LookPath("xclip"); err == nil {
 			cmd = exec.Command("xclip", "-selection", "clipboard")
 		} else if _, err := exec.LookPath("xsel"); err == nil {
@@ -349,17 +37,19 @@ func copyToClipboard(text string) error {
 	return cmd.Run()
 }
 
-func init() {
-	inviteCreateCmd.Flags().Duration("invite-ttl", 15*time.Minute, "invite link expiration time")
-	inviteCreateCmd.Flags().Duration("ttl", 0, "session expiry duration (omit for no expiry)")
-	inviteCreateCmd.Flags().String("address", "", "Agent Vault server address (default: from session)")
-	inviteCreateCmd.Flags().String("name", "", "pre-set the agent name (creates a named/persistent agent)")
-	inviteCreateCmd.Flags().String("role", "", "vault role for the invited agent (proxy, member, admin; default: proxy)")
-	inviteCreateCmd.Flags().Bool("direct", false, "mint credentials immediately (skip invite ceremony)")
-	inviteListCmd.Flags().String("status", "", "filter by status (pending, redeemed, expired, revoked)")
+// buildAgentInvitePrompt builds the prompt text that an operator pastes into an agent's chat.
+func buildAgentInvitePrompt(inviteURL string, ttl time.Duration) string {
+	return fmt.Sprintf(`You are being invited to register as a persistent agent with Agent Vault, a local HTTP proxy that lets you call external APIs without seeing credentials.
 
-	inviteCmd.AddCommand(inviteCreateCmd)
-	inviteCmd.AddCommand(inviteListCmd)
-	inviteCmd.AddCommand(inviteRevokeCmd)
-	agentCmd.AddCommand(inviteCmd)
+To accept this invite, make the following HTTP request:
+
+POST %s
+Content-Type: application/json
+
+{}
+
+The response contains your session token and usage instructions.
+
+This invite expires in %s and can only be used once.
+`, inviteURL, formatDuration(ttl))
 }

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -37,7 +37,7 @@ You have access to Agent Vault, an HTTP proxy that attaches credentials to your 
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault |
-| `AGENT_VAULT_VAULT` | Vault the session is scoped to |
+| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`; instance-level agent sessions use `X-Vault` header instead) |
 
 ## Discover Available Services (Start Here)
 

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -37,7 +37,7 @@ You have access to Agent Vault, an HTTP proxy that attaches credentials to your 
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault |
-| `AGENT_VAULT_VAULT` | Vault the session is scoped to |
+| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`; for instance-level agent sessions, use the `X-Vault` header instead) |
 
 ## Discover Available Services (Start Here)
 
@@ -46,7 +46,10 @@ You have access to Agent Vault, an HTTP proxy that attaches credentials to your 
 ```
 GET {AGENT_VAULT_ADDR}/discover
 Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+X-Vault: {vault_name}
 ```
+
+**Note:** If `AGENT_VAULT_VAULT` is set, the server uses it automatically. Instance-level agent sessions (persistent agents) must include the `X-Vault` header on all vault-scoped requests.
 
 Response includes `vault`, `proxy_url`, `services` (host + description), and `available_credentials` (key names only, values are never exposed). Use `available_credentials` to reference existing credentials in proposals instead of creating duplicate slots.
 
@@ -168,9 +171,11 @@ Content-Type: application/json
 - Always check `available_credentials` first to avoid proposing duplicates
 - Include `obtain` and `obtain_instructions` to help the human find the credential
 
-## Persistent Agent Mode
+## Instance-Level Agent Sessions
 
-If you were registered as a persistent agent (via a persistent invite), you received a session token (`av_session_token`). If your session has no expiry, this token works indefinitely. If it does expire, contact your operator for a new session.
+If you were registered as a persistent agent (via an agent invite), your session is instance-level -- it is not scoped to a single vault. You may have access to multiple vaults. Include the `X-Vault` header on all vault-scoped requests (proxy, discover, proposals, credentials) to select which vault to operate on.
+
+If your session has no expiry, the token works indefinitely. If it does expire, contact your operator for a new session.
 
 ## Error Handling
 

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -1,120 +1,146 @@
 ---
 title: "Agents"
-description: "Understand the two types of agents in Agent Vault and how to connect them."
+description: "Understand how agents connect to Agent Vault and how to manage them."
 ---
 
-An `Agent` is any AI-powered process that connects to a [vault](/learn/vaults) to proxy requests and raise [proposals](/learn/proposals) through Agent Vault. Agent Vault supports three ways to connect agents: **temporary**, **direct connect**, and **persistent**.
+An `Agent` is any AI-powered process that connects to Agent Vault to proxy requests and raise [proposals](/learn/proposals). Agents are **instance-level entities** (like users) that can be granted access to multiple [vaults](/learn/vaults) with independent roles per vault.
 
-## Temporary agents
+There are two ways to connect an agent: **wrapping** a local process or **inviting** any agent via a prompt.
 
-A temporary agent is an ephemeral session with no stored identity. It connects to a vault, does its work, and the session expires. There is nothing to manage afterward.
+## Wrapping with `vault run`
 
-### `agent-vault vault run` (recommended for local dev)
-
-Wraps a local agent process with the environment variables it needs. No invite, no token management.
+The simplest approach for local development. Wraps a local agent process with the environment variables it needs — no invite, no token management.
 
 ```bash
-agent-vault vault run -- claude
+agent-vault vault run -- claude    # Claude Code
 agent-vault vault run --vault my-vault -- claude
 ```
 
-The agent can immediately make proxied requests and raise proposals.
+The agent receives a temporary, vault-scoped session and can immediately make proxied requests and raise proposals.
 
-### One-time invite
+## Inviting an agent
 
-For agents you can paste a prompt into, like Devin or other cloud-hosted agents.
-
-```bash
-agent-vault vault agent invite create --vault my-vault
-```
-
-Outputs a prompt with the invite URL. Paste it into the agent's chat. The token is burned on redemption and the agent receives a single session token.
-
-## Direct connect
-
-Direct connect skips the invite ceremony entirely. Instead of creating an invite link for the agent to redeem, it mints a scoped session token immediately and outputs the environment variables you can paste into any agent.
+For agents you can't wrap (cloud-hosted agents, existing sessions, CI pipelines), create an invite. The agent redeems the invite via HTTP and receives a session token.
 
 ```bash
-agent-vault vault agent invite create --direct --vault my-vault
+agent-vault agent invite my-agent
 ```
 
-This prints an `export` block with `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT` (and copies it to your clipboard). Paste these into the agent's environment or chat.
+Outputs a prompt with the invite URL. Paste it into the agent's chat. The agent redeems the invite and receives an instance-level session token.
 
-### Options
+### Vault pre-assignments
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--role` | `proxy` | Vault role: `proxy`, `member`, or `admin` |
-| `--ttl` | `24h` | Session lifetime (min 5m, max 7d) |
-| `--label` | | Optional label to identify the session |
+Optionally pre-assign vault access at invite time using the `--vault` flag (repeatable):
 
 ```bash
-# Create a 1-hour proxy session
-agent-vault vault agent invite create --direct --ttl 1h
+# Invite with proxy access to the default vault
+agent-vault agent invite my-agent --vault default:proxy
 
-# Create an admin session with a label
-agent-vault vault agent invite create --direct --role admin --label "ci-pipeline" --ttl 4h
+# Invite with access to multiple vaults
+agent-vault agent invite my-agent --vault default:member --vault payments:proxy
 ```
+
+The format is `vault_name:role` where role is `proxy`, `member`, or `admin` (defaults to `proxy` if omitted).
 
 <Note>
-Direct connect sessions have a maximum TTL of 7 days. For agents that need indefinite access, use [persistent agents](#persistent-agents) instead.
+Agent names must be 3-64 characters, lowercase alphanumeric and hyphens only, and globally unique across the instance.
 </Note>
 
-## Persistent agents
+### Adding vaults after creation
 
-A persistent agent has a named identity that outlives any single session. It receives a **session token** on creation (with configurable expiry, including no expiry). Best for CI/CD pipelines, always-on assistants, or agents that need to survive restarts.
+You can also grant vault access after the agent has been created:
 
 ```bash
-agent-vault vault agent invite create --name my-agent --vault my-vault
+agent-vault vault agent add my-agent --role proxy
+agent-vault vault agent add my-agent --vault payments --role member
 ```
 
-Paste the output into the agent's chat. The agent redeems the invite and receives a session token. By default the session has no expiry. Use `--ttl` to set a finite session lifetime (see [Agent protocol](/agents/protocol#session-token)).
+## Managing agents
 
-<Note>
-Agent names must be 3-64 characters, lowercase alphanumeric and hyphens only, and globally unique across all vaults.
-</Note>
+Agents are managed at two levels: **instance-level** (the agent identity) and **vault-level** (per-vault access).
 
-### Managing persistent agents
+### Instance-level commands
 
 ```bash
-# List agents
-agent-vault vault agent list --vault my-vault
+# List all agents across the instance
+agent-vault agent list
 
-# View agent details (vault, status, active sessions)
-agent-vault vault agent info my-agent
+# View agent details (vaults, status, active sessions)
+agent-vault agent info my-agent
 
 # Revoke an agent (deletes all sessions)
-agent-vault vault agent revoke my-agent
+agent-vault agent revoke my-agent
 
-# Rename an agent (keeps the same vault access)
-agent-vault vault agent rename my-agent new-name
+# Rename an agent
+agent-vault agent rename my-agent new-name
+```
+
+### Vault-level commands
+
+```bash
+# List agents in a specific vault
+agent-vault vault agent list --vault my-vault
+
+# Add an existing agent to a vault
+agent-vault vault agent add my-agent --role proxy
+
+# Change an agent's vault role
+agent-vault vault agent set-role my-agent --role member
+
+# Remove an agent from a vault
+agent-vault vault agent remove my-agent
 ```
 
 ### Rotating a session
 
 ```bash
-agent-vault vault agent rotate my-agent
+agent-vault agent rotate my-agent
 ```
 
-This creates a rotation invite. Paste the prompt into the agent's chat. The agent redeems it and receives a new session token. The old sessions are invalidated when the rotation invite is redeemed.
+This creates a rotation invite. Paste the prompt into the agent's chat. The agent redeems it and receives a new session token. Old sessions are invalidated when the rotation invite is redeemed.
 
-## Choosing the right type
+### Managing invites
 
-| Scenario | Type | Why |
+```bash
+# List pending invites
+agent-vault agent invite list --status pending
+
+# Revoke a pending invite
+agent-vault agent invite revoke <token_suffix>
+```
+
+## The X-Vault header
+
+Instance-level agent sessions are not scoped to a single vault. Instead, agents select a vault per-request using the `X-Vault` header:
+
+```
+GET /discover
+Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+X-Vault: my-vault
+```
+
+This applies to all vault-scoped requests: `/discover`, `/proxy/...`, `/v1/proposals`, and `/v1/credentials`.
+
+<Note>
+Agents created via `agent-vault vault run` receive vault-scoped sessions and do not need the `X-Vault` header — the vault is embedded in the session.
+</Note>
+
+## Choosing the right approach
+
+| Scenario | Approach | Why |
 |---|---|---|
-| Local dev with Claude Code or Cursor | Temporary (`agent-vault vault run`) | Simplest setup, no tokens to manage |
-| Paste into a cloud agent for a task | Temporary (one-time invite) | Session expires when the task is done |
-| Quick scripted access, CI jobs | Direct connect | Instant token, no invite ceremony |
-| CI/CD pipeline on every push | Persistent | Reconnects without human intervention |
-| Always-on assistant (e.g. OpenClaw) | Persistent | Survives process restarts |
+| Local dev with Claude Code or Cursor | `agent-vault vault run` | Simplest setup, no tokens to manage |
+| Cloud-hosted agent (e.g. Devin) | `agent-vault agent invite` | Paste a prompt, agent connects itself |
+| CI/CD pipeline | `agent-vault agent invite` | Named identity, survives restarts |
+| Always-on assistant | `agent-vault agent invite` | Multi-vault access, session rotation |
 
 <Tip>
-When in doubt, start with a temporary agent. You can always upgrade to persistent later.
+When in doubt, start with `agent-vault vault run`. You can always create a named agent later.
 </Tip>
 
 ## What happens after connecting
 
-Regardless of type, every agent follows the same [protocol](/agents/protocol) once connected:
+Regardless of how an agent connects, it follows the same [protocol](/agents/protocol):
 
 1. Call `/discover` to learn which services are available
 2. Route requests through the proxy at `/proxy/{host}/{path}`

--- a/docs/agents/protocol.mdx
+++ b/docs/agents/protocol.mdx
@@ -16,62 +16,39 @@ Every request an agent makes to Agent Vault requires a session token. How the ag
 | Method | How the agent gets a token |
 |---|---|
 | `agent-vault vault run` | Agent Vault sets `AGENT_VAULT_SESSION_TOKEN` on the child process automatically |
-| One-time invite | Agent calls `GET {invite_url}` and receives a token in the response |
-| Direct connect | A human runs `agent-vault vault agent invite create --direct` and pastes the resulting env vars into the agent |
-| Persistent invite | Agent calls `POST {invite_url}` and receives a session token (with optional expiry or no expiry) |
+| Agent invite | Agent calls `POST {invite_url}` and receives a session token |
 
-All three methods deliver the same set of connection details:
+Both methods deliver the same core connection details:
 
 | Variable | Description |
 |---|---|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_SESSION_TOKEN` | Bearer token for all Agent Vault requests |
-| `AGENT_VAULT_VAULT` | Vault the session is scoped to |
 
-### Direct session API
+### Session types
 
-The direct connect flow uses `POST /v1/sessions/direct` to mint a scoped session without an invite. This is called by the CLI on behalf of the human, not by the agent itself.
+There are two session types:
 
-```json
-POST {AGENT_VAULT_ADDR}/v1/sessions/direct
-Authorization: Bearer {user_or_agent_session_token}
-Content-Type: application/json
+- **Vault-scoped sessions** — created by `agent-vault vault run`. The vault is embedded in the session. No extra headers needed.
+- **Instance-level sessions** — created via agent invites. The agent must include an `X-Vault` header on every vault-scoped request to select which vault to use.
 
-{
-  "vault": "default",
-  "vault_role": "proxy",
-  "ttl_seconds": 3600,
-  "label": "ci-pipeline"
-}
+### The X-Vault header
+
+Instance-level agent sessions must include `X-Vault: {vault_name}` on all vault-scoped requests (discover, proxy, proposals, credentials):
+
+```
+GET {AGENT_VAULT_ADDR}/discover
+Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+X-Vault: my-vault
 ```
 
-```json Response
-{
-  "av_addr": "http://127.0.0.1:14321",
-  "av_session_token": "...",
-  "av_vault": "default",
-  "vault_role": "proxy",
-  "proxy_url": "http://127.0.0.1:14321/proxy",
-  "services": [{ "host": "api.stripe.com", "description": "Stripe API" }],
-  "instructions": "...",
-  "expires_at": "2025-01-02T03:04:05Z"
-}
-```
+Agents created via `agent-vault vault run` do not need this header — the vault is embedded in the session token.
 
-| Field | Default | Description |
-|---|---|---|
-| `vault` | `default` | Target vault |
-| `vault_role` | `proxy` | Role for the new session (`proxy`, `member`, or `admin`). Capped based on the caller's own role. |
-| `ttl_seconds` | `86400` (24h) | Session lifetime in seconds (min 300, max 604800) |
-| `label` | | Optional label for identifying the session (max 128 chars) |
+### Instance-level agent sessions
 
-Role capping: vault members can only mint `proxy` sessions. Vault admins can mint any role. The requested role is silently downgraded if needed.
+Agents invited via `agent-vault agent invite` receive instance-level sessions that can access multiple vaults. The session token can be configured with no expiry (works indefinitely) or a specific TTL. If the session expires, the operator can issue a new one via [rotation](/agents/overview#rotating-a-session).
 
-### Persistent agent sessions
-
-Persistent agents receive a session token directly, which can be configured with no expiry (works indefinitely) or a specific TTL. If the session expires, the operator can issue a new one via rotation.
-
-See [Agents overview](/agents/overview#persistent-agents) for the full lifecycle.
+See [Agents overview](/agents/overview) for the full lifecycle.
 
 ## Discover services
 
@@ -80,11 +57,16 @@ Before proxying anything, the agent calls `/discover` to learn which hosts have 
 ```
 GET {AGENT_VAULT_ADDR}/discover
 Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+X-Vault: my-vault
 ```
+
+<Note>
+The `X-Vault` header is required for instance-level sessions. Vault-scoped sessions (from `vault run`) can omit it.
+</Note>
 
 ```json Response
 {
-  "vault": "default",
+  "vault": "my-vault",
   "proxy_url": "http://127.0.0.1:14321/proxy",
   "services": [
     { "host": "api.stripe.com", "description": "Stripe API" },
@@ -181,7 +163,7 @@ See [Proposals](/learn/proposals) for the full proposal lifecycle, including sto
 
 | Status | Meaning | What the agent does |
 |---|---|---|
-| 401 | Invalid or expired token | Re-check `AGENT_VAULT_SESSION_TOKEN`. [Persistent agents](/agents/overview#persistent-agents): contact operator for a new session. |
+| 401 | Invalid or expired token | Re-check `AGENT_VAULT_SESSION_TOKEN`. Contact operator for a new session or [rotation](/agents/overview#rotating-a-session). |
 | 403 | Host not allowed | Create a proposal to request access. The response includes a `proposal_hint`. |
 | 429 | Too many pending proposals | Wait for existing proposals to be reviewed. |
 | 502 | Missing credential or upstream error | Tell the user a credential may need to be added. |

--- a/docs/first-proposal.mdx
+++ b/docs/first-proposal.mdx
@@ -16,19 +16,19 @@ If you haven't logged in yet, you'll be guided through setup automatically.
 <Tabs>
   <Tab title="CLI">
     ```bash
-    agent-vault vault agent invite create
+    agent-vault agent invite my-agent
     ```
 
     This generates a one-time onboarding prompt and copies it to your clipboard.
   </Tab>
   <Tab title="Web UI">
-    Go to **Agents** in your vault and click **Create invite**. Copy the generated prompt.
+    Go to the **Agents** tab and click **Invite agent**. Enter a name and optionally pre-assign vault access. Copy the generated prompt.
   </Tab>
 </Tabs>
 
 ## 2. Paste the prompt into your agent
 
-Open your agent (Claude Code, Cursor, or any supported agent) and paste the invite prompt. The agent redeems the invite automatically and receives a session token scoped to your vault.
+Open your agent (Claude Code, Cursor, or any supported agent) and paste the invite prompt. The agent redeems the invite automatically and receives a session token.
 
 ## 3. Give the agent a task
 

--- a/docs/guides/connect-coding-agent.mdx
+++ b/docs/guides/connect-coding-agent.mdx
@@ -40,13 +40,13 @@ For agents you can't wrap with `vault run` (e.g. cloud-hosted agents, or when yo
   <Tab title="Web UI">
     <Steps>
       <Step title="Open the Agents tab">
-        Navigate to your vault and click the **Agents** tab.
+        Navigate to the **Agents** tab in the home view.
       </Step>
       <Step title="Create an invite">
-        Click **Invite agent**, choose **Session**, and configure the role and TTL.
+        Click **Invite agent**, enter a name, and optionally pre-assign vault access.
       </Step>
       <Step title="Copy the prompt">
-        On the **Paste into chat** tab, copy the invite prompt.
+        Copy the invite prompt that appears.
       </Step>
       <Step title="Paste into the agent">
         Paste the prompt into your agent's chat. The agent redeems the invite automatically and receives a session token.
@@ -55,10 +55,16 @@ For agents you can't wrap with `vault run` (e.g. cloud-hosted agents, or when yo
   </Tab>
   <Tab title="CLI">
     ```bash
-    agent-vault vault agent invite create
+    agent-vault agent invite my-agent
     ```
 
     This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into the agent's chat.
+
+    Pre-assign vault access with `--vault`:
+
+    ```bash
+    agent-vault agent invite my-agent --vault default:proxy
+    ```
   </Tab>
 </Tabs>
 
@@ -77,17 +83,13 @@ You don't need to pre-configure anything. The agent discovers what it needs, ask
 
 ## For long-lived agents
 
-Session invites expire (default 24 hours). If your agent needs ongoing access without human intervention, use a [persistent agent](/agents/overview#persistent-agents) instead:
-
-```bash
-agent-vault vault agent invite create --name my-agent
-```
+Invited agents are instance-level entities with named identities that persist across sessions. You can manage vault access, rotate sessions, and revoke agents at any time. See [Agents overview](/agents/overview) for the full lifecycle.
 
 ## Next steps
 
 <CardGroup cols={2}>
   <Card title="Agents overview" icon="robot" href="/agents/overview">
-    Temporary, direct connect, and persistent agent types.
+    How agents work, vault access, and management commands.
   </Card>
   <Card title="Proposals" icon="file-circle-check" href="/learn/proposals">
     How agents request access to new services.

--- a/docs/guides/connect-custom-agent.mdx
+++ b/docs/guides/connect-custom-agent.mdx
@@ -17,53 +17,41 @@ If you're using Claude Code, Cursor, or another supported agent, see the [Quicks
 ## Get connection credentials
 
 <Tabs>
-  <Tab title="Web UI">
-    <Steps>
-      <Step title="Open the Agents tab">
-        Navigate to your vault and click the **Agents** tab.
-      </Step>
-      <Step title="Create an invite">
-        Click **Invite agent**, choose **Session**, and configure the role and TTL.
-      </Step>
-      <Step title="Switch to Manual setup">
-        After creating the invite, click the **Manual setup** tab. This shows the environment variables your agent needs.
-      </Step>
-      <Step title="Copy the values">
-        Copy `AGENT_VAULT_ADDR` and `AGENT_VAULT_SESSION_TOKEN` into your agent's environment.
-      </Step>
-    </Steps>
+  <Tab title="vault run (simplest)">
+    For local development, wrap your agent process directly:
+
+    ```bash
+    agent-vault vault run -- my-agent
+    ```
+
+    This sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT` in the child process automatically. No invite needed.
   </Tab>
-  <Tab title="CLI">
-    ```bash
-    agent-vault vault agent invite create --direct --vault my-vault
-    ```
-
-    This prints an `export` block you can paste directly into a shell or `.env` file:
+  <Tab title="Agent invite">
+    For CI pipelines, cloud-hosted agents, or when you need the agent to redeem an invite via HTTP:
 
     ```bash
-    export AGENT_VAULT_ADDR="http://127.0.0.1:14321"
-    export AGENT_VAULT_SESSION_TOKEN="..."
-    export AGENT_VAULT_VAULT="my-vault"
+    agent-vault agent invite my-agent --vault default:proxy
     ```
 
-    Use `--ttl` and `--role` to control session lifetime and permissions:
+    This prints an invite prompt. The agent redeems it via `POST {invite_url}` and receives:
+    - `av_addr` — the Agent Vault server URL
+    - `av_session_token` — bearer token for all requests
+    - `vaults` — list of accessible vaults
 
-    ```bash
-    # 4-hour session with member permissions
-    agent-vault vault agent invite create --direct --ttl 4h --role member
-    ```
+    Instance-level sessions require the `X-Vault` header on every vault-scoped request.
   </Tab>
 </Tabs>
 
 ## Environment variables
 
-Your agent needs two values to operate. A third is optional but recommended.
+Your agent needs these values to operate:
 
 | Variable | Required | Description |
 |---|---|---|
 | `AGENT_VAULT_ADDR` | Yes | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_SESSION_TOKEN` | Yes | Bearer token for authenticating all requests to Agent Vault |
-| `AGENT_VAULT_VAULT` | No | Vault name the session is scoped to (useful for logging/display) |
+
+For instance-level sessions (from agent invites), the agent must also send the `X-Vault` header on every vault-scoped request. For vault-scoped sessions (from `vault run`), the vault is embedded in the session.
 
 ## Make proxied requests
 
@@ -177,7 +165,7 @@ Discovery is optional. If your agent already knows which hosts are configured, i
 
 | Status | Meaning | What to do |
 |---|---|---|
-| 401 | Invalid or expired session token | Re-authenticate. For persistent agents, contact the operator for a new session. |
+| 401 | Invalid or expired session token | Re-authenticate. Contact the operator for a [session rotation](/agents/overview#rotating-a-session). |
 | 403 | Host not allowed | The service isn't configured in the vault. Create a [proposal](/learn/proposals) to request access, or ask the vault admin to add it. The response body includes a `proposal_hint`. |
 | 429 | Too many pending proposals | Wait for existing proposals to be reviewed before creating new ones. |
 | 502 | Missing credential or upstream error | A credential may need to be added to the vault. Inform the user. |
@@ -194,7 +182,7 @@ Discovery is optional. If your agent already knows which hosts are configured, i
   <Card title="Credentials" icon="key" href="/learn/credentials">
     Managing secrets in Agent Vault.
   </Card>
-  <Card title="Persistent agents" icon="rotate" href="/agents/overview#persistent-agents">
-    Long-lived agents that survive session expiry.
+  <Card title="Agents overview" icon="rotate" href="/agents/overview">
+    Agent lifecycle, vault access, and management.
   </Card>
 </CardGroup>

--- a/docs/learn/permissions.mdx
+++ b/docs/learn/permissions.mdx
@@ -13,7 +13,7 @@ Instance-level roles govern administrative operations across the entire Agent Va
 | ------------------------------------- | --------------- | --------------- |
 | [Instance settings](/guides/instance-settings) (invite-only, domains) | Yes | No |
 | Manage users (list, remove, set-role) | Yes             | No              |
-| Manage agents (list, revoke, rotate, rename) | Yes      | No              |
+| Manage agents (invite, list, revoke, rotate, rename) | Yes | Yes |
 | List / delete all vaults              | Yes             | No              |
 | See all vaults & join as admin        | Yes             | No              |
 | Send test emails                      | Yes             | No              |
@@ -42,11 +42,11 @@ Vault-level roles govern what users and [agents](/agents/overview) can do inside
 | Set / delete credentials directly               | Yes   | Yes      | No       |
 | Approve / reject [proposals](/learn/proposals) | Yes   | Yes      | No       |
 | Manage vault [services](/learn/services)       | Yes   | Yes      | No       |
-| Invite agents (proxy only)                     | Yes   | Yes      | No       |
-| Invite agents (any role)                       | Yes   | No       | No       |
+| Add agents to vault (proxy only)               | Yes   | Yes      | No       |
+| Add agents to vault (any role)                 | Yes   | No       | No       |
 | Invite users to vault                          | Yes   | No       | No       |
 | Manage vault users (remove, set-role)          | Yes   | No       | No       |
-| Manage agents (revoke, rotate, rename)         | Yes   | No       | No       |
+| Manage vault agents (remove, set-role)         | Yes   | No       | No       |
 | Delete vault                                   | Yes   | No       | No       |
 
 The **proxy** role is the most restricted, ideal for agents that only need to proxy requests and raise proposals for human review. The **member** role adds the ability to manage credentials, approve proposals, and configure vault services. The **admin** role has full control, including inviting users and agents with any role.
@@ -110,7 +110,7 @@ agent-vault vault user set-role alice@example.com --role proxy --vault my-vault
     - **See all vaults**: Owners see every vault in their vault list, including vaults they have not joined.
     - **Join any vault**: `agent-vault owner vault join <name>` grants the owner admin access to a vault. Useful for recovering orphaned vaults.
     - **Delete any vault**: `agent-vault owner vault remove <name>` removes a vault regardless of membership.
-    - **Manage agents**: `agent-vault vault agent list`, `info`, `revoke`, `rotate`, and `rename` are owner-only operations that work across all vaults.
+    - **Manage agents**: `agent-vault agent list`, `info`, `revoke`, `rotate`, and `rename` are instance-level operations. Any authenticated user can invite agents; vault admins control per-vault agent access.
 
     These operations affect vault existence and agent lifecycle. To access vault contents (credentials, proposals, proxy), the owner must first join the vault.
 

--- a/docs/learn/vaults.mdx
+++ b/docs/learn/vaults.mdx
@@ -41,32 +41,21 @@ Vault resolution priority: `--vault` flag > `agent-vault.json` > user context > 
 ## Invite agents to a vault
 
 <Tabs>
-  <Tab title="One-time invite">
-    For temporary agent sessions you can paste a prompt into (cloud-hosted, chat-based, or on another machine).
+  <Tab title="Agent invite">
+    For any agent you can paste a prompt into (cloud-hosted, chat-based, CI pipelines, or always-on assistants).
 
     <Steps>
       <Step title="Create the invite">
         ```bash
-        agent-vault vault agent invite create --vault my-vault
+        agent-vault agent invite my-agent --vault my-vault:proxy
         ```
         Outputs a prompt with the invite URL and usage instructions. Copied to your clipboard
-        automatically. Default TTL: 15 minutes.
+        automatically. The `--vault` flag pre-assigns vault access (format: `name:role`).
       </Step>
       <Step title="Paste into the agent's chat">
-        The agent redeems the invite automatically. Single-use — the token is burned
-        on redemption.
+        The agent redeems the invite automatically and receives a session token.
       </Step>
     </Steps>
-
-  </Tab>
-  <Tab title="Persistent invite">
-    For CI/CD pipelines, always-on assistants, or agents like OpenClaw that need to survive restarts.
-
-    ```bash
-    agent-vault vault agent invite create --name my-agent --vault my-vault
-    ```
-
-    The agent receives a **session token** (with configurable expiry, including no expiry).
 
   </Tab>
 </Tabs>

--- a/docs/quickstart/claude-code.mdx
+++ b/docs/quickstart/claude-code.mdx
@@ -52,7 +52,7 @@ You didn't pre-configure anything. The agent discovered what it needed, asked fo
 If you can't use `vault run` (e.g. you're connecting a remote or cloud-hosted Claude Code instance), use the invite flow instead:
 
 ```bash
-agent-vault vault agent invite create
+agent-vault agent invite my-agent
 ```
 
 This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Claude Code — it redeems the invite automatically and receives a session token plus usage instructions inline.

--- a/docs/quickstart/codex.mdx
+++ b/docs/quickstart/codex.mdx
@@ -52,7 +52,7 @@ You didn't pre-configure anything. The agent discovered what it needed, asked fo
 If you can't use `vault run` (e.g. you're connecting a remote or cloud-hosted Codex instance), use the invite flow instead:
 
 ```bash
-agent-vault vault agent invite create
+agent-vault agent invite my-agent
 ```
 
 This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Codex — it redeems the invite automatically and receives a session token plus usage instructions inline.

--- a/docs/quickstart/cursor.mdx
+++ b/docs/quickstart/cursor.mdx
@@ -52,7 +52,7 @@ You didn't pre-configure anything. The agent discovered what it needed, asked fo
 If you can't use `vault run` (e.g. you're connecting a remote or cloud-hosted Cursor instance), use the invite flow instead:
 
 ```bash
-agent-vault vault agent invite create
+agent-vault agent invite my-agent
 ```
 
 This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Cursor — it redeems the invite automatically and receives a session token plus usage instructions inline.

--- a/docs/quickstart/custom-agent.mdx
+++ b/docs/quickstart/custom-agent.mdx
@@ -10,27 +10,29 @@ description: "Connect any HTTP-capable agent or script to Agent Vault using envi
 
 ## Quick start
 
-Create a direct-connect session to get the environment variables your agent needs. If you haven't logged in yet, you'll be guided through setup automatically.
+The simplest way to connect a custom agent is with `vault run`, which sets up the environment variables automatically:
 
 ```bash
-agent-vault vault agent invite create --direct
+agent-vault vault run -- my-agent
 ```
 
-This prints an `export` block:
-
-```bash
-export AGENT_VAULT_ADDR="http://127.0.0.1:14321"
-export AGENT_VAULT_SESSION_TOKEN="..."
-export AGENT_VAULT_VAULT="default"
-```
-
-Paste these into your agent's environment, then start your agent.
+This sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT` in your agent's environment.
 
 ### Target a specific vault
 
 ```bash
-agent-vault vault agent invite create --direct --vault myproject
+agent-vault vault run --vault myproject -- my-agent
 ```
+
+### Alternative: agent invite
+
+For agents that can't be wrapped with `vault run` (e.g. cloud-hosted or CI pipelines), create an invite:
+
+```bash
+agent-vault agent invite my-agent --vault default:proxy
+```
+
+The agent redeems the invite via HTTP and receives a session token. See [Connect a custom agent](/guides/connect-custom-agent) for the full walkthrough.
 
 ## Try it out
 
@@ -102,7 +104,7 @@ Requests to hosts not in this list should go direct, not through the proxy.
 
 <CardGroup cols={2}>
   <Card title="Connect a custom agent" icon="plug" href="/guides/connect-custom-agent">
-    Full guide with error handling, proposals, and persistent agents.
+    Full guide with error handling and proposals.
   </Card>
   <Card title="Agent protocol" icon="code" href="/agents/protocol">
     HTTP reference for sessions, discovery, proxy, and proposals.

--- a/docs/quickstart/hermes-agent.mdx
+++ b/docs/quickstart/hermes-agent.mdx
@@ -15,14 +15,14 @@ To get the most out of this guide, you'll need to:
 If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
-agent-vault vault agent invite create
+agent-vault agent invite hermes
 ```
 
 This generates a one-time onboarding prompt and copies it to your clipboard.
 
 ## 2. Paste the prompt into Hermes Agent
 
-Open Hermes Agent's chat and paste the invite prompt. Hermes Agent redeems the invite automatically and receives a session token scoped to your vault.
+Open Hermes Agent's chat and paste the invite prompt. Hermes Agent redeems the invite automatically and receives a session token.
 
 ## 3. Start using it
 

--- a/docs/quickstart/nanoclaw.mdx
+++ b/docs/quickstart/nanoclaw.mdx
@@ -15,14 +15,14 @@ To get the most out of this guide, you'll need to:
 If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
-agent-vault vault agent invite create
+agent-vault agent invite nanoclaw
 ```
 
 This generates a one-time onboarding prompt and copies it to your clipboard.
 
 ## 2. Paste the prompt into NanoClaw
 
-Open NanoClaw's chat and paste the invite prompt. NanoClaw redeems the invite automatically and receives a session token scoped to your vault.
+Open NanoClaw's chat and paste the invite prompt. NanoClaw redeems the invite automatically and receives a session token.
 
 ## 3. Start using it
 

--- a/docs/quickstart/openclaw.mdx
+++ b/docs/quickstart/openclaw.mdx
@@ -15,14 +15,14 @@ To get the most out of this guide, you'll need to:
 If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
-agent-vault vault agent invite create
+agent-vault agent invite openclaw
 ```
 
 This generates a one-time onboarding prompt and copies it to your clipboard.
 
 ## 2. Paste the prompt into OpenClaw
 
-Open OpenClaw's chat and paste the invite prompt. OpenClaw redeems the invite automatically and receives a session token scoped to your vault.
+Open OpenClaw's chat and paste the invite prompt. OpenClaw redeems the invite automatically and receives a session token.
 
 ## 3. Start using it
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -383,57 +383,88 @@ description: "Complete reference for all Agent Vault CLI commands."
   </Accordion>
 </AccordionGroup>
 
-## Agent invites
+## Agents (instance-level)
 
 <AccordionGroup>
-  <Accordion title="agent-vault vault agent invite create">
+  <Accordion title="agent-vault agent invite">
     ```bash
-    agent-vault vault agent invite create [flags]
+    agent-vault agent invite <name> [flags]
     ```
 
-    Create an agent invite and print the onboarding prompt (copies to clipboard). By default creates a one-time invite. Use `--name` to create a persistent (named) agent. Use `--direct` to skip the invite ceremony and mint a session token immediately.
+    Create an agent invite and print the onboarding prompt (copies to clipboard). The agent redeems the invite via HTTP and receives an instance-level session token.
 
     | Flag | Default | Description |
     |------|---------|-------------|
-    | `--vault` | `default` | Target vault |
-    | `--invite-ttl` | `15m` | Invite link expiration time |
-    | `--ttl` | | Session expiry (omit for no expiry; min 5m, max 7d) |
-    | `--direct` | `false` | Mint a session token immediately (skip invite ceremony) |
-    | `--name` | | Agent name (creates a persistent/named agent) |
-    | `--label` | | Optional session label |
-    | `--address` | | Server address override (default: from session) |
-    | `--role` | `proxy` | Vault role for the invited agent: `proxy`, `member`, or `admin` |
+    | `--vault` | | Vault pre-assignment in `name:role` format (repeatable). Role defaults to `proxy`. |
 
-    `--direct` and `--name` are mutually exclusive.
+    ```bash
+    # Invite with vault pre-assignments
+    agent-vault agent invite my-agent --vault default:proxy --vault payments:member
+    ```
   </Accordion>
 
-  <Accordion title="agent-vault vault agent invite list">
+  <Accordion title="agent-vault agent invite list">
     ```bash
-    agent-vault vault agent invite list [flags]
+    agent-vault agent invite list [flags]
     ```
 
-    List agent invites for a vault.
+    List agent invites.
 
     | Flag | Default | Description |
     |------|---------|-------------|
-    | `--vault` | `default` | Target vault |
     | `--status` | | Filter by status (e.g. `pending`) |
   </Accordion>
 
-  <Accordion title="agent-vault vault agent invite revoke">
+  <Accordion title="agent-vault agent invite revoke">
     ```bash
-    agent-vault vault agent invite revoke <token_suffix> [flags]
+    agent-vault agent invite revoke <token_suffix>
     ```
 
     Revoke a pending invite by the last 8 or more characters of the token.
+  </Accordion>
 
-    | Flag | Default | Description |
-    |------|---------|-------------|
-    | `--vault` | `default` | Target vault |
+  <Accordion title="agent-vault agent list">
+    ```bash
+    agent-vault agent list
+    ```
+
+    List all agents across the instance.
+  </Accordion>
+
+  <Accordion title="agent-vault agent info">
+    ```bash
+    agent-vault agent info <name>
+    ```
+
+    Show agent details including vaults, status, and active session count.
+  </Accordion>
+
+  <Accordion title="agent-vault agent revoke">
+    ```bash
+    agent-vault agent revoke <name>
+    ```
+
+    Revoke an agent. Deletes all sessions across all vaults.
+  </Accordion>
+
+  <Accordion title="agent-vault agent rotate">
+    ```bash
+    agent-vault agent rotate <name>
+    ```
+
+    Create a rotation invite to re-issue an agent's session. The old sessions are invalidated when the agent redeems the new invite.
+  </Accordion>
+
+  <Accordion title="agent-vault agent rename">
+    ```bash
+    agent-vault agent rename <name> <new-name>
+    ```
+
+    Rename an agent. Keeps the same vault access.
   </Accordion>
 </AccordionGroup>
 
-## Agents
+## Agents (vault-level)
 
 <AccordionGroup>
   <Accordion title="agent-vault vault agent list">
@@ -441,55 +472,32 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault agent list [flags]
     ```
 
-    List registered agents.
+    List agents in a specific vault.
 
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--vault` | `default` | Target vault |
   </Accordion>
 
-  <Accordion title="agent-vault vault agent info">
+  <Accordion title="agent-vault vault agent add">
     ```bash
-    agent-vault vault agent info <name> [flags]
+    agent-vault vault agent add <name> [flags]
     ```
 
-    Show agent details including vault, status, and active sessions.
+    Add an existing instance agent to a vault.
 
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--vault` | `default` | Target vault |
+    | `--role` | `proxy` | Vault role: `proxy`, `member`, or `admin` |
   </Accordion>
 
-  <Accordion title="agent-vault vault agent revoke">
+  <Accordion title="agent-vault vault agent remove">
     ```bash
-    agent-vault vault agent revoke <name> [flags]
+    agent-vault vault agent remove <name> [flags]
     ```
 
-    Revoke an agent. Deletes all sessions.
-
-    | Flag | Default | Description |
-    |------|---------|-------------|
-    | `--vault` | `default` | Target vault |
-  </Accordion>
-
-  <Accordion title="agent-vault vault agent rotate">
-    ```bash
-    agent-vault vault agent rotate <name> [flags]
-    ```
-
-    Create a rotation invite to re-issue an agent's session. The old sessions are invalidated when the agent redeems the new invite.
-
-    | Flag | Default | Description |
-    |------|---------|-------------|
-    | `--vault` | `default` | Target vault |
-  </Accordion>
-
-  <Accordion title="agent-vault vault agent rename">
-    ```bash
-    agent-vault vault agent rename <name> <new-name> [flags]
-    ```
-
-    Rename an agent.
+    Remove an agent from a vault.
 
     | Flag | Default | Description |
     |------|---------|-------------|
@@ -501,7 +509,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault agent set-role <name> [flags]
     ```
 
-    Set an agent's vault role.
+    Change an agent's vault role.
 
     | Flag | Default | Description |
     |------|---------|-------------|

--- a/internal/server/instructions_admin.txt
+++ b/internal/server/instructions_admin.txt
@@ -2,23 +2,27 @@ You have access to Agent Vault, an HTTP proxy that attaches credentials to your 
 
 IMPORTANT: Whenever your task involves ANY external service or API (Linear, GitHub, Stripe, Jira, Slack, Asana, GitLab, or any other authenticated service), you MUST check Agent Vault BEFORE telling the user you lack access. Call /discover to see what's available, then route requests through the proxy. If the service isn't listed, raise a proposal — never just say "I can't access that."
 
-Your vault role is **admin**. You have full vault access: proxy, discover, proposals, direct credential management, proposal approval/rejection, vault service management, and the ability to invite agents with any role and invite users to the vault.
+You are an instance-level agent. You may have access to multiple vaults. Use the X-Vault header to select which vault to operate on for each request.
 
 ## Quick Start
 
-1. Store env vars from the redemption response: AGENT_VAULT_ADDR (server URL), AGENT_VAULT_SESSION_TOKEN (bearer token), AGENT_VAULT_VAULT (vault name)
-2. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN} — do this FIRST before any external service interaction
-3. For hosts in the response, route through the proxy: {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}
+1. Store env vars from the redemption response: AGENT_VAULT_ADDR (server URL), AGENT_VAULT_SESSION_TOKEN (bearer token)
+2. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN} and X-Vault: {vault_name} — do this FIRST before any external service interaction
+3. For hosts in the response, route through the proxy: {AGENT_VAULT_ADDR}/proxy/{target_host}/{path} (include X-Vault header)
 4. If a needed service isn't listed, raise a proposal — the user can approve and provide credentials.
+
+## Multi-Vault Access
+
+Your session is instance-level. Include the X-Vault header on all vault-scoped requests (proxy, discover, proposals, credentials). If you have access to multiple vaults, switch between them by changing the X-Vault header value.
 
 ## Admin Capabilities
 
-As an admin, you can also:
-- Set credentials: POST {AGENT_VAULT_ADDR}/v1/credentials with {"vault": "...", "credentials": {"KEY": "value"}}
-- Delete credentials: DELETE {AGENT_VAULT_ADDR}/v1/credentials with {"vault": "...", "keys": ["KEY"]}
+For vaults where you have admin role, you can also:
+- Set credentials: POST {AGENT_VAULT_ADDR}/v1/credentials with X-Vault header and {"vault": "...", "credentials": {"KEY": "value"}}
+- Delete credentials: DELETE {AGENT_VAULT_ADDR}/v1/credentials with X-Vault header and {"vault": "...", "keys": ["KEY"]}
 - Approve proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/approve with {"vault": "...", "credentials": {"KEY": "value"}}
 - Reject proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/reject with {"vault": "...", "reason": "..."}
-- Invite agents with any role: POST {AGENT_VAULT_ADDR}/v1/invites with {"vault": "...", "vault_role": "member|proxy|admin"}
+- Invite agents: POST {AGENT_VAULT_ADDR}/v1/agents/invites with {"name": "...", "vaults": [{"vault_name": "...", "vault_role": "proxy|member|admin"}]}
 - Invite users: POST {AGENT_VAULT_ADDR}/v1/users/invites with {"email": "...", "vaults": [{"vault_name": "...", "vault_role": "member|admin"}]}
 
 ## Full Reference

--- a/internal/server/persistent_instructions_admin.txt
+++ b/internal/server/persistent_instructions_admin.txt
@@ -2,7 +2,7 @@ You are a persistent agent registered with Agent Vault, an HTTP proxy that attac
 
 IMPORTANT: Whenever your task involves ANY external service or API (Linear, GitHub, Stripe, Jira, Slack, Asana, GitLab, or any other authenticated service), you MUST check Agent Vault BEFORE telling the user you lack access. Call /discover to see what's available, then route requests through the proxy. If the service isn't listed, raise a proposal — never just say "I can't access that."
 
-Your vault role is **admin**. You have full vault access: proxy, discover, proposals, direct credential management, proposal approval/rejection, vault service management, and the ability to invite agents with any role and invite users to the vault.
+You are an instance-level agent. You may have access to multiple vaults. Use the X-Vault header to select which vault to operate on for each request.
 
 ## Token
 
@@ -10,18 +10,22 @@ You received a session token (av_session_token). Use it for all proxy/discover/p
 
 ## Quick Start
 
-1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_session_token} — do this FIRST
-2. For hosts in the response, route through the proxy: {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}
+1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_session_token} and X-Vault: {vault_name} — do this FIRST
+2. For hosts in the response, route through the proxy: {AGENT_VAULT_ADDR}/proxy/{target_host}/{path} (include X-Vault header)
 3. If a needed service isn't listed, raise a proposal.
+
+## Multi-Vault Access
+
+Your session is instance-level. Include the X-Vault header on all vault-scoped requests (proxy, discover, proposals, credentials). If you have access to multiple vaults, switch between them by changing the X-Vault header value.
 
 ## Admin Capabilities
 
-As an admin, you can also:
-- Set credentials: POST {AGENT_VAULT_ADDR}/v1/credentials with {"vault": "...", "credentials": {"KEY": "value"}}
-- Delete credentials: DELETE {AGENT_VAULT_ADDR}/v1/credentials with {"vault": "...", "keys": ["KEY"]}
+For vaults where you have admin role, you can also:
+- Set credentials: POST {AGENT_VAULT_ADDR}/v1/credentials with X-Vault header and {"vault": "...", "credentials": {"KEY": "value"}}
+- Delete credentials: DELETE {AGENT_VAULT_ADDR}/v1/credentials with X-Vault header and {"vault": "...", "keys": ["KEY"]}
 - Approve proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/approve with {"vault": "...", "credentials": {"KEY": "value"}}
 - Reject proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/reject with {"vault": "...", "reason": "..."}
-- Invite agents with any role: POST {AGENT_VAULT_ADDR}/v1/invites with {"vault": "...", "vault_role": "member|proxy|admin"}
+- Invite agents: POST {AGENT_VAULT_ADDR}/v1/agents/invites with {"name": "...", "vaults": [{"vault_name": "...", "vault_role": "proxy|member|admin"}]}
 - Invite users: POST {AGENT_VAULT_ADDR}/v1/users/invites with {"email": "...", "vaults": [{"vault_name": "...", "vault_role": "member|admin"}]}
 
 ## Full Reference

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,6 +64,12 @@ var passwordResetEmailHTML string
 //go:embed test_email.html
 var testEmailHTML string
 
+// agentVaultJSON is the JSON representation of an agent's vault grant (reused across handlers).
+type agentVaultJSON struct {
+	VaultName string `json:"vault_name"`
+	VaultRole string `json:"vault_role"`
+}
+
 // Server is the Agent Vault HTTP server.
 type Server struct {
 	httpServer  *http.Server
@@ -137,15 +143,22 @@ type Store interface {
 	ApplyProposal(ctx context.Context, vaultID string, proposalID int, mergedServicesJSON string, credentials map[string]store.EncryptedCredential, deleteCredentialKeys []string) error
 	ExpirePendingProposals(ctx context.Context, before time.Time) (int, error)
 
-	// Invites
-	CreateInvite(ctx context.Context, vaultID, vaultRole, createdBy string, expiresAt time.Time, sessionTTLSeconds int) (*store.Invite, error)
+	// Agent invites (instance-level)
+	CreateAgentInvite(ctx context.Context, agentName, createdBy string, expiresAt time.Time, sessionTTLSeconds int, vaults []store.AgentInviteVault) (*store.Invite, error)
+	CreateRotationInvite(ctx context.Context, agentID, createdBy string, expiresAt time.Time) (*store.Invite, error)
 	GetInviteByToken(ctx context.Context, token string) (*store.Invite, error)
-	ListInvites(ctx context.Context, vaultID, status string) ([]store.Invite, error)
+	ListInvites(ctx context.Context, status string) ([]store.Invite, error)
+	ListInvitesByVault(ctx context.Context, vaultID, status string) ([]store.Invite, error)
 	RedeemInvite(ctx context.Context, token, sessionID string) error
 	RevokeInvite(ctx context.Context, token string) error
 	GetInviteByID(ctx context.Context, id int) (*store.Invite, error)
 	RevokeInviteByID(ctx context.Context, id int) error
-	CountPendingInvites(ctx context.Context, vaultID string) (int, error)
+	CountPendingInvites(ctx context.Context) (int, error)
+	HasPendingInviteByAgentName(ctx context.Context, name string) (bool, error)
+	GetPendingInviteByAgentName(ctx context.Context, name string) (*store.Invite, error)
+	AddAgentInviteVault(ctx context.Context, inviteID int, vaultID, role string) error
+	RemoveAgentInviteVault(ctx context.Context, inviteID int, vaultID string) error
+	UpdateAgentInviteVaultRole(ctx context.Context, inviteID int, vaultID, role string) error
 	ExpirePendingInvites(ctx context.Context, before time.Time) (int, error)
 
 	// User invites (instance-level)
@@ -195,22 +208,24 @@ type Store interface {
 	GetAllSettings(ctx context.Context) (map[string]string, error)
 
 	// Agents
-	CreateAgent(ctx context.Context, name, vaultID string, tokenHash, tokenSalt []byte, tokenPrefix, vaultRole, createdBy string) (*store.Agent, error)
+	CreateAgent(ctx context.Context, name, createdBy string) (*store.Agent, error)
 	GetAgentByID(ctx context.Context, id string) (*store.Agent, error)
 	GetAgentByName(ctx context.Context, name string) (*store.Agent, error)
-	GetAgentByTokenPrefix(ctx context.Context, prefix string) (*store.Agent, error)
 	ListAgents(ctx context.Context, vaultID string) ([]store.Agent, error)
 	ListAllAgents(ctx context.Context) ([]store.Agent, error)
 	RevokeAgent(ctx context.Context, id string) error
-	UpdateAgentServiceToken(ctx context.Context, id string, tokenHash, tokenSalt []byte, tokenPrefix string) error
-	UpdateAgentVaultRole(ctx context.Context, id, role string) error
 	RenameAgent(ctx context.Context, id string, newName string) error
 	CountAgentSessions(ctx context.Context, agentID string) (int, error)
 	GetLatestAgentSessionExpiry(ctx context.Context, agentID string) (*time.Time, error)
 	DeleteAgentSessions(ctx context.Context, agentID string) error
-	CreateAgentSession(ctx context.Context, agentID, vaultID, vaultRole string, expiresAt *time.Time) (*store.Session, error)
-	CreatePersistentInvite(ctx context.Context, vaultID, vaultRole, createdBy string, agentName string, expiresAt time.Time) (*store.Invite, error)
-	CreateRotationInvite(ctx context.Context, agentID, vaultID, createdBy string, expiresAt time.Time) (*store.Invite, error)
+	CreateAgentSession(ctx context.Context, agentID string, expiresAt *time.Time) (*store.Session, error)
+
+	// Agent vault grants
+	GrantAgentVaultRole(ctx context.Context, agentID, vaultID, role string) error
+	RevokeAgentVaultAccess(ctx context.Context, agentID, vaultID string) error
+	GetAgentVaultRole(ctx context.Context, agentID, vaultID string) (string, error)
+	ListAgentGrants(ctx context.Context, agentID string) ([]store.AgentVaultGrant, error)
+	ListVaultAgents(ctx context.Context, vaultID string) ([]store.AgentVaultGrant, error)
 
 	Close() error
 }
@@ -500,25 +515,32 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("POST /v1/admin/proposals/{id}/reject", s.requireInitialized(s.requireAuth(limitBody(s.handleAdminProposalReject))))
 	mux.HandleFunc("/proxy/", s.requireInitialized(s.requireAuth(s.handleProxy)))
 
-	// Agent invites
+	// Agent invite redemption (no auth — token is the credential)
 	mux.HandleFunc("GET /invite/{token}", s.requireInitialized(s.handleInviteRedeem))
 	mux.HandleFunc("POST /invite/{token}", s.requireInitialized(limitBody(s.handlePersistentInviteRedeem)))
-	mux.HandleFunc("POST /v1/invites", s.requireInitialized(s.requireAuth(limitBody(s.handleInviteCreate))))
-	mux.HandleFunc("GET /v1/invites", s.requireInitialized(s.requireAuth(s.handleInviteList)))
-	mux.HandleFunc("DELETE /v1/invites/{token}", s.requireInitialized(s.requireAuth(s.handleInviteRevoke)))
-	mux.HandleFunc("DELETE /v1/invites/by-id/{id}", s.requireInitialized(s.requireAuth(s.handleInviteRevokeByID)))
 
-	// Agent management (owner-only)
-	mux.HandleFunc("GET /v1/admin/agents", s.requireInitialized(s.requireAuth(s.handleAgentList)))
-	mux.HandleFunc("GET /v1/admin/agents/{name}", s.requireInitialized(s.requireAuth(s.handleAgentGet)))
-	mux.HandleFunc("DELETE /v1/admin/agents/{name}", s.requireInitialized(s.requireAuth(s.handleAgentRevoke)))
-	mux.HandleFunc("POST /v1/admin/agents/{name}/rotate", s.requireInitialized(s.requireAuth(limitBody(s.handleAgentRotate))))
-	mux.HandleFunc("POST /v1/admin/agents/{name}/rename", s.requireInitialized(s.requireAuth(limitBody(s.handleAgentRename))))
+	// Agent invites (instance-level, requires auth)
+	mux.HandleFunc("POST /v1/agents/invites", s.requireInitialized(s.requireAuth(limitBody(s.handleAgentInviteCreate))))
+	mux.HandleFunc("GET /v1/agents/invites", s.requireInitialized(s.requireAuth(s.handleAgentInviteList)))
+	mux.HandleFunc("DELETE /v1/agents/invites/{token}", s.requireInitialized(s.requireAuth(s.handleAgentInviteRevoke)))
+	mux.HandleFunc("DELETE /v1/agents/invites/by-id/{id}", s.requireInitialized(s.requireAuth(s.handleAgentInviteRevokeByID)))
+
+	// Agent management (instance-level)
+	mux.HandleFunc("GET /v1/agents", s.requireInitialized(s.requireAuth(s.handleAgentList)))
+	mux.HandleFunc("GET /v1/agents/{name}", s.requireInitialized(s.requireAuth(s.handleAgentGet)))
+	mux.HandleFunc("DELETE /v1/agents/{name}", s.requireInitialized(s.requireAuth(s.handleAgentRevoke)))
+	mux.HandleFunc("POST /v1/agents/{name}/rotate", s.requireInitialized(s.requireAuth(limitBody(s.handleAgentRotate))))
+	mux.HandleFunc("POST /v1/agents/{name}/rename", s.requireInitialized(s.requireAuth(limitBody(s.handleAgentRename))))
+
+	// Vault-level agent management
+	mux.HandleFunc("GET /v1/vaults/{name}/agents", s.requireInitialized(s.requireAuth(s.handleVaultAgentList)))
+	mux.HandleFunc("POST /v1/vaults/{name}/agents", s.requireInitialized(s.requireAuth(limitBody(s.handleVaultAgentAdd))))
+	mux.HandleFunc("DELETE /v1/vaults/{name}/agents/{agentName}", s.requireInitialized(s.requireAuth(s.handleVaultAgentRemove)))
+	mux.HandleFunc("POST /v1/vaults/{name}/agents/{agentName}/role", s.requireInitialized(s.requireAuth(limitBody(s.handleVaultAgentSetRole))))
 
 	// Instance settings (owner-only)
 	mux.HandleFunc("GET /v1/admin/settings", s.requireInitialized(s.requireAuth(s.handleGetSettings)))
 	mux.HandleFunc("PUT /v1/admin/settings", s.requireInitialized(s.requireAuth(limitBody(s.handleUpdateSettings))))
-	mux.HandleFunc("POST /v1/admin/agents/{name}/vault-role", s.requireInitialized(s.requireAuth(limitBody(s.handleAgentSetRole))))
 
 	// Public user list (any authenticated user)
 	mux.HandleFunc("GET /v1/users", s.requireInitialized(s.requireAuth(s.handlePublicUserList)))
@@ -2263,23 +2285,22 @@ func (s *Server) listCredentialKeys(ctx context.Context, vaultID string) []strin
 func (s *Server) handleDiscover(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Require scoped session — global admin sessions may not use discovery.
+	// Require scoped session or agent session with X-Vault.
 	sess := sessionFromContext(ctx)
-	if sess == nil || sess.VaultID == "" {
+	if sess == nil {
 		proxyError(w, http.StatusForbidden, "forbidden", "Discovery requires a vault-scoped session")
 		return
 	}
 
-	ns, err := s.store.GetVaultByID(ctx, sess.VaultID)
-	if err != nil || ns == nil {
-		proxyError(w, http.StatusInternalServerError, "internal", "Failed to resolve vault")
+	ns, _, err := s.resolveVaultForSession(w, r, sess)
+	if err != nil {
 		return
 	}
 
-	credentialKeys := s.listCredentialKeys(ctx, sess.VaultID)
+	credentialKeys := s.listCredentialKeys(ctx, ns.ID)
 
 	// Load broker config for this vault.
-	brokerCfg, err := s.store.GetBrokerConfig(ctx, sess.VaultID)
+	brokerCfg, err := s.store.GetBrokerConfig(ctx, ns.ID)
 	if err != nil || brokerCfg == nil {
 		// No config means no services — return empty list.
 		w.Header().Set("Content-Type", "application/json")
@@ -2329,12 +2350,18 @@ type proposalCreateRequest struct {
 func (s *Server) handleProposalCreate(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Enforce scoped session.
+	// Enforce scoped session or agent session with X-Vault.
 	sess := sessionFromContext(ctx)
-	if sess == nil || sess.VaultID == "" {
+	if sess == nil {
 		jsonError(w, http.StatusForbidden, "Proposals require a vault-scoped session")
 		return
 	}
+
+	resolvedVault, _, err := s.resolveVaultForSession(w, r, sess)
+	if err != nil {
+		return
+	}
+	vaultID := resolvedVault.ID
 
 	var req proposalCreateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -2349,14 +2376,14 @@ func (s *Server) handleProposalCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate that all credential references resolve to existing or proposed credentials.
-	existingKeys := s.listCredentialKeys(ctx, sess.VaultID)
+	existingKeys := s.listCredentialKeys(ctx, vaultID)
 	if err := proposal.ValidateCredentialRefs(req.Services, req.Credentials, existingKeys); err != nil {
 		jsonError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
 	// Check pending limit.
-	count, err := s.store.CountPendingProposals(ctx, sess.VaultID)
+	count, err := s.store.CountPendingProposals(ctx, vaultID)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to count pending proposals")
 		return
@@ -2388,17 +2415,13 @@ func (s *Server) handleProposalCreate(w http.ResponseWriter, r *http.Request) {
 	servicesJSON, _ := json.Marshal(req.Services)
 	credentialsJSON, _ := json.Marshal(req.Credentials)
 
-	cs, err := s.store.CreateProposal(ctx, sess.VaultID, sess.ID, string(servicesJSON), string(credentialsJSON), req.Message, req.UserMessage, encCredentials)
+	cs, err := s.store.CreateProposal(ctx, vaultID, sess.ID, string(servicesJSON), string(credentialsJSON), req.Message, req.UserMessage, encCredentials)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create proposal")
 		return
 	}
 
-	// Look up vault name for the response message.
-	nsName := sess.VaultID
-	if ns, err := s.store.GetVaultByID(ctx, sess.VaultID); err == nil && ns != nil {
-		nsName = ns.Name
-	}
+	nsName := resolvedVault.Name
 
 	approvalURL := fmt.Sprintf("%s/approve/%d?token=%s", s.baseURL, cs.ID, cs.ApprovalToken)
 
@@ -2413,7 +2436,7 @@ func (s *Server) handleProposalCreate(w http.ResponseWriter, r *http.Request) {
 	// Notify vault members about the new proposal (fire-and-forget).
 	// The goroutine intentionally outlives the request, so we use a detached context.
 	if s.notifier.Enabled() {
-		go s.notifyProposalCreated(sess.VaultID, nsName, cs.ID, req.Message, approvalURL, proposalAgentName) //nolint:gosec // G118: intentional fire-and-forget goroutine
+		go s.notifyProposalCreated(vaultID, nsName, cs.ID, req.Message, approvalURL, proposalAgentName) //nolint:gosec // G118: intentional fire-and-forget goroutine
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -2470,8 +2493,13 @@ func (s *Server) handleProposalGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	sess := sessionFromContext(ctx)
-	if sess == nil || sess.VaultID == "" {
+	if sess == nil {
 		jsonError(w, http.StatusForbidden, "Proposals require a vault-scoped session")
+		return
+	}
+
+	resolvedVault, _, err := s.resolveVaultForSession(w, r, sess)
+	if err != nil {
 		return
 	}
 
@@ -2482,7 +2510,7 @@ func (s *Server) handleProposalGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cs, err := s.store.GetProposal(ctx, sess.VaultID, id)
+	cs, err := s.store.GetProposal(ctx, resolvedVault.ID, id)
 	if err != nil {
 		jsonError(w, http.StatusNotFound, fmt.Sprintf("Proposal %d not found", id))
 		return
@@ -2505,13 +2533,18 @@ func (s *Server) handleProposalList(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	sess := sessionFromContext(ctx)
-	if sess == nil || sess.VaultID == "" {
+	if sess == nil {
 		jsonError(w, http.StatusForbidden, "Proposals require a vault-scoped session")
 		return
 	}
 
+	resolvedVault, _, err := s.resolveVaultForSession(w, r, sess)
+	if err != nil {
+		return
+	}
+
 	status := r.URL.Query().Get("status")
-	list, err := s.store.ListProposals(ctx, sess.VaultID, status)
+	list, err := s.store.ListProposals(ctx, resolvedVault.ID, status)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to list proposals")
 		return
@@ -2891,6 +2924,51 @@ func newProxyClient() *http.Client {
 // proxyClient is initialized in New() to ensure environment is fully configured.
 var proxyClient *http.Client
 
+// resolveVaultForSession resolves the vault ID for the current session.
+// For user scoped sessions (VaultID set), returns the session's vault directly.
+// For agent sessions (VaultID empty), reads vault name from X-Vault header and checks access.
+// Returns vault, vault role, error. Writes error response to w on failure.
+func (s *Server) resolveVaultForSession(w http.ResponseWriter, r *http.Request, sess *store.Session) (*store.Vault, string, error) {
+	ctx := r.Context()
+
+	if sess.VaultID != "" {
+		// User scoped session — vault is baked into the session.
+		ns, err := s.store.GetVaultByID(ctx, sess.VaultID)
+		if err != nil || ns == nil {
+			jsonError(w, http.StatusInternalServerError, "Failed to resolve vault")
+			return nil, "", fmt.Errorf("vault not found")
+		}
+		return ns, sess.VaultRole, nil
+	}
+
+	// Agent session — resolve vault from X-Vault header.
+	if sess.AgentID == "" {
+		jsonError(w, http.StatusForbidden, "Session requires vault scope")
+		return nil, "", fmt.Errorf("no vault context")
+	}
+
+	vaultName := r.Header.Get("X-Vault")
+	if vaultName == "" {
+		jsonError(w, http.StatusBadRequest, "Agent sessions require X-Vault header to specify which vault to use")
+		return nil, "", fmt.Errorf("missing X-Vault header")
+	}
+
+	ns, err := s.store.GetVault(ctx, vaultName)
+	if err != nil || ns == nil {
+		jsonError(w, http.StatusNotFound, "Vault not found: "+vaultName)
+		return nil, "", fmt.Errorf("vault not found")
+	}
+
+	// Check agent has access to this vault.
+	role, err := s.store.GetAgentVaultRole(ctx, sess.AgentID, ns.ID)
+	if err != nil {
+		jsonError(w, http.StatusForbidden, "Agent does not have access to vault: "+vaultName)
+		return nil, "", fmt.Errorf("no vault access")
+	}
+
+	return ns, role, nil
+}
+
 func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// 1. Parse target host and path from /proxy/{target_host}/{path...}
 	trimmed := strings.TrimPrefix(r.URL.Path, "/proxy/")
@@ -2914,22 +2992,19 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	// 2. Enforce scoped session — global admin sessions may not use the proxy.
+	// 2. Resolve vault — user scoped sessions use session vault, agent sessions use X-Vault header.
 	sess := sessionFromContext(ctx)
-	if sess == nil || sess.VaultID == "" {
-		proxyError(w, http.StatusForbidden, "forbidden", "Proxy requires a vault-scoped session")
+	if sess == nil {
+		proxyError(w, http.StatusForbidden, "forbidden", "Proxy requires an authenticated session")
 		return
 	}
-
-	// 3. Look up vault name for error messages.
-	ns, err := s.store.GetVaultByID(ctx, sess.VaultID)
-	if err != nil || ns == nil {
-		proxyError(w, http.StatusInternalServerError, "internal", "Failed to resolve vault")
-		return
+	ns, _, err := s.resolveVaultForSession(w, r, sess)
+	if err != nil {
+		return // error already written
 	}
 
 	// 4. Load broker config for this vault.
-	brokerCfg, err := s.store.GetBrokerConfig(ctx, sess.VaultID)
+	brokerCfg, err := s.store.GetBrokerConfig(ctx, ns.ID)
 	if err != nil || brokerCfg == nil {
 		proxyForbiddenWithHint(w, targetHost, ns.Name)
 		return
@@ -2955,7 +3030,7 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 	// 6. Resolve credentials from matched service's auth config.
 	resolved, err := matched.Auth.Resolve(func(key string) (string, error) {
-		cred, err := s.store.GetCredential(ctx, sess.VaultID, key)
+		cred, err := s.store.GetCredential(ctx, ns.ID, key)
 		if err != nil {
 			return "", fmt.Errorf("credential %q not found", key)
 		}
@@ -2966,7 +3041,7 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 		return string(plaintext), nil
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[agent-vault] credential resolution failed for vault %s: %v\n", sess.VaultID, err)
+		fmt.Fprintf(os.Stderr, "[agent-vault] credential resolution failed for vault %s: %v\n", ns.ID, err)
 		proxyError(w, http.StatusBadGateway, "credential_not_found", "A required credential could not be resolved; check vault configuration")
 		return
 	}
@@ -3039,9 +3114,18 @@ type inviteRedeemResponse struct {
 	Instructions   string            `json:"instructions"`
 }
 
+// handleInviteRedeem serves the SPA for browser-based invite acceptance.
+// All agent invites are now redeemed via POST /invite/{token} (handlePersistentInviteRedeem).
+// GET /invite/{token} serves the browser page OR returns a redirect hint for agents.
 func (s *Server) handleInviteRedeem(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	token := r.PathValue("token")
+
+	// Check if this is a user invite (av_uinv_ prefix) — delegate to SPA.
+	if strings.HasPrefix(token, "av_uinv_") {
+		s.handleSPA(w, r)
+		return
+	}
 
 	inv, err := s.store.GetInviteByToken(ctx, token)
 	if err != nil || inv == nil {
@@ -3049,7 +3133,6 @@ func (s *Server) handleInviteRedeem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check status — return distinct codes for each terminal state.
 	switch inv.Status {
 	case "redeemed":
 		proxyError(w, http.StatusGone, "invite_redeemed", "This invite has already been used — ask for a new one")
@@ -3062,128 +3145,100 @@ func (s *Server) handleInviteRedeem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Lazy expiry check for pending invites whose TTL has passed.
 	if time.Now().After(inv.ExpiresAt) {
 		proxyError(w, http.StatusGone, "invite_expired", "This invite has expired — ask for a new one")
 		return
 	}
 
-	// Persistent invites must be redeemed via POST.
-	if inv.Persistent {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		json.NewEncoder(w).Encode(map[string]string{
-			"error":   "persistent_invite",
-			"message": "This is a persistent agent invite. Use POST /invite/{token} with a JSON body to redeem it.",
-		})
-		return
-	}
-
-	// Burn the invite first to prevent double-redeem race conditions.
-	if err := s.store.RedeemInvite(ctx, token, ""); err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to redeem invite")
-		return
-	}
-
-	// Create a vault-scoped session for the agent with the invite's role.
-	// SessionTTLSeconds > 0 = finite session; 0 = no expiry.
-	var sessExpiry *time.Time
-	if inv.SessionTTLSeconds > 0 {
-		sessExpiry = timePtr(time.Now().Add(time.Duration(inv.SessionTTLSeconds) * time.Second))
-	}
-	sess, err := s.store.CreateScopedSession(ctx, inv.VaultID, inv.VaultRole, sessExpiry)
-	if err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to create session")
-		return
-	}
-
-	// Build the onboarding payload — same data as /discover plus instructions.
-	ns, err := s.store.GetVaultByID(ctx, inv.VaultID)
-	if err != nil || ns == nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to resolve vault")
-		return
-	}
-
-	baseURL := s.baseURL
-	services := s.buildServiceList(ctx, inv.VaultID)
-
+	// All agent invites must be redeemed via POST.
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(inviteRedeemResponse{
-		AVAddr:         baseURL,
-		AVSessionToken: sess.ID,
-		AVVault:        ns.Name,
-		VaultRole:      inv.VaultRole,
-		ProxyURL:       baseURL + "/proxy",
-		Services:       services,
-		Instructions:   instructionsForRole(inv.VaultRole),
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	json.NewEncoder(w).Encode(map[string]string{
+		"error":   "use_post",
+		"message": "Agent invites must be redeemed via POST /invite/{token} with a JSON body.",
 	})
 }
 
-func (s *Server) handleInviteList(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleAgentInviteList(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	nsName := r.URL.Query().Get("vault")
-	if nsName == "" {
-		nsName = store.DefaultVault
-	}
-	ns, err := s.store.GetVault(ctx, nsName)
-	if err != nil || ns == nil {
-		jsonError(w, http.StatusNotFound, "Vault not found")
+	sess := sessionFromContext(ctx)
+	if sess == nil || sess.UserID == "" {
+		jsonError(w, http.StatusForbidden, "Agent invite list requires a user session")
 		return
 	}
 
-	// Check vault access.
-	if _, err := s.requireVaultAccess(w, r, ns.ID); err != nil {
+	user, err := s.store.GetUserByID(ctx, sess.UserID)
+	if err != nil || user == nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to load user")
 		return
 	}
 
 	status := r.URL.Query().Get("status")
-	invites, err := s.store.ListInvites(ctx, ns.ID, status)
+	invites, err := s.store.ListInvites(ctx, status)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to list invites")
 		return
 	}
 
-	type inviteItem struct {
-		ID               int     `json:"id"`
-		Token            string  `json:"token"`
-		Status           string  `json:"status"`
-		Vault            string  `json:"vault"`
-		VaultRole        string  `json:"vault_role"`
-		Persistent       bool    `json:"persistent"`
-		AgentName        string  `json:"agent_name,omitempty"`
-		CreatedAt        string  `json:"created_at"`
-		ExpiresAt        string  `json:"expires_at"`
-		RedeemedAt       *string `json:"redeemed_at,omitempty"`
-		SessionExpiresAt *string `json:"session_expires_at,omitempty"`
+	// Filter: owners see all; others see invites they created or with pre-assignments to vaults they admin.
+	// Pre-load user's vault roles to avoid per-invite queries.
+	var userAdminVaults map[string]bool
+	if user.Role != "owner" {
+		userAdminVaults = make(map[string]bool)
+		if grants, err := s.store.ListUserGrants(ctx, user.ID); err == nil {
+			for _, g := range grants {
+				if g.Role == "admin" {
+					userAdminVaults[g.VaultID] = true
+				}
+			}
+		}
 	}
 
-	// Return full tokens for admin (user) sessions so CLI can do suffix-based revoke.
-	sess := sessionFromContext(ctx)
-	isAdmin := sess != nil && sess.UserID != ""
+	var filtered []store.Invite
+	for _, inv := range invites {
+		if user.Role == "owner" || inv.CreatedBy == user.ID {
+			filtered = append(filtered, inv)
+			continue
+		}
+		for _, v := range inv.Vaults {
+			if userAdminVaults[v.VaultID] {
+				filtered = append(filtered, inv)
+				break
+			}
+		}
+	}
 
-	items := make([]inviteItem, len(invites))
-	for i, inv := range invites {
-		token := inv.Token
-		if !isAdmin && len(token) > 8 {
-			token = token[len(token)-8:]
+	type inviteItem struct {
+		ID               int              `json:"id"`
+		Token            string           `json:"token,omitempty"`
+		AgentName        string           `json:"agent_name"`
+		Status           string           `json:"status"`
+		Vaults           []agentVaultJSON `json:"vaults"`
+		CreatedAt        string      `json:"created_at"`
+		ExpiresAt        string      `json:"expires_at"`
+		RedeemedAt       *string     `json:"redeemed_at,omitempty"`
+		SessionExpiresAt *string     `json:"session_expires_at,omitempty"`
+	}
+
+	items := make([]inviteItem, len(filtered))
+	for i, inv := range filtered {
+		var vaults []agentVaultJSON
+		for _, v := range inv.Vaults {
+			vaults = append(vaults, agentVaultJSON{VaultName: v.VaultName, VaultRole: v.VaultRole})
 		}
 		items[i] = inviteItem{
-			ID:         inv.ID,
-			Token:      token,
-			Status:     inv.Status,
-			Vault:      nsName,
-			VaultRole:  inv.VaultRole,
-			Persistent: inv.Persistent,
-			AgentName:  inv.AgentName,
-			CreatedAt:  inv.CreatedAt.Format(time.RFC3339),
-			ExpiresAt:  inv.ExpiresAt.Format(time.RFC3339),
+			ID:        inv.ID,
+			AgentName: inv.AgentName,
+			Status:    inv.Status,
+			Vaults:    vaults,
+			CreatedAt: inv.CreatedAt.Format(time.RFC3339),
+			ExpiresAt: inv.ExpiresAt.Format(time.RFC3339),
 		}
 		if inv.RedeemedAt != nil {
 			r := inv.RedeemedAt.Format(time.RFC3339)
 			items[i].RedeemedAt = &r
 		}
-		// For redeemed invites, look up session expiry.
 		if inv.Status == "redeemed" && inv.SessionID != "" {
 			if session, err := s.store.GetSession(ctx, inv.SessionID); err == nil && session != nil {
 				e := formatExpiresAt(session.ExpiresAt)
@@ -3193,13 +3248,17 @@ func (s *Server) handleInviteList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(items)
+	json.NewEncoder(w).Encode(map[string]interface{}{"invites": items})
 }
 
-func (s *Server) handleInviteRevoke(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleAgentInviteRevoke(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-
 	token := r.PathValue("token")
+
+	user, err := s.requireUser(w, r)
+	if err != nil {
+		return
+	}
 
 	inv, err := s.store.GetInviteByToken(ctx, token)
 	if err != nil || inv == nil {
@@ -3207,8 +3266,8 @@ func (s *Server) handleInviteRevoke(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check vault access for the invite's vault.
-	if _, err := s.requireVaultAccess(w, r, inv.VaultID); err != nil {
+	if !s.canRevokeAgentInvite(ctx, user, inv) {
+		jsonError(w, http.StatusForbidden, "You do not have permission to revoke this invite")
 		return
 	}
 
@@ -3226,8 +3285,13 @@ func (s *Server) handleInviteRevoke(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{"status": "revoked"})
 }
 
-func (s *Server) handleInviteRevokeByID(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleAgentInviteRevokeByID(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+
+	user, err := s.requireUser(w, r)
+	if err != nil {
+		return
+	}
 
 	idStr := r.PathValue("id")
 	id, err := strconv.Atoi(idStr)
@@ -3242,8 +3306,8 @@ func (s *Server) handleInviteRevokeByID(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Check vault access for the invite's vault.
-	if _, err := s.requireVaultAccess(w, r, inv.VaultID); err != nil {
+	if !s.canRevokeAgentInvite(ctx, user, inv) {
+		jsonError(w, http.StatusForbidden, "You do not have permission to revoke this invite")
 		return
 	}
 
@@ -3259,6 +3323,19 @@ func (s *Server) handleInviteRevokeByID(w http.ResponseWriter, r *http.Request) 
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "revoked"})
+}
+
+// canRevokeAgentInvite checks if the user is the invite creator, an owner, or admin of a pre-assigned vault.
+func (s *Server) canRevokeAgentInvite(ctx context.Context, user *store.User, inv *store.Invite) bool {
+	if user.Role == "owner" || inv.CreatedBy == user.ID {
+		return true
+	}
+	for _, v := range inv.Vaults {
+		if role, err := s.store.GetVaultRole(ctx, user.ID, v.VaultID); err == nil && role == "admin" {
+			return true
+		}
+	}
+	return false
 }
 
 // --- User Management Endpoints ---
@@ -4357,7 +4434,7 @@ func isReservedVaultName(name string) bool {
 // Persistent agents now receive session tokens directly (no service token minting).
 // The POST /v1/agent/session route is no longer registered.
 
-// handlePersistentInviteRedeem handles POST /invite/{token} for persistent agent invites.
+// handlePersistentInviteRedeem handles POST /invite/{token} for agent invite redemption.
 func (s *Server) handlePersistentInviteRedeem(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	token := r.PathValue("token")
@@ -4368,7 +4445,6 @@ func (s *Server) handlePersistentInviteRedeem(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Check status.
 	switch inv.Status {
 	case "redeemed":
 		proxyError(w, http.StatusGone, "invite_redeemed", "This invite has already been used — ask for a new one")
@@ -4385,12 +4461,13 @@ func (s *Server) handlePersistentInviteRedeem(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if !inv.Persistent {
-		proxyError(w, http.StatusBadRequest, "not_persistent", "This is a temporary invite — use GET /invite/{token} instead")
+	// Rotation invite: agent_id is set, no new agent creation needed.
+	if inv.AgentID != "" {
+		s.handleRotationRedeem(w, r, inv, token)
 		return
 	}
 
-	// Parse optional body for agent name.
+	// New agent invite: determine name.
 	var body struct {
 		Name string `json:"name"`
 	}
@@ -4398,15 +4475,8 @@ func (s *Server) handlePersistentInviteRedeem(w http.ResponseWriter, r *http.Req
 		_ = json.NewDecoder(r.Body).Decode(&body)
 	}
 
-	// Rotation invite: agent_id is set, no new agent creation needed.
-	if inv.AgentID != "" {
-		s.handleRotationRedeem(w, r, inv, token)
-		return
-	}
-
-	// New persistent agent invite: determine name.
 	agentName := inv.AgentName
-	if agentName == "" {
+	if agentName == "" && body.Name != "" {
 		agentName = body.Name
 	}
 	if agentName == "" {
@@ -4425,67 +4495,57 @@ func (s *Server) handlePersistentInviteRedeem(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Burn the invite first (atomic CAS via status='pending' guard) to prevent
-	// double-redeem race conditions. Only one concurrent request can succeed.
+	// Burn the invite (atomic CAS via status='pending' guard).
 	if err := s.store.RedeemInvite(ctx, token, ""); err != nil {
 		proxyError(w, http.StatusGone, "invite_redeemed", "This invite has already been used — ask for a new one")
 		return
 	}
 
-	// Create agent record with placeholder service token fields (service tokens are
-	// no longer used — agents get session tokens directly).
-	placeholderHash := []byte("unused")
-	placeholderSalt := []byte("unused")
-	agent, err := s.store.CreateAgent(ctx, agentName, inv.VaultID, placeholderHash, placeholderSalt, "unused", inv.VaultRole, inv.CreatedBy)
+	// Create instance-level agent.
+	agent, err := s.store.CreateAgent(ctx, agentName, inv.CreatedBy)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "[agent-vault] ERROR: CreateAgent(%q): %v\n", agentName, err)
 		jsonError(w, http.StatusInternalServerError, "Failed to create agent")
 		return
 	}
 
-	// Create a non-expiring session for the persistent agent.
-	sess, err := s.store.CreateAgentSession(ctx, agent.ID, inv.VaultID, agent.VaultRole, nil)
+	// Apply vault pre-assignments from the invite.
+	var vaultInfos []agentVaultJSON
+	for _, v := range inv.Vaults {
+		if err := s.store.GrantAgentVaultRole(ctx, agent.ID, v.VaultID, v.VaultRole); err != nil {
+			jsonError(w, http.StatusInternalServerError, "Failed to grant vault access")
+			return
+		}
+		vaultInfos = append(vaultInfos, agentVaultJSON{VaultName: v.VaultName, VaultRole: v.VaultRole})
+	}
+
+	// Create instance-level session (no vault_id).
+	var sessExpiry *time.Time
+	if inv.SessionTTLSeconds > 0 {
+		sessExpiry = timePtr(time.Now().Add(time.Duration(inv.SessionTTLSeconds) * time.Second))
+	}
+	sess, err := s.store.CreateAgentSession(ctx, agent.ID, sessExpiry)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create session")
 		return
 	}
 
-	ns, _ := s.store.GetVaultByID(ctx, inv.VaultID)
-	nsName := store.DefaultVault
-	if ns != nil {
-		nsName = ns.Name
-	}
-
 	baseURL := s.baseURL
-	services := s.buildServiceList(ctx, inv.VaultID)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"av_addr":          baseURL,
 		"av_session_token": sess.ID,
-		"av_vault":         nsName,
-		"vault_role":       inv.VaultRole,
 		"agent_name":       agentName,
 		"proxy_url":        baseURL + "/proxy",
-		"services":         services,
-		"instructions":     persistentInstructionsForRole(inv.VaultRole),
+		"vaults":           vaultInfos,
+		"instructions":     persistentInstructionsAdmin,
 	})
 }
 
-// handleRotationRedeem handles redemption of a rotation invite (persistent invite with agent_id set).
+// handleRotationRedeem handles redemption of a rotation invite (invite with agent_id set).
 func (s *Server) handleRotationRedeem(w http.ResponseWriter, r *http.Request, inv *store.Invite, token string) {
 	ctx := r.Context()
-
-	// Look up existing agent by the invite's agent_id.
-	// We need to query by ID; since GetAgentByName won't work, query the store directly.
-	// Use ListAgents and filter, or add a helper. For now, use the agent_id from the invite
-	// by looking up all agents and matching. But that's inefficient.
-	// Actually, we can use GetAgentByTokenPrefix — but we don't have the prefix.
-	// Let's query directly. We need to find the agent. Let me use a simpler approach:
-	// we query the agents table by iterating. But a better approach: look up agent by name
-	// from the invite. However, the rotation invite doesn't store the agent name.
-	// The invite stores agent_id. We need a GetAgentByID method.
-	// For now, let's add a lightweight lookup. Actually, let me check — we can list all agents
-	// and filter by ID. But that's wasteful. Let me just query by the agent_id.
 
 	agent, err := s.store.GetAgentByID(ctx, inv.AgentID)
 	if err != nil || agent == nil || agent.Status != "active" {
@@ -4493,8 +4553,7 @@ func (s *Server) handleRotationRedeem(w http.ResponseWriter, r *http.Request, in
 		return
 	}
 
-	// Burn the invite first (atomic CAS via status='pending' guard) to prevent
-	// double-redeem race conditions. Only one concurrent request can succeed.
+	// Burn the invite.
 	if err := s.store.RedeemInvite(ctx, token, ""); err != nil {
 		proxyError(w, http.StatusGone, "invite_redeemed", "This invite has already been used — ask for a new one")
 		return
@@ -4506,32 +4565,28 @@ func (s *Server) handleRotationRedeem(w http.ResponseWriter, r *http.Request, in
 		return
 	}
 
-	// Create a new non-expiring session.
-	sess, err := s.store.CreateAgentSession(ctx, agent.ID, agent.VaultID, agent.VaultRole, nil)
+	// Create a new instance-level session.
+	sess, err := s.store.CreateAgentSession(ctx, agent.ID, nil)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create session")
 		return
 	}
 
-	ns, _ := s.store.GetVaultByID(ctx, agent.VaultID)
-	nsName := store.DefaultVault
-	if ns != nil {
-		nsName = ns.Name
+	var vaultInfos []agentVaultJSON
+	for _, v := range agent.Vaults {
+		vaultInfos = append(vaultInfos, agentVaultJSON{VaultName: v.VaultName, VaultRole: v.VaultRole})
 	}
 
 	baseURL := s.baseURL
-	services := s.buildServiceList(ctx, agent.VaultID)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"av_addr":          baseURL,
 		"av_session_token": sess.ID,
-		"av_vault":         nsName,
-		"vault_role":       agent.VaultRole,
 		"agent_name":       agent.Name,
 		"proxy_url":        baseURL + "/proxy",
-		"services":         services,
-		"instructions":     persistentInstructionsForRole(agent.VaultRole),
+		"vaults":           vaultInfos,
+		"instructions":     persistentInstructionsAdmin,
 	})
 }
 
@@ -4540,58 +4595,62 @@ func (s *Server) handleRotationRedeem(w http.ResponseWriter, r *http.Request, in
 func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	nsName := r.URL.Query().Get("vault")
-	if nsName == "" {
-		// Without a vault filter, only owners can list all agents.
-		if _, err := s.requireOwner(w, r); err != nil {
-			return
-		}
+	// Any authenticated user can list agents.
+	// Owners see all; members see agents that share at least one vault.
+	sess := sessionFromContext(ctx)
+	if sess == nil {
+		jsonError(w, http.StatusForbidden, "Authentication required")
+		return
 	}
 
-	var vaultID string
-	if nsName != "" {
-		ns, err := s.store.GetVault(ctx, nsName)
-		if err != nil || ns == nil {
-			jsonError(w, http.StatusNotFound, "Vault not found")
-			return
-		}
-		vaultID = ns.ID
-		// Any vault member can list agents in their vault.
-		if _, err := s.requireVaultAccess(w, r, vaultID); err != nil {
-			return
-		}
-	}
-
-	var agents []store.Agent
-	var agentErr error
-	if vaultID != "" {
-		agents, agentErr = s.store.ListAgents(ctx, vaultID)
-	} else {
-		agents, agentErr = s.store.ListAllAgents(ctx)
-	}
+	agents, agentErr := s.store.ListAllAgents(ctx)
 	if agentErr != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to list agents")
 		return
 	}
 
+	// For non-owner users, filter to agents sharing at least one vault.
+	user, _ := s.userFromSession(ctx, sess)
+	isOwner := user != nil && user.Role == "owner"
+	if !isOwner && user != nil {
+		userGrants, _ := s.store.ListUserGrants(ctx, user.ID)
+		userVaults := make(map[string]bool)
+		for _, g := range userGrants {
+			userVaults[g.VaultID] = true
+		}
+		var filtered []store.Agent
+		for _, ag := range agents {
+			for _, v := range ag.Vaults {
+				if userVaults[v.VaultID] {
+					filtered = append(filtered, ag)
+					break
+				}
+			}
+		}
+		agents = filtered
+	}
+
 	type agentItem struct {
-		Name              string  `json:"name"`
-		VaultID           string  `json:"vault_id"`
-		VaultRole         string  `json:"vault_role"`
-		Status            string  `json:"status"`
-		CreatedAt         string  `json:"created_at"`
-		RevokedAt         *string `json:"revoked_at,omitempty"`
-		SessionExpiresAt  *string `json:"session_expires_at,omitempty"`
+		Name              string           `json:"name"`
+		Status            string           `json:"status"`
+		Vaults            []agentVaultJSON `json:"vaults"`
+		CreatedAt         string           `json:"created_at"`
+		RevokedAt         *string          `json:"revoked_at,omitempty"`
+		SessionExpiresAt  *string          `json:"session_expires_at,omitempty"`
 	}
 
 	items := make([]agentItem, 0, len(agents))
+	seen := make(map[string]bool)
 	for _, ag := range agents {
+		vaults := make([]agentVaultJSON, 0, len(ag.Vaults))
+		for _, v := range ag.Vaults {
+			vaults = append(vaults, agentVaultJSON{VaultName: v.VaultName, VaultRole: v.VaultRole})
+		}
 		item := agentItem{
-			Name:        ag.Name,
-			VaultID:     ag.VaultID,
-			VaultRole:   ag.VaultRole,
-			Status:      ag.Status,
-			CreatedAt:   ag.CreatedAt.Format(time.RFC3339),
+			Name:      ag.Name,
+			Status:    ag.Status,
+			Vaults:    vaults,
+			CreatedAt: ag.CreatedAt.Format(time.RFC3339),
 		}
 		if ag.RevokedAt != nil {
 			s := ag.RevokedAt.Format(time.RFC3339)
@@ -4604,6 +4663,26 @@ func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		items = append(items, item)
+		seen[ag.Name] = true
+	}
+
+	// Include agents with pending invites (not yet redeemed).
+	pendingInvites, _ := s.store.ListInvites(ctx, "pending")
+	for _, inv := range pendingInvites {
+		if seen[inv.AgentName] {
+			continue
+		}
+		vaults := make([]agentVaultJSON, 0, len(inv.Vaults))
+		for _, v := range inv.Vaults {
+			vaults = append(vaults, agentVaultJSON{VaultName: v.VaultName, VaultRole: v.VaultRole})
+		}
+		items = append(items, agentItem{
+			Name:      inv.AgentName,
+			Status:    "pending",
+			Vaults:    vaults,
+			CreatedAt: inv.CreatedAt.Format(time.RFC3339),
+		})
+		seen[inv.AgentName] = true
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -4614,33 +4693,31 @@ func (s *Server) handleAgentGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
 
+	// Any authenticated user can view an agent.
+	sess := sessionFromContext(ctx)
+	if sess == nil {
+		jsonError(w, http.StatusForbidden, "Authentication required")
+		return
+	}
+
 	agent, err := s.store.GetAgentByName(ctx, name)
 	if err != nil {
 		jsonError(w, http.StatusNotFound, "Agent not found")
 		return
 	}
 
-	// Any vault member can view agents in their vault.
-	if _, err := s.requireVaultAccess(w, r, agent.VaultID); err != nil {
-		return
-	}
-
-	// Resolve vault name.
-	ns, _ := s.store.GetVaultByID(ctx, agent.VaultID)
-	nsName := agent.VaultID
-	if ns != nil {
-		nsName = ns.Name
+	vaults := make([]agentVaultJSON, 0, len(agent.Vaults))
+	for _, v := range agent.Vaults {
+		vaults = append(vaults, agentVaultJSON{VaultName: v.VaultName, VaultRole: v.VaultRole})
 	}
 
 	resp := map[string]interface{}{
-		"name":         agent.Name,
-		"vault":        nsName,
-		"vault_id":     agent.VaultID,
-		"vault_role":   agent.VaultRole,
-		"status":       agent.Status,
-		"created_by":   agent.CreatedBy,
-		"created_at":   agent.CreatedAt.Format(time.RFC3339),
-		"updated_at":   agent.UpdatedAt.Format(time.RFC3339),
+		"name":       agent.Name,
+		"status":     agent.Status,
+		"vaults":     vaults,
+		"created_by": agent.CreatedBy,
+		"created_at": agent.CreatedAt.Format(time.RFC3339),
+		"updated_at": agent.UpdatedAt.Format(time.RFC3339),
 	}
 	if agent.RevokedAt != nil {
 		resp["revoked_at"] = agent.RevokedAt.Format(time.RFC3339)
@@ -4661,14 +4738,20 @@ func (s *Server) handleAgentRevoke(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
 
+	// Owner or agent's creator can revoke.
+	user, err := s.requireUser(w, r)
+	if err != nil {
+		return
+	}
+
 	agent, err := s.store.GetAgentByName(ctx, name)
 	if err != nil {
 		jsonError(w, http.StatusNotFound, "Agent not found")
 		return
 	}
 
-	// Vault admins can revoke agents in their vault.
-	if _, err := s.requireVaultAdminSession(w, r, agent.VaultID); err != nil {
+	if user.Role != "owner" && agent.CreatedBy != user.ID {
+		jsonError(w, http.StatusForbidden, "Only the owner or agent creator can revoke agents")
 		return
 	}
 	if agent.Status != "active" {
@@ -4689,15 +4772,20 @@ func (s *Server) handleAgentRotate(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
 
+	// Owner or agent's creator can rotate.
+	user, err := s.requireUser(w, r)
+	if err != nil {
+		return
+	}
+
 	agent, err := s.store.GetAgentByName(ctx, name)
 	if err != nil {
 		jsonError(w, http.StatusNotFound, "Agent not found")
 		return
 	}
 
-	// Vault admins can rotate agents in their vault.
-	user, err := s.requireVaultAdmin(w, r, agent.VaultID)
-	if err != nil {
+	if user.Role != "owner" && agent.CreatedBy != user.ID {
+		jsonError(w, http.StatusForbidden, "Only the owner or agent creator can rotate agents")
 		return
 	}
 	if agent.Status != "active" {
@@ -4706,7 +4794,7 @@ func (s *Server) handleAgentRotate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a rotation invite.
-	inv, err := s.store.CreateRotationInvite(ctx, agent.ID, agent.VaultID, user.ID, time.Now().Add(15*time.Minute))
+	inv, err := s.store.CreateRotationInvite(ctx, agent.ID, user.ID, time.Now().Add(15*time.Minute))
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create rotation invite")
 		return
@@ -4737,14 +4825,20 @@ func (s *Server) handleAgentRename(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
 
+	// Owner or agent's creator can rename.
+	user, err := s.requireUser(w, r)
+	if err != nil {
+		return
+	}
+
 	agent, err := s.store.GetAgentByName(ctx, name)
 	if err != nil {
 		jsonError(w, http.StatusNotFound, "Agent not found")
 		return
 	}
 
-	// Vault admins can rename agents in their vault.
-	if _, err := s.requireVaultAdminSession(w, r, agent.VaultID); err != nil {
+	if user.Role != "owner" && agent.CreatedBy != user.ID {
+		jsonError(w, http.StatusForbidden, "Only the owner or agent creator can rename agents")
 		return
 	}
 
@@ -4780,18 +4874,219 @@ func (s *Server) handleAgentRename(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (s *Server) handleAgentSetRole(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	name := r.PathValue("name")
+// ---------------------------------------------------------------------------
+// Vault-level agent management endpoints
+// ---------------------------------------------------------------------------
 
-	agent, err := s.store.GetAgentByName(ctx, name)
-	if err != nil {
-		jsonError(w, http.StatusNotFound, "Agent not found")
+func (s *Server) handleVaultAgentList(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	nsName := r.PathValue("name")
+
+	ns, err := s.store.GetVault(ctx, nsName)
+	if err != nil || ns == nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", nsName))
 		return
 	}
 
-	// Only vault admins can change agent roles.
-	if _, err := s.requireVaultAdminSession(w, r, agent.VaultID); err != nil {
+	// Any vault member can list agents.
+	if _, err := s.requireVaultAccess(w, r, ns.ID); err != nil {
+		return
+	}
+
+	agents, err := s.store.ListAgents(ctx, ns.ID)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to list vault agents")
+		return
+	}
+
+	type item struct {
+		Name      string `json:"name"`
+		AgentID   string `json:"agent_id"`
+		VaultRole string `json:"vault_role"`
+		Status    string `json:"status"`
+	}
+	items := make([]item, 0, len(agents))
+	seen := make(map[string]bool)
+	for _, ag := range agents {
+		// Find this vault's role from the agent's grants.
+		var role string
+		for _, v := range ag.Vaults {
+			if v.VaultID == ns.ID {
+				role = v.VaultRole
+				break
+			}
+		}
+		items = append(items, item{
+			Name:      ag.Name,
+			AgentID:   ag.ID,
+			VaultRole: role,
+			Status:    ag.Status,
+		})
+		seen[ag.Name] = true
+	}
+
+	// Include pending invite pre-assignments for this vault.
+	pendingInvites, _ := s.store.ListInvitesByVault(ctx, ns.ID, "pending")
+	for _, inv := range pendingInvites {
+		if seen[inv.AgentName] {
+			continue
+		}
+		for _, v := range inv.Vaults {
+			if v.VaultID == ns.ID {
+				items = append(items, item{
+					Name:      inv.AgentName,
+					VaultRole: v.VaultRole,
+					Status:    "pending",
+				})
+				seen[inv.AgentName] = true
+				break
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{"agents": items})
+}
+
+func (s *Server) handleVaultAgentAdd(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	nsName := r.PathValue("name")
+
+	ns, err := s.store.GetVault(ctx, nsName)
+	if err != nil || ns == nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", nsName))
+		return
+	}
+
+	// Vault admin required.
+	if _, err := s.requireVaultAdmin(w, r, ns.ID); err != nil {
+		return
+	}
+
+	var body struct {
+		Name string `json:"name"`
+		Role string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Name == "" {
+		jsonError(w, http.StatusBadRequest, `Request body must include {"name": "agent-name"}`)
+		return
+	}
+	if body.Role == "" {
+		body.Role = "proxy"
+	}
+	if body.Role != "proxy" && body.Role != "member" && body.Role != "admin" {
+		jsonError(w, http.StatusBadRequest, "Role must be one of: proxy, member, admin")
+		return
+	}
+
+	agent, err := s.store.GetAgentByName(ctx, body.Name)
+	if err != nil || agent == nil {
+		// Agent doesn't exist yet — check for a pending invite and add a vault pre-assignment.
+		inv, invErr := s.store.GetPendingInviteByAgentName(ctx, body.Name)
+		if invErr != nil || inv == nil {
+			jsonError(w, http.StatusNotFound, fmt.Sprintf("Agent %q not found", body.Name))
+			return
+		}
+		// Check not already pre-assigned to this vault.
+		for _, v := range inv.Vaults {
+			if v.VaultID == ns.ID {
+				jsonError(w, http.StatusConflict, fmt.Sprintf("Agent %q is already pre-assigned to vault %q", body.Name, nsName))
+				return
+			}
+		}
+		if err := s.store.AddAgentInviteVault(ctx, inv.ID, ns.ID, body.Role); err != nil {
+			jsonError(w, http.StatusInternalServerError, "Failed to add vault pre-assignment to agent invite")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": fmt.Sprintf("agent %q pre-assigned to vault %q with role %q (pending invite acceptance)", body.Name, nsName, body.Role),
+		})
+		return
+	}
+	if agent.Status != "active" {
+		jsonError(w, http.StatusConflict, "Agent is revoked")
+		return
+	}
+
+	// Check not already granted.
+	if _, err := s.store.GetAgentVaultRole(ctx, agent.ID, ns.ID); err == nil {
+		jsonError(w, http.StatusConflict, fmt.Sprintf("Agent %q already has access to vault %q", body.Name, nsName))
+		return
+	}
+
+	if err := s.store.GrantAgentVaultRole(ctx, agent.ID, ns.ID, body.Role); err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to add agent to vault")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]string{
+		"message": fmt.Sprintf("agent %q added to vault %q with role %q", body.Name, nsName, body.Role),
+	})
+}
+
+func (s *Server) handleVaultAgentRemove(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	nsName := r.PathValue("name")
+	agentName := r.PathValue("agentName")
+
+	ns, err := s.store.GetVault(ctx, nsName)
+	if err != nil || ns == nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", nsName))
+		return
+	}
+
+	// Vault admin required.
+	if _, err := s.requireVaultAdmin(w, r, ns.ID); err != nil {
+		return
+	}
+
+	agent, err := s.store.GetAgentByName(ctx, agentName)
+	if err != nil || agent == nil {
+		// Agent doesn't exist yet — check for a pending invite pre-assignment.
+		inv, invErr := s.store.GetPendingInviteByAgentName(ctx, agentName)
+		if invErr != nil || inv == nil {
+			jsonError(w, http.StatusNotFound, fmt.Sprintf("Agent %q not found", agentName))
+			return
+		}
+		if err := s.store.RemoveAgentInviteVault(ctx, inv.ID, ns.ID); err != nil {
+			jsonError(w, http.StatusInternalServerError, "Failed to remove vault pre-assignment")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": fmt.Sprintf("agent %q pre-assignment removed from vault %q", agentName, nsName),
+		})
+		return
+	}
+
+	if err := s.store.RevokeAgentVaultAccess(ctx, agent.ID, ns.ID); err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to remove agent from vault")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"message": fmt.Sprintf("agent %q removed from vault %q", agentName, nsName),
+	})
+}
+
+func (s *Server) handleVaultAgentSetRole(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	nsName := r.PathValue("name")
+	agentName := r.PathValue("agentName")
+
+	ns, err := s.store.GetVault(ctx, nsName)
+	if err != nil || ns == nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", nsName))
+		return
+	}
+
+	// Vault admin required.
+	if _, err := s.requireVaultAdmin(w, r, ns.ID); err != nil {
 		return
 	}
 
@@ -4807,16 +5102,53 @@ func (s *Server) handleAgentSetRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.store.UpdateAgentVaultRole(ctx, agent.ID, body.Role); err != nil {
+	agent, err := s.store.GetAgentByName(ctx, agentName)
+	if err != nil || agent == nil {
+		// Agent doesn't exist yet — check for a pending invite pre-assignment.
+		inv, invErr := s.store.GetPendingInviteByAgentName(ctx, agentName)
+		if invErr != nil || inv == nil {
+			jsonError(w, http.StatusNotFound, fmt.Sprintf("Agent %q not found", agentName))
+			return
+		}
+		// Verify pre-assignment exists for this vault.
+		found := false
+		for _, v := range inv.Vaults {
+			if v.VaultID == ns.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			jsonError(w, http.StatusNotFound, fmt.Sprintf("Agent %q does not have access to vault %q", agentName, nsName))
+			return
+		}
+		if err := s.store.UpdateAgentInviteVaultRole(ctx, inv.ID, ns.ID, body.Role); err != nil {
+			jsonError(w, http.StatusInternalServerError, "Failed to update agent role")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": fmt.Sprintf("agent %q vault %q pre-assignment role updated to %q", agentName, nsName, body.Role),
+		})
+		return
+	}
+
+	// Verify agent has access to this vault.
+	oldRole, err := s.store.GetAgentVaultRole(ctx, agent.ID, ns.ID)
+	if err != nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("Agent %q does not have access to vault %q", agentName, nsName))
+		return
+	}
+
+	if err := s.store.GrantAgentVaultRole(ctx, agent.ID, ns.ID, body.Role); err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to update agent role")
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{
-		"message":  fmt.Sprintf("agent %q role updated to %q", name, body.Role),
-		"agent":    name,
-		"old_role": agent.VaultRole,
+		"message":  fmt.Sprintf("agent %q role in vault %q updated to %q", agentName, nsName, body.Role),
+		"old_role": oldRole,
 		"new_role": body.Role,
 	})
 }
@@ -5352,43 +5684,46 @@ func (s *Server) serveSkill(w http.ResponseWriter, r *http.Request, content []by
 }
 
 // ---------------------------------------------------------------------------
-// Invite create endpoint
+// Agent invite create endpoint (instance-level)
 // ---------------------------------------------------------------------------
 
-func (s *Server) handleInviteCreate(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleAgentInviteCreate(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	type vaultReq struct {
+		VaultName string `json:"vault_name"`
+		VaultRole string `json:"vault_role"`
+	}
 	var req struct {
-		Vault             string `json:"vault"`
-		Persistent        bool   `json:"persistent"`
-		TTLSeconds        int    `json:"ttl_seconds"`
-		AgentName         string `json:"agent_name"`
-		VaultRole         string `json:"vault_role"`
-		SessionTTLSeconds *int   `json:"session_ttl_seconds,omitempty"`
+		Name              string     `json:"name"`
+		TTLSeconds        int        `json:"ttl_seconds"`
+		SessionTTLSeconds *int       `json:"session_ttl_seconds,omitempty"`
+		Vaults            []vaultReq `json:"vaults"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
-	if req.Vault == "" {
-		req.Vault = store.DefaultVault
+
+	// Agent name is required.
+	if req.Name == "" {
+		jsonError(w, http.StatusBadRequest, "Agent name is required")
+		return
 	}
+	if !validateSlug(req.Name) {
+		jsonError(w, http.StatusBadRequest, "Agent name must be 3-64 characters, lowercase alphanumeric and hyphens only")
+		return
+	}
+
 	if req.TTLSeconds <= 0 {
-		req.TTLSeconds = 900 // 15 minutes default
+		req.TTLSeconds = 7 * 24 * 60 * 60 // 7 days default
 	}
-	// Determine if this is a persistent (named agent) invite.
-	// persistent=true or agent_name set → persistent invite.
-	isPersistent := req.Persistent || req.AgentName != ""
-	// Cap invite TTL: 24 hours for temporary, 7 days for persistent.
-	maxTTL := 24 * 60 * 60 // 24 hours
-	if isPersistent {
-		maxTTL = 7 * 24 * 60 * 60 // 7 days
-	}
+	maxTTL := 7 * 24 * 60 * 60
 	if req.TTLSeconds > maxTTL {
 		req.TTLSeconds = maxTTL
 	}
-	// session_ttl_seconds: nil = no expiry, >0 = finite session.
-	// Cap finite session TTL using the same bounds as direct connect sessions.
+
+	// Cap finite session TTL.
 	if req.SessionTTLSeconds != nil && *req.SessionTTLSeconds > 0 {
 		ttl := *req.SessionTTLSeconds
 		if ttl < directSessionMinTTL {
@@ -5399,102 +5734,96 @@ func (s *Server) handleInviteCreate(w http.ResponseWriter, r *http.Request) {
 			req.SessionTTLSeconds = &ttl
 		}
 	}
-	if req.VaultRole == "" {
-		req.VaultRole = "proxy"
-	}
-	if req.VaultRole != "proxy" && req.VaultRole != "member" && req.VaultRole != "admin" {
-		jsonError(w, http.StatusBadRequest, "Vault_role must be one of: proxy, member, admin")
+
+	// Any authenticated user can create agent invites.
+	user, err := s.requireUser(w, r)
+	if err != nil {
 		return
 	}
 
-	ns, err := s.store.GetVault(ctx, req.Vault)
-	if err != nil || ns == nil {
-		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", req.Vault))
+	// Check for duplicate agent name (existing agent or pending invite).
+	existing, _ := s.store.GetAgentByName(ctx, req.Name)
+	if existing != nil {
+		jsonError(w, http.StatusConflict, fmt.Sprintf("An agent named %q already exists", req.Name))
 		return
 	}
-
-	// Role-based invite enforcement:
-	// - Proxy-role agents cannot invite anyone.
-	// - Members can invite agents but only as proxy.
-	// - Admins (user vault admin or admin agent) can invite with any role.
-	sess := sessionFromContext(ctx)
-	if sess == nil {
-		jsonError(w, http.StatusForbidden, "Authentication required")
+	if hasPending, _ := s.store.HasPendingInviteByAgentName(ctx, req.Name); hasPending {
+		jsonError(w, http.StatusConflict, fmt.Sprintf("A pending invite for agent %q already exists", req.Name))
 		return
 	}
-
-	cappedRole, errMsg := s.capRequestedRole(ctx, sess, ns.ID, req.VaultRole)
-	if errMsg != "" {
-		jsonError(w, http.StatusForbidden, errMsg)
-		return
-	}
-	req.VaultRole = cappedRole
 
 	// Check pending invite limit.
-	count, err := s.store.CountPendingInvites(ctx, ns.ID)
+	count, err := s.store.CountPendingInvites(ctx)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to check pending invites")
 		return
 	}
-	if count >= 10 {
+	if count >= 50 {
 		jsonError(w, http.StatusTooManyRequests, fmt.Sprintf("Too many pending invites (%d) — revoke some before creating new ones", count))
 		return
 	}
 
-	createdBy := "api"
-	if sess.UserID != "" {
-		createdBy = sess.UserID
+	// Validate and resolve vault pre-assignments.
+	var inviteVaults []store.AgentInviteVault
+	for _, v := range req.Vaults {
+		if v.VaultRole == "" {
+			v.VaultRole = "proxy"
+		}
+		if v.VaultRole != "proxy" && v.VaultRole != "member" && v.VaultRole != "admin" {
+			jsonError(w, http.StatusBadRequest, fmt.Sprintf("Invalid vault role %q for vault %q", v.VaultRole, v.VaultName))
+			return
+		}
+		ns, err := s.store.GetVault(ctx, v.VaultName)
+		if err != nil || ns == nil {
+			jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", v.VaultName))
+			return
+		}
+		// Inviter must be admin of the vault (or instance owner).
+		if user.Role != "owner" {
+			role, err := s.store.GetVaultRole(ctx, user.ID, ns.ID)
+			if err != nil || role != "admin" {
+				jsonError(w, http.StatusForbidden, fmt.Sprintf("You must be an admin of vault %q to pre-assign it", v.VaultName))
+				return
+			}
+		}
+		inviteVaults = append(inviteVaults, store.AgentInviteVault{
+			VaultID:   ns.ID,
+			VaultName: v.VaultName,
+			VaultRole: v.VaultRole,
+		})
 	}
 
-	expiresAt := time.Now().Add(time.Duration(req.TTLSeconds) * time.Second)
-
-	// Resolve session TTL: nil = no expiry (0 stored), pointer = finite.
 	sessionTTL := 0
 	if req.SessionTTLSeconds != nil {
 		sessionTTL = *req.SessionTTLSeconds
 	}
 
-	if isPersistent {
-		// Check for duplicate agent name.
-		if req.AgentName != "" {
-			existing, _ := s.store.GetAgentByName(ctx, req.AgentName)
-			if existing != nil {
-				jsonError(w, http.StatusConflict, fmt.Sprintf("An agent named %q already exists", req.AgentName))
-				return
-			}
-		}
-
-		inv, err := s.store.CreatePersistentInvite(ctx, ns.ID, req.VaultRole, createdBy, req.AgentName, expiresAt)
-		if err != nil {
-			jsonError(w, http.StatusInternalServerError, "Failed to create persistent invite")
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"token":      inv.Token,
-			"persistent": true,
-			"agent_name": req.AgentName,
-			"vault_role": inv.VaultRole,
-			"expires_at": inv.ExpiresAt.Format(time.RFC3339),
-		})
+	expiresAt := time.Now().Add(time.Duration(req.TTLSeconds) * time.Second)
+	inv, err := s.store.CreateAgentInvite(ctx, req.Name, user.ID, expiresAt, sessionTTL, inviteVaults)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to create agent invite")
 		return
 	}
 
-	inv, err := s.store.CreateInvite(ctx, ns.ID, req.VaultRole, createdBy, expiresAt, sessionTTL)
-	if err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to create invite")
-		return
+	inviteURL := s.baseURL + "/invite/" + inv.Token
+
+	type vaultResp struct {
+		VaultName string `json:"vault_name"`
+		VaultRole string `json:"vault_role"`
+	}
+	vaults := make([]vaultResp, 0, len(inviteVaults))
+	for _, v := range inviteVaults {
+		vaults = append(vaults, vaultResp{VaultName: v.VaultName, VaultRole: v.VaultRole})
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(map[string]interface{}{
-		"token":      inv.Token,
-		"persistent": false,
-		"vault_role": inv.VaultRole,
-		"expires_at": inv.ExpiresAt.Format(time.RFC3339),
+		"token":       inv.Token,
+		"agent_name":  req.Name,
+		"vaults":      vaults,
+		"invite_link": inviteURL,
+		"expires_at":  inv.ExpiresAt.Format(time.RFC3339),
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -150,6 +150,7 @@ type Store interface {
 	ListInvites(ctx context.Context, status string) ([]store.Invite, error)
 	ListInvitesByVault(ctx context.Context, vaultID, status string) ([]store.Invite, error)
 	RedeemInvite(ctx context.Context, token, sessionID string) error
+	UpdateInviteSessionID(ctx context.Context, inviteID int, sessionID string) error
 	RevokeInvite(ctx context.Context, token string) error
 	GetInviteByID(ctx context.Context, id int) (*store.Invite, error)
 	RevokeInviteByID(ctx context.Context, id int) error
@@ -4486,6 +4487,10 @@ func (s *Server) handlePersistentInviteRedeem(w http.ResponseWriter, r *http.Req
 	// Create instance-level agent.
 	agent, err := s.store.CreateAgent(ctx, agentName, inv.CreatedBy)
 	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint") {
+			proxyError(w, http.StatusConflict, "name_taken", fmt.Sprintf("An agent named %q already exists", agentName))
+			return
+		}
 		fmt.Fprintf(os.Stderr, "[agent-vault] ERROR: CreateAgent(%q): %v\n", agentName, err)
 		jsonError(w, http.StatusInternalServerError, "Failed to create agent")
 		return
@@ -4511,6 +4516,9 @@ func (s *Server) handlePersistentInviteRedeem(w http.ResponseWriter, r *http.Req
 		jsonError(w, http.StatusInternalServerError, "Failed to create session")
 		return
 	}
+
+	// Link session back to invite so invite list can show session expiry.
+	_ = s.store.UpdateInviteSessionID(ctx, inv.ID, sess.ID)
 
 	baseURL := s.baseURL
 
@@ -4553,6 +4561,9 @@ func (s *Server) handleRotationRedeem(w http.ResponseWriter, r *http.Request, in
 		jsonError(w, http.StatusInternalServerError, "Failed to create session")
 		return
 	}
+
+	// Link session back to invite so invite list can show session expiry.
+	_ = s.store.UpdateInviteSessionID(ctx, inv.ID, sess.ID)
 
 	var vaultInfos []agentVaultJSON
 	for _, v := range agent.Vaults {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -297,11 +297,21 @@ func (s *Server) requireVaultAccess(w http.ResponseWriter, r *http.Request, vaul
 		return nil, fmt.Errorf("no session")
 	}
 
-	// Agent session: relies on vault_id scoping.
+	// Scoped agent session: vault is baked into the session.
 	if sess.VaultID != "" {
 		if sess.VaultID != vaultID {
 			jsonError(w, http.StatusForbidden, "Session not authorized for this vault")
 			return nil, fmt.Errorf("vault mismatch")
+		}
+		return nil, nil // agent session, no user
+	}
+
+	// Instance-level agent session: check agent vault grants.
+	if sess.AgentID != "" {
+		_, err := s.store.GetAgentVaultRole(r.Context(), sess.AgentID, vaultID)
+		if err != nil {
+			jsonError(w, http.StatusForbidden, "Agent does not have access to this vault")
+			return nil, fmt.Errorf("no agent vault grant")
 		}
 		return nil, nil // agent session, no user
 	}
@@ -3104,16 +3114,6 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 // --- Invites ---
 
-type inviteRedeemResponse struct {
-	AVAddr         string            `json:"av_addr"`
-	AVSessionToken string            `json:"av_session_token"`
-	AVVault        string            `json:"av_vault"`
-	VaultRole      string            `json:"vault_role"`
-	ProxyURL       string            `json:"proxy_url"`
-	Services       []discoverService `json:"services"`
-	Instructions   string            `json:"instructions"`
-}
-
 // handleInviteRedeem serves the SPA for browser-based invite acceptance.
 // All agent invites are now redeemed via POST /invite/{token} (handlePersistentInviteRedeem).
 // GET /invite/{token} serves the browser page OR returns a redirect hint for agents.
@@ -4371,13 +4371,7 @@ func (s *Server) handleVaultUserSetRole(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
-// --- Persistent Agent Identity ---
-
-//go:embed persistent_instructions_proxy.txt
-var persistentInstructionsProxy string
-
-//go:embed persistent_instructions_member.txt
-var persistentInstructionsMember string
+// --- Instance-Level Agent Identity ---
 
 //go:embed persistent_instructions_admin.txt
 var persistentInstructionsAdmin string
@@ -4391,18 +4385,6 @@ func instructionsForRole(role string) string {
 		return instructionsAdmin
 	default:
 		return instructionsProxy
-	}
-}
-
-// persistentInstructionsForRole returns role-specific instructions for persistent agents.
-func persistentInstructionsForRole(role string) string {
-	switch role {
-	case "member":
-		return persistentInstructionsMember
-	case "admin":
-		return persistentInstructionsAdmin
-	default:
-		return persistentInstructionsProxy
 	}
 }
 
@@ -4609,25 +4591,36 @@ func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// For non-owner users, filter to agents sharing at least one vault.
+	// For non-owner users/agents, filter to agents sharing at least one vault.
 	user, _ := s.userFromSession(ctx, sess)
 	isOwner := user != nil && user.Role == "owner"
-	if !isOwner && user != nil {
-		userGrants, _ := s.store.ListUserGrants(ctx, user.ID)
-		userVaults := make(map[string]bool)
-		for _, g := range userGrants {
-			userVaults[g.VaultID] = true
-		}
-		var filtered []store.Agent
-		for _, ag := range agents {
-			for _, v := range ag.Vaults {
-				if userVaults[v.VaultID] {
-					filtered = append(filtered, ag)
-					break
-				}
+	var accessibleVaults map[string]bool
+	if !isOwner {
+		if user != nil {
+			userGrants, _ := s.store.ListUserGrants(ctx, user.ID)
+			accessibleVaults = make(map[string]bool, len(userGrants))
+			for _, g := range userGrants {
+				accessibleVaults[g.VaultID] = true
+			}
+		} else if sess.AgentID != "" {
+			agentGrants, _ := s.store.ListAgentGrants(ctx, sess.AgentID)
+			accessibleVaults = make(map[string]bool, len(agentGrants))
+			for _, g := range agentGrants {
+				accessibleVaults[g.VaultID] = true
 			}
 		}
-		agents = filtered
+		if accessibleVaults != nil {
+			var filtered []store.Agent
+			for _, ag := range agents {
+				for _, v := range ag.Vaults {
+					if accessibleVaults[v.VaultID] {
+						filtered = append(filtered, ag)
+						break
+					}
+				}
+			}
+			agents = filtered
+		}
 	}
 
 	type agentItem struct {
@@ -4667,10 +4660,23 @@ func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Include agents with pending invites (not yet redeemed).
+	// Non-owners only see invites targeting vaults they can access.
 	pendingInvites, _ := s.store.ListInvites(ctx, "pending")
 	for _, inv := range pendingInvites {
 		if seen[inv.AgentName] {
 			continue
+		}
+		if !isOwner && accessibleVaults != nil {
+			hasOverlap := false
+			for _, v := range inv.Vaults {
+				if accessibleVaults[v.VaultID] {
+					hasOverlap = true
+					break
+				}
+			}
+			if !hasOverlap {
+				continue
+			}
 		}
 		vaults := make([]agentVaultJSON, 0, len(inv.Vaults))
 		for _, v := range inv.Vaults {
@@ -5849,9 +5855,18 @@ func (s *Server) handleAdminProposalList(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Proxy-role agents can only view pending proposals (to avoid duplicates).
+	// Proxy-role sessions can only view pending proposals (to avoid duplicates).
 	sess := sessionFromContext(r.Context())
-	isProxy := sess != nil && sess.VaultID != "" && sess.VaultRole == "proxy"
+	isProxy := false
+	if sess != nil {
+		if sess.VaultID != "" {
+			isProxy = sess.VaultRole == "proxy"
+		} else if sess.AgentID != "" {
+			if role, err := s.store.GetAgentVaultRole(ctx, sess.AgentID, ns.ID); err == nil {
+				isProxy = role == "proxy"
+			}
+		}
+	}
 
 	// Lazy expiration.
 	_, _ = s.store.ExpirePendingProposals(ctx, time.Now().Add(-7*24*time.Hour))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -348,6 +348,16 @@ func (m *mockStore) RedeemInvite(_ context.Context, token, sessionID string) err
 	return nil
 }
 
+func (m *mockStore) UpdateInviteSessionID(_ context.Context, inviteID int, sessionID string) error {
+	for _, inv := range m.invites {
+		if inv.ID == inviteID {
+			inv.SessionID = sessionID
+			return nil
+		}
+	}
+	return fmt.Errorf("not found")
+}
+
 func (m *mockStore) RevokeInvite(_ context.Context, token string) error {
 	inv, ok := m.invites[token]
 	if !ok {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -37,6 +37,7 @@ type mockStore struct {
 	emailVerifications []*store.EmailVerification
 	passwordResets     []*store.PasswordReset
 	agents             map[string]*store.Agent               // keyed by name
+	agentVaultGrants   []store.AgentVaultGrant               // agent vault grants
 	settings           map[string]string                     // instance settings
 	sessionCounter     int
 }
@@ -295,11 +296,11 @@ func (m *mockStore) ExpirePendingProposals(_ context.Context, before time.Time) 
 
 // --- Invite mocks ---
 
-func (m *mockStore) CreateInvite(_ context.Context, vaultID, vaultRole, createdBy string, expiresAt time.Time, sessionTTLSeconds int) (*store.Invite, error) {
+func (m *mockStore) CreateAgentInvite(_ context.Context, agentName, createdBy string, expiresAt time.Time, sessionTTLSeconds int, vaults []store.AgentInviteVault) (*store.Invite, error) {
 	inv := &store.Invite{
 		ID: len(m.invites) + 1, Token: "av_inv_test" + fmt.Sprintf("%d", len(m.invites)),
-		VaultID: vaultID, VaultRole: vaultRole, Status: "pending", CreatedBy: createdBy,
-		SessionTTLSeconds: sessionTTLSeconds,
+		AgentName: agentName, Status: "pending", CreatedBy: createdBy,
+		SessionTTLSeconds: sessionTTLSeconds, Vaults: vaults,
 		CreatedAt: time.Now(), ExpiresAt: expiresAt,
 	}
 	m.invites[inv.Token] = inv
@@ -314,11 +315,24 @@ func (m *mockStore) GetInviteByToken(_ context.Context, token string) (*store.In
 	return inv, nil
 }
 
-func (m *mockStore) ListInvites(_ context.Context, vaultID, status string) ([]store.Invite, error) {
+func (m *mockStore) ListInvites(_ context.Context, status string) ([]store.Invite, error) {
 	var result []store.Invite
 	for _, inv := range m.invites {
-		if inv.VaultID == vaultID && (status == "" || inv.Status == status) {
+		if status == "" || inv.Status == status {
 			result = append(result, *inv)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStore) ListInvitesByVault(_ context.Context, vaultID, status string) ([]store.Invite, error) {
+	var result []store.Invite
+	for _, inv := range m.invites {
+		for _, v := range inv.Vaults {
+			if v.VaultID == vaultID && (status == "" || inv.Status == status) {
+				result = append(result, *inv)
+				break
+			}
 		}
 	}
 	return result, nil
@@ -362,14 +376,76 @@ func (m *mockStore) RevokeInviteByID(_ context.Context, id int) error {
 	return fmt.Errorf("not found")
 }
 
-func (m *mockStore) CountPendingInvites(_ context.Context, vaultID string) (int, error) {
+func (m *mockStore) CountPendingInvites(_ context.Context) (int, error) {
 	count := 0
 	for _, inv := range m.invites {
-		if inv.VaultID == vaultID && inv.Status == "pending" {
+		if inv.Status == "pending" {
 			count++
 		}
 	}
 	return count, nil
+}
+
+func (m *mockStore) HasPendingInviteByAgentName(_ context.Context, name string) (bool, error) {
+	for _, inv := range m.invites {
+		if inv.Status == "pending" && inv.AgentName == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (m *mockStore) GetPendingInviteByAgentName(_ context.Context, name string) (*store.Invite, error) {
+	for _, inv := range m.invites {
+		if inv.Status == "pending" && inv.AgentName == name {
+			return inv, nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (m *mockStore) AddAgentInviteVault(_ context.Context, inviteID int, vaultID, role string) error {
+	for _, inv := range m.invites {
+		if inv.ID == inviteID {
+			inv.Vaults = append(inv.Vaults, store.AgentInviteVault{
+				VaultID:   vaultID,
+				VaultRole: role,
+			})
+			return nil
+		}
+	}
+	return fmt.Errorf("invite not found")
+}
+
+func (m *mockStore) RemoveAgentInviteVault(_ context.Context, inviteID int, vaultID string) error {
+	for _, inv := range m.invites {
+		if inv.ID == inviteID {
+			var filtered []store.AgentInviteVault
+			for _, v := range inv.Vaults {
+				if v.VaultID != vaultID {
+					filtered = append(filtered, v)
+				}
+			}
+			inv.Vaults = filtered
+			return nil
+		}
+	}
+	return fmt.Errorf("invite not found")
+}
+
+func (m *mockStore) UpdateAgentInviteVaultRole(_ context.Context, inviteID int, vaultID, role string) error {
+	for _, inv := range m.invites {
+		if inv.ID == inviteID {
+			for i, v := range inv.Vaults {
+				if v.VaultID == vaultID {
+					inv.Vaults[i].VaultRole = role
+					return nil
+				}
+			}
+			return fmt.Errorf("vault not found on invite")
+		}
+	}
+	return fmt.Errorf("invite not found")
 }
 
 func (m *mockStore) Close() error { return nil }
@@ -796,19 +872,14 @@ func (m *mockStore) GetProposalByApprovalToken(_ context.Context, token string) 
 
 // --- Agent mock methods ---
 
-func (m *mockStore) CreateAgent(_ context.Context, name, vaultID string, tokenHash, tokenSalt []byte, tokenPrefix, vaultRole, createdBy string) (*store.Agent, error) {
+func (m *mockStore) CreateAgent(_ context.Context, name, createdBy string) (*store.Agent, error) {
 	ag := &store.Agent{
-		ID:                 "agent-" + name,
-		Name:               name,
-		VaultID:            vaultID,
-		ServiceTokenHash:   tokenHash,
-		ServiceTokenSalt:   tokenSalt,
-		ServiceTokenPrefix: tokenPrefix,
-		VaultRole:          vaultRole,
-		Status:             "active",
-		CreatedBy:          createdBy,
-		CreatedAt:          time.Now(),
-		UpdatedAt:          time.Now(),
+		ID:        "agent-" + name,
+		Name:      name,
+		Status:    "active",
+		CreatedBy: createdBy,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
 	}
 	m.agents[name] = ag
 	return ag, nil
@@ -831,23 +902,50 @@ func (m *mockStore) GetAgentByID(_ context.Context, id string) (*store.Agent, er
 	return nil, fmt.Errorf("agent not found")
 }
 
-func (m *mockStore) UpdateAgentVaultRole(_ context.Context, id, role string) error {
-	for _, ag := range m.agents {
-		if ag.ID == id {
-			ag.VaultRole = role
+func (m *mockStore) GrantAgentVaultRole(_ context.Context, agentID, vaultID, role string) error {
+	m.agentVaultGrants = append(m.agentVaultGrants, store.AgentVaultGrant{
+		AgentID: agentID, VaultID: vaultID, VaultRole: role, CreatedAt: time.Now(),
+	})
+	return nil
+}
+
+func (m *mockStore) RevokeAgentVaultAccess(_ context.Context, agentID, vaultID string) error {
+	for i, g := range m.agentVaultGrants {
+		if g.AgentID == agentID && g.VaultID == vaultID {
+			m.agentVaultGrants = append(m.agentVaultGrants[:i], m.agentVaultGrants[i+1:]...)
 			return nil
 		}
 	}
-	return fmt.Errorf("agent not found")
+	return fmt.Errorf("grant not found")
 }
 
-func (m *mockStore) GetAgentByTokenPrefix(_ context.Context, prefix string) (*store.Agent, error) {
-	for _, ag := range m.agents {
-		if ag.ServiceTokenPrefix == prefix && ag.Status == "active" {
-			return ag, nil
+func (m *mockStore) GetAgentVaultRole(_ context.Context, agentID, vaultID string) (string, error) {
+	for _, g := range m.agentVaultGrants {
+		if g.AgentID == agentID && g.VaultID == vaultID {
+			return g.VaultRole, nil
 		}
 	}
-	return nil, fmt.Errorf("agent not found")
+	return "", fmt.Errorf("no grant")
+}
+
+func (m *mockStore) ListAgentGrants(_ context.Context, agentID string) ([]store.AgentVaultGrant, error) {
+	var result []store.AgentVaultGrant
+	for _, g := range m.agentVaultGrants {
+		if g.AgentID == agentID {
+			result = append(result, g)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockStore) ListVaultAgents(_ context.Context, vaultID string) ([]store.AgentVaultGrant, error) {
+	var result []store.AgentVaultGrant
+	for _, g := range m.agentVaultGrants {
+		if g.VaultID == vaultID {
+			result = append(result, g)
+		}
+	}
+	return result, nil
 }
 
 func (m *mockStore) ListAgents(_ context.Context, vaultID string) ([]store.Agent, error) {
@@ -855,9 +953,14 @@ func (m *mockStore) ListAgents(_ context.Context, vaultID string) ([]store.Agent
 		return nil, fmt.Errorf("vaultID is required")
 	}
 	var result []store.Agent
-	for _, ag := range m.agents {
-		if ag.VaultID == vaultID {
-			result = append(result, *ag)
+	for _, g := range m.agentVaultGrants {
+		if g.VaultID == vaultID {
+			for _, ag := range m.agents {
+				if ag.ID == g.AgentID {
+					result = append(result, *ag)
+					break
+				}
+			}
 		}
 	}
 	return result, nil
@@ -883,18 +986,6 @@ func (m *mockStore) RevokeAgent(_ context.Context, id string) error {
 					delete(m.sessions, sid)
 				}
 			}
-			return nil
-		}
-	}
-	return fmt.Errorf("agent not found")
-}
-
-func (m *mockStore) UpdateAgentServiceToken(_ context.Context, id string, tokenHash, tokenSalt []byte, tokenPrefix string) error {
-	for _, ag := range m.agents {
-		if ag.ID == id {
-			ag.ServiceTokenHash = tokenHash
-			ag.ServiceTokenSalt = tokenSalt
-			ag.ServiceTokenPrefix = tokenPrefix
 			return nil
 		}
 	}
@@ -946,13 +1037,11 @@ func (m *mockStore) DeleteAgentSessions(_ context.Context, agentID string) error
 	return nil
 }
 
-func (m *mockStore) CreateAgentSession(_ context.Context, agentID, vaultID, vaultRole string, expiresAt *time.Time) (*store.Session, error) {
+func (m *mockStore) CreateAgentSession(_ context.Context, agentID string, expiresAt *time.Time) (*store.Session, error) {
 	id := "agent-session-" + agentID + "-" + fmt.Sprintf("%d", len(m.sessions))
 	s := &store.Session{
 		ID:        id,
-		VaultID:   vaultID,
 		AgentID:   agentID,
-		VaultRole: vaultRole,
 		ExpiresAt: expiresAt,
 		CreatedAt: time.Now(),
 	}
@@ -960,24 +1049,12 @@ func (m *mockStore) CreateAgentSession(_ context.Context, agentID, vaultID, vaul
 	return s, nil
 }
 
-func (m *mockStore) CreatePersistentInvite(_ context.Context, vaultID, vaultRole, createdBy string, agentName string, expiresAt time.Time) (*store.Invite, error) {
-	token := "av_inv_persistent_" + fmt.Sprintf("%d", len(m.invites))
-	inv := &store.Invite{
-		ID: len(m.invites) + 1, Token: token,
-		VaultID: vaultID, VaultRole: vaultRole, Status: "pending", CreatedBy: createdBy,
-		Persistent: true, AgentName: agentName,
-		CreatedAt: time.Now(), ExpiresAt: expiresAt,
-	}
-	m.invites[token] = inv
-	return inv, nil
-}
-
-func (m *mockStore) CreateRotationInvite(_ context.Context, agentID, vaultID, createdBy string, expiresAt time.Time) (*store.Invite, error) {
+func (m *mockStore) CreateRotationInvite(_ context.Context, agentID, createdBy string, expiresAt time.Time) (*store.Invite, error) {
 	token := "av_inv_rotation_" + fmt.Sprintf("%d", len(m.invites))
 	inv := &store.Invite{
 		ID: len(m.invites) + 1, Token: token,
-		VaultID: vaultID, Status: "pending", CreatedBy: createdBy,
-		Persistent: true, AgentID: agentID,
+		Status: "pending", CreatedBy: createdBy,
+		AgentID: agentID,
 		CreatedAt: time.Now(), ExpiresAt: expiresAt,
 	}
 	m.invites[token] = inv
@@ -2756,15 +2833,18 @@ func TestAdminProposalRejectRequiresAdminSession(t *testing.T) {
 func TestHandleInviteRedeem(t *testing.T) {
 	srv, ms := setupInviteTest(t)
 
-	// Seed a valid invite.
+	// Seed a valid invite (all invites are now persistent/named).
 	inv := &store.Invite{
 		ID: 1, Token: "av_inv_validtoken1234567890abcdef",
-		VaultID: "root-ns-id", Status: "pending",
+		Status: "pending", AgentName: "test-agent",
 		CreatedAt: time.Now(), ExpiresAt: time.Now().Add(15 * time.Minute),
 	}
 	ms.invites[inv.Token] = inv
 
-	req := httptest.NewRequest(http.MethodGet, "/invite/"+inv.Token, nil)
+	// All invites require POST now.
+	body := strings.NewReader(`{}`)
+	req := httptest.NewRequest(http.MethodPost, "/invite/"+inv.Token, body)
+	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)
 
@@ -2772,20 +2852,17 @@ func TestHandleInviteRedeem(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var resp inviteRedeemResponse
+	var resp map[string]interface{}
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if resp.AVSessionToken == "" {
+	if resp["av_session_token"] == nil || resp["av_session_token"].(string) == "" {
 		t.Fatal("expected non-empty session token")
 	}
-	if resp.AVVault != "default" {
-		t.Fatalf("expected vault default, got %s", resp.AVVault)
+	if resp["agent_name"] != "test-agent" {
+		t.Fatalf("expected agent_name test-agent, got %v", resp["agent_name"])
 	}
-	if len(resp.Services) != 1 {
-		t.Fatalf("expected 1 service, got %d", len(resp.Services))
-	}
-	if resp.Instructions == "" {
+	if resp["instructions"] == nil || resp["instructions"].(string) == "" {
 		t.Fatal("expected non-empty instructions")
 	}
 
@@ -2798,7 +2875,9 @@ func TestHandleInviteRedeem(t *testing.T) {
 func TestHandleInviteRedeem_NotFound(t *testing.T) {
 	srv, _ := setupInviteTest(t)
 
-	req := httptest.NewRequest(http.MethodGet, "/invite/av_inv_nonexistent", nil)
+	body := strings.NewReader(`{}`)
+	req := httptest.NewRequest(http.MethodPost, "/invite/av_inv_nonexistent", body)
+	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)
 
@@ -2812,12 +2891,14 @@ func TestHandleInviteRedeem_Expired(t *testing.T) {
 
 	inv := &store.Invite{
 		ID: 1, Token: "av_inv_expiredtoken12345678abcdef",
-		VaultID: "root-ns-id", Status: "pending",
+		Status: "pending", AgentName: "test-agent",
 		CreatedAt: time.Now().Add(-20 * time.Minute), ExpiresAt: time.Now().Add(-5 * time.Minute),
 	}
 	ms.invites[inv.Token] = inv
 
-	req := httptest.NewRequest(http.MethodGet, "/invite/"+inv.Token, nil)
+	reqBody := strings.NewReader(`{}`)
+	req := httptest.NewRequest(http.MethodPost, "/invite/"+inv.Token, reqBody)
+	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)
 
@@ -2825,10 +2906,10 @@ func TestHandleInviteRedeem_Expired(t *testing.T) {
 		t.Fatalf("expected 410, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	var body map[string]string
-	json.NewDecoder(rec.Body).Decode(&body)
-	if body["error"] != "invite_expired" {
-		t.Fatalf("expected error code invite_expired, got %s", body["error"])
+	var resp map[string]string
+	json.NewDecoder(rec.Body).Decode(&resp)
+	if resp["error"] != "invite_expired" {
+		t.Fatalf("expected error code invite_expired, got %s", resp["error"])
 	}
 }
 
@@ -2837,12 +2918,14 @@ func TestHandleInviteRedeem_AlreadyRedeemed(t *testing.T) {
 
 	inv := &store.Invite{
 		ID: 1, Token: "av_inv_redeemedtoken123456abcdef",
-		VaultID: "root-ns-id", Status: "redeemed",
+		Status: "redeemed", AgentName: "test-agent",
 		CreatedAt: time.Now(), ExpiresAt: time.Now().Add(15 * time.Minute),
 	}
 	ms.invites[inv.Token] = inv
 
-	req := httptest.NewRequest(http.MethodGet, "/invite/"+inv.Token, nil)
+	reqBody := strings.NewReader(`{}`)
+	req := httptest.NewRequest(http.MethodPost, "/invite/"+inv.Token, reqBody)
+	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)
 
@@ -2850,10 +2933,10 @@ func TestHandleInviteRedeem_AlreadyRedeemed(t *testing.T) {
 		t.Fatalf("expected 410, got %d", rec.Code)
 	}
 
-	var body map[string]string
-	json.NewDecoder(rec.Body).Decode(&body)
-	if body["error"] != "invite_redeemed" {
-		t.Fatalf("expected error code invite_redeemed, got %s", body["error"])
+	var resp map[string]string
+	json.NewDecoder(rec.Body).Decode(&resp)
+	if resp["error"] != "invite_redeemed" {
+		t.Fatalf("expected error code invite_redeemed, got %s", resp["error"])
 	}
 }
 
@@ -2862,12 +2945,14 @@ func TestHandleInviteRedeem_Revoked(t *testing.T) {
 
 	inv := &store.Invite{
 		ID: 1, Token: "av_inv_revokedtoken1234567abcdef",
-		VaultID: "root-ns-id", Status: "revoked",
+		Status: "revoked", AgentName: "test-agent",
 		CreatedAt: time.Now(), ExpiresAt: time.Now().Add(15 * time.Minute),
 	}
 	ms.invites[inv.Token] = inv
 
-	req := httptest.NewRequest(http.MethodGet, "/invite/"+inv.Token, nil)
+	reqBody := strings.NewReader(`{}`)
+	req := httptest.NewRequest(http.MethodPost, "/invite/"+inv.Token, reqBody)
+	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)
 
@@ -2875,10 +2960,10 @@ func TestHandleInviteRedeem_Revoked(t *testing.T) {
 		t.Fatalf("expected 410, got %d", rec.Code)
 	}
 
-	var body map[string]string
-	json.NewDecoder(rec.Body).Decode(&body)
-	if body["error"] != "invite_revoked" {
-		t.Fatalf("expected error code invite_revoked, got %s", body["error"])
+	var resp map[string]string
+	json.NewDecoder(rec.Body).Decode(&resp)
+	if resp["error"] != "invite_revoked" {
+		t.Fatalf("expected error code invite_revoked, got %s", resp["error"])
 	}
 }
 
@@ -3192,8 +3277,7 @@ func TestPersistentInviteRedeemGET405(t *testing.T) {
 
 	inv := &store.Invite{
 		ID: 1, Token: "av_inv_persistent_test",
-		VaultID: "root-ns-id", Status: "pending", Persistent: true,
-		AgentName: "testbot",
+		Status: "pending", AgentName: "testbot",
 		CreatedAt: time.Now(), ExpiresAt: time.Now().Add(15 * time.Minute),
 	}
 	ms.invites[inv.Token] = inv
@@ -3212,8 +3296,8 @@ func TestPersistentInviteRedeemPOST(t *testing.T) {
 
 	inv := &store.Invite{
 		ID: 1, Token: "av_inv_persistent_post",
-		VaultID: "root-ns-id", Status: "pending", Persistent: true,
-		AgentName: "mybot", CreatedBy: "owner-user-id",
+		Status: "pending", AgentName: "mybot",
+		CreatedBy: "owner-user-id",
 		CreatedAt: time.Now(), ExpiresAt: time.Now().Add(15 * time.Minute),
 	}
 	ms.invites[inv.Token] = inv
@@ -3253,17 +3337,18 @@ func TestPersistentInviteRedeemPOST(t *testing.T) {
 	}
 }
 
-func TestPersistentInviteRedeemPOST_NameFromBody(t *testing.T) {
+func TestPersistentInviteRedeemPOST_InviteNameTakesPrecedence(t *testing.T) {
 	srv, ms := setupInviteTest(t)
 
 	inv := &store.Invite{
 		ID: 1, Token: "av_inv_persistent_nobody",
-		VaultID: "root-ns-id", Status: "pending", Persistent: true,
+		Status: "pending", AgentName: "test-agent",
 		CreatedBy: "owner-user-id",
 		CreatedAt: time.Now(), ExpiresAt: time.Now().Add(15 * time.Minute),
 	}
 	ms.invites[inv.Token] = inv
 
+	// Body name should NOT override invite-specified name.
 	body := strings.NewReader(`{"name": "bodybot"}`)
 	req := httptest.NewRequest(http.MethodPost, "/invite/"+inv.Token, body)
 	req.Header.Set("Content-Type", "application/json")
@@ -3276,51 +3361,57 @@ func TestPersistentInviteRedeemPOST_NameFromBody(t *testing.T) {
 
 	var resp map[string]interface{}
 	json.NewDecoder(rec.Body).Decode(&resp)
-	if resp["agent_name"] != "bodybot" {
-		t.Fatalf("expected agent_name bodybot, got %v", resp["agent_name"])
+	if resp["agent_name"] != "test-agent" {
+		t.Fatalf("expected agent_name test-agent, got %v", resp["agent_name"])
 	}
 }
 
-func TestPersistentInviteRedeemPOST_NoName400(t *testing.T) {
+func TestInviteRedeemPOST_UsesInviteName(t *testing.T) {
 	srv, ms := setupInviteTest(t)
 
 	inv := &store.Invite{
-		ID: 1, Token: "av_inv_persistent_noname",
-		VaultID: "root-ns-id", Status: "pending", Persistent: true,
+		ID: 1, Token: "av_inv_persistent_named",
+		Status: "pending", AgentName: "preset-bot",
 		CreatedBy: "owner-user-id",
 		CreatedAt: time.Now(), ExpiresAt: time.Now().Add(15 * time.Minute),
 	}
 	ms.invites[inv.Token] = inv
 
+	// Empty body should use the invite's pre-set AgentName.
 	body := strings.NewReader(`{}`)
 	req := httptest.NewRequest(http.MethodPost, "/invite/"+inv.Token, body)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for missing name, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+	if resp["agent_name"] != "preset-bot" {
+		t.Fatalf("expected agent_name preset-bot, got %v", resp["agent_name"])
 	}
 }
 
-func TestTemporaryInvitePOST400(t *testing.T) {
+func TestInviteRedeemGET_Returns405(t *testing.T) {
 	srv, ms := setupInviteTest(t)
 
 	inv := &store.Invite{
-		ID: 1, Token: "av_inv_temp_post",
-		VaultID: "root-ns-id", Status: "pending", Persistent: false,
+		ID: 1, Token: "av_inv_get_test",
+		Status: "pending", AgentName: "test-agent",
 		CreatedAt: time.Now(), ExpiresAt: time.Now().Add(15 * time.Minute),
 	}
 	ms.invites[inv.Token] = inv
 
-	body := strings.NewReader(`{"name": "bot"}`)
-	req := httptest.NewRequest(http.MethodPost, "/invite/"+inv.Token, body)
-	req.Header.Set("Content-Type", "application/json")
+	// GET should return 405 since all invites are now persistent.
+	req := httptest.NewRequest(http.MethodGet, "/invite/"+inv.Token, nil)
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for POST on temporary invite, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for GET on invite, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -3329,13 +3420,13 @@ func TestDuplicateAgentName409(t *testing.T) {
 
 	// Pre-create an agent.
 	ms.agents["existing"] = &store.Agent{
-		ID: "agent-existing", Name: "existing", VaultID: "root-ns-id", Status: "active",
+		ID: "agent-existing", Name: "existing", Status: "active",
 	}
 
 	inv := &store.Invite{
 		ID: 1, Token: "av_inv_dup_name",
-		VaultID: "root-ns-id", Status: "pending", Persistent: true,
-		AgentName: "existing", CreatedBy: "owner-user-id",
+		Status: "pending", AgentName: "existing",
+		CreatedBy: "owner-user-id",
 		CreatedAt: time.Now(), ExpiresAt: time.Now().Add(15 * time.Minute),
 	}
 	ms.invites[inv.Token] = inv
@@ -3357,10 +3448,12 @@ func TestDuplicateAgentName409(t *testing.T) {
 func TestAgentList(t *testing.T) {
 	srv, ms, sessID := setupAgentTest(t)
 
-	ms.agents["bot1"] = &store.Agent{ID: "a1", Name: "bot1", VaultID: "root-ns-id", Status: "active", CreatedAt: time.Now(), UpdatedAt: time.Now()}
-	ms.agents["bot2"] = &store.Agent{ID: "a2", Name: "bot2", VaultID: "root-ns-id", Status: "active", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	ms.agents["bot1"] = &store.Agent{ID: "a1", Name: "bot1", Status: "active", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	ms.agents["bot2"] = &store.Agent{ID: "a2", Name: "bot2", Status: "active", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	ms.agentVaultGrants = append(ms.agentVaultGrants, store.AgentVaultGrant{AgentID: "a1", VaultID: "root-ns-id", VaultRole: "proxy"})
+	ms.agentVaultGrants = append(ms.agentVaultGrants, store.AgentVaultGrant{AgentID: "a2", VaultID: "root-ns-id", VaultRole: "proxy"})
 
-	req := httptest.NewRequest(http.MethodGet, "/v1/admin/agents", nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/agents", nil)
 	req.Header.Set("Authorization", "Bearer "+sessID)
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)
@@ -3380,9 +3473,9 @@ func TestAgentList(t *testing.T) {
 func TestAgentRevoke(t *testing.T) {
 	srv, ms, sessID := setupAgentTest(t)
 
-	ms.agents["revokebot"] = &store.Agent{ID: "a1", Name: "revokebot", VaultID: "root-ns-id", Status: "active"}
+	ms.agents["revokebot"] = &store.Agent{ID: "a1", Name: "revokebot", Status: "active"}
 
-	req := httptest.NewRequest(http.MethodDelete, "/v1/admin/agents/revokebot", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/v1/agents/revokebot", nil)
 	req.Header.Set("Authorization", "Bearer "+sessID)
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)
@@ -3400,9 +3493,9 @@ func TestAgentRevoke(t *testing.T) {
 func TestAgentRotate(t *testing.T) {
 	srv, ms, sessID := setupAgentTest(t)
 
-	ms.agents["rotatebot"] = &store.Agent{ID: "a1", Name: "rotatebot", VaultID: "root-ns-id", Status: "active"}
+	ms.agents["rotatebot"] = &store.Agent{ID: "a1", Name: "rotatebot", Status: "active"}
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/admin/agents/rotatebot/rotate", nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/rotatebot/rotate", nil)
 	req.Header.Set("Authorization", "Bearer "+sessID)
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)
@@ -3424,10 +3517,10 @@ func TestAgentRotate(t *testing.T) {
 func TestAgentRename(t *testing.T) {
 	srv, ms, sessID := setupAgentTest(t)
 
-	ms.agents["oldbot"] = &store.Agent{ID: "a1", Name: "oldbot", VaultID: "root-ns-id", Status: "active"}
+	ms.agents["oldbot"] = &store.Agent{ID: "a1", Name: "oldbot", Status: "active"}
 
 	body := strings.NewReader(`{"name": "newbot"}`)
-	req := httptest.NewRequest(http.MethodPost, "/v1/admin/agents/oldbot/rename", body)
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/oldbot/rename", body)
 	req.Header.Set("Authorization", "Bearer "+sessID)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()

--- a/internal/store/migration_verify_test.go
+++ b/internal/store/migration_verify_test.go
@@ -1,0 +1,35 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestMigrationOnDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db")
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer s.Close()
+
+	rows, err := s.db.Query("PRAGMA table_info(agents)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notnull int
+		var dflt *string
+		var pk int
+		rows.Scan(&cid, &name, &typ, &notnull, &dflt, &pk)
+		if name == "service_token_hash" {
+			t.Fatal("agents table still has service_token_hash column after migration 035")
+		}
+	}
+	t.Log("OK: agents table schema is correct")
+}

--- a/internal/store/migrations/035_instance_level_agents.sql
+++ b/internal/store/migrations/035_instance_level_agents.sql
@@ -1,0 +1,110 @@
+-- Move agents from vault-scoped to instance-level entities.
+-- Agents now have multi-vault access via agent_vault_grants (like vault_grants for users).
+-- Agent invites support vault pre-assignments via agent_invite_vaults (like user_invite_vaults).
+
+PRAGMA foreign_keys = OFF;
+
+-- 1. Create agent_vault_grants table (parallels vault_grants for users).
+CREATE TABLE agent_vault_grants (
+    agent_id   TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    vault_id   TEXT NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+    vault_role TEXT NOT NULL DEFAULT 'proxy'
+               CHECK(vault_role IN ('proxy', 'member', 'admin')),
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (agent_id, vault_id)
+);
+CREATE INDEX idx_agent_vault_grants_vault ON agent_vault_grants(vault_id);
+
+-- 2. Migrate existing agent-vault relationships to grants.
+INSERT INTO agent_vault_grants (agent_id, vault_id, vault_role, created_at)
+SELECT id, vault_id, vault_role, created_at FROM agents WHERE vault_id IS NOT NULL;
+
+-- 3. Rebuild agents table: remove vault_id, vault_role, and legacy service_token_* columns.
+--    Instance-level agents authenticate via session tokens, not service tokens.
+CREATE TABLE agents_new (
+    id         TEXT PRIMARY KEY,
+    name       TEXT NOT NULL UNIQUE,
+    status     TEXT NOT NULL DEFAULT 'active'
+               CHECK(status IN ('active','revoked')),
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    revoked_at TEXT
+);
+
+INSERT INTO agents_new (id, name, status, created_by, created_at, updated_at, revoked_at)
+SELECT id, name, status, created_by, created_at, updated_at, revoked_at
+FROM agents;
+
+DROP TABLE agents;
+ALTER TABLE agents_new RENAME TO agents;
+CREATE UNIQUE INDEX idx_agents_name ON agents(name);
+
+-- 4. Create agent_invite_vaults table (parallels user_invite_vaults).
+CREATE TABLE agent_invite_vaults (
+    invite_id  INTEGER NOT NULL REFERENCES invites(id) ON DELETE CASCADE,
+    vault_id   TEXT    NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+    vault_role TEXT    NOT NULL DEFAULT 'proxy'
+               CHECK(vault_role IN ('proxy', 'member', 'admin')),
+    PRIMARY KEY (invite_id, vault_id)
+);
+CREATE INDEX idx_agent_invite_vaults_vault ON agent_invite_vaults(vault_id);
+
+-- 5. Migrate existing invite vault assignments to agent_invite_vaults.
+INSERT INTO agent_invite_vaults (invite_id, vault_id, vault_role)
+SELECT id, vault_id, vault_role FROM invites WHERE vault_id IS NOT NULL;
+
+-- 6. Rebuild invites table: remove vault_id, vault_role, persistent.
+--    All invites are now named (agent_name required). Vault context is in agent_invite_vaults.
+CREATE TABLE invites_new (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    token               TEXT,
+    token_hash          TEXT,
+    agent_name          TEXT NOT NULL,
+    agent_id            TEXT REFERENCES agents(id),
+    session_ttl_seconds INTEGER,
+    session_label       TEXT,
+    status              TEXT NOT NULL DEFAULT 'pending'
+                        CHECK(status IN ('pending','redeemed','expired','revoked')),
+    session_id          TEXT,
+    created_by          TEXT NOT NULL,
+    created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+    expires_at          TEXT NOT NULL,
+    redeemed_at         TEXT,
+    revoked_at          TEXT
+);
+
+INSERT INTO invites_new (id, token_hash, agent_name, agent_id, session_ttl_seconds, session_label, status, session_id, created_by, created_at, expires_at, redeemed_at, revoked_at)
+SELECT id, token_hash, COALESCE(agent_name, 'unnamed-' || id), agent_id, session_ttl_seconds, session_label, status, session_id, created_by, created_at, expires_at, redeemed_at, revoked_at
+FROM invites;
+
+DROP TABLE invites;
+ALTER TABLE invites_new RENAME TO invites;
+CREATE INDEX idx_invites_token_hash ON invites(token_hash);
+CREATE INDEX idx_invites_status ON invites(status);
+
+-- 7. Rebuild sessions table to allow NULL vault_id for instance-level agent sessions.
+--    User scoped sessions still have vault_id set. Agent sessions have vault_id = NULL.
+CREATE TABLE sessions_new (
+    id         TEXT PRIMARY KEY,
+    expires_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    vault_id   TEXT REFERENCES vaults(id) ON DELETE CASCADE,
+    user_id    TEXT REFERENCES users(id) ON DELETE CASCADE,
+    agent_id   TEXT REFERENCES agents(id) ON DELETE CASCADE,
+    vault_role TEXT CHECK(vault_role IN ('proxy', 'member', 'admin')),
+    label      TEXT
+);
+
+INSERT INTO sessions_new (id, expires_at, created_at, vault_id, user_id, agent_id, vault_role, label)
+SELECT id, expires_at, created_at, vault_id, user_id, agent_id, vault_role, label
+FROM sessions;
+
+-- For existing agent sessions, clear vault_id (they become instance-level).
+UPDATE sessions_new SET vault_id = NULL, vault_role = NULL WHERE agent_id IS NOT NULL AND agent_id != '';
+
+DROP TABLE sessions;
+ALTER TABLE sessions_new RENAME TO sessions;
+CREATE INDEX idx_sessions_agent_id ON sessions(agent_id);
+
+PRAGMA foreign_keys = ON;

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1319,6 +1319,14 @@ func (s *SQLiteStore) RedeemInvite(ctx context.Context, token, sessionID string)
 	return nil
 }
 
+func (s *SQLiteStore) UpdateInviteSessionID(ctx context.Context, inviteID int, sessionID string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE invites SET session_id = ? WHERE id = ?`,
+		sessionID, inviteID,
+	)
+	return err
+}
+
 func (s *SQLiteStore) RevokeInvite(ctx context.Context, token string) error {
 	nowStr := time.Now().UTC().Format(time.DateTime)
 
@@ -1402,11 +1410,11 @@ func (s *SQLiteStore) GetPendingInviteByAgentName(ctx context.Context, name stri
 		return nil, err
 	}
 	if !rows.Next() {
-		rows.Close()
+		_ = rows.Close()
 		return nil, sql.ErrNoRows
 	}
 	inv, err := scanInviteRow(rows)
-	rows.Close()
+	_ = rows.Close()
 	if err != nil {
 		return nil, err
 	}
@@ -2621,7 +2629,7 @@ func (s *SQLiteStore) batchLoadAgentVaultGrants(ctx context.Context, agents []Ag
 	query := `SELECT avg.agent_id, avg.vault_id, v.name, avg.vault_role, avg.created_at
 		 FROM agent_vault_grants avg
 		 JOIN vaults v ON v.id = avg.vault_id
-		 WHERE avg.agent_id IN (` + strings.Join(placeholders, ",") + `)`
+		 WHERE avg.agent_id IN (` + strings.Join(placeholders, ",") + `)` // #nosec G202 -- placeholders are static "?" strings, not user input
 
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1126,26 +1126,50 @@ func newInviteToken() string {
 	return "av_inv_" + hex.EncodeToString(b[:])
 }
 
-func (s *SQLiteStore) CreateInvite(ctx context.Context, vaultID, vaultRole, createdBy string, expiresAt time.Time, sessionTTLSeconds int) (*Invite, error) {
+func (s *SQLiteStore) CreateAgentInvite(ctx context.Context, agentName, createdBy string, expiresAt time.Time, sessionTTLSeconds int, vaults []AgentInviteVault) (*Invite, error) {
 	now := time.Now().UTC()
 	token := newInviteToken()
 
-	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO invites (token_hash, vault_id, vault_role, status, created_by, created_at, expires_at, session_ttl_seconds)
-		 VALUES (?, ?, ?, 'pending', ?, ?, ?, ?)`,
-		hashToken(token), vaultID, vaultRole, createdBy, now.Format(time.DateTime), expiresAt.UTC().Format(time.DateTime), nullableInt(sessionTTLSeconds),
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.ExecContext(ctx,
+		`INSERT INTO invites (token_hash, agent_name, status, created_by, created_at, expires_at, session_ttl_seconds)
+		 VALUES (?, ?, 'pending', ?, ?, ?, ?)`,
+		hashToken(token), agentName, createdBy, now.Format(time.DateTime), expiresAt.UTC().Format(time.DateTime), nullableInt(sessionTTLSeconds),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("inserting invite: %w", err)
 	}
 
+	inviteID, _ := res.LastInsertId()
+
+	// Insert vault pre-assignments.
+	for _, v := range vaults {
+		_, err := tx.ExecContext(ctx,
+			`INSERT INTO agent_invite_vaults (invite_id, vault_id, vault_role) VALUES (?, ?, ?)`,
+			inviteID, v.VaultID, v.VaultRole,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("inserting invite vault: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("committing invite: %w", err)
+	}
+
 	return &Invite{
+		ID:                int(inviteID),
 		Token:             token,
-		VaultID:           vaultID,
-		VaultRole:         vaultRole,
+		AgentName:         agentName,
 		Status:            "pending",
 		CreatedBy:         createdBy,
 		SessionTTLSeconds: sessionTTLSeconds,
+		Vaults:            vaults,
 		CreatedAt:         now,
 		ExpiresAt:         expiresAt.UTC(),
 	}, nil
@@ -1153,58 +1177,128 @@ func (s *SQLiteStore) CreateInvite(ctx context.Context, vaultID, vaultRole, crea
 
 func (s *SQLiteStore) GetInviteByToken(ctx context.Context, token string) (*Invite, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, '' as token, vault_id, vault_role, status, session_id, created_by,
-		        persistent, agent_name, agent_id,
-		        created_at, expires_at, redeemed_at, revoked_at,
-		        session_ttl_seconds
+		`SELECT id, '' as token, agent_name, agent_id, session_ttl_seconds,
+		        status, session_id, created_by,
+		        created_at, expires_at, redeemed_at, revoked_at
 		 FROM invites WHERE token_hash = ?`, hashToken(token),
 	)
-	return scanInvite(row)
+	inv, err := scanInvite(row)
+	if err != nil {
+		return nil, err
+	}
+	inv.Vaults, err = s.loadAgentInviteVaults(ctx, inv.ID)
+	if err != nil {
+		return nil, err
+	}
+	return inv, nil
 }
 
-func (s *SQLiteStore) ListInvites(ctx context.Context, vaultID, status string) ([]Invite, error) {
+func (s *SQLiteStore) ListInvites(ctx context.Context, status string) ([]Invite, error) {
 	// Lazily expire pending invites that are past their TTL.
 	nowStr := time.Now().UTC().Format(time.DateTime)
 	_, _ = s.db.ExecContext(ctx,
-		`UPDATE invites SET status = 'expired' WHERE vault_id = ? AND status = 'pending' AND expires_at <= ?`,
-		vaultID, nowStr,
+		`UPDATE invites SET status = 'expired' WHERE status = 'pending' AND expires_at <= ?`,
+		nowStr,
 	)
 
 	var rows *sql.Rows
 	var err error
 	if status != "" {
 		rows, err = s.db.QueryContext(ctx,
-			`SELECT id, '' as token, vault_id, vault_role, status, session_id, created_by,
-			        persistent, agent_name, agent_id,
-			        created_at, expires_at, redeemed_at, revoked_at,
-			        session_ttl_seconds
-			 FROM invites WHERE vault_id = ? AND status = ? ORDER BY created_at DESC`,
-			vaultID, status,
+			`SELECT id, '' as token, agent_name, agent_id, session_ttl_seconds,
+			        status, session_id, created_by,
+			        created_at, expires_at, redeemed_at, revoked_at
+			 FROM invites WHERE status = ? ORDER BY created_at DESC`,
+			status,
 		)
 	} else {
 		rows, err = s.db.QueryContext(ctx,
-			`SELECT id, '' as token, vault_id, vault_role, status, session_id, created_by,
-			        persistent, agent_name, agent_id,
-			        created_at, expires_at, redeemed_at, revoked_at,
-			        session_ttl_seconds
-			 FROM invites WHERE vault_id = ? ORDER BY created_at DESC`,
-			vaultID,
+			`SELECT id, '' as token, agent_name, agent_id, session_ttl_seconds,
+			        status, session_id, created_by,
+			        created_at, expires_at, redeemed_at, revoked_at
+			 FROM invites ORDER BY created_at DESC`,
 		)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("listing invites: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
 
 	var invites []Invite
 	for rows.Next() {
 		inv, err := scanInviteRow(rows)
 		if err != nil {
+			_ = rows.Close()
 			return nil, err
 		}
 		invites = append(invites, *inv)
 	}
-	return invites, rows.Err()
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	_ = rows.Close()
+
+	// Load vault pre-assignments after closing rows to avoid connection deadlock.
+	for i := range invites {
+		invites[i].Vaults, _ = s.loadAgentInviteVaults(ctx, invites[i].ID)
+	}
+	return invites, nil
+}
+
+func (s *SQLiteStore) ListInvitesByVault(ctx context.Context, vaultID, status string) ([]Invite, error) {
+	// Lazily expire pending invites that are past their TTL.
+	nowStr := time.Now().UTC().Format(time.DateTime)
+	_, _ = s.db.ExecContext(ctx,
+		`UPDATE invites SET status = 'expired' WHERE status = 'pending' AND expires_at <= ?`,
+		nowStr,
+	)
+
+	var rows *sql.Rows
+	var err error
+	if status != "" {
+		rows, err = s.db.QueryContext(ctx,
+			`SELECT DISTINCT i.id, '' as token, i.agent_name, i.agent_id, i.session_ttl_seconds,
+			        i.status, i.session_id, i.created_by,
+			        i.created_at, i.expires_at, i.redeemed_at, i.revoked_at
+			 FROM invites i
+			 JOIN agent_invite_vaults aiv ON aiv.invite_id = i.id
+			 WHERE aiv.vault_id = ? AND i.status = ? ORDER BY i.created_at DESC`,
+			vaultID, status,
+		)
+	} else {
+		rows, err = s.db.QueryContext(ctx,
+			`SELECT DISTINCT i.id, '' as token, i.agent_name, i.agent_id, i.session_ttl_seconds,
+			        i.status, i.session_id, i.created_by,
+			        i.created_at, i.expires_at, i.redeemed_at, i.revoked_at
+			 FROM invites i
+			 JOIN agent_invite_vaults aiv ON aiv.invite_id = i.id
+			 WHERE aiv.vault_id = ? ORDER BY i.created_at DESC`,
+			vaultID,
+		)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("listing invites by vault: %w", err)
+	}
+
+	var invites []Invite
+	for rows.Next() {
+		inv, err := scanInviteRow(rows)
+		if err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		invites = append(invites, *inv)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	_ = rows.Close()
+
+	for i := range invites {
+		invites[i].Vaults, _ = s.loadAgentInviteVaults(ctx, invites[i].ID)
+	}
+	return invites, nil
 }
 
 func (s *SQLiteStore) RedeemInvite(ctx context.Context, token, sessionID string) error {
@@ -1245,13 +1339,20 @@ func (s *SQLiteStore) RevokeInvite(ctx context.Context, token string) error {
 
 func (s *SQLiteStore) GetInviteByID(ctx context.Context, id int) (*Invite, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, '' as token, vault_id, vault_role, status, session_id, created_by,
-		        persistent, agent_name, agent_id,
-		        created_at, expires_at, redeemed_at, revoked_at,
-		        session_ttl_seconds
+		`SELECT id, '' as token, agent_name, agent_id, session_ttl_seconds,
+		        status, session_id, created_by,
+		        created_at, expires_at, redeemed_at, revoked_at
 		 FROM invites WHERE id = ?`, id,
 	)
-	return scanInvite(row)
+	inv, err := scanInvite(row)
+	if err != nil {
+		return nil, err
+	}
+	inv.Vaults, err = s.loadAgentInviteVaults(ctx, inv.ID)
+	if err != nil {
+		return nil, err
+	}
+	return inv, nil
 }
 
 func (s *SQLiteStore) RevokeInviteByID(ctx context.Context, id int) error {
@@ -1272,13 +1373,73 @@ func (s *SQLiteStore) RevokeInviteByID(ctx context.Context, id int) error {
 	return nil
 }
 
-func (s *SQLiteStore) CountPendingInvites(ctx context.Context, vaultID string) (int, error) {
+func (s *SQLiteStore) CountPendingInvites(ctx context.Context) (int, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM invites WHERE vault_id = ? AND status = 'pending'",
-		vaultID,
+		"SELECT COUNT(*) FROM invites WHERE status = 'pending'",
 	).Scan(&count)
 	return count, err
+}
+
+func (s *SQLiteStore) HasPendingInviteByAgentName(ctx context.Context, name string) (bool, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM invites WHERE status = 'pending' AND agent_name = ?",
+		name,
+	).Scan(&count)
+	return count > 0, err
+}
+
+func (s *SQLiteStore) GetPendingInviteByAgentName(ctx context.Context, name string) (*Invite, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, '' as token, agent_name, agent_id, session_ttl_seconds,
+		        status, session_id, created_by,
+		        created_at, expires_at, redeemed_at, revoked_at
+		 FROM invites WHERE status = 'pending' AND agent_name = ? LIMIT 1`,
+		name,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !rows.Next() {
+		rows.Close()
+		return nil, sql.ErrNoRows
+	}
+	inv, err := scanInviteRow(rows)
+	rows.Close()
+	if err != nil {
+		return nil, err
+	}
+	vaults, err := s.loadAgentInviteVaults(ctx, inv.ID)
+	if err != nil {
+		return nil, err
+	}
+	inv.Vaults = vaults
+	return inv, nil
+}
+
+func (s *SQLiteStore) AddAgentInviteVault(ctx context.Context, inviteID int, vaultID, role string) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO agent_invite_vaults (invite_id, vault_id, vault_role) VALUES (?, ?, ?)`,
+		inviteID, vaultID, role,
+	)
+	return err
+}
+
+func (s *SQLiteStore) RemoveAgentInviteVault(ctx context.Context, inviteID int, vaultID string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM agent_invite_vaults WHERE invite_id = ? AND vault_id = ?`,
+		inviteID, vaultID,
+	)
+	return err
+}
+
+func (s *SQLiteStore) UpdateAgentInviteVaultRole(ctx context.Context, inviteID int, vaultID, role string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE agent_invite_vaults SET vault_role = ? WHERE invite_id = ? AND vault_id = ?`,
+		role, inviteID, vaultID,
+	)
+	return err
 }
 
 func (s *SQLiteStore) ExpirePendingInvites(ctx context.Context, before time.Time) (int, error) {
@@ -1295,11 +1456,9 @@ func (s *SQLiteStore) ExpirePendingInvites(ctx context.Context, before time.Time
 }
 
 // scanInviteFields populates an Invite from pre-scanned fields.
-func scanInviteFields(inv *Invite, sessionID, agentName, agentID sql.NullString, persistent int, createdAt, expiresAt string, redeemedAt, revokedAt sql.NullString, sessionTTL sql.NullInt64) {
-	inv.SessionID = sessionID.String
-	inv.Persistent = persistent != 0
-	inv.AgentName = agentName.String
+func scanInviteFields(inv *Invite, agentID, sessionID sql.NullString, createdAt, expiresAt string, redeemedAt, revokedAt sql.NullString, sessionTTL sql.NullInt64) {
 	inv.AgentID = agentID.String
+	inv.SessionID = sessionID.String
 	inv.CreatedAt, _ = time.Parse(time.DateTime, createdAt)
 	inv.ExpiresAt, _ = time.Parse(time.DateTime, expiresAt)
 	if redeemedAt.Valid {
@@ -1316,43 +1475,66 @@ func scanInviteFields(inv *Invite, sessionID, agentName, agentID sql.NullString,
 }
 
 // scanInvite scans a single invite row from a *sql.Row.
+// Expected column order: id, token, agent_name, agent_id, session_ttl_seconds,
+//
+//	status, session_id, created_by, created_at, expires_at, redeemed_at, revoked_at
 func scanInvite(row *sql.Row) (*Invite, error) {
 	var inv Invite
-	var sessionID, agentName, agentID sql.NullString
-	var persistent int
+	var agentID, sessionID sql.NullString
 	var createdAt, expiresAt string
 	var redeemedAt, revokedAt sql.NullString
 	var sessionTTL sql.NullInt64
 
-	if err := row.Scan(&inv.ID, &inv.Token, &inv.VaultID, &inv.VaultRole, &inv.Status,
-		&sessionID, &inv.CreatedBy, &persistent, &agentName, &agentID,
-		&createdAt, &expiresAt, &redeemedAt, &revokedAt,
-		&sessionTTL); err != nil {
+	if err := row.Scan(&inv.ID, &inv.Token, &inv.AgentName, &agentID, &sessionTTL,
+		&inv.Status, &sessionID, &inv.CreatedBy,
+		&createdAt, &expiresAt, &redeemedAt, &revokedAt); err != nil {
 		return nil, err
 	}
 
-	scanInviteFields(&inv, sessionID, agentName, agentID, persistent, createdAt, expiresAt, redeemedAt, revokedAt, sessionTTL)
+	scanInviteFields(&inv, agentID, sessionID, createdAt, expiresAt, redeemedAt, revokedAt, sessionTTL)
 	return &inv, nil
 }
 
 // scanInviteRow scans a single invite from a *sql.Rows.
 func scanInviteRow(rows *sql.Rows) (*Invite, error) {
 	var inv Invite
-	var sessionID, agentName, agentID sql.NullString
-	var persistent int
+	var agentID, sessionID sql.NullString
 	var createdAt, expiresAt string
 	var redeemedAt, revokedAt sql.NullString
 	var sessionTTL sql.NullInt64
 
-	if err := rows.Scan(&inv.ID, &inv.Token, &inv.VaultID, &inv.VaultRole, &inv.Status,
-		&sessionID, &inv.CreatedBy, &persistent, &agentName, &agentID,
-		&createdAt, &expiresAt, &redeemedAt, &revokedAt,
-		&sessionTTL); err != nil {
+	if err := rows.Scan(&inv.ID, &inv.Token, &inv.AgentName, &agentID, &sessionTTL,
+		&inv.Status, &sessionID, &inv.CreatedBy,
+		&createdAt, &expiresAt, &redeemedAt, &revokedAt); err != nil {
 		return nil, err
 	}
 
-	scanInviteFields(&inv, sessionID, agentName, agentID, persistent, createdAt, expiresAt, redeemedAt, revokedAt, sessionTTL)
+	scanInviteFields(&inv, agentID, sessionID, createdAt, expiresAt, redeemedAt, revokedAt, sessionTTL)
 	return &inv, nil
+}
+
+// loadAgentInviteVaults loads the vault pre-assignments for an invite.
+func (s *SQLiteStore) loadAgentInviteVaults(ctx context.Context, inviteID int) ([]AgentInviteVault, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT aiv.vault_id, v.name, aiv.vault_role
+		 FROM agent_invite_vaults aiv
+		 JOIN vaults v ON v.id = aiv.vault_id
+		 WHERE aiv.invite_id = ?`, inviteID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("loading invite vaults: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var vaults []AgentInviteVault
+	for rows.Next() {
+		var v AgentInviteVault
+		if err := rows.Scan(&v.VaultID, &v.VaultName, &v.VaultRole); err != nil {
+			return nil, err
+		}
+		vaults = append(vaults, v)
+	}
+	return vaults, rows.Err()
 }
 
 // --- Vault Invites ---
@@ -2081,109 +2263,127 @@ func (s *SQLiteStore) CreateOAuthUserAndAccount(ctx context.Context, email, role
 
 // --- Agents ---
 
-func (s *SQLiteStore) CreateAgent(ctx context.Context, name, vaultID string, tokenHash, tokenSalt []byte, tokenPrefix, vaultRole, createdBy string) (*Agent, error) {
+func (s *SQLiteStore) CreateAgent(ctx context.Context, name, createdBy string) (*Agent, error) {
 	id := newUUID()
 	now := time.Now().UTC()
 	nowStr := now.Format(time.DateTime)
 
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO agents (id, name, vault_id, service_token_hash, service_token_salt, service_token_prefix, vault_role, status, created_by, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?)`,
-		id, name, vaultID, tokenHash, tokenSalt, tokenPrefix, vaultRole, createdBy, nowStr, nowStr,
+		`INSERT INTO agents (id, name, status, created_by, created_at, updated_at)
+		 VALUES (?, ?, 'active', ?, ?, ?)`,
+		id, name, createdBy, nowStr, nowStr,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating agent: %w", err)
 	}
 
 	return &Agent{
-		ID:                 id,
-		Name:               name,
-		VaultID:            vaultID,
-		ServiceTokenHash:   tokenHash,
-		ServiceTokenSalt:   tokenSalt,
-		ServiceTokenPrefix: tokenPrefix,
-		VaultRole:          vaultRole,
-		Status:             "active",
-		CreatedBy:          createdBy,
-		CreatedAt:          now,
-		UpdatedAt:          now,
+		ID:        id,
+		Name:      name,
+		Status:    "active",
+		CreatedBy: createdBy,
+		CreatedAt: now,
+		UpdatedAt: now,
 	}, nil
 }
 
 func (s *SQLiteStore) GetAgentByID(ctx context.Context, id string) (*Agent, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, name, vault_id, service_token_hash, service_token_salt, service_token_prefix,
-		        vault_role, status, created_by, created_at, updated_at, revoked_at
+		`SELECT id, name, status, created_by, created_at, updated_at, revoked_at
 		 FROM agents WHERE id = ?`, id,
 	)
-	return scanAgent(row)
+	ag, err := scanAgent(row)
+	if err != nil {
+		return nil, err
+	}
+	ag.Vaults, err = s.loadAgentVaultGrants(ctx, ag.ID)
+	if err != nil {
+		return nil, err
+	}
+	return ag, nil
 }
 
 func (s *SQLiteStore) GetAgentByName(ctx context.Context, name string) (*Agent, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, name, vault_id, service_token_hash, service_token_salt, service_token_prefix,
-		        vault_role, status, created_by, created_at, updated_at, revoked_at
+		`SELECT id, name, status, created_by, created_at, updated_at, revoked_at
 		 FROM agents WHERE name = ?`, name,
 	)
-	return scanAgent(row)
+	ag, err := scanAgent(row)
+	if err != nil {
+		return nil, err
+	}
+	ag.Vaults, err = s.loadAgentVaultGrants(ctx, ag.ID)
+	if err != nil {
+		return nil, err
+	}
+	return ag, nil
 }
 
-func (s *SQLiteStore) GetAgentByTokenPrefix(ctx context.Context, prefix string) (*Agent, error) {
-	row := s.db.QueryRowContext(ctx,
-		`SELECT id, name, vault_id, service_token_hash, service_token_salt, service_token_prefix,
-		        vault_role, status, created_by, created_at, updated_at, revoked_at
-		 FROM agents WHERE service_token_prefix = ? AND status = 'active'`, prefix,
-	)
-	return scanAgent(row)
-}
-
-// ListAgents returns agents for a specific vault. Use ListAllAgents for cross-vault listing.
+// ListAgents returns agents that have access to a specific vault via agent_vault_grants.
 func (s *SQLiteStore) ListAgents(ctx context.Context, vaultID string) ([]Agent, error) {
 	if vaultID == "" {
 		return nil, fmt.Errorf("vaultID is required; use ListAllAgents for cross-vault listing")
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, name, vault_id, service_token_hash, service_token_salt, service_token_prefix,
-		        vault_role, status, created_by, created_at, updated_at, revoked_at
-		 FROM agents WHERE vault_id = ? ORDER BY name`, vaultID,
+		`SELECT a.id, a.name, a.status, a.created_by, a.created_at, a.updated_at, a.revoked_at
+		 FROM agents a
+		 JOIN agent_vault_grants avg ON avg.agent_id = a.id
+		 WHERE avg.vault_id = ? ORDER BY a.name`, vaultID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("listing agents: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
 
 	var agents []Agent
 	for rows.Next() {
 		ag, err := scanAgentRow(rows)
 		if err != nil {
+			_ = rows.Close()
 			return nil, err
 		}
 		agents = append(agents, *ag)
 	}
-	return agents, rows.Err()
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	_ = rows.Close()
+
+	if err := s.batchLoadAgentVaultGrants(ctx, agents); err != nil {
+		return nil, err
+	}
+	return agents, nil
 }
 
-// ListAllAgents returns all agents across all vaults (owner-only use case).
+// ListAllAgents returns all agents with their vault grants.
 func (s *SQLiteStore) ListAllAgents(ctx context.Context) ([]Agent, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, name, vault_id, service_token_hash, service_token_salt, service_token_prefix,
-		        vault_role, status, created_by, created_at, updated_at, revoked_at
+		`SELECT id, name, status, created_by, created_at, updated_at, revoked_at
 		 FROM agents ORDER BY name`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("listing all agents: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
 
 	var agents []Agent
 	for rows.Next() {
 		ag, err := scanAgentRow(rows)
 		if err != nil {
+			_ = rows.Close()
 			return nil, err
 		}
 		agents = append(agents, *ag)
 	}
-	return agents, rows.Err()
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	_ = rows.Close()
+
+	if err := s.batchLoadAgentVaultGrants(ctx, agents); err != nil {
+		return nil, err
+	}
+	return agents, nil
 }
 
 func (s *SQLiteStore) RevokeAgent(ctx context.Context, id string) error {
@@ -2217,40 +2417,6 @@ func (s *SQLiteStore) RevokeAgent(ctx context.Context, id string) error {
 	return tx.Commit()
 }
 
-func (s *SQLiteStore) UpdateAgentServiceToken(ctx context.Context, id string, tokenHash, tokenSalt []byte, tokenPrefix string) error {
-	nowStr := time.Now().UTC().Format(time.DateTime)
-
-	res, err := s.db.ExecContext(ctx,
-		`UPDATE agents SET service_token_hash = ?, service_token_salt = ?, service_token_prefix = ?, updated_at = ?
-		 WHERE id = ? AND status = 'active'`,
-		tokenHash, tokenSalt, tokenPrefix, nowStr, id,
-	)
-	if err != nil {
-		return fmt.Errorf("updating agent service token: %w", err)
-	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return sql.ErrNoRows
-	}
-	return nil
-}
-
-func (s *SQLiteStore) UpdateAgentVaultRole(ctx context.Context, id, role string) error {
-	nowStr := time.Now().UTC().Format(time.DateTime)
-
-	res, err := s.db.ExecContext(ctx,
-		`UPDATE agents SET vault_role = ?, updated_at = ? WHERE id = ? AND status = 'active'`,
-		role, nowStr, id,
-	)
-	if err != nil {
-		return fmt.Errorf("updating agent vault role: %w", err)
-	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return sql.ErrNoRows
-	}
-	return nil
-}
 
 func (s *SQLiteStore) RenameAgent(ctx context.Context, id string, newName string) error {
 	nowStr := time.Now().UTC().Format(time.DateTime)
@@ -2316,7 +2482,7 @@ func (s *SQLiteStore) DeleteAgentSessions(ctx context.Context, agentID string) e
 	return nil
 }
 
-func (s *SQLiteStore) CreateAgentSession(ctx context.Context, agentID, vaultID, vaultRole string, expiresAt *time.Time) (*Session, error) {
+func (s *SQLiteStore) CreateAgentSession(ctx context.Context, agentID string, expiresAt *time.Time) (*Session, error) {
 	rawToken := newSessionToken()
 	tokenHash := hashSessionToken(rawToken)
 	now := time.Now().UTC()
@@ -2327,80 +2493,58 @@ func (s *SQLiteStore) CreateAgentSession(ctx context.Context, agentID, vaultID, 
 	}
 
 	_, err := s.db.ExecContext(ctx,
-		"INSERT INTO sessions (id, vault_id, agent_id, vault_role, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?)",
-		tokenHash, vaultID, agentID, vaultRole, expiresAtStr, now.Format(time.DateTime),
+		"INSERT INTO sessions (id, agent_id, expires_at, created_at) VALUES (?, ?, ?, ?)",
+		tokenHash, agentID, expiresAtStr, now.Format(time.DateTime),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating agent session: %w", err)
 	}
 
-	return &Session{ID: rawToken, VaultID: vaultID, AgentID: agentID, VaultRole: vaultRole, ExpiresAt: utcTimePtr(expiresAt), CreatedAt: now}, nil
+	return &Session{ID: rawToken, AgentID: agentID, ExpiresAt: utcTimePtr(expiresAt), CreatedAt: now}, nil
 }
 
-func (s *SQLiteStore) CreatePersistentInvite(ctx context.Context, vaultID, vaultRole, createdBy string, agentName string, expiresAt time.Time) (*Invite, error) {
+func (s *SQLiteStore) CreateRotationInvite(ctx context.Context, agentID, createdBy string, expiresAt time.Time) (*Invite, error) {
 	now := time.Now().UTC()
 	token := newInviteToken()
 
-	var agName sql.NullString
-	if agentName != "" {
-		agName = sql.NullString{String: agentName, Valid: true}
-	}
-
-	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO invites (token_hash, vault_id, vault_role, status, created_by, persistent, agent_name, created_at, expires_at)
-		 VALUES (?, ?, ?, 'pending', ?, 1, ?, ?, ?)`,
-		hashToken(token), vaultID, vaultRole, createdBy, agName, now.Format(time.DateTime), expiresAt.UTC().Format(time.DateTime),
-	)
+	// Use agent's existing name for the invite record.
+	var agentName string
+	err := s.db.QueryRowContext(ctx, "SELECT name FROM agents WHERE id = ?", agentID).Scan(&agentName)
 	if err != nil {
-		return nil, fmt.Errorf("inserting persistent invite: %w", err)
+		return nil, fmt.Errorf("looking up agent for rotation: %w", err)
 	}
 
-	return &Invite{
-		Token:      token,
-		VaultID:    vaultID,
-		VaultRole:  vaultRole,
-		Status:     "pending",
-		CreatedBy:  createdBy,
-		Persistent: true,
-		AgentName:  agentName,
-		CreatedAt:  now,
-		ExpiresAt:  expiresAt.UTC(),
-	}, nil
-}
-
-func (s *SQLiteStore) CreateRotationInvite(ctx context.Context, agentID, vaultID, createdBy string, expiresAt time.Time) (*Invite, error) {
-	now := time.Now().UTC()
-	token := newInviteToken()
-
-	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO invites (token_hash, vault_id, status, created_by, persistent, agent_id, created_at, expires_at)
-		 VALUES (?, ?, 'pending', ?, 1, ?, ?, ?)`,
-		hashToken(token), vaultID, createdBy, agentID, now.Format(time.DateTime), expiresAt.UTC().Format(time.DateTime),
+	res, err := s.db.ExecContext(ctx,
+		`INSERT INTO invites (token_hash, agent_name, agent_id, status, created_by, created_at, expires_at)
+		 VALUES (?, ?, ?, 'pending', ?, ?, ?)`,
+		hashToken(token), agentName, agentID, createdBy, now.Format(time.DateTime), expiresAt.UTC().Format(time.DateTime),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("inserting rotation invite: %w", err)
 	}
 
+	inviteID, _ := res.LastInsertId()
 	return &Invite{
-		Token:       token,
-		VaultID: vaultID,
-		Status:      "pending",
-		CreatedBy:   createdBy,
-		Persistent:  true,
-		AgentID:     agentID,
-		CreatedAt:   now,
-		ExpiresAt:   expiresAt.UTC(),
+		ID:        int(inviteID),
+		Token:     token,
+		AgentName: agentName,
+		AgentID:   agentID,
+		Status:    "pending",
+		CreatedBy: createdBy,
+		CreatedAt: now,
+		ExpiresAt: expiresAt.UTC(),
 	}, nil
 }
 
+// scanAgent scans a single agent row from a *sql.Row.
+// Expected column order: id, name, status, created_by, created_at, updated_at, revoked_at
 func scanAgent(row *sql.Row) (*Agent, error) {
 	var ag Agent
 	var createdAt, updatedAt string
 	var revokedAt sql.NullString
 
-	if err := row.Scan(&ag.ID, &ag.Name, &ag.VaultID,
-		&ag.ServiceTokenHash, &ag.ServiceTokenSalt, &ag.ServiceTokenPrefix,
-		&ag.VaultRole, &ag.Status, &ag.CreatedBy, &createdAt, &updatedAt, &revokedAt); err != nil {
+	if err := row.Scan(&ag.ID, &ag.Name,
+		&ag.Status, &ag.CreatedBy, &createdAt, &updatedAt, &revokedAt); err != nil {
 		return nil, err
 	}
 
@@ -2418,9 +2562,8 @@ func scanAgentRow(rows *sql.Rows) (*Agent, error) {
 	var createdAt, updatedAt string
 	var revokedAt sql.NullString
 
-	if err := rows.Scan(&ag.ID, &ag.Name, &ag.VaultID,
-		&ag.ServiceTokenHash, &ag.ServiceTokenSalt, &ag.ServiceTokenPrefix,
-		&ag.VaultRole, &ag.Status, &ag.CreatedBy, &createdAt, &updatedAt, &revokedAt); err != nil {
+	if err := rows.Scan(&ag.ID, &ag.Name,
+		&ag.Status, &ag.CreatedBy, &createdAt, &updatedAt, &revokedAt); err != nil {
 		return nil, err
 	}
 
@@ -2431,6 +2574,138 @@ func scanAgentRow(rows *sql.Rows) (*Agent, error) {
 		ag.RevokedAt = &t
 	}
 	return &ag, nil
+}
+
+// loadAgentVaultGrants loads all vault grants for an agent.
+func (s *SQLiteStore) loadAgentVaultGrants(ctx context.Context, agentID string) ([]AgentVaultGrant, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT avg.agent_id, avg.vault_id, v.name, avg.vault_role, avg.created_at
+		 FROM agent_vault_grants avg
+		 JOIN vaults v ON v.id = avg.vault_id
+		 WHERE avg.agent_id = ?`, agentID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("loading agent vault grants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var grants []AgentVaultGrant
+	for rows.Next() {
+		var g AgentVaultGrant
+		var createdAt string
+		if err := rows.Scan(&g.AgentID, &g.VaultID, &g.VaultName, &g.VaultRole, &createdAt); err != nil {
+			return nil, err
+		}
+		g.CreatedAt, _ = time.Parse(time.DateTime, createdAt)
+		grants = append(grants, g)
+	}
+	return grants, rows.Err()
+}
+
+// batchLoadAgentVaultGrants loads vault grants for all agents in a single query.
+func (s *SQLiteStore) batchLoadAgentVaultGrants(ctx context.Context, agents []Agent) error {
+	if len(agents) == 0 {
+		return nil
+	}
+
+	// Build agent ID list and index map.
+	idxMap := make(map[string][]int, len(agents))
+	args := make([]interface{}, len(agents))
+	placeholders := make([]string, len(agents))
+	for i, ag := range agents {
+		idxMap[ag.ID] = append(idxMap[ag.ID], i)
+		args[i] = ag.ID
+		placeholders[i] = "?"
+	}
+
+	query := `SELECT avg.agent_id, avg.vault_id, v.name, avg.vault_role, avg.created_at
+		 FROM agent_vault_grants avg
+		 JOIN vaults v ON v.id = avg.vault_id
+		 WHERE avg.agent_id IN (` + strings.Join(placeholders, ",") + `)`
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("batch loading agent vault grants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var g AgentVaultGrant
+		var createdAt string
+		if err := rows.Scan(&g.AgentID, &g.VaultID, &g.VaultName, &g.VaultRole, &createdAt); err != nil {
+			return err
+		}
+		g.CreatedAt, _ = time.Parse(time.DateTime, createdAt)
+		for _, idx := range idxMap[g.AgentID] {
+			agents[idx].Vaults = append(agents[idx].Vaults, g)
+		}
+	}
+	return rows.Err()
+}
+
+func (s *SQLiteStore) GrantAgentVaultRole(ctx context.Context, agentID, vaultID, role string) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO agent_vault_grants (agent_id, vault_id, vault_role) VALUES (?, ?, ?)
+		 ON CONFLICT(agent_id, vault_id) DO UPDATE SET vault_role = excluded.vault_role`,
+		agentID, vaultID, role,
+	)
+	if err != nil {
+		return fmt.Errorf("granting agent vault role: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) RevokeAgentVaultAccess(ctx context.Context, agentID, vaultID string) error {
+	res, err := s.db.ExecContext(ctx,
+		"DELETE FROM agent_vault_grants WHERE agent_id = ? AND vault_id = ?",
+		agentID, vaultID,
+	)
+	if err != nil {
+		return fmt.Errorf("revoking agent vault access: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+func (s *SQLiteStore) GetAgentVaultRole(ctx context.Context, agentID, vaultID string) (string, error) {
+	var role string
+	err := s.db.QueryRowContext(ctx,
+		"SELECT vault_role FROM agent_vault_grants WHERE agent_id = ? AND vault_id = ?",
+		agentID, vaultID,
+	).Scan(&role)
+	return role, err
+}
+
+func (s *SQLiteStore) ListAgentGrants(ctx context.Context, agentID string) ([]AgentVaultGrant, error) {
+	return s.loadAgentVaultGrants(ctx, agentID)
+}
+
+func (s *SQLiteStore) ListVaultAgents(ctx context.Context, vaultID string) ([]AgentVaultGrant, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT avg.agent_id, avg.vault_id, v.name, avg.vault_role, avg.created_at
+		 FROM agent_vault_grants avg
+		 JOIN vaults v ON v.id = avg.vault_id
+		 WHERE avg.vault_id = ?`, vaultID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing vault agents: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var grants []AgentVaultGrant
+	for rows.Next() {
+		var g AgentVaultGrant
+		var createdAt string
+		if err := rows.Scan(&g.AgentID, &g.VaultID, &g.VaultName, &g.VaultRole, &createdAt); err != nil {
+			return nil, err
+		}
+		g.CreatedAt, _ = time.Parse(time.DateTime, createdAt)
+		grants = append(grants, g)
+	}
+	return grants, rows.Err()
 }
 
 // newUUID generates a v4 UUID using crypto/rand.

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -28,8 +28,8 @@ func TestOpenAndMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("querying schema_migrations: %v", err)
 	}
-	if version != 34 {
-		t.Fatalf("expected migration version 34, got %d", version)
+	if version != 35 {
+		t.Fatalf("expected migration version 35, got %d", version)
 	}
 }
 
@@ -880,14 +880,13 @@ func TestCascadeDeleteVaultRemovesProposals(t *testing.T) {
 
 // --- Invites ---
 
-func TestCreateInvite(t *testing.T) {
+func TestCreateAgentInvite(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
-	ns, _ := s.CreateVault(ctx, "inv-test")
 
-	inv, err := s.CreateInvite(ctx, ns.ID, "proxy", "admin", time.Now().Add(15*time.Minute), 0)
+	inv, err := s.CreateAgentInvite(ctx, "testbot", "admin", time.Now().Add(15*time.Minute), 0, nil)
 	if err != nil {
-		t.Fatalf("CreateInvite: %v", err)
+		t.Fatalf("CreateAgentInvite: %v", err)
 	}
 	if inv.Status != "pending" {
 		t.Fatalf("expected status pending, got %s", inv.Status)
@@ -895,14 +894,16 @@ func TestCreateInvite(t *testing.T) {
 	if len(inv.Token) < 7 || inv.Token[:7] != "av_inv_" {
 		t.Fatalf("unexpected token format: %s", inv.Token)
 	}
+	if inv.AgentName != "testbot" {
+		t.Fatalf("expected agent_name testbot, got %s", inv.AgentName)
+	}
 }
 
 func TestRedeemInvite(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
-	ns, _ := s.CreateVault(ctx, "inv-redeem")
 
-	inv, _ := s.CreateInvite(ctx, ns.ID, "proxy", "admin", time.Now().Add(15*time.Minute), 0)
+	inv, _ := s.CreateAgentInvite(ctx, "redeembot", "admin", time.Now().Add(15*time.Minute), 0, nil)
 
 	err := s.RedeemInvite(ctx, inv.Token, "sess-123")
 	if err != nil {
@@ -927,9 +928,8 @@ func TestRedeemInvite(t *testing.T) {
 func TestRedeemInvite_Expired(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
-	ns, _ := s.CreateVault(ctx, "inv-expired")
 
-	inv, _ := s.CreateInvite(ctx, ns.ID, "proxy", "admin", time.Now().Add(-1*time.Minute), 0)
+	inv, _ := s.CreateAgentInvite(ctx, "expiredbot", "admin", time.Now().Add(-1*time.Minute), 0, nil)
 
 	err := s.RedeemInvite(ctx, inv.Token, "sess-456")
 	if err != sql.ErrNoRows {
@@ -940,9 +940,8 @@ func TestRedeemInvite_Expired(t *testing.T) {
 func TestRedeemInvite_AlreadyRedeemed(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
-	ns, _ := s.CreateVault(ctx, "inv-double")
 
-	inv, _ := s.CreateInvite(ctx, ns.ID, "proxy", "admin", time.Now().Add(15*time.Minute), 0)
+	inv, _ := s.CreateAgentInvite(ctx, "doublebot", "admin", time.Now().Add(15*time.Minute), 0, nil)
 	s.RedeemInvite(ctx, inv.Token, "sess-1")
 
 	err := s.RedeemInvite(ctx, inv.Token, "sess-2")
@@ -954,9 +953,8 @@ func TestRedeemInvite_AlreadyRedeemed(t *testing.T) {
 func TestRevokeInvite(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
-	ns, _ := s.CreateVault(ctx, "inv-revoke")
 
-	inv, _ := s.CreateInvite(ctx, ns.ID, "proxy", "admin", time.Now().Add(15*time.Minute), 0)
+	inv, _ := s.CreateAgentInvite(ctx, "revokebot", "admin", time.Now().Add(15*time.Minute), 0, nil)
 
 	if err := s.RevokeInvite(ctx, inv.Token); err != nil {
 		t.Fatalf("RevokeInvite: %v", err)
@@ -974,12 +972,11 @@ func TestRevokeInvite(t *testing.T) {
 func TestCountPendingInvites(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
-	ns, _ := s.CreateVault(ctx, "inv-count")
 
-	inv1, _ := s.CreateInvite(ctx, ns.ID, "proxy", "admin", time.Now().Add(15*time.Minute), 0)
-	s.CreateInvite(ctx, ns.ID, "proxy", "admin", time.Now().Add(15*time.Minute), 0)
+	inv1, _ := s.CreateAgentInvite(ctx, "countbot1", "admin", time.Now().Add(15*time.Minute), 0, nil)
+	s.CreateAgentInvite(ctx, "countbot2", "admin", time.Now().Add(15*time.Minute), 0, nil)
 
-	count, err := s.CountPendingInvites(ctx, ns.ID)
+	count, err := s.CountPendingInvites(ctx)
 	if err != nil {
 		t.Fatalf("CountPendingInvites: %v", err)
 	}
@@ -990,7 +987,7 @@ func TestCountPendingInvites(t *testing.T) {
 	// Revoke one — count should drop.
 	s.RevokeInvite(ctx, inv1.Token)
 
-	count, _ = s.CountPendingInvites(ctx, ns.ID)
+	count, _ = s.CountPendingInvites(ctx)
 	if count != 1 {
 		t.Fatalf("expected 1 pending invite after revoke, got %d", count)
 	}
@@ -999,11 +996,10 @@ func TestCountPendingInvites(t *testing.T) {
 func TestExpirePendingInvites(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
-	ns, _ := s.CreateVault(ctx, "inv-expire")
 
 	// Create two invites: one already expired, one still valid.
-	s.CreateInvite(ctx, ns.ID, "proxy", "admin", time.Now().Add(-1*time.Minute), 0)
-	s.CreateInvite(ctx, ns.ID, "proxy", "admin", time.Now().Add(15*time.Minute), 0)
+	s.CreateAgentInvite(ctx, "expirebot1", "admin", time.Now().Add(-1*time.Minute), 0, nil)
+	s.CreateAgentInvite(ctx, "expirebot2", "admin", time.Now().Add(15*time.Minute), 0, nil)
 
 	n, err := s.ExpirePendingInvites(ctx, time.Now())
 	if err != nil {
@@ -1013,7 +1009,7 @@ func TestExpirePendingInvites(t *testing.T) {
 		t.Fatalf("expected 1 expired invite, got %d", n)
 	}
 
-	pending, _ := s.ListInvites(ctx, ns.ID, "pending")
+	pending, _ := s.ListInvites(ctx, "pending")
 	if len(pending) != 1 {
 		t.Fatalf("expected 1 remaining pending invite, got %d", len(pending))
 	}
@@ -1022,44 +1018,52 @@ func TestExpirePendingInvites(t *testing.T) {
 func TestListInvites(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
-	ns, _ := s.CreateVault(ctx, "inv-list")
 
-	s.CreateInvite(ctx, ns.ID, "proxy", "admin", time.Now().Add(15*time.Minute), 0)
-	inv2, _ := s.CreateInvite(ctx, ns.ID, "proxy", "admin", time.Now().Add(15*time.Minute), 0)
+	s.CreateAgentInvite(ctx, "listbot1", "admin", time.Now().Add(15*time.Minute), 0, nil)
+	inv2, _ := s.CreateAgentInvite(ctx, "listbot2", "admin", time.Now().Add(15*time.Minute), 0, nil)
 	s.RevokeInvite(ctx, inv2.Token)
 
 	// All invites.
-	all, _ := s.ListInvites(ctx, ns.ID, "")
+	all, _ := s.ListInvites(ctx, "")
 	if len(all) != 2 {
 		t.Fatalf("expected 2 total invites, got %d", len(all))
 	}
 
 	// Pending only.
-	pending, _ := s.ListInvites(ctx, ns.ID, "pending")
+	pending, _ := s.ListInvites(ctx, "pending")
 	if len(pending) != 1 {
 		t.Fatalf("expected 1 pending invite, got %d", len(pending))
 	}
 
 	// Revoked only.
-	revoked, _ := s.ListInvites(ctx, ns.ID, "revoked")
+	revoked, _ := s.ListInvites(ctx, "revoked")
 	if len(revoked) != 1 {
 		t.Fatalf("expected 1 revoked invite, got %d", len(revoked))
 	}
 }
 
-func TestInviteCascadeDelete(t *testing.T) {
+func TestInviteWithVaultPreAssignment(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
-	ns, _ := s.CreateVault(ctx, "inv-cascade")
-	s.CreateInvite(ctx, ns.ID, "proxy", "admin", time.Now().Add(15*time.Minute), 0)
+	ns, _ := s.GetVault(ctx, "default")
 
-	if err := s.DeleteVault(ctx, "inv-cascade"); err != nil {
-		t.Fatal(err)
+	inv, err := s.CreateAgentInvite(ctx, "vaultbot", "admin", time.Now().Add(15*time.Minute), 0, []AgentInviteVault{
+		{VaultID: ns.ID, VaultRole: "proxy"},
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentInvite with vaults: %v", err)
+	}
+	if len(inv.Vaults) != 1 {
+		t.Fatalf("expected 1 vault pre-assignment, got %d", len(inv.Vaults))
+	}
+	if inv.Vaults[0].VaultRole != "proxy" {
+		t.Fatalf("expected vault role proxy, got %s", inv.Vaults[0].VaultRole)
 	}
 
-	list, _ := s.ListInvites(ctx, ns.ID, "")
-	if len(list) != 0 {
-		t.Fatalf("expected 0 invites after cascade delete, got %d", len(list))
+	// Fetch and verify vaults are loaded.
+	fetched, _ := s.GetInviteByToken(ctx, inv.Token)
+	if len(fetched.Vaults) != 1 {
+		t.Fatalf("fetched invite: expected 1 vault, got %d", len(fetched.Vaults))
 	}
 }
 
@@ -1314,8 +1318,7 @@ func TestCreateAgent(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
-	ns, _ := s.GetVault(ctx, "default")
-	ag, err := s.CreateAgent(ctx, "claudebot", ns.ID, []byte("hash"), []byte("salt"), "abcdef0123456789", "proxy", "creator1")
+	ag, err := s.CreateAgent(ctx, "claudebot", "creator1")
 	if err != nil {
 		t.Fatalf("CreateAgent: %v", err)
 	}
@@ -1325,17 +1328,13 @@ func TestCreateAgent(t *testing.T) {
 	if ag.Status != "active" {
 		t.Fatalf("expected status active, got %s", ag.Status)
 	}
-	if ag.ServiceTokenPrefix != "abcdef0123456789" {
-		t.Fatalf("expected prefix abcdef0123456789, got %s", ag.ServiceTokenPrefix)
-	}
 }
 
 func TestGetAgentByName(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
-	ns, _ := s.GetVault(ctx, "default")
-	s.CreateAgent(ctx, "myagent", ns.ID, []byte("h"), []byte("s"), "prefix1234567890", "proxy", "creator1")
+	s.CreateAgent(ctx, "myagent", "creator1")
 
 	ag, err := s.GetAgentByName(ctx, "myagent")
 	if err != nil {
@@ -1351,38 +1350,20 @@ func TestGetAgentByName(t *testing.T) {
 	}
 }
 
-func TestGetAgentByTokenPrefix(t *testing.T) {
-	s := openTestDB(t)
-	ctx := context.Background()
-
-	ns, _ := s.GetVault(ctx, "default")
-	s.CreateAgent(ctx, "bot1", ns.ID, []byte("h"), []byte("s"), "aaaa000000000001", "proxy", "creator1")
-
-	ag, err := s.GetAgentByTokenPrefix(ctx, "aaaa000000000001")
-	if err != nil {
-		t.Fatalf("GetAgentByTokenPrefix: %v", err)
-	}
-	if ag.Name != "bot1" {
-		t.Fatalf("expected bot1, got %s", ag.Name)
-	}
-
-	// Revoked agents should not be returned.
-	s.RevokeAgent(ctx, ag.ID)
-	_, err = s.GetAgentByTokenPrefix(ctx, "aaaa000000000001")
-	if err != sql.ErrNoRows {
-		t.Fatalf("expected ErrNoRows for revoked agent, got %v", err)
-	}
-}
-
 func TestListAgents(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
 	ns, _ := s.GetVault(ctx, "default")
 	ns2, _ := s.CreateVault(ctx, "staging")
-	s.CreateAgent(ctx, "a1", ns.ID, []byte("h"), []byte("s"), "prefix0000000001", "proxy", "c")
-	s.CreateAgent(ctx, "a2", ns.ID, []byte("h"), []byte("s"), "prefix0000000002", "proxy", "c")
-	s.CreateAgent(ctx, "a3", ns2.ID, []byte("h"), []byte("s"), "prefix0000000003", "proxy", "c")
+	a1, _ := s.CreateAgent(ctx, "a1", "c")
+	a2, _ := s.CreateAgent(ctx, "a2", "c")
+	a3, _ := s.CreateAgent(ctx, "a3", "c")
+
+	// Grant vault access.
+	s.GrantAgentVaultRole(ctx, a1.ID, ns.ID, "proxy")
+	s.GrantAgentVaultRole(ctx, a2.ID, ns.ID, "proxy")
+	s.GrantAgentVaultRole(ctx, a3.ID, ns2.ID, "proxy")
 
 	// All agents (cross-vault)
 	all, err := s.ListAllAgents(ctx)
@@ -1407,12 +1388,11 @@ func TestDuplicateAgentName(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
-	ns, _ := s.GetVault(ctx, "default")
-	_, err := s.CreateAgent(ctx, "dup", ns.ID, []byte("h"), []byte("s"), "prefix0000000001", "proxy", "c")
+	_, err := s.CreateAgent(ctx, "dup", "c")
 	if err != nil {
 		t.Fatalf("first create: %v", err)
 	}
-	_, err = s.CreateAgent(ctx, "dup", ns.ID, []byte("h2"), []byte("s2"), "prefix0000000002", "proxy", "c")
+	_, err = s.CreateAgent(ctx, "dup", "c")
 	if err == nil {
 		t.Fatal("expected error for duplicate agent name")
 	}
@@ -1422,11 +1402,10 @@ func TestRevokeAgent(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
-	ns, _ := s.GetVault(ctx, "default")
-	ag, _ := s.CreateAgent(ctx, "torevoke", ns.ID, []byte("h"), []byte("s"), "prefix0000000001", "proxy", "c")
+	ag, _ := s.CreateAgent(ctx, "torevoke", "c")
 
 	// Create a session for this agent.
-	sess, err := s.CreateAgentSession(ctx, ag.ID, ns.ID, "proxy", tp(time.Now().Add(24*time.Hour)))
+	sess, err := s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
 	if err != nil {
 		t.Fatalf("CreateAgentSession: %v", err)
 	}
@@ -1452,33 +1431,11 @@ func TestRevokeAgent(t *testing.T) {
 	}
 }
 
-func TestUpdateAgentServiceToken(t *testing.T) {
-	s := openTestDB(t)
-	ctx := context.Background()
-
-	ns, _ := s.GetVault(ctx, "default")
-	ag, _ := s.CreateAgent(ctx, "rotatable", ns.ID, []byte("old-hash"), []byte("old-salt"), "oldprefix0000000", "proxy", "c")
-
-	err := s.UpdateAgentServiceToken(ctx, ag.ID, []byte("new-hash"), []byte("new-salt"), "newprefix0000000")
-	if err != nil {
-		t.Fatalf("UpdateAgentServiceToken: %v", err)
-	}
-
-	updated, _ := s.GetAgentByName(ctx, "rotatable")
-	if string(updated.ServiceTokenHash) != "new-hash" {
-		t.Fatalf("expected new-hash, got %s", updated.ServiceTokenHash)
-	}
-	if updated.ServiceTokenPrefix != "newprefix0000000" {
-		t.Fatalf("expected newprefix0000000, got %s", updated.ServiceTokenPrefix)
-	}
-}
-
 func TestRenameAgent(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
-	ns, _ := s.GetVault(ctx, "default")
-	ag, _ := s.CreateAgent(ctx, "oldname", ns.ID, []byte("h"), []byte("s"), "prefix0000000001", "proxy", "c")
+	ag, _ := s.CreateAgent(ctx, "oldname", "c")
 
 	err := s.RenameAgent(ctx, ag.ID, "newname")
 	if err != nil {
@@ -1500,16 +1457,15 @@ func TestCountAgentSessions(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
-	ns, _ := s.GetVault(ctx, "default")
-	ag, _ := s.CreateAgent(ctx, "counter", ns.ID, []byte("h"), []byte("s"), "prefix0000000001", "proxy", "c")
+	ag, _ := s.CreateAgent(ctx, "counter", "c")
 
 	count, _ := s.CountAgentSessions(ctx, ag.ID)
 	if count != 0 {
 		t.Fatalf("expected 0 sessions, got %d", count)
 	}
 
-	s.CreateAgentSession(ctx, ag.ID, ns.ID, "proxy", tp(time.Now().Add(24*time.Hour)))
-	s.CreateAgentSession(ctx, ag.ID, ns.ID, "proxy", tp(time.Now().Add(24*time.Hour)))
+	s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
+	s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
 
 	count, _ = s.CountAgentSessions(ctx, ag.ID)
 	if count != 2 {
@@ -1517,7 +1473,7 @@ func TestCountAgentSessions(t *testing.T) {
 	}
 
 	// Expired sessions should not be counted.
-	s.CreateAgentSession(ctx, ag.ID, ns.ID, "proxy", tp(time.Now().Add(-1*time.Hour)))
+	s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(-1*time.Hour)))
 	count, _ = s.CountAgentSessions(ctx, ag.ID)
 	if count != 2 {
 		t.Fatalf("expected 2 active sessions (1 expired), got %d", count)
@@ -1528,18 +1484,18 @@ func TestCreateAgentSession(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
-	ns, _ := s.GetVault(ctx, "default")
-	ag, _ := s.CreateAgent(ctx, "sessbot", ns.ID, []byte("h"), []byte("s"), "prefix0000000001", "proxy", "c")
+	ag, _ := s.CreateAgent(ctx, "sessbot", "c")
 
-	sess, err := s.CreateAgentSession(ctx, ag.ID, ns.ID, "proxy", tp(time.Now().Add(24*time.Hour)))
+	sess, err := s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
 	if err != nil {
 		t.Fatalf("CreateAgentSession: %v", err)
 	}
 	if sess.AgentID != ag.ID {
 		t.Fatalf("expected agent_id %s, got %s", ag.ID, sess.AgentID)
 	}
-	if sess.VaultID != ns.ID {
-		t.Fatalf("expected vault_id %s, got %s", ns.ID, sess.VaultID)
+	// Instance-level agent sessions have empty VaultID.
+	if sess.VaultID != "" {
+		t.Fatalf("expected empty vault_id for agent session, got %s", sess.VaultID)
 	}
 
 	// Verify GetSession returns agent_id.
@@ -1566,46 +1522,31 @@ func TestGetSessionBackwardCompat(t *testing.T) {
 	}
 }
 
-func TestCreatePersistentInvite(t *testing.T) {
+func TestCreateAgentInviteWithVaults(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
 	ns, _ := s.GetVault(ctx, "default")
-	inv, err := s.CreatePersistentInvite(ctx, ns.ID, "proxy", "creator1", "mybot", time.Now().Add(15*time.Minute))
+	inv, err := s.CreateAgentInvite(ctx, "mybot", "creator1", time.Now().Add(15*time.Minute), 0, []AgentInviteVault{
+		{VaultID: ns.ID, VaultRole: "proxy"},
+	})
 	if err != nil {
-		t.Fatalf("CreatePersistentInvite: %v", err)
-	}
-	if !inv.Persistent {
-		t.Fatal("expected persistent=true")
+		t.Fatalf("CreateAgentInvite: %v", err)
 	}
 	if inv.AgentName != "mybot" {
 		t.Fatalf("expected agent_name mybot, got %s", inv.AgentName)
 	}
+	if len(inv.Vaults) != 1 {
+		t.Fatalf("expected 1 vault, got %d", len(inv.Vaults))
+	}
 
 	// Fetch and verify.
 	fetched, _ := s.GetInviteByToken(ctx, inv.Token)
-	if !fetched.Persistent {
-		t.Fatal("fetched invite should be persistent")
-	}
 	if fetched.AgentName != "mybot" {
 		t.Fatalf("fetched agent_name: expected mybot, got %s", fetched.AgentName)
 	}
-}
-
-func TestCreatePersistentInviteNoName(t *testing.T) {
-	s := openTestDB(t)
-	ctx := context.Background()
-
-	ns, _ := s.GetVault(ctx, "default")
-	inv, err := s.CreatePersistentInvite(ctx, ns.ID, "proxy", "creator1", "", time.Now().Add(15*time.Minute))
-	if err != nil {
-		t.Fatalf("CreatePersistentInvite (no name): %v", err)
-	}
-	if !inv.Persistent {
-		t.Fatal("expected persistent=true")
-	}
-	if inv.AgentName != "" {
-		t.Fatalf("expected empty agent_name, got %s", inv.AgentName)
+	if len(fetched.Vaults) != 1 {
+		t.Fatalf("fetched: expected 1 vault, got %d", len(fetched.Vaults))
 	}
 }
 
@@ -1613,15 +1554,11 @@ func TestCreateRotationInvite(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
-	ns, _ := s.GetVault(ctx, "default")
-	ag, _ := s.CreateAgent(ctx, "rotatebot", ns.ID, []byte("h"), []byte("s"), "prefix0000000001", "proxy", "c")
+	ag, _ := s.CreateAgent(ctx, "rotatebot", "c")
 
-	inv, err := s.CreateRotationInvite(ctx, ag.ID, ns.ID, "creator1", time.Now().Add(15*time.Minute))
+	inv, err := s.CreateRotationInvite(ctx, ag.ID, "creator1", time.Now().Add(15*time.Minute))
 	if err != nil {
 		t.Fatalf("CreateRotationInvite: %v", err)
-	}
-	if !inv.Persistent {
-		t.Fatal("rotation invite should be persistent")
 	}
 	if inv.AgentID != ag.ID {
 		t.Fatalf("expected agent_id %s, got %s", ag.ID, inv.AgentID)
@@ -1638,11 +1575,10 @@ func TestDeleteAgentSessions(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
-	ns, _ := s.GetVault(ctx, "default")
-	ag, _ := s.CreateAgent(ctx, "delbot", ns.ID, []byte("h"), []byte("s"), "prefix0000000001", "proxy", "c")
+	ag, _ := s.CreateAgent(ctx, "delbot", "c")
 
-	s.CreateAgentSession(ctx, ag.ID, ns.ID, "proxy", tp(time.Now().Add(24*time.Hour)))
-	s.CreateAgentSession(ctx, ag.ID, ns.ID, "proxy", tp(time.Now().Add(24*time.Hour)))
+	s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
+	s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
 
 	count, _ := s.CountAgentSessions(ctx, ag.ID)
 	if count != 2 {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -56,13 +56,14 @@ type MasterKeyRecord struct {
 }
 
 // Session represents an authenticated session.
-// If VaultID is non-empty, the session is scoped to that vault.
+// User sessions: VaultID may be set (scoped) or empty (global login).
+// Agent sessions: VaultID is empty; vault resolved per-request via X-Vault header.
 type Session struct {
 	ID        string
 	UserID    string     // non-empty for user login sessions, empty for agent sessions
-	VaultID   string     // empty = global (admin), non-empty = scoped to vault
-	AgentID   string     // non-empty for sessions minted by a persistent agent
-	VaultRole string     // "proxy", "member", or "admin" — set for scoped sessions (temp invite + agent)
+	VaultID   string     // empty for global/agent sessions, non-empty for user scoped sessions
+	AgentID   string     // non-empty for agent sessions
+	VaultRole string     // set for user scoped sessions; empty for agent sessions (resolved per-request)
 	ExpiresAt *time.Time // nil = never expires
 	CreatedAt time.Time
 }
@@ -116,40 +117,51 @@ type EncryptedCredential struct {
 	Nonce      []byte
 }
 
-// Invite represents a one-time-use, time-limited token that an agent
-// can redeem to receive a vault-scoped session.
+// Invite represents a named agent invite with optional vault pre-assignments.
+// All invites create named, instance-level agents on redemption.
 type Invite struct {
 	ID                int
 	Token             string
-	VaultID           string
-	VaultRole         string     // "proxy", "member", or "admin"
-	Status            string     // pending, redeemed, expired, revoked
-	SessionID         string     // populated after redemption
-	CreatedBy         string     // session ID of the creator
-	Persistent        bool       // true for persistent agent invites (redeemed via POST)
-	AgentName         string     // pre-set agent name (persistent invites only)
-	AgentID           string     // set for rotation invites (references existing agent)
-	SessionTTLSeconds int        // desired session lifetime when redeemed (0 = use default)
+	AgentName         string             // required: agent name (3-64 chars, lowercase alphanumeric + hyphens)
+	AgentID           string             // set for rotation invites (references existing agent)
+	SessionTTLSeconds int                // desired session lifetime when redeemed (0 = no expiry)
+	Status            string             // pending, redeemed, expired, revoked
+	SessionID         string             // populated after redemption
+	CreatedBy         string             // session ID of the creator
+	Vaults            []AgentInviteVault // pre-assigned vault access
 	CreatedAt         time.Time
 	ExpiresAt         time.Time
 	RedeemedAt        *time.Time
 	RevokedAt         *time.Time
 }
 
-// Agent represents a named, persistent agent with a session token.
+// AgentInviteVault represents a pre-assigned vault grant on an agent invite.
+type AgentInviteVault struct {
+	VaultID   string
+	VaultName string // populated via JOIN on reads
+	VaultRole string // "proxy", "member", or "admin"
+}
+
+// Agent represents a named, instance-level agent entity.
+// Agents have multi-vault access via AgentVaultGrant records.
 type Agent struct {
-	ID                 string
-	Name               string
-	VaultID            string
-	ServiceTokenHash   []byte
-	ServiceTokenSalt   []byte
-	ServiceTokenPrefix string // first 16 hex chars of the token, for lookup
-	VaultRole          string // "proxy", "member", or "admin"
-	Status             string // "active" or "revoked"
-	CreatedBy          string // user ID of the creator
-	CreatedAt          time.Time
-	UpdatedAt          time.Time
-	RevokedAt          *time.Time
+	ID        string
+	Name      string
+	Status    string // "active" or "revoked"
+	CreatedBy string // user ID of the creator
+	Vaults    []AgentVaultGrant
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	RevokedAt *time.Time
+}
+
+// AgentVaultGrant represents an agent's access to a vault with a specific role.
+type AgentVaultGrant struct {
+	AgentID   string
+	VaultID   string
+	VaultName string // populated via JOIN on reads
+	VaultRole string // "proxy", "member", or "admin"
+	CreatedAt time.Time
 }
 
 // UserInvite represents an instance-level invitation for a new user.
@@ -288,15 +300,22 @@ type Store interface {
 	GetProposalCredentials(ctx context.Context, vaultID string, proposalID int) (map[string]EncryptedCredential, error)
 	ApplyProposal(ctx context.Context, vaultID string, proposalID int, mergedServicesJSON string, credentials map[string]EncryptedCredential, deleteCredentialKeys []string) error
 
-	// Invites
-	CreateInvite(ctx context.Context, vaultID, vaultRole, createdBy string, expiresAt time.Time, sessionTTLSeconds int) (*Invite, error)
+	// Agent invites (instance-level)
+	CreateAgentInvite(ctx context.Context, agentName, createdBy string, expiresAt time.Time, sessionTTLSeconds int, vaults []AgentInviteVault) (*Invite, error)
+	CreateRotationInvite(ctx context.Context, agentID, createdBy string, expiresAt time.Time) (*Invite, error)
 	GetInviteByToken(ctx context.Context, token string) (*Invite, error)
-	ListInvites(ctx context.Context, vaultID, status string) ([]Invite, error)
+	ListInvites(ctx context.Context, status string) ([]Invite, error)
+	ListInvitesByVault(ctx context.Context, vaultID, status string) ([]Invite, error)
 	RedeemInvite(ctx context.Context, token, sessionID string) error
 	RevokeInvite(ctx context.Context, token string) error
 	GetInviteByID(ctx context.Context, id int) (*Invite, error)
 	RevokeInviteByID(ctx context.Context, id int) error
-	CountPendingInvites(ctx context.Context, vaultID string) (int, error)
+	CountPendingInvites(ctx context.Context) (int, error)
+	HasPendingInviteByAgentName(ctx context.Context, name string) (bool, error)
+	GetPendingInviteByAgentName(ctx context.Context, name string) (*Invite, error)
+	AddAgentInviteVault(ctx context.Context, inviteID int, vaultID, role string) error
+	RemoveAgentInviteVault(ctx context.Context, inviteID int, vaultID string) error
+	UpdateAgentInviteVaultRole(ctx context.Context, inviteID int, vaultID, role string) error
 	ExpirePendingInvites(ctx context.Context, before time.Time) (int, error)
 
 	// User invites (instance-level)
@@ -342,22 +361,24 @@ type Store interface {
 	CreateOAuthUserAndAccount(ctx context.Context, email, role, provider, providerUserID, oauthEmail, name, avatarURL string) (*User, *OAuthAccount, error)
 
 	// Agents
-	CreateAgent(ctx context.Context, name, vaultID string, tokenHash, tokenSalt []byte, tokenPrefix, vaultRole, createdBy string) (*Agent, error)
+	CreateAgent(ctx context.Context, name, createdBy string) (*Agent, error)
 	GetAgentByID(ctx context.Context, id string) (*Agent, error)
 	GetAgentByName(ctx context.Context, name string) (*Agent, error)
-	GetAgentByTokenPrefix(ctx context.Context, prefix string) (*Agent, error)
 	ListAgents(ctx context.Context, vaultID string) ([]Agent, error)
 	ListAllAgents(ctx context.Context) ([]Agent, error)
 	RevokeAgent(ctx context.Context, id string) error
-	UpdateAgentServiceToken(ctx context.Context, id string, tokenHash, tokenSalt []byte, tokenPrefix string) error
-	UpdateAgentVaultRole(ctx context.Context, id, role string) error
 	RenameAgent(ctx context.Context, id string, newName string) error
 	CountAgentSessions(ctx context.Context, agentID string) (int, error)
 	GetLatestAgentSessionExpiry(ctx context.Context, agentID string) (*time.Time, error)
 	DeleteAgentSessions(ctx context.Context, agentID string) error
-	CreateAgentSession(ctx context.Context, agentID, vaultID, vaultRole string, expiresAt *time.Time) (*Session, error)
-	CreatePersistentInvite(ctx context.Context, vaultID, vaultRole, createdBy string, agentName string, expiresAt time.Time) (*Invite, error)
-	CreateRotationInvite(ctx context.Context, agentID, vaultID, createdBy string, expiresAt time.Time) (*Invite, error)
+	CreateAgentSession(ctx context.Context, agentID string, expiresAt *time.Time) (*Session, error)
+
+	// Agent vault grants
+	GrantAgentVaultRole(ctx context.Context, agentID, vaultID, role string) error
+	RevokeAgentVaultAccess(ctx context.Context, agentID, vaultID string) error
+	GetAgentVaultRole(ctx context.Context, agentID, vaultID string) (string, error)
+	ListAgentGrants(ctx context.Context, agentID string) ([]AgentVaultGrant, error)
+	ListVaultAgents(ctx context.Context, vaultID string) ([]AgentVaultGrant, error)
 
 	// Instance settings
 	GetSetting(ctx context.Context, key string) (string, error)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -307,6 +307,7 @@ type Store interface {
 	ListInvites(ctx context.Context, status string) ([]Invite, error)
 	ListInvitesByVault(ctx context.Context, vaultID, status string) ([]Invite, error)
 	RedeemInvite(ctx context.Context, token, sessionID string) error
+	UpdateInviteSessionID(ctx context.Context, inviteID int, sessionID string) error
 	RevokeInvite(ctx context.Context, token string) error
 	GetInviteByID(ctx context.Context, id int) (*Invite, error)
 	RevokeInviteByID(ctx context.Context, id int) error

--- a/web/src/components/InstanceLayout.tsx
+++ b/web/src/components/InstanceLayout.tsx
@@ -1,9 +1,9 @@
 import { type ReactNode, useRef, useState } from "react";
-import { Link, Outlet, useLocation, useNavigate, useRouteContext } from "@tanstack/react-router";
+import { Link, Outlet, useNavigate, useRouteContext } from "@tanstack/react-router";
 import type { AuthContext } from "../router";
 import Navbar from "./Navbar";
 
-type InstanceTab = "agents" | "settings";
+type InstanceTab = "settings";
 
 interface NavItem {
   id: InstanceTab;
@@ -13,36 +13,13 @@ interface NavItem {
 
 export default function InstanceLayout() {
   const { auth } = useRouteContext({ from: "/_auth" }) as { auth: AuthContext };
-  const location = useLocation();
   const navigate = useNavigate();
   const [isExiting, setIsExiting] = useState(false);
   const sidebarRef = useRef<HTMLElement>(null);
 
-  const pathSegments = location.pathname.split("/");
-  const lastSegment = pathSegments[pathSegments.length - 1] as InstanceTab;
-  const activeTab: InstanceTab = ["agents", "settings"].includes(lastSegment)
-    ? (lastSegment as InstanceTab)
-    : "agents";
+  const activeTab: InstanceTab = "settings";
 
   const navItems: NavItem[] = [
-    {
-      id: "agents",
-      label: "Agents",
-      icon: (
-        <svg className="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <rect x="4" y="4" width="16" height="16" rx="2" ry="2" />
-          <rect x="9" y="9" width="6" height="6" />
-          <line x1="9" y1="1" x2="9" y2="4" />
-          <line x1="15" y1="1" x2="15" y2="4" />
-          <line x1="9" y1="20" x2="9" y2="23" />
-          <line x1="15" y1="20" x2="15" y2="23" />
-          <line x1="20" y1="9" x2="23" y2="9" />
-          <line x1="20" y1="14" x2="23" y2="14" />
-          <line x1="1" y1="9" x2="4" y2="9" />
-          <line x1="1" y1="14" x2="4" y2="14" />
-        </svg>
-      ),
-    },
     {
       id: "settings",
       label: "Settings",

--- a/web/src/components/VaultsLayout.tsx
+++ b/web/src/components/VaultsLayout.tsx
@@ -3,7 +3,7 @@ import { Link, Outlet, useLocation, useRouteContext } from "@tanstack/react-rout
 import type { AuthContext } from "../router";
 import Navbar from "./Navbar";
 
-type HomeTab = "vaults" | "users";
+type HomeTab = "vaults" | "users" | "agents";
 
 interface NavItem {
   id: HomeTab;
@@ -33,13 +33,31 @@ const navItems: NavItem[] = [
       </svg>
     ),
   },
+  {
+    id: "agents",
+    label: "Agents",
+    icon: (
+      <svg className="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="4" y="4" width="16" height="16" rx="2" ry="2" />
+        <rect x="9" y="9" width="6" height="6" />
+        <line x1="9" y1="1" x2="9" y2="4" />
+        <line x1="15" y1="1" x2="15" y2="4" />
+        <line x1="9" y1="20" x2="9" y2="23" />
+        <line x1="15" y1="20" x2="15" y2="23" />
+        <line x1="20" y1="9" x2="23" y2="9" />
+        <line x1="20" y1="14" x2="23" y2="14" />
+        <line x1="1" y1="9" x2="4" y2="9" />
+        <line x1="1" y1="14" x2="4" y2="14" />
+      </svg>
+    ),
+  },
 ];
 
 export default function VaultsLayout() {
   const { auth } = useRouteContext({ from: "/_auth" }) as { auth: AuthContext };
   const location = useLocation();
 
-  const activeTab: HomeTab = location.pathname === "/vaults/users" ? "users" : "vaults";
+  const activeTab: HomeTab = location.pathname === "/vaults/users" ? "users" : location.pathname === "/vaults/agents" ? "agents" : "vaults";
 
   return (
     <div className="min-h-screen w-full flex flex-col bg-bg">
@@ -52,7 +70,7 @@ export default function VaultsLayout() {
               {navItems.map((item) => (
                 <li key={item.id}>
                   <Link
-                    to={item.id === "vaults" ? "/vaults" : "/vaults/users"}
+                    to={item.id === "vaults" ? "/vaults" : item.id === "users" ? "/vaults/users" : "/vaults/agents"}
                     className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors no-underline ${
                       activeTab === item.id
                         ? "bg-bg/50 text-text font-semibold"

--- a/web/src/pages/home/AllAgentsTab.tsx
+++ b/web/src/pages/home/AllAgentsTab.tsx
@@ -1,0 +1,657 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+import { useRouteContext } from "@tanstack/react-router";
+import { LoadingSpinner, ErrorBanner, StatusBadge, timeAgo } from "../../components/shared";
+import DataTable, { type Column } from "../../components/DataTable";
+import DropdownMenu from "../../components/DropdownMenu";
+import ConfirmDeleteModal from "../../components/ConfirmDeleteModal";
+import Modal from "../../components/Modal";
+import Button from "../../components/Button";
+import Input from "../../components/Input";
+import FormField from "../../components/FormField";
+import CopyButton from "../../components/CopyButton";
+import Select from "../../components/Select";
+import { apiFetch } from "../../lib/api";
+import type { AuthContext } from "../../router";
+
+interface AgentRow {
+  name: string;
+  status: string;
+  created_at: string;
+  vaults: { vault_name: string; vault_role: string }[];
+  // For pending invites shown inline
+  invite_id?: number;
+}
+
+interface VaultOption {
+  id: string;
+  name: string;
+  role: string;
+}
+
+function RowActions({
+  agent,
+  onRevoke,
+  onDone,
+}: {
+  agent: AgentRow;
+  onRevoke: (agent: AgentRow) => void;
+  onDone: () => void;
+}) {
+  if (agent.status === "revoked") return null;
+
+  if (agent.status === "pending" && agent.invite_id) {
+    return (
+      <DropdownMenu
+        width={192}
+        items={[
+          {
+            label: "Revoke invite",
+            onClick: async () => {
+              await apiFetch(
+                `/v1/agents/invites/by-id/${agent.invite_id}`,
+                { method: "DELETE" }
+              );
+              onDone();
+            },
+            variant: "danger",
+          },
+        ]}
+      />
+    );
+  }
+
+  return (
+    <DropdownMenu
+      width={192}
+      items={[
+        { label: "Revoke agent", onClick: () => onRevoke(agent), variant: "danger" },
+      ]}
+    />
+  );
+}
+
+export default function AllAgentsTab() {
+  const { auth } = useRouteContext({ from: "/_auth" }) as { auth: AuthContext };
+  const [rows, setRows] = useState<AgentRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [revokeTarget, setRevokeTarget] = useState<AgentRow | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [agentsResp, invResp] = await Promise.all([
+        fetch("/v1/agents"),
+        fetch("/v1/agents/invites?status=pending"),
+      ]);
+
+      if (!agentsResp.ok) {
+        const data = await agentsResp.json();
+        setError(data.error || "Failed to load agents.");
+        return;
+      }
+
+      const agentsData = await agentsResp.json();
+      const activeRows: AgentRow[] = (agentsData.agents ?? []).map(
+        (a: { name: string; status: string; created_at: string; vaults?: { vault_name: string; vault_role: string }[] }) => ({
+          name: a.name,
+          status: a.status,
+          created_at: a.created_at,
+          vaults: a.vaults ?? [],
+        })
+      );
+
+      let pendingRows: AgentRow[] = [];
+      if (invResp.ok) {
+        const invData = await invResp.json();
+        const agentNames = new Set(activeRows.map((a) => a.name));
+        pendingRows = (invData.invites ?? [])
+          .filter((inv: { agent_name: string; status: string }) =>
+            inv.status === "pending" && !agentNames.has(inv.agent_name)
+          )
+          .map(
+            (inv: { id: number; agent_name: string; created_at: string; vaults?: { vault_name: string; vault_role: string }[] }) => ({
+              name: inv.agent_name,
+              status: "pending",
+              created_at: inv.created_at,
+              vaults: inv.vaults ?? [],
+              invite_id: inv.id,
+            })
+          );
+      }
+
+      setRows([...activeRows, ...pendingRows]);
+    } catch {
+      setError("Network error.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const columns = useMemo<Column<AgentRow>[]>(() => {
+    const cols: Column<AgentRow>[] = [
+      {
+        key: "name",
+        header: "Name",
+        render: (agent) => (
+          <span className="text-sm font-mono font-medium text-text">
+            {agent.name}
+          </span>
+        ),
+      },
+      {
+        key: "status",
+        header: "Status",
+        render: (agent) => <StatusBadge status={agent.status} />,
+      },
+      {
+        key: "vaults",
+        header: "Vaults",
+        render: (agent) => {
+          if (agent.vaults.length === 0) return <span className="text-sm text-text-dim">{"\u2014"}</span>;
+          return (
+            <div className="flex flex-wrap gap-1">
+              {agent.vaults.map((v) => (
+                <span
+                  key={v.vault_name}
+                  className="inline-block px-2 py-0.5 bg-primary/10 text-primary text-xs font-medium rounded-full"
+                >
+                  {v.vault_name}:{v.vault_role}
+                </span>
+              ))}
+            </div>
+          );
+        },
+      },
+      {
+        key: "created_at",
+        header: "Created",
+        render: (agent) => (
+          <span className="text-sm text-text-muted">{timeAgo(agent.created_at)}</span>
+        ),
+      },
+      {
+        key: "actions",
+        header: "",
+        align: "right" as const,
+        render: (agent: AgentRow) => (
+          <RowActions agent={agent} onRevoke={setRevokeTarget} onDone={fetchData} />
+        ),
+      },
+    ];
+    return cols;
+  }, [fetchData]);
+
+  return (
+    <div className="p-8 w-full max-w-[960px]">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-[22px] font-semibold text-text tracking-tight mb-1">
+            Agents
+          </h2>
+          <p className="text-sm text-text-muted">
+            All agents across the instance.
+          </p>
+        </div>
+        <InviteAgentButton onInvited={fetchData} isOwner={auth.is_owner} />
+      </div>
+
+      {loading ? (
+        <LoadingSpinner />
+      ) : error ? (
+        <ErrorBanner message={error} />
+      ) : (
+        <DataTable
+          columns={columns}
+          data={rows}
+          rowKey={(row) => row.invite_id ? `invite-${row.invite_id}` : row.name}
+          emptyTitle="No agents"
+          emptyDescription="Invite an agent to give it access to your instance."
+        />
+      )}
+
+      <ConfirmDeleteModal
+        open={revokeTarget !== null}
+        onClose={() => setRevokeTarget(null)}
+        onConfirm={async () => {
+          if (!revokeTarget) return;
+          const resp = await apiFetch(
+            `/v1/agents/${encodeURIComponent(revokeTarget.name)}`,
+            { method: "DELETE" }
+          );
+          if (!resp.ok) {
+            const data = await resp.json().catch(() => ({}));
+            throw new Error(data.error || "Failed to revoke agent");
+          }
+          setRevokeTarget(null);
+          fetchData();
+        }}
+        title="Revoke agent"
+        description={`This will permanently revoke the agent "${revokeTarget?.name}" and invalidate all its sessions. This action cannot be undone.`}
+        confirmLabel="Revoke agent"
+        confirmValue={revokeTarget?.name ?? ""}
+        inputLabel="Type the agent name to confirm"
+      />
+    </div>
+  );
+}
+
+interface VaultAssignment {
+  vault_name: string;
+  vault_role: "proxy" | "member" | "admin";
+}
+
+function InviteAgentButton({
+  onInvited,
+  isOwner,
+}: {
+  onInvited: () => void;
+  isOwner: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [vaultAssignments, setVaultAssignments] = useState<VaultAssignment[]>([]);
+  const [availableVaults, setAvailableVaults] = useState<VaultOption[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [inviteResult, setInviteResult] = useState<{ token: string } | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    fetch("/v1/vaults")
+      .then((r) => r.json())
+      .then((data) => {
+        const vaults = (data.vaults ?? []).filter(
+          (v: VaultOption) => isOwner || v.role === "admin"
+        );
+        setAvailableVaults(vaults);
+      })
+      .catch(() => {});
+  }, [open, isOwner]);
+
+  function close() {
+    setOpen(false);
+    setName("");
+    setVaultAssignments([]);
+    setError("");
+    setInviteResult(null);
+  }
+
+  function addVault() {
+    const assignedNames = new Set(vaultAssignments.map((a) => a.vault_name));
+    const next = availableVaults.find((v) => !assignedNames.has(v.name));
+    if (next) {
+      setVaultAssignments([...vaultAssignments, { vault_name: next.name, vault_role: "proxy" }]);
+    }
+  }
+
+  function removeVault(idx: number) {
+    setVaultAssignments(vaultAssignments.filter((_, i) => i !== idx));
+  }
+
+  function updateVault(idx: number, field: "vault_name" | "vault_role", value: string) {
+    const updated = [...vaultAssignments];
+    updated[idx] = { ...updated[idx], [field]: value };
+    setVaultAssignments(updated);
+  }
+
+  async function handleCreate() {
+    if (!name.trim()) return;
+    setSubmitting(true);
+    setError("");
+    try {
+      const payload: Record<string, unknown> = { name: name.trim() };
+      if (vaultAssignments.length > 0) {
+        payload.vaults = vaultAssignments;
+      }
+      const resp = await apiFetch("/v1/agents/invites", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      const data = await resp.json();
+      if (resp.ok) {
+        onInvited();
+        setInviteResult({ token: data.token });
+      } else {
+        setError(data.error || "Failed to create invite.");
+      }
+    } catch {
+      setError("Network error.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function buildPrompt(): string {
+    const inviteUrl = `${window.location.origin}/invite/${inviteResult?.token}`;
+    return [
+      "You are being invited to register as an agent with Agent Vault, a local HTTP proxy that lets you call external APIs without seeing credentials.",
+      "",
+      "To accept this invite, make the following HTTP request:",
+      "",
+      `POST ${inviteUrl}`,
+      "Content-Type: application/json",
+      "",
+      "{}",
+      "",
+      "The response contains your session token and usage instructions.",
+      "",
+      "This invite expires in 15 minutes and can only be used once.",
+    ].join("\n");
+  }
+
+  const assignedNames = new Set(vaultAssignments.map((a) => a.vault_name));
+  const canAddMore = availableVaults.some((v) => !assignedNames.has(v.name));
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>
+        <svg
+          className="w-4 h-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <rect x="4" y="4" width="16" height="16" rx="2" ry="2" />
+          <rect x="9" y="9" width="6" height="6" />
+          <line x1="9" y1="1" x2="9" y2="4" />
+          <line x1="15" y1="1" x2="15" y2="4" />
+          <line x1="9" y1="20" x2="9" y2="23" />
+          <line x1="15" y1="20" x2="15" y2="23" />
+          <line x1="20" y1="9" x2="23" y2="9" />
+          <line x1="20" y1="14" x2="23" y2="14" />
+          <line x1="1" y1="9" x2="4" y2="9" />
+          <line x1="1" y1="14" x2="4" y2="14" />
+        </svg>
+        Invite agent
+      </Button>
+
+      <Modal
+        open={open}
+        onClose={close}
+        title={inviteResult ? "Connect Your Agent" : "Invite Agent"}
+        description={inviteResult ? "Paste this into your agent's chat." : "Invite an AI agent to the instance."}
+        footer={
+          inviteResult ? (
+            <Button onClick={close}>Done</Button>
+          ) : (
+            <>
+              <Button variant="secondary" onClick={close}>Cancel</Button>
+              <Button onClick={handleCreate} disabled={!name.trim()} loading={submitting}>
+                Create invite
+              </Button>
+            </>
+          )
+        }
+      >
+        {inviteResult ? (
+          <InviteResultView token={inviteResult.token} buildPrompt={buildPrompt} onRedeemed={onInvited} />
+        ) : (
+          <div className="space-y-4">
+            <FormField
+              label="Agent name"
+              helperText="Lowercase letters, numbers, and hyphens (3-64 chars)."
+            >
+              <Input
+                type="text"
+                placeholder="my-agent"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoFocus
+              />
+            </FormField>
+
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <label className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+                  Vault access (optional)
+                </label>
+                {canAddMore && (
+                  <button
+                    type="button"
+                    onClick={addVault}
+                    className="text-xs text-primary hover:underline"
+                  >
+                    + Add vault
+                  </button>
+                )}
+              </div>
+              {vaultAssignments.length === 0 ? (
+                <p className="text-sm text-text-muted">
+                  No vaults pre-assigned. The agent will join the instance without vault access.
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {vaultAssignments.map((assignment, idx) => (
+                    <div key={idx} className="flex items-center gap-2">
+                      <select
+                        value={assignment.vault_name}
+                        onChange={(e) => updateVault(idx, "vault_name", e.target.value)}
+                        className="flex-1 px-3 py-2 bg-surface border border-border rounded-lg text-text text-sm outline-none"
+                      >
+                        {availableVaults.map((v) => (
+                          <option
+                            key={v.name}
+                            value={v.name}
+                            disabled={assignedNames.has(v.name) && v.name !== assignment.vault_name}
+                          >
+                            {v.name}
+                          </option>
+                        ))}
+                      </select>
+                      <Select
+                        value={assignment.vault_role}
+                        onChange={(e) => updateVault(idx, "vault_role", e.target.value)}
+                        className="w-28"
+                      >
+                        <option value="proxy">Proxy</option>
+                        <option value="member">Member</option>
+                        <option value="admin">Admin</option>
+                      </Select>
+                      <button
+                        type="button"
+                        onClick={() => removeVault(idx)}
+                        className="text-text-muted hover:text-danger p-1"
+                        title="Remove"
+                      >
+                        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <line x1="18" y1="6" x2="6" y2="18" />
+                          <line x1="6" y1="6" x2="18" y2="18" />
+                        </svg>
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {error && <ErrorBanner message={error} />}
+          </div>
+        )}
+      </Modal>
+    </>
+  );
+}
+
+type InviteTab = "prompt" | "token";
+
+function InviteResultView({
+  token,
+  buildPrompt,
+  onRedeemed,
+}: {
+  token: string;
+  buildPrompt: () => string;
+  onRedeemed: () => void;
+}) {
+  const [tab, setTab] = useState<InviteTab>("token");
+  const [redeeming, setRedeeming] = useState(false);
+  const [redeemError, setRedeemError] = useState("");
+  const [sessionToken, setSessionToken] = useState<string | null>(null);
+  const prompt = buildPrompt();
+  const vaultAddr = window.location.origin;
+
+  async function handleRedeem() {
+    setRedeeming(true);
+    setRedeemError("");
+    try {
+      const resp = await fetch(`/invite/${token}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+      if (!resp.ok) {
+        const data = await resp.json().catch(() => ({}));
+        setRedeemError(data.message || data.error || "Failed to redeem invite.");
+        return;
+      }
+      const data = await resp.json();
+      setSessionToken(data.av_session_token);
+      onRedeemed();
+    } catch {
+      setRedeemError("Network error.");
+    } finally {
+      setRedeeming(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="inline-flex rounded-lg bg-bg p-0.5 border border-border">
+        {([
+          { key: "token" as const, label: "Raw token" },
+          { key: "prompt" as const, label: "Invite prompt" },
+        ]).map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setTab(key)}
+            className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+              tab === key
+                ? "bg-surface text-text shadow-sm"
+                : "text-text-muted hover:text-text"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "prompt" ? (
+        <>
+          <p className="text-sm text-text-muted">
+            Paste this into your agent's chat and it will connect automatically.
+          </p>
+          <div className="relative">
+            <textarea
+              readOnly
+              value={prompt}
+              rows={10}
+              className="w-full px-4 py-3 bg-bg border border-border rounded-lg text-text text-sm font-mono outline-none select-all resize-none leading-relaxed"
+              onFocus={(e) => e.target.select()}
+            />
+            <CopyButton
+              value={prompt}
+              className="absolute top-2 right-2 px-3 py-1.5 bg-primary text-primary-text rounded-md text-xs font-semibold hover:bg-primary-hover transition-colors"
+            />
+          </div>
+          <p className="text-xs text-text-dim">
+            Works with Claude Code, Cursor, ChatGPT, and other chat-based agents.
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-text-muted">
+            Copy the token to configure the agent directly via environment variables.
+          </p>
+          <div className="space-y-3">
+            <div>
+              <label className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-1 block">
+                Vault address
+              </label>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 px-3 py-2 bg-bg border border-border rounded-lg text-text text-sm font-mono truncate">
+                  {vaultAddr}
+                </code>
+                <CopyButton
+                  value={vaultAddr}
+                  className="shrink-0 px-3 py-2 bg-primary text-primary-text rounded-lg text-sm font-semibold hover:bg-primary-hover transition-colors"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-1 block">
+                Token
+              </label>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 px-3 py-2 bg-bg border border-border rounded-lg text-text text-sm font-mono truncate">
+                  {sessionToken ?? "••••••••••••••••••••••••••••••••"}
+                </code>
+                <RedeemCopyButton
+                  sessionToken={sessionToken}
+                  redeeming={redeeming}
+                  onRedeem={handleRedeem}
+                />
+              </div>
+              {redeemError && (
+                <p className="text-sm text-danger mt-1">{redeemError}</p>
+              )}
+            </div>
+          </div>
+          <p className="text-xs text-text-dim">
+            Set as <code className="text-text-muted">AGENT_VAULT_ADDR</code> and <code className="text-text-muted">AGENT_VAULT_SESSION_TOKEN</code> in the agent's environment.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+function RedeemCopyButton({
+  sessionToken,
+  redeeming,
+  onRedeem,
+}: {
+  sessionToken: string | null;
+  redeeming: boolean;
+  onRedeem: () => Promise<void>;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleClick() {
+    if (sessionToken) {
+      try {
+        await navigator.clipboard.writeText(sessionToken);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch {}
+      return;
+    }
+    await onRedeem();
+  }
+
+  // After redeem completes and sessionToken is set, auto-copy once.
+  useEffect(() => {
+    if (sessionToken && !copied) {
+      navigator.clipboard.writeText(sessionToken).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }).catch(() => {});
+    }
+  }, [sessionToken]);
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={redeeming}
+      className="shrink-0 px-3 py-2 bg-primary text-primary-text rounded-lg text-sm font-semibold hover:bg-primary-hover transition-colors disabled:opacity-50"
+    >
+      {redeeming ? "Copying..." : copied ? "Copied!" : "Copy"}
+    </button>
+  );
+}

--- a/web/src/pages/home/AllAgentsTab.tsx
+++ b/web/src/pages/home/AllAgentsTab.tsx
@@ -80,8 +80,8 @@ export default function AllAgentsTab() {
   const fetchData = useCallback(async () => {
     try {
       const [agentsResp, invResp] = await Promise.all([
-        fetch("/v1/agents"),
-        fetch("/v1/agents/invites?status=pending"),
+        apiFetch("/v1/agents"),
+        apiFetch("/v1/agents/invites?status=pending"),
       ]);
 
       if (!agentsResp.ok) {
@@ -261,7 +261,7 @@ function InviteAgentButton({
 
   useEffect(() => {
     if (!open) return;
-    fetch("/v1/vaults")
+    apiFetch("/v1/vaults")
       .then((r) => r.json())
       .then((data) => {
         const vaults = (data.vaults ?? []).filter(

--- a/web/src/pages/vault/AgentsTab.tsx
+++ b/web/src/pages/vault/AgentsTab.tsx
@@ -1,57 +1,67 @@
 import { useState, useEffect } from "react";
-import { useVaultParams, StatusBadge, LoadingSpinner, ErrorBanner, timeAgo, timeUntil } from "./shared";
+import { useVaultParams, StatusBadge, LoadingSpinner, ErrorBanner } from "./shared";
 import DataTable, { type Column } from "../../components/DataTable";
 import Modal from "../../components/Modal";
 import DropdownMenu from "../../components/DropdownMenu";
 import Button from "../../components/Button";
-import Input from "../../components/Input";
 import Select from "../../components/Select";
 import FormField from "../../components/FormField";
-import CopyButton from "../../components/CopyButton";
 import { apiFetch } from "../../lib/api";
 
 interface AgentRow {
   name: string;
-  vault_role?: string;
+  vault_role: string;
   status: string;
-  created_at: string;
-  invite_id?: number;
-  invite_token?: string;
-  session_expires_at?: string;
 }
 
 function RowActions({
   agent,
+  vaultName,
+  vaultRole,
   onDone,
 }: {
   agent: AgentRow;
+  vaultName: string;
+  vaultRole: string;
   onDone: () => void;
 }) {
+  if (vaultRole !== "admin") return null;
   if (agent.status === "revoked") return null;
 
-  async function handleRevoke() {
-    if (agent.status === "pending" && agent.invite_id) {
-      await apiFetch(`/v1/invites/by-id/${agent.invite_id}`, {
-        method: "DELETE",
-      });
-    } else {
-      await apiFetch(
-        `/v1/admin/agents/${encodeURIComponent(agent.name)}`,
-        { method: "DELETE" }
-      );
-    }
+  const currentRole = agent.vault_role;
+
+  async function handleSetRole(newRole: string) {
+    await apiFetch(
+      `/v1/vaults/${encodeURIComponent(vaultName)}/agents/${encodeURIComponent(agent.name)}/role`,
+      {
+        method: "POST",
+        body: JSON.stringify({ role: newRole }),
+      }
+    );
     onDone();
   }
+
+  async function handleRemove() {
+    await apiFetch(
+      `/v1/vaults/${encodeURIComponent(vaultName)}/agents/${encodeURIComponent(agent.name)}`,
+      { method: "DELETE" }
+    );
+    onDone();
+  }
+
+  const roleItems = (["proxy", "member", "admin"] as const)
+    .filter((r) => r !== currentRole)
+    .map((r) => ({
+      label: `Set role: ${r}`,
+      onClick: () => handleSetRole(r),
+    }));
 
   return (
     <DropdownMenu
       width={192}
       items={[
-        {
-          label: agent.status === "pending" ? "Revoke invite" : "Revoke agent",
-          onClick: handleRevoke,
-          variant: "danger",
-        },
+        ...roleItems,
+        { label: "Remove from vault", onClick: handleRemove, variant: "danger" as const },
       ]}
     />
   );
@@ -87,31 +97,6 @@ export default function AgentsTab() {
       header: "Status",
       render: (agent) => <StatusBadge status={agent.status} />,
     },
-    {
-      key: "created",
-      header: "Last Seen",
-      render: (agent) => (
-        <span className="text-sm text-text-muted">
-          {agent.invite_token ? "\u2014" : timeAgo(agent.created_at)}
-        </span>
-      ),
-    },
-    {
-      key: "session_expires",
-      header: "Session Expires",
-      render: (agent) => {
-        if (!agent.session_expires_at) {
-          return <span className="text-sm text-text-dim">{"\u2014"}</span>;
-        }
-        const label = timeUntil(agent.session_expires_at);
-        const isExpired = label === "Expired";
-        return (
-          <span className={`text-sm ${isExpired ? "text-danger" : "text-text-muted"}`}>
-            {label}
-          </span>
-        );
-      },
-    },
     ...(vaultRole === "admin"
       ? [
           {
@@ -119,7 +104,12 @@ export default function AgentsTab() {
             header: "",
             align: "right" as const,
             render: (agent: AgentRow) => (
-              <RowActions agent={agent} onDone={fetchData} />
+              <RowActions
+                agent={agent}
+                vaultName={vaultName}
+                vaultRole={vaultRole}
+                onDone={fetchData}
+              />
             ),
           },
         ]
@@ -134,57 +124,26 @@ export default function AgentsTab() {
 
   async function fetchData() {
     try {
-      const canFetchInvites = vaultRole === "admin" || vaultRole === "member";
-      const [agentsResp, invResp] = await Promise.all([
-        fetch(`/v1/admin/agents?vault=${encodeURIComponent(vaultName)}`),
-        canFetchInvites
-          ? fetch(`/v1/invites?vault=${encodeURIComponent(vaultName)}`)
-          : Promise.resolve(null),
-      ]);
+      const resp = await fetch(
+        `/v1/vaults/${encodeURIComponent(vaultName)}/agents`
+      );
 
-      if (!agentsResp.ok) {
-        const data = await agentsResp.json();
+      if (!resp.ok) {
+        const data = await resp.json();
         setError(data.error || "Failed to load agents.");
         return;
       }
-      const agentsData = await agentsResp.json();
-      const activeRows: AgentRow[] = (agentsData.agents ?? []).map(
-        (a: { name: string; vault_role?: string; status: string; created_at: string; session_expires_at?: string }) => ({
-          name: a.name,
-          vault_role: a.vault_role,
-          status: a.status,
-          created_at: a.created_at,
-          session_expires_at: a.session_expires_at,
-        })
-      );
 
-      let inviteRows: AgentRow[] = [];
-      if (invResp && invResp.ok) {
-        const invites = await invResp.json();
-        const agentNames = new Set(activeRows.map((a) => a.name));
-        inviteRows = (invites ?? [])
-          .filter((inv: { status: string; persistent: boolean; agent_name?: string }) => {
-            if (inv.status === "pending" || inv.status === "revoked") return true;
-            if (inv.status === "redeemed") {
-              if (inv.persistent && inv.agent_name && agentNames.has(inv.agent_name)) return false;
-              return true;
-            }
-            return false;
+      const data = await resp.json();
+      setRows(
+        (data.agents ?? []).map(
+          (a: { name: string; vault_role: string; status: string }) => ({
+            name: a.name,
+            vault_role: a.vault_role,
+            status: a.status,
           })
-          .map(
-            (inv: { id: number; agent_name?: string; vault_role?: string; persistent: boolean; token: string; status: string; created_at: string; session_expires_at?: string }) => ({
-              name: inv.agent_name || (inv.persistent ? "Unnamed agent" : "Session"),
-              vault_role: inv.vault_role,
-              status: inv.status === "redeemed" ? "active" : inv.status,
-              created_at: inv.created_at,
-              invite_id: inv.id,
-              invite_token: inv.token,
-              session_expires_at: inv.session_expires_at,
-            })
-          );
-      }
-
-      setRows([...activeRows, ...inviteRows]);
+        )
+      );
     } catch {
       setError("Network error.");
     } finally {
@@ -203,8 +162,8 @@ export default function AgentsTab() {
             AI agents with access to this vault.
           </p>
         </div>
-        {(vaultRole === "admin" || vaultRole === "member") && (
-          <InviteAgentButton vaultName={vaultName} vaultRole={vaultRole} onInvited={fetchData} />
+        {vaultRole === "admin" && (
+          <AddAgentButton vaultName={vaultName} vaultAgents={rows} onAdded={fetchData} />
         )}
       </div>
 
@@ -216,121 +175,75 @@ export default function AgentsTab() {
         <DataTable
           columns={columns}
           data={rows}
-          rowKey={(row) => row.invite_token ?? row.name}
-          emptyTitle="No agents registered"
-          emptyDescription="Invite an agent to give it access to this vault."
+          rowKey={(row) => row.name}
+          emptyTitle="No agents in this vault"
+          emptyDescription="Add an existing agent to give it access to this vault."
         />
       )}
     </div>
   );
 }
 
-type InviteStep = "select" | "done";
-type DeliveryTab = "prompt" | "envvars";
-type SessionExpiry = 3600 | 28800 | 86400 | 604800 | 0; // 0 = no expiry
-
-type VaultRoleOption = "proxy" | "member" | "admin";
-
-const roleDescriptions: Record<VaultRoleOption, string> = {
-  proxy: "Proxy requests, discover services, and raise proposals. Recommended for most use cases.",
-  member: "All proxy permissions, plus set/delete credentials, approve proposals, and manage services.",
-  admin: "All member permissions, plus invite users and agents with any role.",
-};
-
-function RoleSelector({
-  value,
-  onChange,
-  disabled,
-}: {
-  value: VaultRoleOption;
-  onChange: (role: VaultRoleOption) => void;
-  disabled: boolean;
-}) {
-  return (
-    <FormField
-      label="Role"
-      helperText={<>{disabled ? "Members can only invite proxy-role agents." : roleDescriptions[value]} <a href="https://docs.agent-vault.dev/learn/permissions#vault-roles" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Learn more</a></>}
-    >
-      <Select
-        value={value}
-        onChange={(e) => onChange(e.target.value as VaultRoleOption)}
-        disabled={disabled}
-      >
-        <option value="proxy">Proxy</option>
-        <option value="member">Member</option>
-        <option value="admin">Admin</option>
-      </Select>
-    </FormField>
-  );
+interface InstanceAgent {
+  name: string;
+  status: string;
 }
 
-function InviteAgentButton({
+function AddAgentButton({
   vaultName,
-  vaultRole,
-  onInvited,
+  vaultAgents,
+  onAdded,
 }: {
   vaultName: string;
-  vaultRole: string;
-  onInvited: () => void;
+  vaultAgents: AgentRow[];
+  onAdded: () => void;
 }) {
   const [open, setOpen] = useState(false);
-  const [step, setStep] = useState<InviteStep>("select");
-  const [name, setName] = useState("");
-  const [selectedRole, setSelectedRole] = useState<VaultRoleOption>("proxy");
+  const [agentName, setAgentName] = useState("");
+  const [role, setRole] = useState("proxy");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
-  const [inviteToken, setInviteToken] = useState("");
-  const [sessionTTL, setSessionTTL] = useState<SessionExpiry>(0);
-  const [deliveryTab, setDeliveryTab] = useState<DeliveryTab>("prompt");
-  const [directConnectResult, setDirectConnectResult] = useState<{
-    av_addr: string;
-    av_session_token: string;
-    av_vault: string;
-    vault_role: string;
-    expires_at: string;
-  } | null>(null);
-  const [loadingEnvVars, setLoadingEnvVars] = useState(false);
+  const [instanceAgents, setInstanceAgents] = useState<InstanceAgent[]>([]);
 
-  // Members can only invite proxy-role agents
-  const canSelectRole = vaultRole === "admin";
+  useEffect(() => {
+    if (!open) return;
+    fetch("/v1/agents")
+      .then((r) => r.json())
+      .then((data) => setInstanceAgents(data.agents ?? []))
+      .catch(() => {});
+  }, [open]);
+
+  const availableAgents = instanceAgents.filter(
+    (a) =>
+      (a.status === "active" || a.status === "pending") &&
+      !vaultAgents.some((va) => va.name === a.name)
+  );
 
   function close() {
     setOpen(false);
-    setStep("select");
-    setName("");
-    setSelectedRole("proxy");
+    setAgentName("");
+    setRole("proxy");
     setError("");
-    setInviteToken("");
-    setSessionTTL(0);
-    setDeliveryTab("prompt");
-    setDirectConnectResult(null);
-    setLoadingEnvVars(false);
   }
 
-  // Whether this invite creates a named persistent agent
-  const isPersistent = name.trim().length > 0;
-
-  async function handleCreate() {
+  async function handleAdd() {
+    if (!agentName) return;
     setSubmitting(true);
     setError("");
     try {
-      const resp = await apiFetch("/v1/invites", {
-        method: "POST",
-        body: JSON.stringify({
-          vault: vaultName,
-          persistent: isPersistent,
-          vault_role: canSelectRole ? selectedRole : "proxy",
-          ...(isPersistent ? { agent_name: name.trim() } : {}),
-          ...(sessionTTL > 0 ? { session_ttl_seconds: sessionTTL } : {}),
-        }),
-      });
-      const data = await resp.json();
+      const resp = await apiFetch(
+        `/v1/vaults/${encodeURIComponent(vaultName)}/agents`,
+        {
+          method: "POST",
+          body: JSON.stringify({ name: agentName, role }),
+        }
+      );
       if (resp.ok) {
-        onInvited();
-        setInviteToken(data.token || "");
-        setStep("done");
+        onAdded();
+        close();
       } else {
-        setError(data.error || "Failed to create invite.");
+        const data = await resp.json();
+        setError(data.error || "Failed to add agent.");
       }
     } catch {
       setError("Network error.");
@@ -338,80 +251,6 @@ function InviteAgentButton({
       setSubmitting(false);
     }
   }
-
-  async function fetchEnvVars() {
-    if (directConnectResult) return;
-    setLoadingEnvVars(true);
-    try {
-      const resp = await apiFetch("/v1/sessions/direct", {
-        method: "POST",
-        body: JSON.stringify({
-          vault: vaultName,
-          vault_role: canSelectRole ? selectedRole : "proxy",
-          ...(sessionTTL > 0 ? { ttl_seconds: sessionTTL } : {}),
-        }),
-      });
-      const data = await resp.json();
-      if (resp.ok) {
-        setDirectConnectResult(data);
-      } else {
-        setError(data.error || "Failed to create session.");
-      }
-    } catch {
-      setError("Network error.");
-    } finally {
-      setLoadingEnvVars(false);
-    }
-  }
-
-  function buildPrompt(): string {
-    const inviteUrl = `${window.location.origin}/invite/${inviteToken}`;
-    if (isPersistent) {
-      const lines = [
-        "You are being invited to register as an agent with Agent Vault, a local HTTP proxy that lets you call external APIs without seeing credentials.",
-        "",
-        "To accept this invite, make the following HTTP request:",
-        "",
-        `POST ${inviteUrl}`,
-        "Content-Type: application/json",
-        "",
-        "{}",
-        "",
-        "The response contains your session token and usage instructions.",
-        "",
-        "This invite expires in 15 minutes and can only be used once.",
-      ];
-      return lines.join("\n");
-    }
-    return [
-      "You are being invited to use Agent Vault, a local HTTP proxy that lets you call external APIs (Stripe, GitHub, etc.) without seeing the underlying credentials.",
-      "",
-      "To accept this invite, make the following HTTP request:",
-      "",
-      `GET ${inviteUrl}`,
-      "",
-      "The response contains your session token and usage instructions. Do this before making any external API calls.",
-      "",
-      "This invite expires in 15 minutes and can only be used once.",
-    ].join("\n");
-  }
-
-  const title = step === "done" ? "Connect Your Agent" : "Invite Agent";
-  const description = step === "done"
-    ? "Choose how you'd like to connect."
-    : "Connect an AI agent to this vault.";
-
-  const footer =
-    step === "done" ? (
-      <Button onClick={close}>Done</Button>
-    ) : (
-      <>
-        <Button variant="secondary" onClick={close}>Cancel</Button>
-        <Button onClick={handleCreate} loading={submitting}>
-          Create invite
-        </Button>
-      </>
-    );
 
   return (
     <>
@@ -425,167 +264,60 @@ function InviteAgentButton({
           strokeLinecap="round"
           strokeLinejoin="round"
         >
-          <rect x="4" y="4" width="16" height="16" rx="2" ry="2" />
-          <rect x="9" y="9" width="6" height="6" />
-          <line x1="9" y1="1" x2="9" y2="4" />
-          <line x1="15" y1="1" x2="15" y2="4" />
-          <line x1="9" y1="20" x2="9" y2="23" />
-          <line x1="15" y1="20" x2="15" y2="23" />
-          <line x1="20" y1="9" x2="23" y2="9" />
-          <line x1="20" y1="14" x2="23" y2="14" />
-          <line x1="1" y1="9" x2="4" y2="9" />
-          <line x1="1" y1="14" x2="4" y2="14" />
+          <line x1="12" y1="5" x2="12" y2="19" />
+          <line x1="5" y1="12" x2="19" y2="12" />
         </svg>
-        Invite agent
+        Add agent
       </Button>
 
-      <Modal open={open} onClose={close} title={title} description={description} footer={footer}>
-        {step === "done" ? (
-          <div className="space-y-4">
-            <div className="flex border-b border-border">
-              <button
-                onClick={() => setDeliveryTab("prompt")}
-                className={`px-4 py-2 text-sm font-medium transition-colors relative ${
-                  deliveryTab === "prompt"
-                    ? "text-primary"
-                    : "text-text-muted hover:text-text"
-                }`}
+      <Modal
+        open={open}
+        onClose={close}
+        title="Add Agent to Vault"
+        description="Add an existing instance agent to this vault."
+        footer={
+          <>
+            <Button variant="secondary" onClick={close}>Cancel</Button>
+            <Button onClick={handleAdd} disabled={!agentName} loading={submitting}>
+              Add agent
+            </Button>
+          </>
+        }
+      >
+        <div className="space-y-4">
+          <FormField label="Agent">
+            {availableAgents.length === 0 ? (
+              <p className="text-sm text-text-muted py-2">
+                All instance agents already have access to this vault.
+              </p>
+            ) : (
+              <Select
+                value={agentName}
+                onChange={(e) => setAgentName(e.target.value)}
+                autoFocus
               >
-                Paste into chat
-                {deliveryTab === "prompt" && (
-                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                )}
-              </button>
-              <button
-                onClick={() => {
-                  setDeliveryTab("envvars");
-                  fetchEnvVars();
-                }}
-                className={`px-4 py-2 text-sm font-medium transition-colors relative ${
-                  deliveryTab === "envvars"
-                    ? "text-primary"
-                    : "text-text-muted hover:text-text"
-                }`}
-              >
-                Manual setup
-                {deliveryTab === "envvars" && (
-                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
-                )}
-              </button>
-            </div>
-
-            {deliveryTab === "prompt" ? (
-              <>
-                <p className="text-sm text-text-muted">
-                  Paste this into your agent's chat and it will connect automatically to Agent Vault.
-                </p>
-                {(() => {
-                  const prompt = buildPrompt();
-                  return (
-                    <div className="relative">
-                      <textarea
-                        readOnly
-                        value={prompt}
-                        rows={10}
-                        className="w-full px-4 py-3 bg-bg border border-border rounded-lg text-text text-sm font-mono outline-none select-all resize-none leading-relaxed"
-                        onFocus={(e) => e.target.select()}
-                      />
-                      <CopyButton
-                        value={prompt}
-                        className="absolute top-2 right-2 px-3 py-1.5 bg-primary text-primary-text rounded-md text-xs font-semibold hover:bg-primary-hover transition-colors"
-                      />
-                    </div>
-                  );
-                })()}
-                <p className="text-xs text-text-dim">
-                  Works with Claude Code, Cursor, ChatGPT, and other chat-based agents.
-                </p>
-              </>
-            ) : loadingEnvVars ? (
-              <div className="py-8 flex justify-center">
-                <LoadingSpinner />
-              </div>
-            ) : directConnectResult ? (
-              <>
-                <p className="text-sm text-text-muted">
-                  Your agent needs these values to connect to Agent Vault. <a href="https://docs.agent-vault.dev/guides/connect-custom-agent" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Learn more</a>
-                </p>
-                <div className="space-y-2">
-                  {([
-                    { label: "AGENT_VAULT_ADDR", value: directConnectResult.av_addr },
-                    { label: "AGENT_VAULT_SESSION_TOKEN", value: directConnectResult.av_session_token },
-                  ] as const).map((env) => (
-                    <div key={env.label}>
-                      <label className="block text-xs font-medium text-text-muted mb-1">{env.label}</label>
-                      <div className="flex items-center gap-2">
-                        <input
-                          readOnly
-                          value={env.value}
-                          className="flex-1 px-3 py-2 bg-bg border border-border rounded-lg text-text text-sm font-mono outline-none select-all"
-                          onFocus={(e) => e.target.select()}
-                        />
-                        <CopyButton value={env.value} />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-                <p className="text-xs text-text-dim">
-                  Role: {directConnectResult.vault_role}{directConnectResult.expires_at ? <> &middot; Expires: {new Date(directConnectResult.expires_at).toLocaleString()}</> : <> &middot; No expiry</>}
-                </p>
-              </>
-            ) : null}
-          </div>
-        ) : (
-          <div className="space-y-4">
-            <FormField
-              label="Agent name"
-              helperText="Optional. Lowercase letters, numbers, and hyphens (3-64 chars)."
-            >
-              <Input
-                type="text"
-                placeholder="my-agent"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-              />
-            </FormField>
-
-            <RoleSelector
-              value={selectedRole}
-              onChange={setSelectedRole}
-              disabled={!canSelectRole}
-            />
-
-            <div>
-              <label className="block text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
-                Session expiry
-              </label>
-              <div className="flex gap-2 flex-wrap">
-                {([
-                  { label: "1h", value: 3600 as SessionExpiry },
-                  { label: "8h", value: 28800 as SessionExpiry },
-                  { label: "24h", value: 86400 as SessionExpiry },
-                  { label: "7d", value: 604800 as SessionExpiry },
-                  { label: "No expiry", value: 0 as SessionExpiry },
-                ]).map((opt) => (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    onClick={() => setSessionTTL(opt.value)}
-                    className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-                      sessionTTL === opt.value
-                        ? "bg-primary text-primary-text"
-                        : "bg-bg border border-border text-text-muted hover:border-border-focus"
-                    }`}
-                  >
-                    {opt.label}
-                  </button>
+                <option value="" disabled>
+                  Select an agent...
+                </option>
+                {availableAgents.map((a) => (
+                  <option key={a.name} value={a.name}>
+                    {a.name}
+                  </option>
                 ))}
-              </div>
-            </div>
+              </Select>
+            )}
+          </FormField>
 
-            {error && <ErrorBanner message={error} />}
-          </div>
-        )}
+          <FormField label="Role">
+            <Select value={role} onChange={(e) => setRole(e.target.value)}>
+              <option value="proxy">Proxy</option>
+              <option value="member">Member</option>
+              <option value="admin">Admin</option>
+            </Select>
+          </FormField>
+
+          {error && <ErrorBanner message={error} />}
+        </div>
       </Modal>
     </>
   );

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -12,6 +12,7 @@ import ForgotPassword from "./pages/ForgotPassword";
 import VaultsLayout from "./components/VaultsLayout";
 import VaultsListTab from "./pages/home/VaultsListTab";
 import AllUsersTab from "./pages/home/AllUsersTab";
+import AllAgentsTab from "./pages/home/AllAgentsTab";
 import UserInvite from "./pages/UserInvite";
 import ProposalApprove from "./pages/ProposalApprove";
 import VaultLayout from "./components/VaultLayout";
@@ -24,7 +25,6 @@ import SettingsTab from "./pages/vault/SettingsTab";
 import InstanceLayout from "./components/InstanceLayout";
 import AccountLayout from "./components/AccountLayout";
 import AccountSettingsTab from "./pages/account/SettingsTab";
-import InstanceAgentsTab from "./pages/instance/AgentsTab";
 import InstanceSettingsTab from "./pages/instance/SettingsTab";
 import OAuthCallback from "./pages/OAuthCallback";
 
@@ -204,6 +204,12 @@ const vaultsUsersRoute = createRoute({
   component: AllUsersTab,
 });
 
+const vaultsAgentsRoute = createRoute({
+  getParentRoute: () => vaultsLayoutRoute,
+  path: "/agents",
+  component: AllAgentsTab,
+});
+
 const accountRoute = createRoute({
   getParentRoute: () => authLayoutRoute,
   path: "/account",
@@ -240,14 +246,8 @@ const manageIndexRoute = createRoute({
   getParentRoute: () => manageInstanceRoute,
   path: "/",
   beforeLoad: async () => {
-    throw redirect({ to: "/manage/agents" });
+    throw redirect({ to: "/manage/settings" });
   },
-});
-
-const manageAgentsRoute = createRoute({
-  getParentRoute: () => manageInstanceRoute,
-  path: "/agents",
-  component: InstanceAgentsTab,
 });
 
 const manageSettingsRoute = createRoute({
@@ -345,6 +345,7 @@ const routeTree = rootRoute.addChildren([
     vaultsLayoutRoute.addChildren([
       vaultsIndexRoute,
       vaultsUsersRoute,
+      vaultsAgentsRoute,
     ]),
     accountRoute.addChildren([
       accountIndexRoute,
@@ -352,7 +353,6 @@ const routeTree = rootRoute.addChildren([
     ]),
     manageInstanceRoute.addChildren([
       manageIndexRoute,
-      manageAgentsRoute,
       manageSettingsRoute,
     ]),
     vaultLayoutRoute.addChildren([


### PR DESCRIPTION
## Summary
- **Agents are now instance-level entities** (like users) instead of vault-scoped. Agent sessions select vaults per-request via `X-Vault` header, enabling multi-vault access with independent roles per vault.
- **New agent invite flow**: `POST /v1/agents/invites` with optional vault pre-assignments. Instance-level endpoints for list, info, revoke, rotate, rename.
- **Migration 035** restructures agent/invite tables, moves existing vault-scoped agents to the instance-level model with grants preserved.
- **CLI + Frontend + Docs** updated throughout to reflect the new model.
- **Security/correctness fixes**: agent list filtering by vault membership, `requireVaultAccess` for instance-level agents, proxy-role enforcement in proposal list, session_id write-back on invite redemption, TOCTOU race handling on agent name, consistent `apiFetch` usage in frontend.

## Test plan
- [x] `make test` passes (all Go tests green)
- [ ] Manual: create agent invite, redeem, verify multi-vault access via X-Vault header
- [ ] Manual: verify rotation invite flow
- [ ] Manual: verify frontend AllAgentsTab and vault-level AgentsTab render correctly
- [ ] Manual: verify migration from existing vault-scoped agents preserves data

🤖 Generated with [Claude Code](https://claude.com/claude-code)