### PR TITLE
feat: add vault create and delete to TypeScript SDK

### DIFF
--- a/sdks/sdk-typescript/README.md
+++ b/sdks/sdk-typescript/README.md
@@ -38,6 +38,23 @@ const av = new AgentVault({
 });
 ```
 
+## Manage vaults
+
+Create and delete vaults using an instance-level token:
+
+```typescript
+import { AgentVault } from "@infisical/agent-vault-sdk";
+
+const av = new AgentVault({ token: "YOUR_AGENT_TOKEN" });
+
+// Create a vault (caller becomes vault admin)
+const vault = await av.createVault({ name: "my-project" });
+console.log(vault.id, vault.createdAt);
+
+// Delete a vault (requires vault admin or instance owner)
+await av.deleteVault("my-project");
+```
+
 ## Mint a vault-scoped session
 
 Use an instance-level agent token to mint a scoped session token for an agent sandbox:
@@ -69,3 +86,12 @@ const vault = new VaultClient({
   address: "http://localhost:14321",
 });
 ```
+
+## Releasing
+
+Releases are automated via GitHub Actions using [npm OIDC trusted publishing](https://docs.npmjs.com/generating-provenance-statements). To publish a new version:
+
+1. Push a git tag matching the pattern `node-sdk/v<version>` (e.g., `node-sdk/v0.2.0`).
+2. The CI workflow extracts the version from the tag, sets it in `package.json`, and publishes to npm with provenance attestation.
+
+The `version` field in `package.json` is a placeholder — the actual published version is always derived from the git tag.

--- a/sdks/sdk-typescript/src/client.ts
+++ b/sdks/sdk-typescript/src/client.ts
@@ -1,6 +1,36 @@
 import { HttpClient } from "./http.js";
-import type { AgentVaultConfig } from "./types.js";
+import type { AgentVaultConfig, VaultCreated, VaultDeleted } from "./types.js";
 import { VaultClient } from "./vault.js";
+
+/**
+ * Options for creating a vault.
+ */
+export interface CreateVaultOptions {
+  /** Vault name (3-64 chars, lowercase alphanumeric and hyphens only). */
+  name: string;
+}
+
+/**
+ * A newly created vault.
+ */
+export interface Vault {
+  /** Vault UUID. */
+  id: string;
+  /** Vault name. */
+  name: string;
+  /** ISO 8601 creation timestamp. */
+  createdAt: string;
+}
+
+/**
+ * Result of deleting a vault.
+ */
+export interface DeleteVaultResult {
+  /** Name of the deleted vault. */
+  name: string;
+  /** Always `true` on success. */
+  deleted: boolean;
+}
 
 /**
  * Instance-level client for Agent Vault.
@@ -38,5 +68,49 @@ export class AgentVault {
       this._httpClient.withHeaders({ "X-Vault": name }),
       name,
     );
+  }
+
+  /**
+   * Create a new vault.
+   *
+   * The calling actor becomes the vault admin. Any authenticated actor
+   * (user or agent) can create vaults. Requires an instance-level session
+   * (vault-scoped tokens cannot create vaults).
+   *
+   * @throws {ApiError} 400 if the name is invalid or reserved.
+   * @throws {ApiError} 409 if a vault with this name already exists.
+   */
+  async createVault(options: CreateVaultOptions): Promise<Vault> {
+    const res = await this._httpClient.post<VaultCreated>("/v1/vaults", {
+      name: options.name,
+    });
+
+    return {
+      id: res.id,
+      name: res.name,
+      createdAt: res.created_at,
+    };
+  }
+
+  /**
+   * Delete a vault by name.
+   *
+   * Requires vault admin role or instance owner. The default vault cannot
+   * be deleted. Requires an instance-level session (vault-scoped tokens
+   * cannot delete vaults).
+   *
+   * @throws {ApiError} 400 if attempting to delete the default vault.
+   * @throws {ApiError} 403 if not a vault admin or instance owner.
+   * @throws {ApiError} 404 if the vault does not exist.
+   */
+  async deleteVault(name: string): Promise<DeleteVaultResult> {
+    const res = await this._httpClient.del<VaultDeleted>(
+      `/v1/vaults/${encodeURIComponent(name)}`,
+    );
+
+    return {
+      name: res.name,
+      deleted: res.deleted,
+    };
   }
 }

--- a/sdks/sdk-typescript/src/index.ts
+++ b/sdks/sdk-typescript/src/index.ts
@@ -10,3 +10,6 @@ export type { AgentVaultConfig, VaultClientConfig, ClientConfig } from "./types.
 
 // Session resource types
 export type { CreateSessionOptions, Session } from "./resources/sessions.js";
+
+// Vault types (instance-level operations)
+export type { CreateVaultOptions, Vault, DeleteVaultResult } from "./client.js";

--- a/sdks/sdk-typescript/src/types.ts
+++ b/sdks/sdk-typescript/src/types.ts
@@ -44,3 +44,16 @@ export interface ScopedSession {
   av_addr?: string;
   proxy_url?: string;
 }
+
+/** @internal Wire format for POST /v1/vaults response. */
+export interface VaultCreated {
+  id: string;
+  name: string;
+  created_at: string;
+}
+
+/** @internal Wire format for DELETE /v1/vaults/{name} response. */
+export interface VaultDeleted {
+  name: string;
+  deleted: boolean;
+}

--- a/sdks/sdk-typescript/tests/vaults.test.ts
+++ b/sdks/sdk-typescript/tests/vaults.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { AgentVault } from "../src/client.js";
+import { ApiError } from "../src/errors.js";
+import { createMockFetch } from "./helpers.js";
+
+describe("AgentVault vault operations", () => {
+  describe("createVault()", () => {
+    it("sends POST /v1/vaults with name", async () => {
+      const mockFetch = createMockFetch({
+        status: 201,
+        body: {
+          id: "vault-uuid-123",
+          name: "my-project",
+          created_at: "2026-04-15T16:30:45Z",
+        },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av.createVault({ name: "my-project" });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("http://localhost:14321/v1/vaults");
+      expect(init?.method).toBe("POST");
+
+      const body = JSON.parse(init?.body as string);
+      expect(body.name).toBe("my-project");
+    });
+
+    it("returns camelCased response", async () => {
+      const mockFetch = createMockFetch({
+        status: 201,
+        body: {
+          id: "vault-uuid-456",
+          name: "production",
+          created_at: "2026-04-15T18:00:00Z",
+        },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      const vault = await av.createVault({ name: "production" });
+
+      expect(vault.id).toBe("vault-uuid-456");
+      expect(vault.name).toBe("production");
+      expect(vault.createdAt).toBe("2026-04-15T18:00:00Z");
+    });
+
+    it("does not send X-Vault header", async () => {
+      const mockFetch = createMockFetch({
+        status: 201,
+        body: {
+          id: "id",
+          name: "test",
+          created_at: "2026-04-15T00:00:00Z",
+        },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av.createVault({ name: "test" });
+
+      const init = mockFetch.mock.calls[0]![1]!;
+      const headers = init.headers as Record<string, string>;
+      expect(headers["X-Vault"]).toBeUndefined();
+    });
+
+    it("throws ApiError on 409 conflict", async () => {
+      const mockFetch = createMockFetch({
+        ok: false,
+        status: 409,
+        statusText: "Conflict",
+        body: { error: 'Vault "my-project" already exists' },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await expect(av.createVault({ name: "my-project" })).rejects.toThrow(
+        ApiError,
+      );
+      await expect(
+        av.createVault({ name: "my-project" }),
+      ).rejects.toMatchObject({ status: 409 });
+    });
+  });
+
+  describe("deleteVault()", () => {
+    it("sends DELETE /v1/vaults/{name}", async () => {
+      const mockFetch = createMockFetch({
+        body: { name: "my-vault", deleted: true },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av.deleteVault("my-vault");
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("http://localhost:14321/v1/vaults/my-vault");
+      expect(init?.method).toBe("DELETE");
+    });
+
+    it("returns the deletion result", async () => {
+      const mockFetch = createMockFetch({
+        body: { name: "staging", deleted: true },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      const result = await av.deleteVault("staging");
+
+      expect(result.name).toBe("staging");
+      expect(result.deleted).toBe(true);
+    });
+
+    it("URL-encodes the vault name", async () => {
+      const mockFetch = createMockFetch({
+        body: { name: "my vault", deleted: true },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av.deleteVault("my vault");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("http://localhost:14321/v1/vaults/my%20vault");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `createVault()` and `deleteVault()` methods to the `AgentVault` instance-level client
- Add wire-format types (`VaultCreated`, `VaultDeleted`) and public type exports (`Vault`, `CreateVaultOptions`, `DeleteVaultResult`)
- Add unit tests covering request format, response mapping, URL encoding, and error handling
- Update README with vault management usage examples and release process docs

## Test plan
- [x] All 46 SDK tests pass (`npm test`) including 7 new vault operation tests
- [ ] Manual smoke test against a running Agent Vault instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)