### PR TITLE
refactor: rename agent session token to agent token

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,5 +24,9 @@
   "enabledPlugins": {
     "feature-dev@claude-plugins-official": true,
     "mintlify@claude-plugins-official": true
+  },
+  "attributes": {
+    "commit": "",
+    "pr": ""
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Agent Vault is an HTTP proxy that attaches credentials to your outbound requests
 
 ## The X-Vault header
 
-If you received your session via an agent invite (instance-level session), you must include `X-Vault: {vault_name}` on all vault-scoped requests (discover, proxy, proposals). If `AGENT_VAULT_VAULT` is set, use that value. Vault-scoped sessions (from `vault run`) do not need this header.
+If you received your token via an agent invite (instance-level agent token), you must include `X-Vault: {vault_name}` on all vault-scoped requests (discover, proxy, proposals). If `AGENT_VAULT_VAULT` is set, use that value. Vault-scoped sessions (from `vault run`) do not need this header.
 
 ## Discover available services
 
@@ -103,4 +103,4 @@ Content-Type: application/json
 - **Never** extract, log, or display credential values
 - **Never** hardcode tokens — always read from `AGENT_VAULT_SESSION_TOKEN`
 - **Only** request hosts returned by `/discover` — if not listed, propose a proposal
-- Do not modify or forge the `Authorization` header beyond using your session token
+- Do not modify or forge the `Authorization` header beyond using your token

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ The server exposes a generic HTTP proxy at `/proxy/{target_host}/{path}[?query]`
 Agent Vault provides two skill files that teach agents how to interact with it:
 
 - `cmd/skill_cli.md` (`agent-vault-cli`) -- For agents launched via `vault run` that have the `agent-vault` binary on `$PATH`. Covers CLI commands (`discover`, `catalog`, `proposal create`, `credential get`) and the proxy URL pattern.
-- `cmd/skill_http.md` (`agent-vault-http`) -- For agents without the binary (invite-redeemed, remote, instance-level). Covers HTTP endpoints only, including instance-level agent sessions and X-Vault header.
+- `cmd/skill_http.md` (`agent-vault-http`) -- For agents without the binary (invite-redeemed, remote, instance-level). Covers HTTP endpoints only, including instance-level agent tokens and X-Vault header.
 
 Both skills are embedded in the Go binary. `vault run` installs both to `~/.{claude,cursor,agents}/skills/agent-vault-{cli,http}/SKILL.md`. The server serves them at public endpoints:
 - `GET /v1/skills/cli` -- returns CLI skill as text/markdown
@@ -257,26 +257,26 @@ OAuth state table (`oauth_states`) stores SHA-256 hashed state params, PKCE code
 
 ## Agent Invite API
 
-Agent invites let a human onboard any agent (including cloud-hosted agents like Devin or chat-based agents) by pasting a short prompt into the agent's chat. The agent redeems the invite via a POST request and receives an instance-level session token plus full usage instructions.
+Agent invites let a human onboard any agent (including cloud-hosted agents like Devin or chat-based agents) by pasting a short prompt into the agent's chat. The agent redeems the invite via a POST request and receives an instance-level agent token plus full usage instructions.
 
 - `POST /v1/agents/invites` -- create an agent invite (any authenticated user). Body: `{"name": "my-agent", "role": "member", "vaults": [{"vault_name": "default", "vault_role": "proxy"}]}`. Name is required. `role` sets instance-level role (default `member`). Vault pre-assignments are optional.
 - `GET /v1/agents/invites[?status=pending]` -- list agent invites
 - `DELETE /v1/agents/invites/{token}` -- revoke a pending agent invite by token suffix
 - `DELETE /v1/agents/invites/by-id/{id}` -- revoke a pending agent invite by numeric ID
-- `POST /invite/{token}` -- redeem an agent invite. Body: `{}`. Returns `av_session_token`, agent name, vault list, and usage instructions. Creates an instance-level agent session (vault_id = NULL). Also used for rotation invite redemption.
+- `POST /invite/{token}` -- redeem an agent invite. Body: `{}`. Returns `av_agent_token`, agent name, vault list, and usage instructions. Creates an instance-level agent token (vault_id = NULL). Also used for rotation invite redemption.
 
 Invite states: `pending`, `redeemed`, `expired`, or `revoked`. Token format: `av_inv_` + 64 hex chars. Default TTL: 15 minutes.
 
 ## Instance-Level Agent API
 
-Agents are instance-level entities (like users) with instance-level roles (`owner`/`member`) and multi-vault access via the unified `vault_grants` table. Agent sessions are instance-level (vault_id = NULL) and select vaults per-request via the `X-Vault` header.
+Agents are instance-level entities (like users) with instance-level roles (`owner`/`member`) and multi-vault access via the unified `vault_grants` table. Agent tokens are instance-level (vault_id = NULL) and select vaults per-request via the `X-Vault` header.
 
 - **Agent names**: globally unique, 3-64 chars, lowercase alphanumeric + hyphens.
 - **Instance role**: `owner` or `member`, same as users. Owner agents can perform administrative operations.
-- **Session token**: `av_sess_` + 64 hex chars, hashed with SHA-256. Configurable expiry (including no expiry).
+- **Agent token**: `av_agt_` + 64 hex chars, hashed with SHA-256. Configurable expiry (including no expiry).
 - **Multi-vault**: Agents can be granted access to multiple vaults with independent roles per vault.
-- **X-Vault header**: Instance-level agent sessions must include `X-Vault: {vault_name}` on all vault-scoped requests (proxy, discover, proposals, credentials).
-- **Rotation**: `POST /v1/agents/{name}/rotate` creates a rotation invite. The operator pastes the prompt into the agent's chat. The agent POSTs to the invite URL and receives a new session token. Old sessions are invalidated at redemption time (not at invite creation).
+- **X-Vault header**: Instance-level agent tokens must include `X-Vault: {vault_name}` on all vault-scoped requests (proxy, discover, proposals, credentials).
+- **Rotation**: `POST /v1/agents/{name}/rotate` creates a rotation invite. The operator pastes the prompt into the agent's chat. The agent POSTs to the invite URL and receives a new agent token. Old tokens are invalidated at redemption time (not at invite creation).
 
 ### Instance-Level Agent Endpoints
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Secret managers return credentials directly to the caller. This breaks down with
 
 Agent Vault takes a different approach: **agents never see credentials at all**. Instead, they route HTTP requests through a local proxy that injects the right credentials at the network layer.
 
-- **Brokered access, not retrieval** - Your agent gets a session token and a proxy URL. It sends requests to `proxy/{host}/{path}` and Agent Vault authenticates them. There is nothing to leak. [Learn more](https://docs.agent-vault.dev/learn/security)
+- **Brokered access, not retrieval** - Your agent gets a token and a proxy URL. It sends requests to `proxy/{host}/{path}` and Agent Vault authenticates them. There is nothing to leak. [Learn more](https://docs.agent-vault.dev/learn/security)
 - **Works with any agent** - Custom Python/TypeScript agents, sandboxed processes, coding agents (Claude Code, Cursor, Codex), anything that can make HTTP requests. [Learn more](https://docs.agent-vault.dev/quickstart)
 - **Self-service access** - Agents discover available services at runtime and [propose access](https://docs.agent-vault.dev/learn/proposals) for anything missing. You review and approve in your browser with one click.
 - **Encrypted at rest** - Credentials are encrypted with AES-256-GCM using an Argon2id-derived key. The master password never touches disk. [Learn more](https://docs.agent-vault.dev/learn/credentials)

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -86,7 +86,7 @@ var agentInfoCmd = &cobra.Command{
 			CreatedAt      string `json:"created_at"`
 			UpdatedAt      string `json:"updated_at"`
 			RevokedAt      *string `json:"revoked_at,omitempty"`
-			ActiveSessions int     `json:"active_sessions"`
+			ActiveTokens int     `json:"active_tokens"`
 			Vaults         []struct {
 				VaultName string `json:"vault_name"`
 				VaultRole string `json:"vault_role"`
@@ -105,7 +105,7 @@ var agentInfoCmd = &cobra.Command{
 		if info.RevokedAt != nil {
 			_, _ = fmt.Fprintf(w, "%s %s\n", fieldLabel("Revoked:"), *info.RevokedAt)
 		}
-		_, _ = fmt.Fprintf(w, "%s %d\n", fieldLabel("Active sessions:"), info.ActiveSessions)
+		_, _ = fmt.Fprintf(w, "%s %d\n", fieldLabel("Active tokens:"), info.ActiveTokens)
 		if len(info.Vaults) > 0 {
 			_, _ = fmt.Fprintf(w, "%s\n", fieldLabel("Vaults:"))
 			for _, v := range info.Vaults {
@@ -120,7 +120,7 @@ var agentInfoCmd = &cobra.Command{
 
 var agentRevokeCmd = &cobra.Command{
 	Use:   "delete <name>",
-	Short: "Delete an agent and all its sessions",
+	Short: "Delete an agent and all its tokens",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
@@ -141,7 +141,7 @@ var agentRevokeCmd = &cobra.Command{
 
 var agentRotateCmd = &cobra.Command{
 	Use:   "rotate <name>",
-	Short: "Create a rotation invite to re-issue an agent's session",
+	Short: "Create a rotation invite to re-issue an agent's token",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]

--- a/cmd/invite.go
+++ b/cmd/invite.go
@@ -48,7 +48,7 @@ Content-Type: application/json
 
 {}
 
-The response contains your session token and usage instructions.
+The response contains your agent token and usage instructions.
 
 This invite expires in %s and can only be used once.
 `, inviteURL, formatDuration(ttl))

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -37,7 +37,7 @@ You have access to Agent Vault, an HTTP proxy that attaches credentials to your 
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault |
-| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`; instance-level agent sessions use `X-Vault` header instead) |
+| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`; instance-level agent tokens use `X-Vault` header instead) |
 
 ## Discover Available Services (Start Here)
 

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -37,7 +37,7 @@ You have access to Agent Vault, an HTTP proxy that attaches credentials to your 
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault |
-| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`; for instance-level agent sessions, use the `X-Vault` header instead) |
+| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`; for instance-level agent tokens, use the `X-Vault` header instead) |
 
 ## Discover Available Services (Start Here)
 
@@ -49,7 +49,7 @@ Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
 X-Vault: {vault_name}
 ```
 
-**Note:** If `AGENT_VAULT_VAULT` is set, the server uses it automatically. Instance-level agent sessions (persistent agents) must include the `X-Vault` header on all vault-scoped requests.
+**Note:** If `AGENT_VAULT_VAULT` is set, the server uses it automatically. Instance-level agent tokens (persistent agents) must include the `X-Vault` header on all vault-scoped requests.
 
 Response includes `vault`, `proxy_url`, `services` (host + description), and `available_credentials` (key names only, values are never exposed). Use `available_credentials` to reference existing credentials in proposals instead of creating duplicate slots.
 
@@ -171,15 +171,15 @@ Content-Type: application/json
 - Always check `available_credentials` first to avoid proposing duplicates
 - Include `obtain` and `obtain_instructions` to help the human find the credential
 
-## Instance-Level Agent Sessions
+## Instance-Level Agent Tokens
 
-If you were registered as a persistent agent (via an agent invite), your session is instance-level -- it is not scoped to a single vault. You may have access to multiple vaults. Include the `X-Vault` header on all vault-scoped requests (proxy, discover, proposals, credentials) to select which vault to operate on.
+If you were registered as a persistent agent (via an agent invite), your token is instance-level -- it is not scoped to a single vault. You may have access to multiple vaults. Include the `X-Vault` header on all vault-scoped requests (proxy, discover, proposals, credentials) to select which vault to operate on.
 
-If your session has no expiry, the token works indefinitely. If it does expire, contact your operator for a new session.
+If your token has no expiry, it works indefinitely. If it does expire, contact your operator for a new token.
 
 ## Error Handling
 
-- 401: Invalid or expired token -- check `AGENT_VAULT_SESSION_TOKEN` (persistent agents: contact operator for a new session)
+- 401: Invalid or expired token -- check `AGENT_VAULT_SESSION_TOKEN` (persistent agents: contact operator for a new token)
 - 403: Host not allowed -- create a proposal
 - 429: Too many pending proposals -- wait for review
 - 502: Missing credential or upstream unreachable, tell user a credential may need to be added
@@ -190,4 +190,4 @@ If your session has no expiry, the token works indefinitely. If it does expire, 
 - **Never** hardcode tokens -- always read from `AGENT_VAULT_SESSION_TOKEN`
 - **Only** request hosts returned by `/discover` -- if a host isn't listed, create a proposal
 - If you receive a `credential_not_found` error, inform the user which credential is missing
-- Do not modify or forge the `Authorization` header beyond using your session token
+- Do not modify or forge the `Authorization` header beyond using your token

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -20,13 +20,13 @@ The agent receives a temporary, vault-scoped session and can immediately make pr
 
 ## Inviting an agent
 
-For agents you can't wrap (cloud-hosted agents, existing sessions, CI pipelines), create an invite. The agent redeems the invite via HTTP and receives a session token.
+For agents you can't wrap (cloud-hosted agents, existing sessions, CI pipelines), create an invite. The agent redeems the invite via HTTP and receives an agent token.
 
 ```bash
 agent-vault agent invite my-agent
 ```
 
-Outputs a prompt with the invite URL. Paste it into the agent's chat. The agent redeems the invite and receives an instance-level session token.
+Outputs a prompt with the invite URL. Paste it into the agent's chat. The agent redeems the invite and receives an instance-level agent token.
 
 ### Instance role
 
@@ -103,13 +103,13 @@ agent-vault vault agent set-role my-agent --role member
 agent-vault vault agent remove my-agent
 ```
 
-### Rotating a session
+### Rotating an agent token
 
 ```bash
 agent-vault agent rotate my-agent
 ```
 
-This creates a rotation invite. Paste the prompt into the agent's chat. The agent redeems it and receives a new session token. Old sessions are invalidated when the rotation invite is redeemed.
+This creates a rotation invite. Paste the prompt into the agent's chat. The agent redeems it and receives a new agent token. Old tokens are invalidated when the rotation invite is redeemed.
 
 ### Managing invites
 
@@ -123,7 +123,7 @@ agent-vault agent invite revoke <token_suffix>
 
 ## The X-Vault header
 
-Instance-level agent sessions are not scoped to a single vault. Instead, agents select a vault per-request using the `X-Vault` header:
+Instance-level agent tokens are not scoped to a single vault. Instead, agents select a vault per-request using the `X-Vault` header:
 
 ```
 GET /discover

--- a/docs/agents/protocol.mdx
+++ b/docs/agents/protocol.mdx
@@ -9,14 +9,14 @@ Agent Vault agents follow a standard HTTP protocol to interact with the server. 
 Agents must never extract, log, or display credential values. They reference credentials by key name only.
 </Warning>
 
-## Session token
+## Bearer token
 
-Every request an agent makes to Agent Vault requires a session token. How the agent gets one depends on how it connects:
+Every request an agent makes to Agent Vault requires a bearer token. How the agent gets one depends on how it connects:
 
 | Method | How the agent gets a token |
 |---|---|
 | `agent-vault vault run` | Agent Vault sets `AGENT_VAULT_SESSION_TOKEN` on the child process automatically |
-| Agent invite | Agent calls `POST {invite_url}` and receives a session token |
+| Agent invite | Agent calls `POST {invite_url}` and receives an agent token |
 
 Both methods deliver the same core connection details:
 
@@ -30,11 +30,11 @@ Both methods deliver the same core connection details:
 There are two session types:
 
 - **Vault-scoped sessions** — created by `agent-vault vault run`. The vault is embedded in the session. No extra headers needed.
-- **Instance-level sessions** — created via agent invites. The agent must include an `X-Vault` header on every vault-scoped request to select which vault to use.
+- **Instance-level agent tokens** — created via agent invites. The agent must include an `X-Vault` header on every vault-scoped request to select which vault to use.
 
 ### The X-Vault header
 
-Instance-level agent sessions must include `X-Vault: {vault_name}` on all vault-scoped requests (discover, proxy, proposals, credentials):
+Instance-level agent tokens must include `X-Vault: {vault_name}` on all vault-scoped requests (discover, proxy, proposals, credentials):
 
 ```
 GET {AGENT_VAULT_ADDR}/discover
@@ -44,9 +44,9 @@ X-Vault: my-vault
 
 Agents created via `agent-vault vault run` do not need this header — the vault is embedded in the session token.
 
-### Instance-level agent sessions
+### Instance-level agent tokens
 
-Agents invited via `agent-vault agent invite` receive instance-level sessions that can access multiple vaults. The session token can be configured with no expiry (works indefinitely) or a specific TTL. If the session expires, the operator can issue a new one via [rotation](/agents/overview#rotating-a-session).
+Agents invited via `agent-vault agent invite` receive instance-level agent tokens that can access multiple vaults. The agent token can be configured with no expiry (works indefinitely) or a specific TTL. If the token expires, the operator can issue a new one via [rotation](/agents/overview#rotating-an-agent-token).
 
 See [Agents overview](/agents/overview) for the full lifecycle.
 
@@ -61,7 +61,7 @@ X-Vault: my-vault
 ```
 
 <Note>
-The `X-Vault` header is required for instance-level sessions. Vault-scoped sessions (from `vault run`) can omit it.
+The `X-Vault` header is required for instance-level agent tokens. Vault-scoped sessions (from `vault run`) can omit it.
 </Note>
 
 ```json Response
@@ -163,7 +163,7 @@ See [Proposals](/learn/proposals) for the full proposal lifecycle, including sto
 
 | Status | Meaning | What the agent does |
 |---|---|---|
-| 401 | Invalid or expired token | Re-check `AGENT_VAULT_SESSION_TOKEN`. Contact operator for a new session or [rotation](/agents/overview#rotating-a-session). |
+| 401 | Invalid or expired token | Re-check `AGENT_VAULT_SESSION_TOKEN`. Contact operator for a new token or [rotation](/agents/overview#rotating-an-agent-token). |
 | 403 | Host not allowed | Create a proposal to request access. The response includes a `proposal_hint`. |
 | 429 | Too many pending proposals | Wait for existing proposals to be reviewed. |
 | 502 | Missing credential or upstream error | Tell the user a credential may need to be added. |

--- a/docs/first-proposal.mdx
+++ b/docs/first-proposal.mdx
@@ -28,7 +28,7 @@ If you haven't logged in yet, you'll be guided through setup automatically.
 
 ## 2. Paste the prompt into your agent
 
-Open your agent (Claude Code, Cursor, or any supported agent) and paste the invite prompt. The agent redeems the invite automatically and receives a session token.
+Open your agent (Claude Code, Cursor, or any supported agent) and paste the invite prompt. The agent redeems the invite automatically and receives an agent token.
 
 ## 3. Give the agent a task
 

--- a/docs/guides/connect-coding-agent.mdx
+++ b/docs/guides/connect-coding-agent.mdx
@@ -49,7 +49,7 @@ For agents you can't wrap with `vault run` (e.g. cloud-hosted agents, or when yo
         Copy the invite prompt that appears.
       </Step>
       <Step title="Paste into the agent">
-        Paste the prompt into your agent's chat. The agent redeems the invite automatically and receives a session token.
+        Paste the prompt into your agent's chat. The agent redeems the invite automatically and receives an agent token.
       </Step>
     </Steps>
   </Tab>
@@ -83,7 +83,7 @@ You don't need to pre-configure anything. The agent discovers what it needs, ask
 
 ## For long-lived agents
 
-Invited agents are instance-level entities with named identities that persist across sessions. You can manage vault access, rotate sessions, and revoke agents at any time. See [Agents overview](/agents/overview) for the full lifecycle.
+Invited agents are instance-level entities with named identities that persist across sessions. You can manage vault access, rotate agent tokens, and revoke agents at any time. See [Agents overview](/agents/overview) for the full lifecycle.
 
 ## Next steps
 

--- a/docs/guides/connect-custom-agent.mdx
+++ b/docs/guides/connect-custom-agent.mdx
@@ -35,10 +35,10 @@ If you're using Claude Code, Cursor, or another supported agent, see the [Quicks
 
     This prints an invite prompt. The agent redeems it via `POST {invite_url}` and receives:
     - `av_addr` — the Agent Vault server URL
-    - `av_session_token` — bearer token for all requests
+    - `av_agent_token` — bearer token for all requests
     - `vaults` — list of accessible vaults
 
-    Instance-level sessions require the `X-Vault` header on every vault-scoped request.
+    Instance-level agent tokens require the `X-Vault` header on every vault-scoped request.
   </Tab>
 </Tabs>
 
@@ -51,7 +51,7 @@ Your agent needs these values to operate:
 | `AGENT_VAULT_ADDR` | Yes | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_SESSION_TOKEN` | Yes | Bearer token for authenticating all requests to Agent Vault |
 
-For instance-level sessions (from agent invites), the agent must also send the `X-Vault` header on every vault-scoped request. For vault-scoped sessions (from `vault run`), the vault is embedded in the session.
+For instance-level agent tokens (from agent invites), the agent must also send the `X-Vault` header on every vault-scoped request. For vault-scoped sessions (from `vault run`), the vault is embedded in the session.
 
 ## Make proxied requests
 
@@ -63,7 +63,7 @@ The proxy URL format is:
 {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
 ```
 
-Every request to the proxy must include your session token in the `Authorization` header. Agent Vault strips it before forwarding and replaces it with the real credentials from the vault's services.
+Every request to the proxy must include your agent token in the `Authorization` header. Agent Vault strips it before forwarding and replaces it with the real credentials from the vault's services.
 
 <CodeGroup>
 
@@ -165,7 +165,7 @@ Discovery is optional. If your agent already knows which hosts are configured, i
 
 | Status | Meaning | What to do |
 |---|---|---|
-| 401 | Invalid or expired session token | Re-authenticate. Contact the operator for a [session rotation](/agents/overview#rotating-a-session). |
+| 401 | Invalid or expired token | Re-authenticate. Contact the operator for a [token rotation](/agents/overview#rotating-an-agent-token). |
 | 403 | Host not allowed | The service isn't configured in the vault. Create a [proposal](/learn/proposals) to request access, or ask the vault admin to add it. The response body includes a `proposal_hint`. |
 | 429 | Too many pending proposals | Wait for existing proposals to be reviewed before creating new ones. |
 | 502 | Missing credential or upstream error | A credential may need to be added to the vault. Inform the user. |

--- a/docs/learn/security.mdx
+++ b/docs/learn/security.mdx
@@ -46,7 +46,8 @@ All tokens are generated from `crypto/rand` (256 bits of entropy) and hashed bef
 
 | Token | Prefix | Storage hash | TTL | Notes |
 | ----- | ------ | ------------ | --- | ----- |
-| Session | `av_sess_` | SHA-256 | Configurable (or no expiry) | Scoped to a vault or user-global |
+| Session | `av_sess_` | SHA-256 | Configurable (or no expiry) | Vault-scoped or user-global |
+| Agent token | `av_agt_` | SHA-256 | Configurable (or no expiry) | Instance-level agent identity |
 | Invite | `av_inv_` | SHA-256 | 15 minutes | Single-use, burned on redemption |
 | Approval | `av_appr_` | SHA-256 | 24 hours | Grants read-only access to a [proposal](/learn/proposals) |
 | Vault invite | `av_uinv_` | SHA-256 | 48 hours | For onboarding human users |
@@ -90,11 +91,11 @@ Agent Vault resolves hostnames to IP addresses, validates every resolved IP agai
 
 ## Transport security
 
-All proxied requests are forwarded over **HTTPS**, regardless of how the agent connects to Agent Vault locally. The agent's `Authorization` header (containing its Agent Vault session token) is stripped before forwarding; real credentials are injected server-side based on the vault's [services](/learn/services).
+All proxied requests are forwarded over **HTTPS**, regardless of how the agent connects to Agent Vault locally. The agent's `Authorization` header (containing its Agent Vault token) is stripped before forwarding; real credentials are injected server-side based on the vault's [services](/learn/services).
 
 This means:
-- Agents authenticate to Agent Vault with a session token that grants no direct access to credentials.
-- The session token never reaches the target service.
+- Agents authenticate to Agent Vault with a token that grants no direct access to credentials.
+- The agent's token never reaches the target service.
 - Credential values only exist in the outbound request headers, never in the agent's address space.
 
 ## Access control

--- a/docs/learn/vaults.mdx
+++ b/docs/learn/vaults.mdx
@@ -53,7 +53,7 @@ Vault resolution priority: `--vault` flag > `AGENT_VAULT_VAULT` env var > `agent
         automatically. The `--vault` flag pre-assigns vault access (format: `name:role`).
       </Step>
       <Step title="Paste into the agent's chat">
-        The agent redeems the invite automatically and receives a session token.
+        The agent redeems the invite automatically and receives an agent token.
       </Step>
     </Steps>
 

--- a/docs/quickstart/claude-code.mdx
+++ b/docs/quickstart/claude-code.mdx
@@ -55,7 +55,7 @@ If you can't use `vault run` (e.g. you're connecting a remote or cloud-hosted Cl
 agent-vault agent invite my-agent
 ```
 
-This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Claude Code — it redeems the invite automatically and receives a session token plus usage instructions inline.
+This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Claude Code — it redeems the invite automatically and receives an agent token plus usage instructions inline.
 
 ## Next steps
 

--- a/docs/quickstart/codex.mdx
+++ b/docs/quickstart/codex.mdx
@@ -55,7 +55,7 @@ If you can't use `vault run` (e.g. you're connecting a remote or cloud-hosted Co
 agent-vault agent invite my-agent
 ```
 
-This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Codex — it redeems the invite automatically and receives a session token plus usage instructions inline.
+This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Codex — it redeems the invite automatically and receives an agent token plus usage instructions inline.
 
 ## Next steps
 

--- a/docs/quickstart/cursor.mdx
+++ b/docs/quickstart/cursor.mdx
@@ -55,7 +55,7 @@ If you can't use `vault run` (e.g. you're connecting a remote or cloud-hosted Cu
 agent-vault agent invite my-agent
 ```
 
-This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Cursor — it redeems the invite automatically and receives a session token plus usage instructions inline.
+This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Cursor — it redeems the invite automatically and receives an agent token plus usage instructions inline.
 
 ## Next steps
 

--- a/docs/quickstart/custom-agent.mdx
+++ b/docs/quickstart/custom-agent.mdx
@@ -32,7 +32,7 @@ For agents that can't be wrapped with `vault run` (e.g. cloud-hosted or CI pipel
 agent-vault agent invite my-agent --vault default:proxy
 ```
 
-The agent redeems the invite via HTTP and receives a session token. See [Connect a custom agent](/guides/connect-custom-agent) for the full walkthrough.
+The agent redeems the invite via HTTP and receives an agent token. See [Connect a custom agent](/guides/connect-custom-agent) for the full walkthrough.
 
 ## Try it out
 
@@ -75,7 +75,7 @@ console.log(await resp.json());
 If the service isn't configured yet, Agent Vault returns a **403** with a `proposal_hint`. Your agent can use this to create a [proposal](/learn/proposals) requesting access.
 
 <Note>
-Your agent never sees or handles credentials. Agent Vault strips the session token and injects the real API key before forwarding to the target service.
+Your agent never sees or handles credentials. Agent Vault strips the agent's token and injects the real API key before forwarding to the target service.
 </Note>
 
 ## Discover available services

--- a/docs/quickstart/hermes-agent.mdx
+++ b/docs/quickstart/hermes-agent.mdx
@@ -22,7 +22,7 @@ This generates a one-time onboarding prompt and copies it to your clipboard.
 
 ## 2. Paste the prompt into Hermes Agent
 
-Open Hermes Agent's chat and paste the invite prompt. Hermes Agent redeems the invite automatically and receives a session token.
+Open Hermes Agent's chat and paste the invite prompt. Hermes Agent redeems the invite automatically and receives an agent token.
 
 ## 3. Start using it
 

--- a/docs/quickstart/nanoclaw.mdx
+++ b/docs/quickstart/nanoclaw.mdx
@@ -22,7 +22,7 @@ This generates a one-time onboarding prompt and copies it to your clipboard.
 
 ## 2. Paste the prompt into NanoClaw
 
-Open NanoClaw's chat and paste the invite prompt. NanoClaw redeems the invite automatically and receives a session token.
+Open NanoClaw's chat and paste the invite prompt. NanoClaw redeems the invite automatically and receives an agent token.
 
 ## 3. Start using it
 

--- a/docs/quickstart/openclaw.mdx
+++ b/docs/quickstart/openclaw.mdx
@@ -22,7 +22,7 @@ This generates a one-time onboarding prompt and copies it to your clipboard.
 
 ## 2. Paste the prompt into OpenClaw
 
-Open OpenClaw's chat and paste the invite prompt. OpenClaw redeems the invite automatically and receives a session token.
+Open OpenClaw's chat and paste the invite prompt. OpenClaw redeems the invite automatically and receives an agent token.
 
 ## 3. Start using it
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -544,7 +544,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault agent invite <name> [flags]
     ```
 
-    Create an agent invite and print the onboarding prompt (copies to clipboard). The agent redeems the invite via HTTP and receives an instance-level session token.
+    Create an agent invite and print the onboarding prompt (copies to clipboard). The agent redeems the invite via HTTP and receives an instance-level agent token.
 
     | Flag | Default | Description |
     |------|---------|-------------|

--- a/internal/server/handle_agents.go
+++ b/internal/server/handle_agents.go
@@ -109,7 +109,7 @@ func (s *Server) handleAgentInviteList(w http.ResponseWriter, r *http.Request) {
 		CreatedAt        string           `json:"created_at"`
 		ExpiresAt        string           `json:"expires_at"`
 		RedeemedAt       *string          `json:"redeemed_at,omitempty"`
-		SessionExpiresAt *string          `json:"session_expires_at,omitempty"`
+		TokenExpiresAt *string          `json:"token_expires_at,omitempty"`
 	}
 
 	items := make([]inviteItem, len(filtered))
@@ -134,7 +134,7 @@ func (s *Server) handleAgentInviteList(w http.ResponseWriter, r *http.Request) {
 		if inv.Status == "redeemed" && inv.SessionID != "" {
 			if session, err := s.store.GetSession(ctx, inv.SessionID); err == nil && session != nil {
 				e := formatExpiresAt(session.ExpiresAt)
-				items[i].SessionExpiresAt = &e
+				items[i].TokenExpiresAt = &e
 			}
 		}
 	}
@@ -344,25 +344,25 @@ func (s *Server) handlePersistentInviteRedeem(w http.ResponseWriter, r *http.Req
 		vaultInfos = append(vaultInfos, agentVaultJSON{VaultName: v.VaultName, VaultRole: v.VaultRole})
 	}
 
-	// Create instance-level session (no vault_id).
-	var sessExpiry *time.Time
+	// Create instance-level agent token (no vault_id).
+	var tokenExpiry *time.Time
 	if inv.SessionTTLSeconds > 0 {
-		sessExpiry = timePtr(time.Now().Add(time.Duration(inv.SessionTTLSeconds) * time.Second))
+		tokenExpiry = timePtr(time.Now().Add(time.Duration(inv.SessionTTLSeconds) * time.Second))
 	}
-	sess, err := s.store.CreateAgentSession(ctx, agent.ID, sessExpiry)
+	sess, err := s.store.CreateAgentToken(ctx, agent.ID, tokenExpiry)
 	if err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to create session")
+		jsonError(w, http.StatusInternalServerError, "Failed to create agent token")
 		return
 	}
 
-	// Link session back to invite so invite list can show session expiry.
+	// Link token back to invite so invite list can show token expiry.
 	_ = s.store.UpdateInviteSessionID(ctx, inv.ID, sess.ID)
 
 	baseURL := s.baseURL
 
 	jsonOK(w, map[string]interface{}{
 		"av_addr":          baseURL,
-		"av_session_token": sess.ID,
+		"av_agent_token": sess.ID,
 		"agent_name":       agentName,
 		"proxy_url":        baseURL + "/proxy",
 		"vaults":           vaultInfos,
@@ -386,20 +386,20 @@ func (s *Server) handleRotationRedeem(w http.ResponseWriter, r *http.Request, in
 		return
 	}
 
-	// Invalidate existing sessions for this agent (rotation replaces access).
-	if err := s.store.DeleteAgentSessions(ctx, agent.ID); err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to invalidate old sessions")
+	// Invalidate existing tokens for this agent (rotation replaces access).
+	if err := s.store.DeleteAgentTokens(ctx, agent.ID); err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to invalidate old agent tokens")
 		return
 	}
 
-	// Create a new instance-level session.
-	sess, err := s.store.CreateAgentSession(ctx, agent.ID, nil)
+	// Create a new instance-level agent token.
+	sess, err := s.store.CreateAgentToken(ctx, agent.ID, nil)
 	if err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to create session")
+		jsonError(w, http.StatusInternalServerError, "Failed to create agent token")
 		return
 	}
 
-	// Link session back to invite so invite list can show session expiry.
+	// Link token back to invite so invite list can show token expiry.
 	_ = s.store.UpdateInviteSessionID(ctx, inv.ID, sess.ID)
 
 	var vaultInfos []agentVaultJSON
@@ -411,7 +411,7 @@ func (s *Server) handleRotationRedeem(w http.ResponseWriter, r *http.Request, in
 
 	jsonOK(w, map[string]interface{}{
 		"av_addr":          baseURL,
-		"av_session_token": sess.ID,
+		"av_agent_token": sess.ID,
 		"agent_name":       agent.Name,
 		"proxy_url":        baseURL + "/proxy",
 		"vaults":           vaultInfos,
@@ -465,7 +465,7 @@ func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 		Vaults           []agentVaultJSON `json:"vaults"`
 		CreatedAt        string           `json:"created_at"`
 		RevokedAt        *string          `json:"revoked_at,omitempty"`
-		SessionExpiresAt *string          `json:"session_expires_at,omitempty"`
+		TokenExpiresAt *string          `json:"token_expires_at,omitempty"`
 	}
 
 	items := make([]agentItem, 0, len(agents))
@@ -487,9 +487,9 @@ func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 			item.RevokedAt = &s
 		}
 		if ag.Status == "active" {
-			if expiry, err := s.store.GetLatestAgentSessionExpiry(ctx, ag.ID); err == nil && expiry != nil {
+			if expiry, err := s.store.GetLatestAgentTokenExpiry(ctx, ag.ID); err == nil && expiry != nil {
 				e := expiry.Format(time.RFC3339)
-				item.SessionExpiresAt = &e
+				item.TokenExpiresAt = &e
 			}
 		}
 		items = append(items, item)
@@ -567,11 +567,11 @@ func (s *Server) handleAgentGet(w http.ResponseWriter, r *http.Request) {
 		resp["revoked_at"] = agent.RevokedAt.Format(time.RFC3339)
 	}
 
-	// Count active sessions.
-	sessionCount, _ := s.store.CountAgentSessions(ctx, agent.ID)
-	resp["active_sessions"] = sessionCount
-	if expiry, err := s.store.GetLatestAgentSessionExpiry(ctx, agent.ID); err == nil && expiry != nil {
-		resp["session_expires_at"] = expiry.Format(time.RFC3339)
+	// Count active tokens.
+	tokenCount, _ := s.store.CountAgentTokens(ctx, agent.ID)
+	resp["active_tokens"] = tokenCount
+	if expiry, err := s.store.GetLatestAgentTokenExpiry(ctx, agent.ID); err == nil && expiry != nil {
+		resp["token_expires_at"] = expiry.Format(time.RFC3339)
 	}
 
 	jsonOK(w, resp)
@@ -655,7 +655,7 @@ func (s *Server) handleAgentRotate(w http.ResponseWriter, r *http.Request) {
 
   {}
 
-The response contains your new session token and usage instructions.
+The response contains your new agent token and usage instructions.
 
 This link expires in 15 minutes and can only be used once.
 `, inviteURL)

--- a/internal/server/handle_discovery.go
+++ b/internal/server/handle_discovery.go
@@ -22,7 +22,7 @@ type discoverResponse struct {
 func (s *Server) handleDiscover(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Require scoped session or agent session with X-Vault.
+	// Require scoped session or agent token with X-Vault.
 	sess := sessionFromContext(ctx)
 	if sess == nil {
 		proxyError(w, http.StatusForbidden, "forbidden", "Discovery requires a vault-scoped session")

--- a/internal/server/handle_proposals.go
+++ b/internal/server/handle_proposals.go
@@ -114,7 +114,7 @@ type proposalCreateRequest struct {
 func (s *Server) handleProposalCreate(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// Enforce scoped session or agent session with X-Vault.
+	// Enforce scoped session or agent token with X-Vault.
 	sess := sessionFromContext(ctx)
 	if sess == nil {
 		jsonError(w, http.StatusForbidden, "Proposals require a vault-scoped session")

--- a/internal/server/handle_proxy.go
+++ b/internal/server/handle_proxy.go
@@ -122,7 +122,7 @@ var proxyClient *http.Client
 
 // resolveVaultForSession resolves the vault ID for the current session.
 // For user scoped sessions (VaultID set), returns the session's vault directly.
-// For agent sessions (VaultID empty), reads vault name from X-Vault header and checks access.
+// For agent tokens (VaultID empty), reads vault name from X-Vault header and checks access.
 // Returns vault, vault role, error. Writes error response to w on failure.
 func (s *Server) resolveVaultForSession(w http.ResponseWriter, r *http.Request, sess *store.Session) (*store.Vault, string, error) {
 	ctx := r.Context()
@@ -137,7 +137,7 @@ func (s *Server) resolveVaultForSession(w http.ResponseWriter, r *http.Request, 
 		return ns, sess.VaultRole, nil
 	}
 
-	// Agent session — resolve vault from X-Vault header.
+	// Agent token — resolve vault from X-Vault header.
 	if sess.AgentID == "" {
 		jsonError(w, http.StatusForbidden, "Session requires vault scope")
 		return nil, "", fmt.Errorf("no vault context")
@@ -145,7 +145,7 @@ func (s *Server) resolveVaultForSession(w http.ResponseWriter, r *http.Request, 
 
 	vaultName := r.Header.Get("X-Vault")
 	if vaultName == "" {
-		jsonError(w, http.StatusBadRequest, "Agent sessions require X-Vault header to specify which vault to use")
+		jsonError(w, http.StatusBadRequest, "Agent tokens require X-Vault header to specify which vault to use")
 		return nil, "", fmt.Errorf("missing X-Vault header")
 	}
 
@@ -188,7 +188,7 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	// 2. Resolve vault — user scoped sessions use session vault, agent sessions use X-Vault header.
+	// 2. Resolve vault — user scoped sessions use session vault, agent tokens use X-Vault header.
 	sess := sessionFromContext(ctx)
 	if sess == nil {
 		proxyError(w, http.StatusForbidden, "forbidden", "Proxy requires an authenticated session")

--- a/internal/server/persistent_agent_instructions.txt
+++ b/internal/server/persistent_agent_instructions.txt
@@ -2,14 +2,14 @@ You are a persistent agent registered with Agent Vault, an HTTP proxy that attac
 
 ## Token
 
-You received a session token (av_session_token). Use it for all proxy/discover/proposal calls. If your session has no expiry, the token works indefinitely. If it does expire, contact your operator for a new session.
+You received an agent token (av_agent_token). Use it for all proxy/discover/proposal calls. If your token has no expiry, it works indefinitely. If it does expire, contact your operator for a new token.
 
 ## Discovery & Proxy
 
   GET {AGENT_VAULT_ADDR}/discover                              — list brokerable services + available_credentials
   {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]        — proxy a request
 
-Both require: Authorization: Bearer {av_session_token}
+Both require: Authorization: Bearer {av_agent_token}
 
 Agent Vault strips your auth header, attaches real credentials, and forwards over HTTPS. Only proxy hosts returned by /discover — all other requests go direct.
 
@@ -31,7 +31,7 @@ Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic
 ### Creating a Proposal
 
   POST {AGENT_VAULT_ADDR}/v1/proposals
-  Authorization: Bearer {av_session_token}
+  Authorization: Bearer {av_agent_token}
   Content-Type: application/json
 
   {
@@ -55,7 +55,7 @@ Response includes approval_url. After creating:
 
 ## Error Handling
 
-- 401: Invalid/expired token — contact your operator for a new session
+- 401: Invalid/expired token — contact your operator for a new token
 - 403: Host not allowed — raise a proposal
 - 429: Too many pending proposals — wait for review
 - 502: Missing credential or upstream unreachable — tell user

--- a/internal/server/persistent_instructions_admin.txt
+++ b/internal/server/persistent_instructions_admin.txt
@@ -6,11 +6,11 @@ You are an instance-level agent. You may have access to multiple vaults. Use the
 
 ## Token
 
-You received a session token (av_session_token). Use it for all proxy/discover/proposal calls. If your session has no expiry, the token works indefinitely. If it does expire, contact your operator for a new session.
+You received an agent token (av_agent_token). Use it for all proxy/discover/proposal calls. If your token has no expiry, it works indefinitely. If it does expire, contact your operator for a new token.
 
 ## Quick Start
 
-1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_session_token} and X-Vault: {vault_name} — do this FIRST
+1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_agent_token} and X-Vault: {vault_name} — do this FIRST
 2. For hosts in the response, route through the proxy: {AGENT_VAULT_ADDR}/proxy/{target_host}/{path} (include X-Vault header)
 3. If a needed service isn't listed, raise a proposal.
 

--- a/internal/server/persistent_instructions_member.txt
+++ b/internal/server/persistent_instructions_member.txt
@@ -6,11 +6,11 @@ Your vault role is **member**. You can proxy requests, discover services, raise 
 
 ## Token
 
-You received a session token (av_session_token). Use it for all proxy/discover/proposal calls. If your session has no expiry, the token works indefinitely. If it does expire, contact your operator for a new session.
+You received an agent token (av_agent_token). Use it for all proxy/discover/proposal calls. If your token has no expiry, it works indefinitely. If it does expire, contact your operator for a new token.
 
 ## Quick Start
 
-1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_session_token} — do this FIRST
+1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_agent_token} — do this FIRST
 2. For hosts in the response, route through the proxy: {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}
 3. If a needed service isn't listed, raise a proposal.
 

--- a/internal/server/persistent_instructions_proxy.txt
+++ b/internal/server/persistent_instructions_proxy.txt
@@ -6,11 +6,11 @@ Your vault role is **proxy**. You can proxy requests, discover services, and rai
 
 ## Token
 
-You received a session token (av_session_token). Use it for all proxy/discover/proposal calls. If your session has no expiry, the token works indefinitely. If it does expire, contact your operator for a new session.
+You received an agent token (av_agent_token). Use it for all proxy/discover/proposal calls. If your token has no expiry, it works indefinitely. If it does expire, contact your operator for a new token.
 
 ## Quick Start
 
-1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_session_token} — do this FIRST
+1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_agent_token} — do this FIRST
 2. For hosts in the response, route through the proxy: {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}
 3. If a needed service isn't listed, raise a proposal.
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -194,10 +194,10 @@ type Store interface {
 	RevokeAgent(ctx context.Context, id string) error
 	RenameAgent(ctx context.Context, id string, newName string) error
 	UpdateAgentRole(ctx context.Context, agentID, role string) error
-	CountAgentSessions(ctx context.Context, agentID string) (int, error)
-	GetLatestAgentSessionExpiry(ctx context.Context, agentID string) (*time.Time, error)
-	DeleteAgentSessions(ctx context.Context, agentID string) error
-	CreateAgentSession(ctx context.Context, agentID string, expiresAt *time.Time) (*store.Session, error)
+	CountAgentTokens(ctx context.Context, agentID string) (int, error)
+	GetLatestAgentTokenExpiry(ctx context.Context, agentID string) (*time.Time, error)
+	DeleteAgentTokens(ctx context.Context, agentID string) error
+	CreateAgentToken(ctx context.Context, agentID string, expiresAt *time.Time) (*store.Session, error)
 	CountAllOwners(ctx context.Context) (int, error)
 
 	Close() error

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1017,7 +1017,7 @@ func (m *mockStore) RenameAgent(_ context.Context, id string, newName string) er
 	return fmt.Errorf("agent not found")
 }
 
-func (m *mockStore) CountAgentSessions(_ context.Context, agentID string) (int, error) {
+func (m *mockStore) CountAgentTokens(_ context.Context, agentID string) (int, error) {
 	count := 0
 	for _, sess := range m.sessions {
 		if sess.AgentID == agentID && (sess.ExpiresAt == nil || time.Now().Before(*sess.ExpiresAt)) {
@@ -1027,7 +1027,7 @@ func (m *mockStore) CountAgentSessions(_ context.Context, agentID string) (int, 
 	return count, nil
 }
 
-func (m *mockStore) GetLatestAgentSessionExpiry(_ context.Context, agentID string) (*time.Time, error) {
+func (m *mockStore) GetLatestAgentTokenExpiry(_ context.Context, agentID string) (*time.Time, error) {
 	var latest *time.Time
 	now := time.Now()
 	for _, sess := range m.sessions {
@@ -1041,7 +1041,7 @@ func (m *mockStore) GetLatestAgentSessionExpiry(_ context.Context, agentID strin
 	return latest, nil
 }
 
-func (m *mockStore) DeleteAgentSessions(_ context.Context, agentID string) error {
+func (m *mockStore) DeleteAgentTokens(_ context.Context, agentID string) error {
 	for id, sess := range m.sessions {
 		if sess.AgentID == agentID {
 			delete(m.sessions, id)
@@ -1050,8 +1050,8 @@ func (m *mockStore) DeleteAgentSessions(_ context.Context, agentID string) error
 	return nil
 }
 
-func (m *mockStore) CreateAgentSession(_ context.Context, agentID string, expiresAt *time.Time) (*store.Session, error) {
-	id := "agent-session-" + agentID + "-" + fmt.Sprintf("%d", len(m.sessions))
+func (m *mockStore) CreateAgentToken(_ context.Context, agentID string, expiresAt *time.Time) (*store.Session, error) {
+	id := "agent-token-" + agentID + "-" + fmt.Sprintf("%d", len(m.sessions))
 	s := &store.Session{
 		ID:        id,
 		AgentID:   agentID,
@@ -2139,7 +2139,7 @@ func TestProxyStripsAuthHeader(t *testing.T) {
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")
 		if strings.Contains(auth, "scoped-session") {
-			t.Errorf("agent session token leaked to upstream: %q", auth)
+			t.Errorf("agent token leaked to upstream: %q", auth)
 		}
 		if auth != "Bearer sk_live_xxx" {
 			t.Errorf("expected injected auth, got %q", auth)
@@ -2869,8 +2869,8 @@ func TestHandleInviteRedeem(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if resp["av_session_token"] == nil || resp["av_session_token"].(string) == "" {
-		t.Fatal("expected non-empty session token")
+	if resp["av_agent_token"] == nil || resp["av_agent_token"].(string) == "" {
+		t.Fatal("expected non-empty agent token")
 	}
 	if resp["agent_name"] != "test-agent" {
 		t.Fatalf("expected agent_name test-agent, got %v", resp["agent_name"])
@@ -3288,8 +3288,8 @@ func TestPersistentInviteRedeemPOST(t *testing.T) {
 	if resp["agent_name"] != "mybot" {
 		t.Fatalf("expected agent_name mybot, got %v", resp["agent_name"])
 	}
-	if resp["av_session_token"] == nil || resp["av_session_token"].(string) == "" {
-		t.Fatal("expected non-empty av_session_token")
+	if resp["av_agent_token"] == nil || resp["av_agent_token"].(string) == "" {
+		t.Fatal("expected non-empty av_agent_token")
 	}
 
 	// Verify agent was created.
@@ -3412,7 +3412,7 @@ func TestDuplicateAgentName409(t *testing.T) {
 	}
 }
 
-// TestAgentSessionMint tests removed — POST /v1/agent/session endpoint was removed
+// TestAgentTokenMint tests removed — POST /v1/agent/session endpoint was removed
 // as part of the unified token model (service tokens no longer issued).
 
 func TestAgentList(t *testing.T) {

--- a/internal/store/migrations/035_instance_level_agents.sql
+++ b/internal/store/migrations/035_instance_level_agents.sql
@@ -83,8 +83,8 @@ ALTER TABLE invites_new RENAME TO invites;
 CREATE INDEX idx_invites_token_hash ON invites(token_hash);
 CREATE INDEX idx_invites_status ON invites(status);
 
--- 7. Rebuild sessions table to allow NULL vault_id for instance-level agent sessions.
---    User scoped sessions still have vault_id set. Agent sessions have vault_id = NULL.
+-- 7. Rebuild sessions table to allow NULL vault_id for instance-level agent tokens.
+--    User scoped sessions still have vault_id set. Agent tokens have vault_id = NULL.
 CREATE TABLE sessions_new (
     id         TEXT PRIMARY KEY,
     expires_at TEXT,

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -842,13 +842,17 @@ func (s *SQLiteStore) GetBrokerConfig(ctx context.Context, vaultID string) (*Bro
 
 const approvalTokenTTL = 24 * time.Hour
 
-func newApprovalToken() string {
+// newPrefixedToken generates a 256-bit cryptographically random token
+// with the given prefix followed by 64 hex characters.
+func newPrefixedToken(prefix string) string {
 	var b [32]byte
 	if _, err := io.ReadFull(rand.Reader, b[:]); err != nil {
 		panic("crypto/rand: " + err.Error())
 	}
-	return "av_appr_" + hex.EncodeToString(b[:])
+	return prefix + hex.EncodeToString(b[:])
 }
+
+func newApprovalToken() string { return newPrefixedToken("av_appr_") }
 
 func (s *SQLiteStore) CreateProposal(ctx context.Context, vaultID, sessionID, servicesJSON, credentialsJSON, message, userMessage string, credentials map[string]EncryptedCredential) (*Proposal, error) {
 	now := time.Now().UTC()
@@ -1163,15 +1167,7 @@ func scanBrokerConfig(row *sql.Row) (*BrokerConfig, error) {
 
 // --- Invites ---
 
-// newInviteToken generates a cryptographically random invite token
-// with the av_inv_ prefix followed by 64 hex characters (32 random bytes).
-func newInviteToken() string {
-	var b [32]byte
-	if _, err := io.ReadFull(rand.Reader, b[:]); err != nil {
-		panic("crypto/rand: " + err.Error())
-	}
-	return "av_inv_" + hex.EncodeToString(b[:])
-}
+func newInviteToken() string { return newPrefixedToken("av_inv_") }
 
 func (s *SQLiteStore) CreateAgentInvite(ctx context.Context, agentName, createdBy string, expiresAt time.Time, sessionTTLSeconds int, agentRole string, vaults []AgentInviteVault) (*Invite, error) {
 	now := time.Now().UTC()
@@ -1598,13 +1594,7 @@ func (s *SQLiteStore) loadAgentInviteVaults(ctx context.Context, inviteID int) (
 
 // --- Vault Invites ---
 
-func newUserInviteToken() string {
-	var b [32]byte
-	if _, err := io.ReadFull(rand.Reader, b[:]); err != nil {
-		panic("crypto/rand: " + err.Error())
-	}
-	return "av_uinv_" + hex.EncodeToString(b[:])
-}
+func newUserInviteToken() string { return newPrefixedToken("av_uinv_") }
 
 func (s *SQLiteStore) CreateUserInvite(ctx context.Context, email, createdBy, role string, expiresAt time.Time, vaults []UserInviteVault) (*UserInvite, error) {
 	now := time.Now().UTC()
@@ -2472,10 +2462,10 @@ func (s *SQLiteStore) RevokeAgent(ctx context.Context, id string) error {
 		return sql.ErrNoRows
 	}
 
-	// Cascade: delete all sessions minted by this agent.
+	// Cascade: delete all tokens minted for this agent.
 	_, err = tx.ExecContext(ctx, "DELETE FROM sessions WHERE agent_id = ?", id)
 	if err != nil {
-		return fmt.Errorf("deleting agent sessions: %w", err)
+		return fmt.Errorf("deleting agent tokens: %w", err)
 	}
 
 	return tx.Commit()
@@ -2499,7 +2489,7 @@ func (s *SQLiteStore) RenameAgent(ctx context.Context, id string, newName string
 	return nil
 }
 
-func (s *SQLiteStore) CountAgentSessions(ctx context.Context, agentID string) (int, error) {
+func (s *SQLiteStore) CountAgentTokens(ctx context.Context, agentID string) (int, error) {
 	var count int
 	nowStr := nowUTC()
 	err := s.db.QueryRowContext(ctx,
@@ -2509,8 +2499,8 @@ func (s *SQLiteStore) CountAgentSessions(ctx context.Context, agentID string) (i
 	return count, err
 }
 
-func (s *SQLiteStore) GetLatestAgentSessionExpiry(ctx context.Context, agentID string) (*time.Time, error) {
-	// Check for non-expiring sessions first — they represent "never expires".
+func (s *SQLiteStore) GetLatestAgentTokenExpiry(ctx context.Context, agentID string) (*time.Time, error) {
+	// Check for non-expiring tokens first — they represent "never expires".
 	var hasNonExpiring int
 	if err := s.db.QueryRowContext(ctx,
 		"SELECT COUNT(*) FROM sessions WHERE agent_id = ? AND expires_at IS NULL",
@@ -2538,16 +2528,16 @@ func (s *SQLiteStore) GetLatestAgentSessionExpiry(ctx context.Context, agentID s
 	return &t, nil
 }
 
-func (s *SQLiteStore) DeleteAgentSessions(ctx context.Context, agentID string) error {
+func (s *SQLiteStore) DeleteAgentTokens(ctx context.Context, agentID string) error {
 	_, err := s.db.ExecContext(ctx, "DELETE FROM sessions WHERE agent_id = ?", agentID)
 	if err != nil {
-		return fmt.Errorf("deleting agent sessions: %w", err)
+		return fmt.Errorf("deleting agent tokens: %w", err)
 	}
 	return nil
 }
 
-func (s *SQLiteStore) CreateAgentSession(ctx context.Context, agentID string, expiresAt *time.Time) (*Session, error) {
-	rawToken := newSessionToken()
+func (s *SQLiteStore) CreateAgentToken(ctx context.Context, agentID string, expiresAt *time.Time) (*Session, error) {
+	rawToken := newAgentToken()
 	tokenHash := hashSessionToken(rawToken)
 	now := time.Now().UTC()
 
@@ -2561,7 +2551,7 @@ func (s *SQLiteStore) CreateAgentSession(ctx context.Context, agentID string, ex
 		tokenHash, agentID, expiresAtStr, now.Format(time.DateTime),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("creating agent session: %w", err)
+		return nil, fmt.Errorf("creating agent token: %w", err)
 	}
 
 	return &Session{ID: rawToken, AgentID: agentID, ExpiresAt: utcTimePtr(expiresAt), CreatedAt: now}, nil
@@ -2719,12 +2709,5 @@ func newUUID() string {
 		uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:16])
 }
 
-// newSessionToken generates a 256-bit cryptographically random session token
-// with an av_sess_ prefix followed by 64 hex characters.
-func newSessionToken() string {
-	var b [32]byte
-	if _, err := io.ReadFull(rand.Reader, b[:]); err != nil {
-		panic("crypto/rand: " + err.Error())
-	}
-	return "av_sess_" + hex.EncodeToString(b[:])
-}
+func newSessionToken() string { return newPrefixedToken("av_sess_") }
+func newAgentToken() string   { return newPrefixedToken("av_agt_") }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1404,10 +1404,10 @@ func TestRevokeAgent(t *testing.T) {
 
 	ag, _ := s.CreateAgent(ctx, "torevoke", "c", "member")
 
-	// Create a session for this agent.
-	sess, err := s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
+	// Create a token for this agent.
+	sess, err := s.CreateAgentToken(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
 	if err != nil {
-		t.Fatalf("CreateAgentSession: %v", err)
+		t.Fatalf("CreateAgentToken: %v", err)
 	}
 
 	// Revoke
@@ -1453,49 +1453,49 @@ func TestRenameAgent(t *testing.T) {
 	}
 }
 
-func TestCountAgentSessions(t *testing.T) {
+func TestCountAgentTokens(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
 	ag, _ := s.CreateAgent(ctx, "counter", "c", "member")
 
-	count, _ := s.CountAgentSessions(ctx, ag.ID)
+	count, _ := s.CountAgentTokens(ctx, ag.ID)
 	if count != 0 {
-		t.Fatalf("expected 0 sessions, got %d", count)
+		t.Fatalf("expected 0 tokens, got %d", count)
 	}
 
-	s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
-	s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
+	s.CreateAgentToken(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
+	s.CreateAgentToken(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
 
-	count, _ = s.CountAgentSessions(ctx, ag.ID)
+	count, _ = s.CountAgentTokens(ctx, ag.ID)
 	if count != 2 {
-		t.Fatalf("expected 2 sessions, got %d", count)
+		t.Fatalf("expected 2 tokens, got %d", count)
 	}
 
-	// Expired sessions should not be counted.
-	s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(-1*time.Hour)))
-	count, _ = s.CountAgentSessions(ctx, ag.ID)
+	// Expired tokens should not be counted.
+	s.CreateAgentToken(ctx, ag.ID, tp(time.Now().Add(-1*time.Hour)))
+	count, _ = s.CountAgentTokens(ctx, ag.ID)
 	if count != 2 {
-		t.Fatalf("expected 2 active sessions (1 expired), got %d", count)
+		t.Fatalf("expected 2 active tokens (1 expired), got %d", count)
 	}
 }
 
-func TestCreateAgentSession(t *testing.T) {
+func TestCreateAgentToken(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
 	ag, _ := s.CreateAgent(ctx, "sessbot", "c", "member")
 
-	sess, err := s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
+	sess, err := s.CreateAgentToken(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
 	if err != nil {
-		t.Fatalf("CreateAgentSession: %v", err)
+		t.Fatalf("CreateAgentToken: %v", err)
 	}
 	if sess.AgentID != ag.ID {
 		t.Fatalf("expected agent_id %s, got %s", ag.ID, sess.AgentID)
 	}
-	// Instance-level agent sessions have empty VaultID.
+	// Instance-level agent tokens have empty VaultID.
 	if sess.VaultID != "" {
-		t.Fatalf("expected empty vault_id for agent session, got %s", sess.VaultID)
+		t.Fatalf("expected empty vault_id for agent token, got %s", sess.VaultID)
 	}
 
 	// Verify GetSession returns agent_id.
@@ -1571,28 +1571,28 @@ func TestCreateRotationInvite(t *testing.T) {
 	}
 }
 
-func TestDeleteAgentSessions(t *testing.T) {
+func TestDeleteAgentTokens(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
 	ag, _ := s.CreateAgent(ctx, "delbot", "c", "member")
 
-	s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
-	s.CreateAgentSession(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
+	s.CreateAgentToken(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
+	s.CreateAgentToken(ctx, ag.ID, tp(time.Now().Add(24*time.Hour)))
 
-	count, _ := s.CountAgentSessions(ctx, ag.ID)
+	count, _ := s.CountAgentTokens(ctx, ag.ID)
 	if count != 2 {
-		t.Fatalf("expected 2 sessions before delete, got %d", count)
+		t.Fatalf("expected 2 tokens before delete, got %d", count)
 	}
 
-	err := s.DeleteAgentSessions(ctx, ag.ID)
+	err := s.DeleteAgentTokens(ctx, ag.ID)
 	if err != nil {
-		t.Fatalf("DeleteAgentSessions: %v", err)
+		t.Fatalf("DeleteAgentTokens: %v", err)
 	}
 
-	count, _ = s.CountAgentSessions(ctx, ag.ID)
+	count, _ = s.CountAgentTokens(ctx, ag.ID)
 	if count != 0 {
-		t.Fatalf("expected 0 sessions after delete, got %d", count)
+		t.Fatalf("expected 0 tokens after delete, got %d", count)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -59,13 +59,13 @@ type MasterKeyRecord struct {
 
 // Session represents an authenticated session.
 // User sessions: VaultID may be set (scoped) or empty (global login).
-// Agent sessions: VaultID is empty; vault resolved per-request via X-Vault header.
+// Agent tokens: VaultID is empty; vault resolved per-request via X-Vault header.
 type Session struct {
 	ID        string
-	UserID    string     // non-empty for user login sessions, empty for agent sessions
-	VaultID   string     // empty for global/agent sessions, non-empty for user scoped sessions
-	AgentID   string     // non-empty for agent sessions
-	VaultRole string     // set for user scoped sessions; empty for agent sessions (resolved per-request)
+	UserID    string     // non-empty for user login sessions, empty for agent tokens
+	VaultID   string     // empty for global/agent tokens, non-empty for user scoped sessions
+	AgentID   string     // non-empty for agent tokens
+	VaultRole string     // set for user scoped sessions; empty for agent tokens (resolved per-request)
 	ExpiresAt *time.Time // nil = never expires
 	CreatedAt time.Time
 }
@@ -367,10 +367,10 @@ type Store interface {
 	RevokeAgent(ctx context.Context, id string) error
 	RenameAgent(ctx context.Context, id string, newName string) error
 	UpdateAgentRole(ctx context.Context, agentID, role string) error
-	CountAgentSessions(ctx context.Context, agentID string) (int, error)
-	GetLatestAgentSessionExpiry(ctx context.Context, agentID string) (*time.Time, error)
-	DeleteAgentSessions(ctx context.Context, agentID string) error
-	CreateAgentSession(ctx context.Context, agentID string, expiresAt *time.Time) (*Session, error)
+	CountAgentTokens(ctx context.Context, agentID string) (int, error)
+	GetLatestAgentTokenExpiry(ctx context.Context, agentID string) (*time.Time, error)
+	DeleteAgentTokens(ctx context.Context, agentID string) error
+	CreateAgentToken(ctx context.Context, agentID string, expiresAt *time.Time) (*Session, error)
 	CountAllOwners(ctx context.Context) (int, error)
 
 	// Instance settings

--- a/web/src/pages/home/AllAgentsTab.tsx
+++ b/web/src/pages/home/AllAgentsTab.tsx
@@ -370,7 +370,7 @@ function InviteAgentButton({
       "",
       "{}",
       "",
-      "The response contains your session token and usage instructions.",
+      "The response contains your agent token and usage instructions.",
       "",
       "This invite expires in 15 minutes and can only be used once.",
     ].join("\n");
@@ -561,7 +561,7 @@ function InviteResultView({
         return;
       }
       const data = await resp.json();
-      setSessionToken(data.av_session_token);
+      setSessionToken(data.av_agent_token);
       onRedeemed();
     } catch {
       setRedeemError("Network error.");

--- a/web/src/pages/instance/AgentsTab.tsx
+++ b/web/src/pages/instance/AgentsTab.tsx
@@ -11,7 +11,7 @@ interface AgentRow {
   vault_name: string;
   status: string;
   created_at: string;
-  session_expires_at?: string;
+  token_expires_at?: string;
 }
 
 function RowActions({
@@ -74,12 +74,12 @@ export default function InstanceAgentsTab() {
     },
     {
       key: "session_expires",
-      header: "Session Expires",
+      header: "Token Expires",
       render: (agent) => {
-        if (!agent.session_expires_at) {
+        if (!agent.token_expires_at) {
           return <span className="text-sm text-text-dim">{"\u2014"}</span>;
         }
-        const label = timeUntil(agent.session_expires_at);
+        const label = timeUntil(agent.token_expires_at);
         const isExpired = label === "Expired";
         return (
           <span className={`text-sm ${isExpired ? "text-danger" : "text-text-muted"}`}>
@@ -128,13 +128,13 @@ export default function InstanceAgentsTab() {
 
       const agentsData = await agentsResp.json();
       const agentRows: AgentRow[] = (agentsData.agents ?? []).map(
-        (a: { name: string; vault_id: string; status: string; created_at: string; session_expires_at?: string }) => ({
+        (a: { name: string; vault_id: string; status: string; created_at: string; token_expires_at?: string }) => ({
           name: a.name,
           vault_id: a.vault_id,
           vault_name: vaultMap[a.vault_id] || a.vault_id,
           status: a.status,
           created_at: a.created_at,
-          session_expires_at: a.session_expires_at,
+          token_expires_at: a.token_expires_at,
         })
       );
 


### PR DESCRIPTION
## Summary

- Renames the instance-level agent identity credential from "session token" to **"agent token"** with a distinct `av_agt_` prefix, keeping "session token" (`av_sess_`) for vault-scoped sessions only
- Renames Go interface methods (`CreateAgentSession` → `CreateAgentToken`, etc.), API response keys (`av_session_token` → `av_agent_token`, `active_sessions` → `active_tokens`, `session_expires_at` → `token_expires_at`), CLI output, frontend fields, embedded agent instructions, and all documentation
- Extracts a shared `newPrefixedToken(prefix)` helper to deduplicate 5 identical token generation functions

## Test plan

- [x] `go build ./...` compiles clean
- [x] `go test ./...` — all 12 packages pass
- [ ] Smoke test: create agent invite → redeem → verify response key is `av_agent_token` and token starts with `av_agt_`
- [ ] Verify `av_agt_` token works for proxy/discover calls
- [ ] Verify frontend `AllAgentsTab` reads `data.av_agent_token` correctly
- [ ] Verify `AgentsTab` renders "Token Expires" column correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)