### PR TITLE
feat: add credential management to TypeScript SDK

### DIFF
--- a/sdks/sdk-typescript/README.md
+++ b/sdks/sdk-typescript/README.md
@@ -87,6 +87,58 @@ const vault = new VaultClient({
 });
 ```
 
+## Manage credentials
+
+Read, write, and delete credentials (secrets) stored in a vault. Available on both instance-level and vault-scoped clients.
+
+```typescript
+// Via instance-level client
+const vault = av.vault("my-project");
+
+// Or via standalone vault-scoped client
+const vault = new VaultClient();
+```
+
+### List credential keys
+
+```typescript
+const { keys } = await vault.credentials.list();
+// keys: ["STRIPE_KEY", "GITHUB_TOKEN"]
+```
+
+### Reveal credential values
+
+Requires member+ role:
+
+```typescript
+const { credentials } = await vault.credentials.list({ reveal: true });
+// credentials: [{ key: "STRIPE_KEY", value: "sk_live_..." }, ...]
+
+// Filter to a single credential
+const { credentials } = await vault.credentials.list({ reveal: true, key: "STRIPE_KEY" });
+```
+
+### Set credentials
+
+Keys must be SCREAMING_SNAKE_CASE. Existing credentials with the same key are overwritten. Requires member+ role:
+
+```typescript
+const { set } = await vault.credentials.set({
+  STRIPE_KEY: "sk_live_abc",
+  GITHUB_TOKEN: "ghp_xyz",
+});
+// set: ["STRIPE_KEY", "GITHUB_TOKEN"]
+```
+
+### Delete credentials
+
+Requires member+ role:
+
+```typescript
+const { deleted } = await vault.credentials.delete(["STRIPE_KEY", "GITHUB_TOKEN"]);
+// deleted: ["STRIPE_KEY", "GITHUB_TOKEN"]
+```
+
 ## Releasing
 
 Releases are automated via GitHub Actions using [npm OIDC trusted publishing](https://docs.npmjs.com/generating-provenance-statements). To publish a new version:

--- a/sdks/sdk-typescript/src/index.ts
+++ b/sdks/sdk-typescript/src/index.ts
@@ -13,3 +13,12 @@ export type { CreateSessionOptions, Session } from "./resources/sessions.js";
 
 // Vault types (instance-level operations)
 export type { CreateVaultOptions, Vault, DeleteVaultResult } from "./client.js";
+
+// Credential resource types
+export type {
+  ListCredentialsOptions,
+  Credential,
+  ListCredentialsResult,
+  SetCredentialsResult,
+  DeleteCredentialsResult,
+} from "./resources/credentials.js";

--- a/sdks/sdk-typescript/src/resources/credentials.ts
+++ b/sdks/sdk-typescript/src/resources/credentials.ts
@@ -1,0 +1,151 @@
+import type { HttpClient } from "../http.js";
+import type {
+  CredentialsList,
+  CredentialsSet,
+  CredentialsDeleted,
+} from "../types.js";
+
+/**
+ * Options for listing credentials.
+ *
+ * The `key` filter is only accepted when `reveal` is `true` — the server
+ * ignores it otherwise. The union type enforces this at compile time.
+ */
+export type ListCredentialsOptions =
+  | { reveal?: false; key?: never }
+  | { reveal: true; key?: string };
+
+/**
+ * A credential entry with its decrypted value.
+ */
+export interface Credential {
+  /** Credential key (SCREAMING_SNAKE_CASE). */
+  key: string;
+  /** Decrypted credential value. */
+  value: string;
+}
+
+/**
+ * Result of listing credentials.
+ */
+export interface ListCredentialsResult {
+  /** All credential key names in the vault. */
+  keys: string[];
+  /** Decrypted credentials (only present when reveal was requested). */
+  credentials?: Credential[];
+}
+
+/**
+ * Result of setting credentials.
+ */
+export interface SetCredentialsResult {
+  /** Keys that were set. */
+  set: string[];
+}
+
+/**
+ * Result of deleting credentials.
+ */
+export interface DeleteCredentialsResult {
+  /** Keys that were deleted. */
+  deleted: string[];
+}
+
+/**
+ * Resource for managing vault credentials (secrets).
+ * Maps to `GET/POST/DELETE /v1/credentials`.
+ */
+export class CredentialsResource {
+  constructor(
+    private readonly httpClient: HttpClient,
+    private readonly vaultName: string | undefined,
+  ) {}
+
+  /**
+   * List credential keys, optionally revealing their decrypted values.
+   *
+   * Without `reveal`, returns only key names (requires proxy+ role).
+   * With `reveal: true`, returns decrypted values (requires member+ role).
+   * With `reveal: true` and `key`, returns a single credential.
+   *
+   * @throws {ApiError} 403 if the caller lacks sufficient permissions.
+   * @throws {ApiError} 404 if the vault or credential is not found.
+   */
+  async list(options?: ListCredentialsOptions): Promise<ListCredentialsResult> {
+    const query: Record<string, string> = {};
+    if (this.vaultName) {
+      query.vault = this.vaultName;
+    }
+    if (options?.reveal) {
+      query.reveal = "true";
+    }
+    if (options?.key) {
+      query.key = options.key;
+    }
+
+    const res = await this.httpClient.get<CredentialsList>("/v1/credentials", {
+      query,
+    });
+
+    return {
+      keys: res.keys,
+      credentials: res.credentials?.map((c) => ({
+        key: c.key,
+        value: c.value ?? "",
+      })),
+    };
+  }
+
+  /**
+   * Set one or more credentials in the vault.
+   *
+   * Keys must be SCREAMING_SNAKE_CASE (`^[A-Z][A-Z0-9_]*$`).
+   * Existing credentials with the same key are overwritten.
+   * Requires member+ role.
+   *
+   * @param credentials - Map of credential key to plaintext value.
+   * @throws {ApiError} 400 if any key fails validation or credentials map is empty.
+   * @throws {ApiError} 403 if the caller lacks sufficient permissions.
+   * @throws {ApiError} 404 if the vault is not found.
+   */
+  async set(
+    credentials: Record<string, string>,
+  ): Promise<SetCredentialsResult> {
+    const body: Record<string, unknown> = { credentials };
+    if (this.vaultName) {
+      body.vault = this.vaultName;
+    }
+
+    const res = await this.httpClient.post<CredentialsSet>(
+      "/v1/credentials",
+      body,
+    );
+
+    return { set: res.set };
+  }
+
+  /**
+   * Delete one or more credentials from the vault.
+   *
+   * Keys must be SCREAMING_SNAKE_CASE (`^[A-Z][A-Z0-9_]*$`).
+   * Requires member+ role.
+   *
+   * @param keys - Credential keys to delete.
+   * @throws {ApiError} 400 if any key fails validation or keys array is empty.
+   * @throws {ApiError} 403 if the caller lacks sufficient permissions.
+   * @throws {ApiError} 404 if the vault is not found.
+   */
+  async delete(keys: string[]): Promise<DeleteCredentialsResult> {
+    const body: Record<string, unknown> = { keys };
+    if (this.vaultName) {
+      body.vault = this.vaultName;
+    }
+
+    const res = await this.httpClient.del<CredentialsDeleted>(
+      "/v1/credentials",
+      body,
+    );
+
+    return { deleted: res.deleted };
+  }
+}

--- a/sdks/sdk-typescript/src/types.ts
+++ b/sdks/sdk-typescript/src/types.ts
@@ -57,3 +57,25 @@ export interface VaultDeleted {
   name: string;
   deleted: boolean;
 }
+
+/** @internal Wire entry in GET /v1/credentials response. */
+export interface CredentialEntry {
+  key: string;
+  value?: string;
+}
+
+/** @internal Wire format for GET /v1/credentials response. */
+export interface CredentialsList {
+  keys: string[];
+  credentials?: CredentialEntry[];
+}
+
+/** @internal Wire format for POST /v1/credentials response. */
+export interface CredentialsSet {
+  set: string[];
+}
+
+/** @internal Wire format for DELETE /v1/credentials response. */
+export interface CredentialsDeleted {
+  deleted: string[];
+}

--- a/sdks/sdk-typescript/src/vault.ts
+++ b/sdks/sdk-typescript/src/vault.ts
@@ -1,4 +1,5 @@
 import { HttpClient } from "./http.js";
+import { CredentialsResource } from "./resources/credentials.js";
 import { SessionsResource } from "./resources/sessions.js";
 import type { VaultClientConfig } from "./types.js";
 
@@ -41,15 +42,23 @@ export class VaultClient {
    */
   readonly sessions: SessionsResource | undefined;
 
+  /**
+   * Credentials resource for managing vault credentials (secrets).
+   * Available on all VaultClient instances — both via `AgentVault.vault(name)` and standalone.
+   */
+  readonly credentials: CredentialsResource;
+
   constructor(config?: VaultClientConfig | InternalArgs) {
     if (config && "marker" in config && config.marker === INTERNAL) {
       this._httpClient = config.httpClient;
       this.name = config.vaultName;
       this.sessions = new SessionsResource(config.httpClient, config.vaultName);
+      this.credentials = new CredentialsResource(config.httpClient, config.vaultName);
     } else {
       this._httpClient = HttpClient.fromConfig(config as VaultClientConfig | undefined);
       this.name = undefined;
       this.sessions = undefined;
+      this.credentials = new CredentialsResource(this._httpClient, undefined);
     }
   }
 

--- a/sdks/sdk-typescript/tests/credentials.test.ts
+++ b/sdks/sdk-typescript/tests/credentials.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect } from "vitest";
+import { AgentVault } from "../src/client.js";
+import { VaultClient } from "../src/vault.js";
+import { createMockFetch } from "./helpers.js";
+
+describe("CredentialsResource", () => {
+  describe("list()", () => {
+    it("sends GET /v1/credentials with vault query param", async () => {
+      const mockFetch = createMockFetch({
+        body: { keys: ["STRIPE_KEY", "GITHUB_TOKEN"] },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av.vault("my-project").credentials.list();
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(
+        "http://localhost:14321/v1/credentials?vault=my-project",
+      );
+      expect(init?.method).toBe("GET");
+    });
+
+    it("sends reveal=true query param when requested", async () => {
+      const mockFetch = createMockFetch({
+        body: {
+          keys: ["STRIPE_KEY"],
+          credentials: [{ key: "STRIPE_KEY", value: "sk_test_123" }],
+        },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av.vault("my-project").credentials.list({ reveal: true });
+
+      const url = mockFetch.mock.calls[0]![0] as string;
+      expect(url).toContain("reveal=true");
+      expect(url).toContain("vault=my-project");
+    });
+
+    it("sends key query param with reveal", async () => {
+      const mockFetch = createMockFetch({
+        body: {
+          keys: ["API_KEY"],
+          credentials: [{ key: "API_KEY", value: "secret123" }],
+        },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av
+        .vault("my-project")
+        .credentials.list({ reveal: true, key: "API_KEY" });
+
+      const url = mockFetch.mock.calls[0]![0] as string;
+      expect(url).toContain("key=API_KEY");
+      expect(url).toContain("reveal=true");
+    });
+
+    it("omits vault query param for standalone VaultClient", async () => {
+      const mockFetch = createMockFetch({
+        body: { keys: ["STRIPE_KEY"] },
+      });
+
+      const vault = new VaultClient({
+        token: "scoped-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await vault.credentials.list();
+
+      const url = mockFetch.mock.calls[0]![0] as string;
+      expect(url).toBe("http://localhost:14321/v1/credentials");
+    });
+
+    it("returns keys array from response", async () => {
+      const mockFetch = createMockFetch({
+        body: { keys: ["STRIPE_KEY", "GITHUB_TOKEN"] },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      const result = await av.vault("default").credentials.list();
+
+      expect(result.keys).toEqual(["STRIPE_KEY", "GITHUB_TOKEN"]);
+      expect(result.credentials).toBeUndefined();
+    });
+
+    it("returns credentials array when reveal=true", async () => {
+      const mockFetch = createMockFetch({
+        body: {
+          keys: ["STRIPE_KEY"],
+          credentials: [{ key: "STRIPE_KEY", value: "sk_live_abc" }],
+        },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      const result = await av
+        .vault("default")
+        .credentials.list({ reveal: true });
+
+      expect(result.credentials).toEqual([
+        { key: "STRIPE_KEY", value: "sk_live_abc" },
+      ]);
+    });
+
+    it("includes X-Vault header when created via AgentVault.vault()", async () => {
+      const mockFetch = createMockFetch({
+        body: { keys: [] },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av.vault("production").credentials.list();
+
+      const init = mockFetch.mock.calls[0]![1]!;
+      const headers = init.headers as Record<string, string>;
+      expect(headers["X-Vault"]).toBe("production");
+    });
+  });
+
+  describe("set()", () => {
+    it("sends POST /v1/credentials with credentials map", async () => {
+      const mockFetch = createMockFetch({
+        body: { set: ["STRIPE_KEY", "GITHUB_TOKEN"] },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av
+        .vault("my-project")
+        .credentials.set({ STRIPE_KEY: "sk_live_abc", GITHUB_TOKEN: "ghp_xyz" });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("http://localhost:14321/v1/credentials");
+      expect(init?.method).toBe("POST");
+
+      const body = JSON.parse(init?.body as string);
+      expect(body.credentials).toEqual({
+        STRIPE_KEY: "sk_live_abc",
+        GITHUB_TOKEN: "ghp_xyz",
+      });
+    });
+
+    it("includes vault in request body when vault name is known", async () => {
+      const mockFetch = createMockFetch({
+        body: { set: ["API_KEY"] },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av.vault("staging").credentials.set({ API_KEY: "secret" });
+
+      const body = JSON.parse(mockFetch.mock.calls[0]![1]?.body as string);
+      expect(body.vault).toBe("staging");
+    });
+
+    it("omits vault from body for standalone VaultClient", async () => {
+      const mockFetch = createMockFetch({
+        body: { set: ["API_KEY"] },
+      });
+
+      const vault = new VaultClient({
+        token: "scoped-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await vault.credentials.set({ API_KEY: "value123" });
+
+      const body = JSON.parse(mockFetch.mock.calls[0]![1]?.body as string);
+      expect(body.credentials).toEqual({ API_KEY: "value123" });
+      expect(body.vault).toBeUndefined();
+    });
+
+    it("returns set array from response", async () => {
+      const mockFetch = createMockFetch({
+        body: { set: ["STRIPE_KEY", "GITHUB_TOKEN"] },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      const result = await av
+        .vault("default")
+        .credentials.set({ STRIPE_KEY: "sk_live_abc", GITHUB_TOKEN: "ghp_xyz" });
+
+      expect(result.set).toEqual(["STRIPE_KEY", "GITHUB_TOKEN"]);
+    });
+
+    it("includes X-Vault header when created via AgentVault.vault()", async () => {
+      const mockFetch = createMockFetch({
+        body: { set: ["KEY"] },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av.vault("production").credentials.set({ KEY: "val" });
+
+      const init = mockFetch.mock.calls[0]![1]!;
+      const headers = init.headers as Record<string, string>;
+      expect(headers["X-Vault"]).toBe("production");
+    });
+  });
+
+  describe("delete()", () => {
+    it("sends DELETE /v1/credentials with keys array", async () => {
+      const mockFetch = createMockFetch({
+        body: { deleted: ["STRIPE_KEY", "GITHUB_TOKEN"] },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av
+        .vault("my-project")
+        .credentials.delete(["STRIPE_KEY", "GITHUB_TOKEN"]);
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("http://localhost:14321/v1/credentials");
+      expect(init?.method).toBe("DELETE");
+
+      const body = JSON.parse(init?.body as string);
+      expect(body.keys).toEqual(["STRIPE_KEY", "GITHUB_TOKEN"]);
+    });
+
+    it("includes vault in request body when vault name is known", async () => {
+      const mockFetch = createMockFetch({
+        body: { deleted: ["API_KEY"] },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av.vault("staging").credentials.delete(["API_KEY"]);
+
+      const body = JSON.parse(mockFetch.mock.calls[0]![1]?.body as string);
+      expect(body.vault).toBe("staging");
+    });
+
+    it("omits vault from body for standalone VaultClient", async () => {
+      const mockFetch = createMockFetch({
+        body: { deleted: ["API_KEY"] },
+      });
+
+      const vault = new VaultClient({
+        token: "scoped-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await vault.credentials.delete(["API_KEY"]);
+
+      const body = JSON.parse(mockFetch.mock.calls[0]![1]?.body as string);
+      expect(body.keys).toEqual(["API_KEY"]);
+      expect(body.vault).toBeUndefined();
+    });
+
+    it("returns deleted array from response", async () => {
+      const mockFetch = createMockFetch({
+        body: { deleted: ["STRIPE_KEY"] },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      const result = await av.vault("default").credentials.delete(["STRIPE_KEY"]);
+
+      expect(result.deleted).toEqual(["STRIPE_KEY"]);
+    });
+
+    it("includes X-Vault header when created via AgentVault.vault()", async () => {
+      const mockFetch = createMockFetch({
+        body: { deleted: ["KEY"] },
+      });
+
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+      await av.vault("production").credentials.delete(["KEY"]);
+
+      const init = mockFetch.mock.calls[0]![1]!;
+      const headers = init.headers as Record<string, string>;
+      expect(headers["X-Vault"]).toBe("production");
+    });
+  });
+});

--- a/sdks/sdk-typescript/tests/vault.test.ts
+++ b/sdks/sdk-typescript/tests/vault.test.ts
@@ -42,6 +42,11 @@ describe("VaultClient", () => {
       const vault = new VaultClient({ token: "scoped-token" });
       expect(vault.sessions).toBeUndefined();
     });
+
+    it("has credentials resource for standalone construction", () => {
+      const vault = new VaultClient({ token: "scoped-token" });
+      expect(vault.credentials).toBeDefined();
+    });
   });
 
   describe("via AgentVault.vault()", () => {
@@ -55,6 +60,12 @@ describe("VaultClient", () => {
       const av = new AgentVault({ token: "agent-token" });
       const vault = av.vault("production");
       expect(vault.sessions).toBeDefined();
+    });
+
+    it("has credentials resource wired up", () => {
+      const av = new AgentVault({ token: "agent-token" });
+      const vault = av.vault("production");
+      expect(vault.credentials).toBeDefined();
     });
 
     it("exposes _httpClient for future resource extensions", () => {


### PR DESCRIPTION
## Summary
- Add `CredentialsResource` class with `list`, `set`, and `delete` methods to `VaultClient`
- Credentials are always available on `VaultClient` (both instance-level via `AgentVault.vault()` and standalone scoped tokens)
- Uses discriminated union type for `ListCredentialsOptions` to enforce `key` filter requires `reveal: true` at compile time
- 17 new tests covering all methods, both client paths, X-Vault header injection, and response transformation

## Changes
- **New:** `src/resources/credentials.ts` — `CredentialsResource` class + public types
- **New:** `tests/credentials.test.ts` — comprehensive test suite
- **Modified:** `src/types.ts` — wire types for credential API responses
- **Modified:** `src/vault.ts` — wire `credentials` property into `VaultClient`
- **Modified:** `src/index.ts` — export public types
- **Modified:** `tests/vault.test.ts` — credentials availability assertions
- **Modified:** `README.md` — usage documentation with examples

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (65/65 tests, including 17 new credential tests)
- [x] `npm run build` produces ESM + CJS + declarations with all new types exported

🤖 Generated with [Claude Code](https://claude.com/claude-code)