### PR TITLE
refactor: restructure home layout and improve UI details

### DIFF
--- a/internal/server/handle_oauth.go
+++ b/internal/server/handle_oauth.go
@@ -357,7 +357,7 @@ func (s *Server) createOAuthSession(w http.ResponseWriter, r *http.Request, user
 
 	http.SetCookie(w, sessionCookie(r, s.baseURL, session.ID, int(sessionTTL.Seconds())))
 
-	target := "/vaults"
+	target := "/"
 	if redirectURL != "" && isValidOAuthRedirect(redirectURL) {
 		target = redirectURL
 	}

--- a/internal/server/handle_users.go
+++ b/internal/server/handle_users.go
@@ -145,19 +145,23 @@ func (s *Server) buildOwnerUserList(ctx context.Context, users []store.User) []m
 		vaultNameByID[v.ID] = v.Name
 	}
 
+	type vaultEntry struct {
+		VaultName string `json:"vault_name"`
+		VaultRole string `json:"vault_role"`
+	}
 	items := make([]map[string]interface{}, len(users))
 	for i, u := range users {
 		grants, _ := s.store.ListUserGrants(ctx, u.ID)
-		vaultNames := make([]string, 0, len(grants))
+		vaults := make([]vaultEntry, 0, len(grants))
 		for _, g := range grants {
 			if name, ok := vaultNameByID[g.VaultID]; ok {
-				vaultNames = append(vaultNames, name)
+				vaults = append(vaults, vaultEntry{VaultName: name, VaultRole: g.Role})
 			}
 		}
 		items[i] = map[string]interface{}{
 			"email":      u.Email,
 			"role":       u.Role,
-			"vaults":     vaultNames,
+			"vaults":     vaults,
 			"created_at": u.CreatedAt.Format(time.RFC3339),
 		}
 	}

--- a/web/src/components/AccountLayout.tsx
+++ b/web/src/components/AccountLayout.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useRef, useState } from "react";
-import { Link, Outlet, useLocation, useNavigate, useRouteContext } from "@tanstack/react-router";
+import { Link, Outlet, useNavigate, useRouteContext } from "@tanstack/react-router";
 import type { AuthContext } from "../router";
 import Navbar from "./Navbar";
 
@@ -13,14 +13,11 @@ interface NavItem {
 
 export default function AccountLayout() {
   const { auth } = useRouteContext({ from: "/_auth" }) as { auth: AuthContext };
-  const location = useLocation();
   const navigate = useNavigate();
   const [isExiting, setIsExiting] = useState(false);
   const sidebarRef = useRef<HTMLElement>(null);
 
-  const pathSegments = location.pathname.split("/");
-  const lastSegment = pathSegments[pathSegments.length - 1] as AccountTab;
-  const activeTab: AccountTab = lastSegment === "settings" ? "settings" : "settings";
+  const activeTab: AccountTab = "settings";
 
   const navItems: NavItem[] = [
     {
@@ -46,16 +43,16 @@ export default function AccountLayout() {
         >
           <div className="px-4 pt-5 pb-3">
             <a
-              href="/vaults"
+              href="/"
               onClick={(e) => {
                 e.preventDefault();
                 if (isExiting) return;
                 setIsExiting(true);
                 const aside = sidebarRef.current;
                 if (aside) {
-                  aside.addEventListener("animationend", () => navigate({ to: "/vaults" }), { once: true });
+                  aside.addEventListener("animationend", (e) => { if (e.target === aside) navigate({ to: "/" }); }, { once: true });
                 } else {
-                  navigate({ to: "/vaults" });
+                  navigate({ to: "/" });
                 }
               }}
               className="flex items-center gap-1.5 text-xs text-text-muted hover:text-text transition-colors"
@@ -63,7 +60,7 @@ export default function AccountLayout() {
               <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <polyline points="15 18 9 12 15 6" />
               </svg>
-              All vaults
+              Home
             </a>
           </div>
 

--- a/web/src/components/HomeLayout.tsx
+++ b/web/src/components/HomeLayout.tsx
@@ -53,11 +53,11 @@ const navItems: NavItem[] = [
   },
 ];
 
-export default function VaultsLayout() {
+export default function HomeLayout() {
   const { auth } = useRouteContext({ from: "/_auth" }) as { auth: AuthContext };
   const location = useLocation();
 
-  const activeTab: HomeTab = location.pathname === "/vaults/users" ? "users" : location.pathname === "/vaults/agents" ? "agents" : "vaults";
+  const activeTab: HomeTab = location.pathname === "/users" ? "users" : location.pathname === "/agents" ? "agents" : "vaults";
 
   return (
     <div className="min-h-screen w-full flex flex-col bg-bg">
@@ -70,7 +70,7 @@ export default function VaultsLayout() {
               {navItems.map((item) => (
                 <li key={item.id}>
                   <Link
-                    to={item.id === "vaults" ? "/vaults" : item.id === "users" ? "/vaults/users" : "/vaults/agents"}
+                    to={item.id === "vaults" ? "/" : item.id === "users" ? "/users" : "/agents"}
                     className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors no-underline ${
                       activeTab === item.id
                         ? "bg-bg/50 text-text font-semibold"

--- a/web/src/components/InstanceLayout.tsx
+++ b/web/src/components/InstanceLayout.tsx
@@ -43,16 +43,16 @@ export default function InstanceLayout() {
         >
           <div className="px-4 pt-5 pb-3">
             <a
-              href="/vaults"
+              href="/"
               onClick={(e) => {
                 e.preventDefault();
                 if (isExiting) return;
                 setIsExiting(true);
                 const aside = sidebarRef.current;
                 if (aside) {
-                  aside.addEventListener("animationend", () => navigate({ to: "/vaults" }), { once: true });
+                  aside.addEventListener("animationend", (e) => { if (e.target === aside) navigate({ to: "/" }); }, { once: true });
                 } else {
-                  navigate({ to: "/vaults" });
+                  navigate({ to: "/" });
                 }
               }}
               className="flex items-center gap-1.5 text-xs text-text-muted hover:text-text transition-colors"
@@ -60,7 +60,7 @@ export default function InstanceLayout() {
               <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <polyline points="15 18 9 12 15 6" />
               </svg>
-              All vaults
+              Home
             </a>
           </div>
 

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -11,7 +11,7 @@ export default function Navbar({ email, vaultName, isOwner }: NavbarProps) {
   return (
     <nav className="flex items-center justify-between px-6 py-4 bg-surface border-b border-border">
       <div className="flex items-center gap-2">
-        <Link to="/vaults" className="font-sans text-base font-semibold text-text tracking-tight hover:text-text no-underline">
+        <Link to="/" className="font-sans text-base font-semibold text-text tracking-tight hover:text-text no-underline">
           Agent Vault
         </Link>
         {vaultName && (

--- a/web/src/components/VaultLayout.tsx
+++ b/web/src/components/VaultLayout.tsx
@@ -90,26 +90,25 @@ export default function VaultLayout() {
         </svg>
       ),
     },
+    {
+      id: "agents",
+      label: "Agents",
+      icon: (
+        <svg className="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="4" y="4" width="16" height="16" rx="2" ry="2" />
+          <rect x="9" y="9" width="6" height="6" />
+          <line x1="9" y1="1" x2="9" y2="4" />
+          <line x1="15" y1="1" x2="15" y2="4" />
+          <line x1="9" y1="20" x2="9" y2="23" />
+          <line x1="15" y1="20" x2="15" y2="23" />
+          <line x1="20" y1="9" x2="23" y2="9" />
+          <line x1="20" y1="14" x2="23" y2="14" />
+          <line x1="1" y1="9" x2="4" y2="9" />
+          <line x1="1" y1="14" x2="4" y2="14" />
+        </svg>
+      ),
+    },
   ];
-
-  memberNav.push({
-    id: "agents",
-    label: "Agents",
-    icon: (
-      <svg className="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <rect x="4" y="4" width="16" height="16" rx="2" ry="2" />
-        <rect x="9" y="9" width="6" height="6" />
-        <line x1="9" y1="1" x2="9" y2="4" />
-        <line x1="15" y1="1" x2="15" y2="4" />
-        <line x1="9" y1="20" x2="9" y2="23" />
-        <line x1="15" y1="20" x2="15" y2="23" />
-        <line x1="20" y1="9" x2="23" y2="9" />
-        <line x1="20" y1="14" x2="23" y2="14" />
-        <line x1="1" y1="9" x2="4" y2="9" />
-        <line x1="1" y1="14" x2="4" y2="14" />
-      </svg>
-    ),
-  });
 
   return (
     <div className="min-h-screen w-full flex flex-col bg-bg">
@@ -122,16 +121,16 @@ export default function VaultLayout() {
         >
           <div className="px-4 pt-5 pb-3">
             <a
-              href="/vaults"
+              href="/"
               onClick={(e) => {
                 e.preventDefault();
                 if (isExiting) return;
                 setIsExiting(true);
                 const aside = sidebarRef.current;
                 if (aside) {
-                  aside.addEventListener("animationend", () => navigate({ to: "/vaults" }), { once: true });
+                  aside.addEventListener("animationend", (e) => { if (e.target === aside) navigate({ to: "/" }); }, { once: true });
                 } else {
-                  navigate({ to: "/vaults" });
+                  navigate({ to: "/" });
                 }
               }}
               className="flex items-center gap-1.5 text-xs text-text-muted hover:text-text transition-colors"

--- a/web/src/pages/ForgotPassword.tsx
+++ b/web/src/pages/ForgotPassword.tsx
@@ -125,7 +125,7 @@ function ForgotPasswordForm() {
       }
 
       if (data.authenticated) {
-        navigate({ to: "/vaults" });
+        navigate({ to: "/" });
       } else {
         setStep("done");
         setSubmitting("");

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -77,7 +77,7 @@ function LoginForm() {
       const data = await resp.json();
 
       if (resp.ok) {
-        navigate({ to: "/vaults" });
+        navigate({ to: "/" });
       } else {
         setFormError(data.error || "Invalid email or password.");
         setSubmitting(false);

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -106,7 +106,7 @@ function CommandBlock({ command }: { command: string }) {
 
 function InstallCLI({ isAuthenticated }: { isAuthenticated: boolean }) {
   const navigate = useNavigate();
-  const destination = isAuthenticated ? "/vaults" : "/login";
+  const destination = isAuthenticated ? "/" : "/login";
 
   function handleContinue() {
     navigate({ to: destination });

--- a/web/src/pages/account/SettingsTab.tsx
+++ b/web/src/pages/account/SettingsTab.tsx
@@ -220,7 +220,7 @@ function ChangePasswordForm({ hasPassword }: { hasPassword: boolean }) {
 
       if (resp.ok) {
         setSuccess(true);
-        setTimeout(() => navigate({ to: "/vaults" }), 1500);
+        setTimeout(() => navigate({ to: "/" }), 1500);
       } else {
         setFormError(data.error || "Failed to change password.");
         setSubmitting(false);

--- a/web/src/pages/home/AllAgentsTab.tsx
+++ b/web/src/pages/home/AllAgentsTab.tsx
@@ -148,6 +148,13 @@ export default function AllAgentsTab() {
         render: (agent) => <StatusBadge status={agent.status} />,
       },
       {
+        key: "role",
+        header: "Role",
+        render: () => (
+          <span className="text-sm text-text-muted capitalize">agent</span>
+        ),
+      },
+      {
         key: "vaults",
         header: "Vaults",
         render: (agent) => {

--- a/web/src/pages/home/AllUsersTab.tsx
+++ b/web/src/pages/home/AllUsersTab.tsx
@@ -16,7 +16,7 @@ interface PublicUser {
   email: string;
   role: string;
   status: "active" | "pending";
-  vaults?: string[];
+  vaults?: { vault_name: string; vault_role: string }[];
   created_at: string;
   invite_token?: string;
 }
@@ -111,11 +111,11 @@ export default function AllUsersTab() {
       if (invResp.ok) {
         const invData = await invResp.json();
         pendingUsers = (invData.invites ?? []).map(
-          (inv: { email: string; token: string; created_at: string; vaults?: { vault_name: string }[] }) => ({
+          (inv: { email: string; token: string; created_at: string; vaults?: { vault_name: string; vault_role: string }[] }) => ({
             email: inv.email,
             role: "member",
             status: "pending" as const,
-            vaults: inv.vaults?.map((v: { vault_name: string }) => v.vault_name) ?? [],
+            vaults: inv.vaults ?? [],
             created_at: inv.created_at,
             invite_token: inv.token,
           })
@@ -195,11 +195,21 @@ export default function AllUsersTab() {
       cols.push({
         key: "vaults",
         header: "Vaults",
-        render: (u) => (
-          <span className="text-sm text-text-muted">
-            {u.vaults && u.vaults.length > 0 ? u.vaults.join(", ") : "\u2014"}
-          </span>
-        ),
+        render: (u) => {
+          if (!u.vaults || u.vaults.length === 0) return <span className="text-sm text-text-dim">{"\u2014"}</span>;
+          return (
+            <div className="flex flex-wrap gap-1">
+              {u.vaults.map((v) => (
+                <span
+                  key={typeof v === "string" ? v : v.vault_name}
+                  className="inline-block px-2 py-0.5 bg-primary/10 text-primary text-xs font-medium rounded-full"
+                >
+                  {typeof v === "string" ? v : `${v.vault_name}:${v.vault_role}`}
+                </span>
+              ))}
+            </div>
+          );
+        },
       });
     }
 

--- a/web/src/pages/home/VaultsListTab.tsx
+++ b/web/src/pages/home/VaultsListTab.tsx
@@ -73,7 +73,7 @@ export default function VaultsListTab() {
   const otherVaults = useMemo(() => filtered.filter((v) => v.membership === "implicit"), [filtered]);
 
   return (
-    <div className="w-full max-w-[960px] px-6 py-10">
+    <div className="p-8 w-full max-w-[960px]">
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>

--- a/web/src/pages/vault/AgentsTab.tsx
+++ b/web/src/pages/vault/AgentsTab.tsx
@@ -84,6 +84,11 @@ export default function AgentsTab() {
       ),
     },
     {
+      key: "status",
+      header: "Status",
+      render: (agent) => <StatusBadge status={agent.status} />,
+    },
+    {
       key: "vault_role",
       header: "Role",
       render: (agent) => (
@@ -91,11 +96,6 @@ export default function AgentsTab() {
           {agent.vault_role || "\u2014"}
         </span>
       ),
-    },
-    {
-      key: "status",
-      header: "Status",
-      render: (agent) => <StatusBadge status={agent.status} />,
     },
     ...(vaultRole === "admin"
       ? [

--- a/web/src/pages/vault/SettingsTab.tsx
+++ b/web/src/pages/vault/SettingsTab.tsx
@@ -67,7 +67,7 @@ export default function SettingsTab() {
       const data = await resp.json().catch(() => ({}));
       throw new Error(data.error || "Failed to delete vault");
     }
-    navigate({ to: "/vaults" });
+    navigate({ to: "/" });
   }
 
   return (

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -9,7 +9,7 @@ import { apiFetch } from "./lib/api";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
 import ForgotPassword from "./pages/ForgotPassword";
-import VaultsLayout from "./components/VaultsLayout";
+import HomeLayout from "./components/HomeLayout";
 import VaultsListTab from "./pages/home/VaultsListTab";
 import AllUsersTab from "./pages/home/AllUsersTab";
 import AllAgentsTab from "./pages/home/AllAgentsTab";
@@ -70,7 +70,7 @@ const loginRoute = createRoute({
     await requireInitializedOrRedirect();
     const resp = await apiFetch("/v1/auth/me");
     if (resp.ok) {
-      throw redirect({ to: "/vaults" });
+      throw redirect({ to: "/" });
     }
   },
   component: Login,
@@ -96,7 +96,7 @@ const forgotPasswordRoute = createRoute({
     await requireInitializedOrRedirect();
     const resp = await apiFetch("/v1/auth/me");
     if (resp.ok) {
-      throw redirect({ to: "/vaults" });
+      throw redirect({ to: "/" });
     }
   },
   component: ForgotPassword,
@@ -173,39 +173,45 @@ const authLayoutRoute = createRoute({
   getParentRoute: () => rootRoute,
   id: "_auth",
   beforeLoad: async () => {
-    await requireInitializedOrRedirect();
-    const resp = await apiFetch("/v1/auth/me");
-    if (!resp.ok) {
+    const [statusResp, meResp] = await Promise.all([
+      apiFetch("/v1/status"),
+      apiFetch("/v1/auth/me"),
+    ]);
+    if (statusResp.ok) {
+      const status = await statusResp.json();
+      if (!status.initialized) throw redirect({ to: "/register" });
+    }
+    if (!meResp.ok) {
       throw redirect({ to: "/login" });
     }
-    const user: AuthContext = await resp.json();
+    const user: AuthContext = await meResp.json();
     return { auth: user };
   },
   component: Outlet,
 });
 
-// --- Vaults Layout (sidebar with Vaults + Users tabs) ---
+// --- Home Layout (sidebar with Vaults + Users + Agents tabs) ---
 
-const vaultsLayoutRoute = createRoute({
+const homeLayoutRoute = createRoute({
   getParentRoute: () => authLayoutRoute,
-  path: "/vaults",
-  component: VaultsLayout,
+  id: "_home",
+  component: HomeLayout,
 });
 
-const vaultsIndexRoute = createRoute({
-  getParentRoute: () => vaultsLayoutRoute,
+const homeIndexRoute = createRoute({
+  getParentRoute: () => homeLayoutRoute,
   path: "/",
   component: VaultsListTab,
 });
 
-const vaultsUsersRoute = createRoute({
-  getParentRoute: () => vaultsLayoutRoute,
+const homeUsersRoute = createRoute({
+  getParentRoute: () => homeLayoutRoute,
   path: "/users",
   component: AllUsersTab,
 });
 
-const vaultsAgentsRoute = createRoute({
-  getParentRoute: () => vaultsLayoutRoute,
+const homeAgentsRoute = createRoute({
+  getParentRoute: () => homeLayoutRoute,
   path: "/agents",
   component: AllAgentsTab,
 });
@@ -236,7 +242,7 @@ const manageInstanceRoute = createRoute({
   beforeLoad: async ({ context }) => {
     const { auth } = context as { auth: AuthContext };
     if (!auth.is_owner) {
-      throw redirect({ to: "/vaults" });
+      throw redirect({ to: "/" });
     }
   },
   component: InstanceLayout,
@@ -264,7 +270,7 @@ const vaultLayoutRoute = createRoute({
   beforeLoad: async ({ params }) => {
     const resp = await apiFetch(`/v1/vaults/${encodeURIComponent(params.name)}/context`);
     if (!resp.ok) {
-      throw redirect({ to: "/vaults" });
+      throw redirect({ to: "/" });
     }
     const ctx: VaultContext = await resp.json();
     return ctx;
@@ -316,25 +322,9 @@ const settingsTabRoute = createRoute({
   component: SettingsTab,
 });
 
-// --- Index Route (root redirect) ---
-
-const indexRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  path: "/",
-  beforeLoad: async () => {
-    await requireInitializedOrRedirect();
-    const meResp = await apiFetch("/v1/auth/me");
-    if (meResp.ok) {
-      throw redirect({ to: "/vaults" });
-    }
-    throw redirect({ to: "/login" });
-  },
-});
-
 // --- Route Tree ---
 
 const routeTree = rootRoute.addChildren([
-  indexRoute,
   loginRoute,
   registerRoute,
   forgotPasswordRoute,
@@ -342,10 +332,10 @@ const routeTree = rootRoute.addChildren([
   proposalApproveRoute,
   oauthCallbackRoute,
   authLayoutRoute.addChildren([
-    vaultsLayoutRoute.addChildren([
-      vaultsIndexRoute,
-      vaultsUsersRoute,
-      vaultsAgentsRoute,
+    homeLayoutRoute.addChildren([
+      homeIndexRoute,
+      homeUsersRoute,
+      homeAgentsRoute,
     ]),
     accountRoute.addChildren([
       accountIndexRoute,


### PR DESCRIPTION
## Summary
- Replace `/vaults` with `/` as the home route, removing the redundant index redirect; rename `VaultsLayout` → `HomeLayout`
- Return vault roles in the owner user list API (`{vault_name, vault_role}` objects instead of plain strings) and display them as `name:role` badges in the Users tab
- Parallelize `/v1/status` + `/v1/auth/me` calls in the auth layout, fix sidebar exit animation target checks, reorder vault agents table columns (Status before Role), add Role column to instance agents tab

## Test plan
- [x] `make build` passes
- [x] `make test` passes
- [ ] Verify `/` loads the home layout with Vaults/Users/Agents tabs
- [ ] Verify back links from vault/account/instance pages navigate to `/`
- [ ] Verify Users tab shows vault memberships as `name:role` badges for owners
- [ ] Verify sidebar exit animations complete cleanly without premature navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)