### PR TITLE
docs: update CLI paths, document new features, and improve README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@ Agent Vault is an HTTP proxy that attaches credentials to your outbound requests
 | `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault |
 | `AGENT_VAULT_VAULT` | Vault the session is scoped to |
 
+## The X-Vault header
+
+If you received your session via an agent invite (instance-level session), you must include `X-Vault: {vault_name}` on all vault-scoped requests (discover, proxy, proposals). If `AGENT_VAULT_VAULT` is set, use that value. Vault-scoped sessions (from `vault run`) do not need this header.
+
 ## Discover available services
 
 Always call this first to learn which services have credentials configured:
@@ -24,9 +28,10 @@ Always call this first to learn which services have credentials configured:
 ```
 GET {AGENT_VAULT_ADDR}/discover
 Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+X-Vault: {vault_name}
 ```
 
-Response includes `vault`, `proxy_url`, `services` (host + description), and `available_credentials` (key names only — values are never exposed).
+Response includes `vault`, `proxy_url`, `services` (host + description), and `available_credentials` (key names only — values are never exposed). Before creating a proposal, check `available_credentials` to avoid requesting credentials that already exist in the vault.
 
 ## Route requests through the proxy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,12 +55,14 @@ Agent Vault requires two things before it becomes operational: a **master passwo
   - `agent-vault account whoami` -- show current user and session info
   - `agent-vault account change-password` -- change your own password (prompts interactively for current + new + confirm; use `--password-stdin` to read current and new passwords as two lines from stdin). Invalidates all existing sessions and issues a new one.
   - `agent-vault account delete` -- permanently delete your own account (owners cannot delete themselves; transfer ownership first)
-- `agent-vault vault [create|list|delete|rename|init]` -- manage vaults (default vault is seeded automatically)
+- `agent-vault vault [create|list|delete|rename|init|use|current]` -- manage vaults (default vault is seeded automatically)
   - `agent-vault vault create <name>` -- create a new vault
   - `agent-vault vault list` -- list vaults the current user has access to (owners see all vaults with `membership` field: `explicit` for joined, `implicit` for visible-but-not-joined)
   - `agent-vault vault delete <name>` -- delete a vault (vault admin or instance owner; cannot delete the default vault; use `--yes` to skip confirmation)
   - `agent-vault vault rename <old-name> <new-name>` -- rename a vault (vault admin or instance owner; cannot rename the default vault)
   - `agent-vault vault init` -- bind the current directory to a vault by writing `agent-vault.json` (interactive picker; use `--vault` to skip picker). The file is meant to be committed so the whole team shares the vault binding. Vault resolution priority: `--vault` flag > `AGENT_VAULT_VAULT` env var > `agent-vault.json` > user context > `"default"`.
+  - `agent-vault vault use <name>` -- set the active vault for subsequent commands (persisted in user context)
+  - `agent-vault vault current` -- show the currently active vault
   - `agent-vault vault user [add|list|remove|set-role]` -- manage vault user access
     - `agent-vault vault user add <email> [--vault <name>] [--role admin|member]` -- add an existing instance user to a vault (direct grant, no invite needed)
     - `agent-vault vault user list [--vault <name>]` -- list vault users (includes pending invite pre-assignments with "pending" status)
@@ -85,29 +87,29 @@ Agent Vault requires two things before it becomes operational: a **master passwo
   - `agent-vault owner vault list` -- list all vaults
   - `agent-vault owner vault join <name>` -- join a vault as admin (for recovering orphaned vaults)
   - `agent-vault owner vault delete <name>` -- delete a vault
-- `agent-vault service [--vault] [list|set|clear]` -- manage services per vault
-  - `agent-vault service list` -- list configured services as YAML
-  - `agent-vault service set` -- interactive service builder (prompts for services, auth config, credentials; requires TTY)
-  - `agent-vault service set -f <file>` -- replace services from YAML file
-  - `agent-vault service clear` -- remove all services (prompts for confirmation; use `--yes` to skip)
+- `agent-vault vault service [list|set|clear]` -- manage services per vault
+  - `agent-vault vault service list` -- list configured services as YAML
+  - `agent-vault vault service set` -- interactive service builder (prompts for services, auth config, credentials; requires TTY)
+  - `agent-vault vault service set -f <file>` -- replace services from YAML file
+  - `agent-vault vault service clear` -- remove all services (prompts for confirmation; use `--yes` to skip)
 - `agent-vault vault credential [list|get|set|delete]` -- manage credentials (alias: `creds`)
   - `agent-vault vault credential list [--reveal]` -- list credential keys; with `--reveal`, shows decrypted values in a KEY+VALUE table (requires member+ role)
   - `agent-vault vault credential get <key>` -- print the decrypted value of a single credential to stdout (pipe-friendly, requires member+ role)
   - `agent-vault vault credential set <key=value> [...]` -- set one or more credentials
   - `agent-vault vault credential delete <key> [...]` -- delete one or more credentials
-- `agent-vault proposal [--vault] [list|show|create|approve|reject|review]` -- manage proposals (proposed service/credential changes)
-  - `agent-vault proposal list [--status pending]` -- list proposals for vault
-  - `agent-vault proposal show <number>` -- show proposal details
-  - `agent-vault proposal create` -- create a proposal to request services or credentials. Supports two modes:
-    - Flag-driven: `--host`, `--auth-type`, `--token-key`/`--username-key`/`--password-key`/`--api-key-key`, `--credential KEY[=description]` (repeatable), `-m/--message`, `--user-message`. Credential slots have no value — the human provides it at approval time.
+- `agent-vault vault proposal [list|show|create|approve|reject|review]` -- manage proposals (proposed service/credential changes)
+  - `agent-vault vault proposal list [--status pending]` -- list proposals for vault
+  - `agent-vault vault proposal show <number>` -- show proposal details
+  - `agent-vault vault proposal create` -- create a proposal to request services or credentials. Supports two modes:
+    - Flag-driven: `--host`, `--description`, `--auth-type`, `--token-key`/`--username-key`/`--password-key`/`--api-key-key`/`--api-key-header`/`--api-key-prefix`, `--credential KEY[=description]` (repeatable), `-m/--message`, `--user-message`. Credential slots have no value — the human provides it at approval time.
     - JSON: `-f <file>` or `-f -` (stdin) for complex/multi-service proposals. `-m` and `--user-message` override JSON fields.
     - `--json` flag outputs machine-readable JSON response with `{id, status, vault, approval_url}`.
     - Auth: works with scoped sessions (via `AGENT_VAULT_SESSION_TOKEN` env var or `vault run`).
-  - `agent-vault proposal approve <number> [KEY=VALUE ...]` -- approve and apply (requires active login session; prompts for missing credentials)
-  - `agent-vault proposal reject <number> [--reason "..."]` -- reject a pending proposal (requires active login session)
-  - `agent-vault proposal review` -- interactively walk through all pending proposals (approve, reject, skip, or quit each; requires active login session)
+  - `agent-vault vault proposal approve <number> [KEY=VALUE ...]` -- approve and apply (requires active login session; prompts for missing credentials)
+  - `agent-vault vault proposal reject <number> [--reason "..."]` -- reject a pending proposal (requires active login session)
+  - `agent-vault vault proposal review` -- interactively walk through all pending proposals (approve, reject, skip, or quit each; requires active login session)
 - `agent-vault agent [invite|list|info|revoke|rotate|rename|set-role]` -- instance-level agent management
-  - `agent-vault agent invite <name> [--role owner|member] [--vault name:role ...]` -- invite an agent to the instance with an instance-level role (default `member`) and optional vault pre-assignments (repeatable --vault flag, format: `name:role`, role defaults to `proxy`)
+  - `agent-vault agent invite <name> [--role owner|member] [--vault name:role ...] [--invite-ttl 15m] [--address <url>] [--token-only]` -- invite an agent to the instance with an instance-level role (default `member`) and optional vault pre-assignments (repeatable --vault flag, format: `name:role`, role defaults to `proxy`). `--invite-ttl` sets expiration (default 15m). `--token-only` outputs only the raw invite token.
   - `agent-vault agent invite list [--status pending]` -- list agent invites
   - `agent-vault agent invite revoke <token_suffix>` -- revoke a pending agent invite
   - `agent-vault agent list` -- list all agents
@@ -121,8 +123,8 @@ Agent Vault requires two things before it becomes operational: a **master passwo
   - `agent-vault vault agent add <name> [--role proxy|member|admin]` -- add an existing instance agent to the vault
   - `agent-vault vault agent remove <name>` -- remove an agent from the vault
   - `agent-vault vault agent set-role <name> --role proxy|member|admin` -- change an agent's vault role
-- `agent-vault email test [--to <email>]` -- send a test email to verify SMTP configuration (owner-only; defaults to sending to the owner's own email)
-- `agent-vault reset [--yes]` -- permanently delete all data and reset the instance to a fresh state (owner-only; requires running server for role verification; auto-stops server before reset)
+- `agent-vault owner email test [--to <email>]` -- send a test email to verify SMTP configuration (owner-only; defaults to sending to the owner's own email)
+- `agent-vault owner reset [--yes]` -- permanently delete all data and reset the instance to a fresh state (owner-only; requires running server for role verification; auto-stops server before reset)
 - `agent-vault vault discover [--json]` -- show available services and credentials for the current vault. Requires a vault-scoped session (via `agent-vault vault run` or `AGENT_VAULT_SESSION_TOKEN` + `AGENT_VAULT_ADDR` env vars). `--json` for machine-readable output.
 - `agent-vault vault run [--address] [--role] [--ttl] -- <agent>` -- wrap an agent process with Agent Vault access
 - `agent-vault vault token [--address] [--role] [--ttl]` -- mint a vault-scoped session token and print it to stdout (pipe-friendly; use with `AGENT_VAULT_SESSION_TOKEN` env var)
@@ -202,6 +204,9 @@ type Service struct {
 - `GET /v1/proposals?status=pending` -- list proposals (scoped session)
 - `POST /v1/admin/proposals/{id}/approve` -- approve and apply a proposal (requires vault access); accepts `{ "vault": "default", "credentials": {"key": "value"} }` with human-provided credential values
 - `POST /v1/admin/proposals/{id}/reject` -- reject a proposal (requires vault access); accepts `{ "vault": "default", "reason": "..." }`
+- `GET /v1/admin/proposals?vault=...&status=...` -- list proposals (admin view, requires vault access)
+- `GET /v1/admin/proposals/{id}?vault=...` -- get proposal details (admin view, requires vault access)
+- `GET /v1/proposals/approve-details` -- get proposal approval page data (used by browser approval flow)
 - Proxy 403 responses include a `proposal_hint` field with the denied host and endpoint to create a proposal
 
 Proposal states: `pending`, `applied`, `rejected`, or `expired` (7-day TTL). Approval atomically merges services into the broker config, upserts/deletes credentials in one transaction. CLI proposal commands (`approve`, `reject`, `review`) communicate with the running server via these admin endpoints, they require an active login session (`agent-vault auth login`).
@@ -222,7 +227,11 @@ When an agent creates a proposal, the response includes an `approval_url` (e.g. 
 
 - `POST /v1/auth/register` -- self-signup. Accepts `{"email": "...", "password": "..."}` (password >= 8 chars). The first user to register becomes the owner (auto-active, auto-granted admin on default vault). Subsequent users receive a 6-digit email verification code and their account is inactive until verified. Returns 409 if the email is already registered.
 - `POST /v1/auth/verify` -- verify email with 6-digit code. Accepts `{"email": "...", "code": "123456"}`. Activates the account on success. Code TTL: 15 minutes.
+- `POST /v1/auth/resend-verification` -- resend email verification code (requires email in body).
+- `POST /v1/auth/forgot-password` -- initiate password reset flow. Sends a reset link via email.
+- `POST /v1/auth/reset-password` -- complete password reset with token from email.
 - `POST /v1/auth/change-password` -- change own password (requires user session). Accepts `{"current_password": "...", "new_password": "..."}` (new password >= 8 chars). Verifies current password, updates to new password, invalidates all existing sessions, and returns a fresh session token. Rejects agent/scoped sessions.
+- `POST /v1/auth/logout` -- invalidate the current session (requires user session).
 - `DELETE /v1/auth/account` -- delete own account (requires user session). Owners cannot delete themselves (returns 409). Deletes all sessions and the user record; vault grants cascade via FK.
 
 ## Instance Settings API
@@ -253,7 +262,8 @@ Agent invites let a human onboard any agent (including cloud-hosted agents like 
 
 - `POST /v1/agents/invites` -- create an agent invite (any authenticated user). Body: `{"name": "my-agent", "role": "member", "vaults": [{"vault_name": "default", "vault_role": "proxy"}]}`. Name is required. `role` sets instance-level role (default `member`). Vault pre-assignments are optional.
 - `GET /v1/agents/invites[?status=pending]` -- list agent invites
-- `DELETE /v1/agents/invites/{token}` -- revoke a pending agent invite
+- `DELETE /v1/agents/invites/{token}` -- revoke a pending agent invite by token suffix
+- `DELETE /v1/agents/invites/by-id/{id}` -- revoke a pending agent invite by numeric ID
 - `POST /invite/{token}` -- redeem an agent invite. Body: `{}`. Returns `av_session_token`, agent name, vault list, and usage instructions. Creates an instance-level agent session (vault_id = NULL). Also used for rotation invite redemption.
 
 Invite states: `pending`, `redeemed`, `expired`, or `revoked`. Token format: `av_inv_` + 64 hex chars. Default TTL: 15 minutes.
@@ -285,6 +295,11 @@ Agents are instance-level entities (like users) with instance-level roles (`owne
 - `DELETE /v1/vaults/{name}/agents/{agentName}` -- remove agent from vault
 - `POST /v1/vaults/{name}/agents/{agentName}/role` -- change vault role; body: `{"role": "member"}`
 
+### Additional Vault Endpoints
+
+- `GET /v1/vaults/{name}/context` -- get vault context info for the current user/agent
+- `GET /v1/vaults/{name}/services/credential-usage` -- list which credential keys are referenced by the vault's services
+
 ## Multi-User Permission Model
 
 Agent Vault uses two independent permission axes:
@@ -305,6 +320,7 @@ Instance-level invites let any authenticated user invite people to Agent Vault. 
 - `POST /v1/users/invites` -- any authenticated user creates an invite; body: `{"email": "...", "vaults": [{"vault_name": "...", "vault_role": "admin|member"}]}`. Vaults array is optional. Sends HTML email if SMTP configured; always returns `invite_link` in response. 48-hour TTL, max 50 pending.
 - `GET /v1/users/invites?status=pending` -- list invites (owners see all; others see invites they created or with pre-assignments to vaults they admin)
 - `DELETE /v1/users/invites/{token}` -- revoke a pending invite
+- `POST /v1/users/invites/{token}/reinvite` -- resend an existing invite (re-sends email notification)
 - `GET /v1/users/invites/{token}/details` -- public, token-based details for the acceptance page
 - `POST /v1/users/invites/{token}/accept` -- accept invite (no auth); body: `{"password": "..."}` for new users, empty for existing users. Creates account if needed, applies pre-assigned vault grants.
 - `GET /invite/{token}` -- serves the browser acceptance page (no auth, token is credential)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
   <img src="assets/banner.png" alt="Agent Vault" />
 </p>
 
-<p align="center"><strong>Secure Credential Access for AI Agents</strong></p>
+<p align="center"><strong>Authenticated HTTP Proxy and Vault for AI Agents</strong></p>
 
 <p align="center">
-An open-source credential broker project by <a href="https://infisical.com">Infisical</a> that sits between your agents and the APIs they call.<br>
-Agent Vault eliminates credential exfiltration risk - just brokered access out of the box.
+An open-source credential broker by <a href="https://infisical.com">Infisical</a> that sits between your agents and the APIs they call.<br>
+Agents should not possess credentials. Agent Vault eliminates credential exfiltration risk with brokered access.
 </p>
 
 <p align="center">
@@ -15,13 +15,15 @@ Agent Vault eliminates credential exfiltration risk - just brokered access out o
 
 ## Why Agent Vault
 
-Traditional secret managers return credentials directly to the caller. This breaks down with AI agents, which are non-deterministic and vulnerable to prompt injection. An attacker can craft a malicious prompt and exfiltrate credentials from the agent.
+Secret managers return credentials directly to the caller. This breaks down with AI agents, which are non-deterministic systems vulnerable to prompt injection that can be tricked into exfiltrating secrets.
 
-- **Brokered access, not retrieval** - Agents route requests through a proxy. There is nothing to leak because agents never have credentials. [Learn more](https://docs.agent-vault.dev/learn/security)
-- **Self-onboarding** - Paste an invite prompt into any agent's chat and it connects itself. No env setup, no config files. Works with [Claude Code](https://docs.agent-vault.dev/quickstart/claude-code), [Cursor](https://docs.agent-vault.dev/quickstart/cursor), and any HTTP-capable agent.
-- **Agent-led access** - The agent discovers what it needs at runtime and raises a [proposal](https://docs.agent-vault.dev/learn/proposals). You review and approve in your browser with one click.
+Agent Vault takes a different approach: **agents never see credentials at all**. Instead, they route HTTP requests through a local proxy that injects the right credentials at the network layer.
+
+- **Brokered access, not retrieval** - Your agent gets a session token and a proxy URL. It sends requests to `proxy/{host}/{path}` and Agent Vault authenticates them. There is nothing to leak. [Learn more](https://docs.agent-vault.dev/learn/security)
+- **Works with any agent** - Custom Python/TypeScript agents, sandboxed processes, coding agents (Claude Code, Cursor, Codex), anything that can make HTTP requests. [Learn more](https://docs.agent-vault.dev/quickstart)
+- **Self-service access** - Agents discover available services at runtime and [propose access](https://docs.agent-vault.dev/learn/proposals) for anything missing. You review and approve in your browser with one click.
 - **Encrypted at rest** - Credentials are encrypted with AES-256-GCM using an Argon2id-derived key. The master password never touches disk. [Learn more](https://docs.agent-vault.dev/learn/credentials)
-- **Multi-user, multi-vault** - Role-based access control with instance-level and vault-level [permissions](https://docs.agent-vault.dev/learn/permissions). Invite teammates, scope agents to specific [vaults](https://docs.agent-vault.dev/learn/vaults), and audit everything.
+- **Multi-user, multi-vault** - Role-based access control with instance and vault-level [permissions](https://docs.agent-vault.dev/learn/permissions). Invite teammates, scope agents to specific [vaults](https://docs.agent-vault.dev/learn/vaults), and audit everything.
 
 <p align="center">
   <img src="docs/images/architecture.png" alt="Agent Vault architecture diagram" />
@@ -61,21 +63,64 @@ sudo mv agent-vault /usr/local/bin/
 ## Quickstart
 
 ```bash
-# Start the server (runs on localhost:14321 by default; use --host and --port to change)
+# Start the server (runs on localhost:14321 by default)
 agent-vault server -d
 
-# Run with your agent
+# Add a credential
+agent-vault vault credential set GITHUB_TOKEN=ghp_xxx
+
+# Configure a service proxy rule
+agent-vault vault service set -f - <<EOF
+services:
+  - host: api.github.com
+    auth:
+      type: bearer
+      token: GITHUB_TOKEN
+EOF
+```
+
+Any command that needs authentication will walk you through setup automatically. Just run it and follow the prompts. You can also run `agent-vault vault service set` interactively or browse templates with `agent-vault catalog`.
+
+The server includes a web UI at `http://localhost:14321` for managing services, credentials, approving proposals, and inviting users and agents.
+
+### Building custom agents
+
+Mint a session token and pass it to your agent process. The agent authenticates every request through the proxy. No credentials in its environment.
+
+```bash
+# Mint a scoped session token
+export AGENT_VAULT_SESSION_TOKEN=$(agent-vault vault token)
+export AGENT_VAULT_ADDR=http://localhost:14321
+```
+
+From your agent code, proxy requests through Agent Vault:
+
+```typescript
+const vault = process.env.AGENT_VAULT_ADDR;
+const token = process.env.AGENT_VAULT_SESSION_TOKEN;
+
+// Proxy an authenticated request (Agent Vault injects the credentials)
+const resp = await fetch(`${vault}/proxy/api.github.com/user/repos`, {
+  headers: { Authorization: `Bearer ${token}` },
+});
+```
+
+If a service isn't configured yet, the agent can [propose access](https://docs.agent-vault.dev/learn/proposals) via `POST /v1/proposals`. You approve in your browser and the agent retries.
+
+### Using with coding agents
+
+Wrap your coding agent with `vault run` for automatic session management:
+
+```bash
 agent-vault vault run -- claude    # Claude Code
-agent-vault vault run -- agent     # Cursor
+agent-vault vault run -- cursor    # Cursor
 agent-vault vault run -- codex     # Codex
 
 # Or create an invite for any agent
 agent-vault agent invite my-agent
 ```
 
-Any command that needs authentication will walk you through setup automatically — just run it and follow the prompts. `agent-vault vault run` wraps your agent process with a scoped session — no tokens to manage. Alternatively, `agent-vault agent invite` prints an invite prompt you can paste into any agent's chat to connect it.
-
-Once connected, ask the agent to call any external API. It will discover available services, [propose access](https://docs.agent-vault.dev/first-proposal) for anything missing, and give you a browser link to approve.
+`vault run` injects `AGENT_VAULT_SESSION_TOKEN`, `AGENT_VAULT_ADDR`, and `AGENT_VAULT_VAULT` into the child process. The agent discovers services, proxies requests, and proposes access for anything missing.
 
 ## Development
 
@@ -89,4 +134,4 @@ make docker     # Build Docker image
 
 ---
 
-> **Beta software.** Agent Vault is under active development and may have breaking changes. Use at your own risk. Please review the [security documentation](https://docs.agent-vault.dev/learn/security) before deploying.
+> **Preview.** Agent Vault is in active development and the API is subject to change. Please review the [security documentation](https://docs.agent-vault.dev/learn/security) before deploying.

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -113,7 +113,14 @@ agent-vault vault proposal create -f - --json <<'EOF'
 EOF
 ```
 
-Key fields:
+Flag-driven auth flags by type:
+- **bearer**: `--auth-type bearer --token-key CREDENTIAL_KEY`
+- **basic**: `--auth-type basic --username-key USER_KEY [--password-key PASS_KEY]`
+- **api-key**: `--auth-type api-key --api-key-key KEY [--api-key-header x-api-key] [--api-key-prefix "ApiKey "]`
+
+Other flags: `--description` (service description), `--user-message` (shown on browser approval page), `--credential KEY=description` (repeatable).
+
+Key fields (JSON mode):
 - `services[].action` -- `"set"` (upsert, needs `host` + `auth`) or `"delete"` (needs `host` only)
 - `services[].auth` -- authentication config. Types: `bearer` (`token`), `basic` (`username`, optional `password`), `api-key` (`key` + `header`, optional `prefix`), `custom` (`headers` map with `{{ KEY }}` templates)
 - `credentials[].action` -- `"set"` (omit `value` for human to supply; include `value` to store back) or `"delete"`

--- a/docs/learn/credentials.mdx
+++ b/docs/learn/credentials.mdx
@@ -13,9 +13,11 @@ Each credential has:
 Credentials can be referenced in vault [services](/learn/services) by key name. When an agent makes a proxied request, Agent Vault resolves the key to the real credential value and attaches it to the outbound request.
 
 <Note>
-  Credentials are write-only: once set, their values cannot be read back by
-  anyone (including vault admins). They are only decrypted in memory at proxy
-  time to attach to outbound requests.
+  Credential values are encrypted at rest and only decrypted in memory when
+  needed. Vault **members** and **admins** can read credential values via
+  `vault credential get` or `vault credential list --reveal`. Agents with the
+  **proxy** role cannot read credential values — they are only injected at proxy
+  time.
 </Note>
 
 Credentials can be added to a [vault](/learn/vaults) in two ways:
@@ -26,15 +28,15 @@ Credentials can be added to a [vault](/learn/vaults) in two ways:
 ## Store a credential
 
 ```bash
-agent-vault credentials set STRIPE_KEY=sk_test_abc123 --vault my-vault
+agent-vault vault credential set STRIPE_KEY=sk_test_abc123 --vault my-vault
 ```
 
-The `credentials` command (alias: `creds`) uses `KEY=VALUE` format. Multiple credentials can be set at once (e.g. `agent-vault credentials set A=1 B=2`). If `STRIPE_KEY` already exists, it is overwritten.
+The `vault credential` command (alias: `vault creds`) uses `KEY=VALUE` format. Multiple credentials can be set at once (e.g. `agent-vault vault credential set A=1 B=2`). If `STRIPE_KEY` already exists, it is overwritten.
 
 ## Delete a credential
 
 ```bash
-agent-vault credentials delete STRIPE_KEY --vault my-vault
+agent-vault vault credential delete STRIPE_KEY --vault my-vault
 ```
 
 Permanently removes the credential from the [vault](/learn/vaults).

--- a/docs/learn/proposals.mdx
+++ b/docs/learn/proposals.mdx
@@ -48,16 +48,16 @@ Approval atomically merges services into the [vault's](/learn/vaults) [service c
   <Tab title="CLI">
     ```bash
     # List pending proposals
-    agent-vault proposal list --vault my-vault --status pending
+    agent-vault vault proposal list --vault my-vault --status pending
 
     # Approve with interactive credential prompts
-    agent-vault proposal approve 3
+    agent-vault vault proposal approve 3
 
     # Approve with credentials inline
-    agent-vault proposal approve 3 STRIPE_KEY=sk_test_abc123
+    agent-vault vault proposal approve 3 STRIPE_KEY=sk_test_abc123
 
     # Skip confirmation prompt
-    agent-vault proposal approve 3 --yes
+    agent-vault vault proposal approve 3 --yes
     ```
 
     The CLI fetches the proposal, displays a summary, prompts for any missing [credential](/learn/credentials) values, and sends the approval to the running server.
@@ -83,7 +83,7 @@ Approval atomically merges services into the [vault's](/learn/vaults) [service c
   <Tab title="CLI">
     ```bash
     # Reject with a reason
-    agent-vault proposal reject 3 --reason "not needed"
+    agent-vault vault proposal reject 3 --reason "not needed"
     ```
 
     The `--reason` flag is optional but recommended so the agent understands why the request was denied.
@@ -95,16 +95,16 @@ Approval atomically merges services into the [vault's](/learn/vaults) [service c
 
 ```bash
 # List all proposals
-agent-vault proposal list --vault my-vault
+agent-vault vault proposal list --vault my-vault
 
 # Filter by status
-agent-vault proposal list --vault my-vault --status pending
+agent-vault vault proposal list --vault my-vault --status pending
 
 # View full details
-agent-vault proposal show 3 --vault my-vault
+agent-vault vault proposal show 3 --vault my-vault
 
 # Walk through all pending proposals interactively
-agent-vault proposal review --vault my-vault
+agent-vault vault proposal review --vault my-vault
 ```
 
 The `review` command presents each pending proposal one by one. For each, choose **Approve**, **Reject**, **Skip**, or **Quit**. At the end, a summary shows the count and IDs of approved, rejected, and skipped proposals.

--- a/docs/learn/security.mdx
+++ b/docs/learn/security.mdx
@@ -149,7 +149,7 @@ A summary of how each category of sensitive data is stored:
 
 | Data | Storage format | Readable after storage? |
 | ---- | -------------- | ----------------------- |
-| Credentials | AES-256-GCM ciphertext + nonce | No (write-only, decrypted only at proxy time) |
+| Credentials | AES-256-GCM ciphertext + nonce | Yes, by vault members and admins via CLI (`credential get`, `credential list --reveal`). Proxy-role agents cannot read values. |
 | User passwords | Argon2id hash + salt + params | No |
 | Session tokens | SHA-256 hash | No (raw returned once at creation) |
 | Master password | Not stored | N/A (derived key held in memory only) |

--- a/docs/learn/services.mdx
+++ b/docs/learn/services.mdx
@@ -36,7 +36,7 @@ services:
 ```
 
 ```bash
-agent-vault service set -f stripe-services.yaml --vault my-vault
+agent-vault vault service set -f stripe-services.yaml --vault my-vault
 ```
 
 The `host` tells Agent Vault which requests this service applies to. The `auth` block tells Agent Vault how to authenticate, referencing [credential](/learn/credentials) keys by name (not the actual credential values). The following section covers all four auth types.
@@ -174,7 +174,7 @@ services:
 ```
 
 ```bash
-agent-vault service set -f services.yaml --vault my-vault
+agent-vault vault service set -f services.yaml --vault my-vault
 ```
 
 Any [agent](/agents/overview) scoped to the [vault](/learn/vaults) named `my-vault` can now proxy requests to these hosts, and Agent Vault attaches the real [credentials](/learn/credentials) at request time.
@@ -184,7 +184,7 @@ Any [agent](/agents/overview) scoped to the [vault](/learn/vaults) named `my-vau
 ### Set from a file
 
 ```bash
-agent-vault service set -f services.yaml --vault my-vault
+agent-vault vault service set -f services.yaml --vault my-vault
 ```
 
 Replaces the entire service configuration with the contents of the file. This is idempotent, running it twice with the same file produces the same result.
@@ -192,7 +192,7 @@ Replaces the entire service configuration with the contents of the file. This is
 ### Set interactively
 
 ```bash
-agent-vault service set --vault my-vault
+agent-vault vault service set --vault my-vault
 ```
 
 Walks you through adding services, auth configs, and credential references one at a time. Requires a TTY (won't work in scripts).
@@ -200,7 +200,7 @@ Walks you through adding services, auth configs, and credential references one a
 ### View current services
 
 ```bash
-agent-vault service list --vault my-vault
+agent-vault vault service list --vault my-vault
 ```
 
 Prints the active services as YAML. If no services are configured, the output is empty.
@@ -208,7 +208,7 @@ Prints the active services as YAML. If no services are configured, the output is
 ### Clear all services
 
 ```bash
-agent-vault service clear --vault my-vault
+agent-vault vault service clear --vault my-vault
 ```
 
 Removes all services. Agents scoped to this [vault](/learn/vaults) will get `403` on every proxy request until new services are configured. Prompts for confirmation unless you pass `--yes`.

--- a/docs/learn/vaults.mdx
+++ b/docs/learn/vaults.mdx
@@ -36,7 +36,7 @@ agent-vault vault init
 
 This file is meant to be committed to version control. When present, all team members and agents running in that directory will automatically target the bound vault without needing `--vault` flags or per-user context.
 
-Vault resolution priority: `--vault` flag > `agent-vault.json` > user context > `"default"`.
+Vault resolution priority: `--vault` flag > `AGENT_VAULT_VAULT` env var > `agent-vault.json` > user context > `"default"`.
 
 ## Invite agents to a vault
 
@@ -65,7 +65,7 @@ Vault resolution priority: `--vault` flag > `agent-vault.json` > user context > 
 <Steps>
   <Step title="Send the invite">
     ```bash
-    agent-vault vault user invite alice@example.com --vault my-vault --role admin
+    agent-vault user invite alice@example.com --vault my-vault:admin
     ```
 
     If SMTP is configured, the invitee receives an HTML email with a browser
@@ -102,16 +102,16 @@ agent-vault vault user set-role alice@example.com --role member --vault my-vault
 # List agents in a vault
 agent-vault vault agent list --vault my-vault
 
-# View agent details
-agent-vault vault agent info my-agent
+# View agent details (instance-level)
+agent-vault agent info my-agent
 
-# Rotate an agent's session
-agent-vault vault agent rotate my-agent
+# Rotate an agent's session (instance-level)
+agent-vault agent rotate my-agent
 
-# Rename an agent
-agent-vault vault agent rename my-agent new-name
+# Rename an agent (instance-level)
+agent-vault agent rename my-agent new-name
 
-# Delete an agent from this vault
+# Remove an agent from this vault
 agent-vault vault agent remove my-agent
 ```
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -338,9 +338,9 @@ description: "Complete reference for all Agent Vault CLI commands."
 ## Services
 
 <AccordionGroup>
-  <Accordion title="agent-vault service list">
+  <Accordion title="agent-vault vault service list">
     ```bash
-    agent-vault service list [flags]
+    agent-vault vault service list [flags]
     ```
 
     Print the current vault services as YAML.
@@ -350,9 +350,9 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `--vault` | `default` | Target vault |
   </Accordion>
 
-  <Accordion title="agent-vault service set">
+  <Accordion title="agent-vault vault service set">
     ```bash
-    agent-vault service set [flags]
+    agent-vault vault service set [flags]
     ```
 
     Set the vault services. Without `-f`, launches an interactive builder that prompts for services, auth configs, and credentials (requires TTY). With `-f`, replaces the services from a YAML file.
@@ -363,9 +363,9 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `-f` | | Path to a YAML services file |
   </Accordion>
 
-  <Accordion title="agent-vault service clear">
+  <Accordion title="agent-vault vault service clear">
     ```bash
-    agent-vault service clear [flags]
+    agent-vault vault service clear [flags]
     ```
 
     Remove all vault services. Prompts for confirmation unless `--yes` is passed.
@@ -550,6 +550,9 @@ description: "Complete reference for all Agent Vault CLI commands."
     |------|---------|-------------|
     | `--role` | `member` | Instance-level role: `owner` or `member` |
     | `--vault` | | Vault pre-assignment in `name:role` format (repeatable). Role defaults to `proxy`. |
+    | `--invite-ttl` | `15m` | Invite link expiration time (Go duration format) |
+    | `--address` | | Agent Vault server address (default: from session) |
+    | `--token-only` | `false` | Output only the raw invite token (for programmatic use) |
 
     ```bash
     # Invite with vault pre-assignments

--- a/docs/self-hosting/environment-variables.mdx
+++ b/docs/self-hosting/environment-variables.mdx
@@ -9,6 +9,8 @@ description: "All environment variables used to configure Agent Vault"
 |----------|---------|-------------|
 | `AGENT_VAULT_MASTER_PASSWORD` | (unset) | Master key for encrypting credentials at rest (AES-256-GCM / Argon2id). Read at startup, then immediately unset from the process. |
 | `AGENT_VAULT_ADDR` | `http://{host}:{port}` | Externally-reachable base URL. Used for generating links in emails, invites, and discovery responses. |
+| `AGENT_VAULT_NETWORK_MODE` | `public` | Proxy network restriction mode. `public` blocks connections to private/reserved IP ranges (RFC-1918, link-local, cloud metadata). `private` allows all outbound connections including private ranges — use this for local/private deployments where the proxy needs to reach internal services. |
+| `AGENT_VAULT_TRUSTED_PROXIES` | (unset) | Comma-separated CIDR ranges of trusted reverse proxies (e.g. `10.0.0.0/8,172.16.0.0/12`). When set, `X-Forwarded-For` is only trusted if the direct connection comes from a listed proxy. Used for rate limiting and audit logging behind a load balancer. |
 
 Master password resolution order:
 


### PR DESCRIPTION
## Summary
- Fix CLI command paths across all docs to match current codebase (`service` → `vault service`, `proposal` → `vault proposal`, `email test` → `owner email test`, `reset` → `owner reset`)
- Document new commands (`vault use`, `vault current`), flags (`--invite-ttl`, `--address`, `--token-only`), X-Vault header, and new API endpoints (reinvite, vault context, credential-usage, approve-details)
- Correct credential visibility model — members/admins can read values, not write-only as previously documented
- Add `AGENT_VAULT_NETWORK_MODE` and `AGENT_VAULT_TRUSTED_PROXIES` environment variables
- Expand README quickstart with custom agent and coding agent sections; update tagline and "Beta" → "Preview"

## Test plan
- [ ] Verify CLI commands in docs match actual binary (`agent-vault --help` subcommands)
- [ ] Confirm new env vars are recognized by the server
- [ ] Check docs site renders correctly with Mintlify

🤖 Generated with [Claude Code](https://claude.com/claude-code)