### PR TITLE
refactor: remove redundant /v1/admin/users endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,7 @@ Agent Vault requires two things before it becomes operational: a **master passwo
   - `agent-vault user invite <email> [--vault <name>:<role> ...]` -- invite a user to the Agent Vault instance with optional vault pre-assignments (repeatable --vault flag, format: `name:role`, role defaults to `member`)
   - `agent-vault user invite list [--status pending]` -- list user invites
   - `agent-vault user invite revoke <token_suffix>` -- revoke a pending invite
-- `agent-vault owner user [list|info|remove|set-role]` -- manage users (owner only, except `info` for self)
-  - `agent-vault owner user list` -- list all users
+- `agent-vault owner user [info|remove|set-role]` -- manage users (owner only, except `info` for self)
   - `agent-vault owner user info [email]` -- view user info (own info if no email given)
   - `agent-vault owner user remove <email>` -- remove a user
   - `agent-vault owner user set-role <email> --role owner|member` -- change instance-level role (last owner cannot be demoted)
@@ -336,8 +335,6 @@ Invite states: `pending`, `accepted`, `expired`, or `revoked`. Token format: `av
 
 All owner-only except `GET /v1/admin/users/{email}` (owner or self):
 
-- `POST /v1/admin/users` -- create a user (email, password)
-- `GET /v1/admin/users` -- list all users (owner-only, includes vault memberships)
 - `GET /v1/admin/users/{email}` -- get user info + vault memberships
 - `DELETE /v1/admin/users/{email}` -- remove user
 - `POST /v1/admin/users/{email}/role` -- set instance-level role (blocks demoting last owner)

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -6,68 +6,12 @@ import (
 	neturl "net/url"
 	"strings"
 
-	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 )
 
 var userCmd = &cobra.Command{
 	Use:   "user",
 	Short: "Manage users (owner only)",
-}
-
-var userListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all users (owner only)",
-	Args:  cobra.NoArgs,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := ensureSession()
-		if err != nil {
-			return err
-		}
-
-		url := sess.Address + "/v1/admin/users"
-		respBody, err := doAdminRequestWithBody("GET", url, sess.Token, nil)
-		if err != nil {
-			return err
-		}
-
-		type vaultGrant struct {
-			VaultName string `json:"vault_name"`
-			VaultRole string `json:"vault_role"`
-		}
-		var result struct {
-			Users []struct {
-				Email     string       `json:"email"`
-				Role      string       `json:"role"`
-				Vaults    []vaultGrant `json:"vaults"`
-				CreatedAt string       `json:"created_at"`
-			} `json:"users"`
-		}
-		if err := json.Unmarshal(respBody, &result); err != nil {
-			return fmt.Errorf("parsing response: %w", err)
-		}
-
-		if len(result.Users) == 0 {
-			fmt.Fprintln(cmd.OutOrStdout(), "No users found.")
-			return nil
-		}
-
-		t := newTable(cmd.OutOrStdout())
-		t.AppendHeader(table.Row{"EMAIL", "ROLE", "VAULTS", "CREATED"})
-		for _, u := range result.Users {
-			var parts []string
-			for _, v := range u.Vaults {
-				parts = append(parts, v.VaultName+"("+v.VaultRole+")")
-			}
-			ns := strings.Join(parts, ", ")
-			if ns == "" {
-				ns = "-"
-			}
-			t.AppendRow(table.Row{u.Email, u.Role, ns, u.CreatedAt})
-		}
-		t.Render()
-		return nil
-	},
 }
 
 var userInfoCmd = &cobra.Command{
@@ -169,6 +113,6 @@ var userSetRoleCmd = &cobra.Command{
 func init() {
 	userSetRoleCmd.Flags().String("role", "", "role to set (owner or member)")
 
-	userCmd.AddCommand(userListCmd, userInfoCmd, userRemoveCmd, userSetRoleCmd)
+	userCmd.AddCommand(userInfoCmd, userRemoveCmd, userSetRoleCmd)
 	ownerCmd.AddCommand(userCmd)
 }

--- a/internal/server/handle_users.go
+++ b/internal/server/handle_users.go
@@ -64,78 +64,6 @@ func (s *Server) handleUserInviteDetails(w http.ResponseWriter, r *http.Request)
 	})
 }
 
-type userCreateRequest struct {
-	Email    string   `json:"email"`
-	Password string   `json:"password"`
-	Vaults   []string `json:"vaults"`
-}
-
-func (s *Server) handleUserCreate(w http.ResponseWriter, r *http.Request) {
-	if _, err := s.requireOwnerActor(w, r); err != nil {
-		return
-	}
-
-	var req userCreateRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		jsonError(w, http.StatusBadRequest, "Invalid request body")
-		return
-	}
-	if err := auth.ValidateEmail(req.Email); err != nil {
-		jsonError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-	if len(req.Password) < 8 {
-		jsonError(w, http.StatusBadRequest, "Password must be at least 8 characters")
-		return
-	}
-
-	ctx := r.Context()
-
-	// Check email uniqueness.
-	if existing, _ := s.store.GetUserByEmail(ctx, req.Email); existing != nil {
-		jsonError(w, http.StatusConflict, fmt.Sprintf("User %q already exists", req.Email))
-		return
-	}
-
-	hash, salt, kdfP, err := auth.HashUserPassword([]byte(req.Password))
-	if err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to hash password")
-		return
-	}
-
-	user, err := s.store.CreateUser(ctx, req.Email, hash, salt, "member", kdfP.Time, kdfP.Memory, kdfP.Threads)
-	if err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to create user")
-		return
-	}
-
-	// Admin-created users are active immediately (no email verification needed).
-	if err := s.store.ActivateUser(ctx, user.ID); err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to activate user")
-		return
-	}
-	user.IsActive = true
-
-	// Grant vault access.
-	for _, nsName := range req.Vaults {
-		ns, err := s.store.GetVault(ctx, nsName)
-		if err != nil || ns == nil {
-			jsonError(w, http.StatusBadRequest, fmt.Sprintf("Vault %q not found", nsName))
-			return
-		}
-		if err := s.store.GrantVaultRole(ctx, user.ID, "user", ns.ID, "member"); err != nil {
-			jsonError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to grant vault %q", nsName))
-			return
-		}
-	}
-
-	jsonCreated(w, map[string]interface{}{
-		"email":  user.Email,
-		"role":   user.Role,
-		"vaults": req.Vaults,
-	})
-}
-
 // buildOwnerUserList returns enriched user data with vault memberships.
 // Pre-fetches all vaults to avoid N*M queries.
 func (s *Server) buildOwnerUserList(ctx context.Context, users []store.User) []map[string]interface{} {
@@ -167,21 +95,6 @@ func (s *Server) buildOwnerUserList(ctx context.Context, users []store.User) []m
 		}
 	}
 	return items
-}
-
-func (s *Server) handleUserList(w http.ResponseWriter, r *http.Request) {
-	if _, err := s.requireOwnerActor(w, r); err != nil {
-		return
-	}
-
-	ctx := r.Context()
-	users, err := s.store.ListUsers(ctx)
-	if err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to list users")
-		return
-	}
-
-	jsonOK(w, map[string]interface{}{"users": s.buildOwnerUserList(ctx, users)})
 }
 
 // handlePublicUserList returns all users to any authenticated user.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -567,8 +567,6 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("GET /v1/users", s.requireInitialized(s.requireAuth(s.handlePublicUserList)))
 
 	// User management (owner-only, except GET self)
-	mux.HandleFunc("POST /v1/admin/users", s.requireInitialized(s.requireAuth(limitBody(s.handleUserCreate))))
-	mux.HandleFunc("GET /v1/admin/users", s.requireInitialized(s.requireAuth(s.handleUserList)))
 	mux.HandleFunc("GET /v1/admin/users/{email}", s.requireInitialized(s.requireAuth(s.handleUserGet)))
 	mux.HandleFunc("DELETE /v1/admin/users/{email}", s.requireInitialized(s.requireAuth(s.handleUserDelete)))
 	mux.HandleFunc("POST /v1/admin/users/{email}/role", s.requireInitialized(s.requireAuth(limitBody(s.handleUserSetRole))))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3114,49 +3114,6 @@ func TestMemberCanApproveProposalInAnyMemberVault(t *testing.T) {
 	}
 }
 
-func TestUserCreateRequiresOwner(t *testing.T) {
-	ms := newMockStore()
-	memberToken := setupMemberSession(t, ms, "root-ns-id")
-	srv := newTestServer(withStore(ms))
-
-	body := `{"email":"new@test.com","password":"password12345","vaults":[]}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/admin/users", strings.NewReader(body))
-	req.Header.Set("Authorization", "Bearer "+memberToken)
-	rec := httptest.NewRecorder()
-
-	srv.httpServer.Handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
-	}
-}
-
-func TestUserCreateSuccess(t *testing.T) {
-	ms, ownerToken := setupMockStoreWithSession(t)
-	srv := newTestServer(withStore(ms))
-
-	body := `{"email":"new@test.com","password":"password12345","vaults":["default"]}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/admin/users", strings.NewReader(body))
-	req.Header.Set("Authorization", "Bearer "+ownerToken)
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-
-	srv.httpServer.Handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusCreated {
-		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	var resp map[string]interface{}
-	json.NewDecoder(rec.Body).Decode(&resp)
-	if resp["email"] != "new@test.com" {
-		t.Fatalf("expected email new@test.com, got %v", resp["email"])
-	}
-	if resp["role"] != "member" {
-		t.Fatalf("expected role member, got %v", resp["role"])
-	}
-}
-
 func TestLastOwnerCannotBeDemoted(t *testing.T) {
 	ms, ownerToken := setupMockStoreWithSession(t)
 	srv := newTestServer(withStore(ms))


### PR DESCRIPTION
## Summary
- Remove `GET /v1/admin/users` endpoint — redundant with `GET /v1/users`, which already returns full data for owners and a reduced view for members
- Remove `POST /v1/admin/users` endpoint — unused outside of tests; users are onboarded via self-registration or invites
- Remove `owner user list` CLI command (was the only caller of `GET /v1/admin/users`)
- Remove 2 associated tests for the create endpoint
- Update CLAUDE.md to reflect the removed endpoints and command

## Test plan
- [x] `make test` passes
- [ ] Verify `agent-vault user list` still works for any authenticated user
- [ ] Verify `agent-vault owner user info/remove/set-role` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)