### PR TITLE
feat: add proxy request methods to TypeScript SDK

### DIFF
--- a/internal/server/handle_proxy.go
+++ b/internal/server/handle_proxy.go
@@ -30,6 +30,7 @@ func isSecureRequest(r *http.Request, baseURL string) bool {
 // proxyForbiddenWithHint writes a 403 with a proposal_hint so agents can
 // programmatically construct a proposal from a denied proxy request.
 func proxyForbiddenWithHint(w http.ResponseWriter, targetHost, nsName string) {
+	w.Header().Set(proxyErrorHeader, "true")
 	jsonStatus(w, http.StatusForbidden, map[string]interface{}{
 		"error":   "forbidden",
 		"message": fmt.Sprintf("No broker service matching host %q in vault %q", targetHost, nsName),

--- a/internal/server/respond.go
+++ b/internal/server/respond.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 )
 
+const proxyErrorHeader = "X-Agent-Vault-Proxy-Error"
+
 // jsonOK writes a 200 JSON response.
 func jsonOK(w http.ResponseWriter, data any) {
 	w.Header().Set("Content-Type", "application/json")
@@ -32,8 +34,11 @@ func jsonError(w http.ResponseWriter, status int, message string) {
 }
 
 // proxyError writes a JSON error response with separate code and message fields.
+// Sets X-Agent-Vault-Proxy-Error so SDK clients can distinguish broker errors
+// from upstream responses that happen to share the same status code.
 func proxyError(w http.ResponseWriter, status int, code, message string) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(proxyErrorHeader, "true")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": code, "message": message})
 }

--- a/sdks/sdk-typescript/README.md
+++ b/sdks/sdk-typescript/README.md
@@ -2,7 +2,7 @@
 
 The official TypeScript SDK for [Agent Vault](https://github.com/Infisical/agent-vault), an open-source credential brokerage layer for AI agents. Agent Vault sits between development agents and target services, proxying requests and injecting credentials so agents never see raw keys or tokens.
 
-The SDK provides a programmatic interface for managing vaults, minting scoped session tokens, and interacting with Agent Vault from TypeScript applications. For more information, see the [documentation](https://agent-vault.infisical.com).
+The SDK provides a programmatic interface for proxying HTTP requests through Agent Vault, managing vaults, minting scoped session tokens, and interacting with Agent Vault from TypeScript applications. For more information, see the [documentation](https://agent-vault.infisical.com).
 
 ## Installation
 
@@ -138,6 +138,102 @@ Requires member+ role:
 const { deleted } = await vault.credentials.delete(["STRIPE_KEY", "GITHUB_TOKEN"]);
 // deleted: ["STRIPE_KEY", "GITHUB_TOKEN"]
 ```
+
+## Proxy requests
+
+Send HTTP requests through the Agent Vault proxy. The broker matches the target host against configured services, injects credentials, and forwards the request to `https://{host}/{path}`. Your agent never sees raw API keys or tokens.
+
+### Basic usage with a vault-scoped token
+
+```typescript
+import { VaultClient } from "@infisical/agent-vault-sdk";
+
+const vault = new VaultClient(); // auto-detects from env vars
+
+// GET request through the proxy
+const res = await vault.proxy.get("api.stripe.com", "/v1/charges", {
+  query: { limit: 10 },
+});
+
+if (res.ok) {
+  const data = await res.json<{ data: { id: string }[] }>();
+  console.log(data.data);
+}
+```
+
+### Instance-level token with vault selection
+
+When using an instance-level agent token, the SDK automatically injects the `X-Vault` header:
+
+```typescript
+import { AgentVault } from "@infisical/agent-vault-sdk";
+
+const av = new AgentVault({ token: "av_agt_..." });
+
+const res = await av.vault("my-project").proxy.post(
+  "api.github.com",
+  "/repos/owner/repo/issues",
+  { body: { title: "Bug report", body: "Repro steps..." } },
+);
+```
+
+### Available methods
+
+```typescript
+vault.proxy.get(host, path?, options?)
+vault.proxy.post(host, path?, options?)
+vault.proxy.put(host, path?, options?)
+vault.proxy.patch(host, path?, options?)
+vault.proxy.delete(host, path?, options?)
+vault.proxy.request(method, host, options?)  // arbitrary HTTP method
+```
+
+### Response
+
+`ProxyResponse` wraps the upstream service's response without auto-parsing. Call `.json()`, `.text()`, or `.arrayBuffer()` to consume the body:
+
+```typescript
+interface ProxyResponse {
+  status: number;
+  statusText: string;
+  ok: boolean;        // true if status is 200-299
+  headers: Headers;
+  json<T>(): Promise<T>;
+  text(): Promise<string>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  body: ReadableStream<Uint8Array> | null;
+}
+```
+
+### Error handling
+
+The SDK distinguishes between broker errors (thrown as exceptions) and upstream errors (returned as responses):
+
+- **Upstream non-2xx** (e.g. Stripe returns 404): resolves normally with `res.ok === false`. Handle it yourself.
+- **`ProxyForbiddenError`**: thrown when no broker service matches the target host. Includes a `proposalHint` with the information needed to create a proposal.
+- **`ApiError`**: thrown for other broker-level failures (missing credentials, auth errors, bad request).
+
+```typescript
+import { ProxyForbiddenError } from "@infisical/agent-vault-sdk";
+
+try {
+  await vault.proxy.get("api.unknown-service.com", "/");
+} catch (err) {
+  if (err instanceof ProxyForbiddenError) {
+    console.log(err.proposalHint.host);               // "api.unknown-service.com"
+    console.log(err.proposalHint.endpoint);            // "POST /v1/proposals"
+    console.log(err.proposalHint.supportedAuthTypes);  // ["bearer", "basic", ...]
+  }
+}
+```
+
+### Important notes
+
+- **Authorization header**: The broker strips any `Authorization` header you set and replaces it with credentials from the vault's service configuration. Do not pass upstream auth tokens in headers — they will be ignored.
+- **Header allowlist**: Only certain headers are forwarded to the upstream service: `Content-Type`, `Accept`, `User-Agent`, `Idempotency-Key`, `X-Request-Id`, and a few others. Other headers are dropped.
+- **Body encoding**: Plain objects and arrays are automatically JSON-stringified with `Content-Type: application/json`. Pass strings or buffers for other content types.
+- **Timeout**: Defaults to 30 seconds. Override per-request with `timeout` in options. Set `timeout: 0` to disable.
+- **Underlying endpoint**: The proxy is served at `/proxy/{host}/{path}` on the Agent Vault server.
 
 ## Manage services
 

--- a/sdks/sdk-typescript/src/errors.ts
+++ b/sdks/sdk-typescript/src/errors.ts
@@ -46,23 +46,42 @@ export class ApiError extends AgentVaultError {
   static async fromResponse(response: Response): Promise<ApiError> {
     let code = "unknown";
     let message = response.statusText;
+    let proposalHint: ProposalHint | undefined;
 
     try {
       const body = await response.json();
       if (typeof body === "object" && body !== null) {
-        const errorField = (body as Record<string, unknown>).error;
-        const messageField = (body as Record<string, unknown>).message;
+        const record = body as Record<string, unknown>;
+        const errorField = record.error;
+        const messageField = record.message;
 
         if (typeof errorField === "string") {
           code = errorField;
-          // Proxy format: separate code and message fields
-          // Standard format: error field IS the message
           message =
             typeof messageField === "string" ? messageField : errorField;
+        }
+
+        if (record.proposal_hint && typeof record.proposal_hint === "object") {
+          const hint = record.proposal_hint as Record<string, unknown>;
+          proposalHint = {
+            host: hint.host as string,
+            endpoint: hint.endpoint as string,
+            supportedAuthTypes: hint.supported_auth_types as string[],
+          };
         }
       }
     } catch {
       // Response body wasn't JSON — fall back to statusText
+    }
+
+    if (proposalHint) {
+      return new ProxyForbiddenError({
+        status: response.status,
+        code,
+        message,
+        headers: response.headers,
+        proposalHint,
+      });
     }
 
     return new ApiError({
@@ -71,5 +90,38 @@ export class ApiError extends AgentVaultError {
       message,
       headers: response.headers,
     });
+  }
+}
+
+/** Structured hint returned by the broker when a proxy request is denied. */
+export interface ProposalHint {
+  host: string;
+  endpoint: string;
+  supportedAuthTypes: string[];
+}
+
+/**
+ * Thrown when a proxy request is denied because no broker service matches the target host.
+ * Contains a `proposalHint` with the information needed to create a proposal.
+ */
+export class ProxyForbiddenError extends ApiError {
+  readonly proposalHint: ProposalHint;
+
+  constructor({
+    status,
+    code,
+    message,
+    headers,
+    proposalHint,
+  }: {
+    status: number;
+    code: string;
+    message: string;
+    headers: Headers;
+    proposalHint: ProposalHint;
+  }) {
+    super({ status, code, message, headers });
+    this.name = "ProxyForbiddenError";
+    this.proposalHint = proposalHint;
   }
 }

--- a/sdks/sdk-typescript/src/http.ts
+++ b/sdks/sdk-typescript/src/http.ts
@@ -1,13 +1,24 @@
 import { AgentVaultError, ApiError } from "./errors.js";
 import type { ClientConfig } from "./types.js";
 
-export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "HEAD";
 
 export interface RequestOptions {
   body?: unknown;
   headers?: Record<string, string>;
-  query?: Record<string, string>;
+  query?: Record<string, string | number | boolean>;
   signal?: AbortSignal;
+}
+
+/** Body types accepted by `raw()`. Compatible with Node and browser runtimes. */
+export type RawRequestBody = string | ArrayBuffer | Buffer | Uint8Array | ReadableStream;
+
+export interface RawRequestOptions {
+  headers?: Record<string, string>;
+  query?: Record<string, string | number | boolean>;
+  body?: RawRequestBody | null;
+  signal?: AbortSignal;
+  timeout?: number;
 }
 
 export interface HttpClientConfig {
@@ -84,18 +95,13 @@ export class HttpClient {
     });
   }
 
-  async request<T>(
-    method: HttpMethod,
-    path: string,
-    options?: RequestOptions,
-  ): Promise<T> {
+  private buildUrl(path: string, query?: Record<string, string | number | boolean>): string {
     let url = `${this.baseUrl}${path}`;
-
-    if (options?.query) {
+    if (query) {
       const params = new URLSearchParams();
-      for (const [key, value] of Object.entries(options.query)) {
+      for (const [key, value] of Object.entries(query)) {
         if (value !== undefined) {
-          params.set(key, value);
+          params.set(key, String(value));
         }
       }
       const qs = params.toString();
@@ -103,22 +109,37 @@ export class HttpClient {
         url += `?${qs}`;
       }
     }
+    return url;
+  }
 
-    const hasBody = options?.body !== undefined;
-    const headers: Record<string, string> = {
+  private buildHeaders(
+    callerHeaders?: Record<string, string>,
+  ): Record<string, string> {
+    // Authorization and User-Agent are protected — callers cannot override them.
+    return {
+      ...this.defaultHeaders,
+      ...callerHeaders,
       "User-Agent": USER_AGENT,
       Authorization: `Bearer ${this.token}`,
-      ...(hasBody ? { "Content-Type": "application/json" } : {}),
-      ...this.defaultHeaders,
-      ...options?.headers,
     };
+  }
 
+  private async doFetch(opts: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    body?: RawRequestBody | string | null;
+    signal?: AbortSignal;
+    timeoutMs: number;
+    label: string;
+  }): Promise<Response> {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+    const useTimeout = opts.timeoutMs > 0 && isFinite(opts.timeoutMs);
+    const timeoutId = useTimeout
+      ? setTimeout(() => controller.abort(), opts.timeoutMs)
+      : undefined;
 
-    // If the caller provided a signal, forward its abort to our controller
-    // so both timeout and caller cancellation go through one AbortController.
-    const callerSignal = options?.signal;
+    const callerSignal = opts.signal;
     const onCallerAbort = () => controller.abort();
     if (callerSignal) {
       if (callerSignal.aborted) {
@@ -128,33 +149,80 @@ export class HttpClient {
       }
     }
 
-    let response: Response;
     try {
-      response = await this.fetchFn(url, {
-        method,
-        headers,
-        body: hasBody ? JSON.stringify(options.body) : undefined,
+      return await this.fetchFn(opts.url, {
+        method: opts.method,
+        headers: opts.headers,
+        body: opts.body,
         signal: controller.signal,
       });
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") {
         throw new AgentVaultError(
-          `Request timed out after ${this.timeout}ms: ${method} ${path}`,
+          `Request timed out after ${opts.timeoutMs}ms: ${opts.label}`,
         );
       }
       throw new AgentVaultError(
         `Network error: ${err instanceof Error ? err.message : String(err)}`,
       );
     } finally {
-      clearTimeout(timeoutId);
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
       callerSignal?.removeEventListener("abort", onCallerAbort);
     }
+  }
+
+  async request<T>(
+    method: HttpMethod,
+    path: string,
+    options?: RequestOptions,
+  ): Promise<T> {
+    const url = this.buildUrl(path, options?.query);
+    const hasBody = options?.body !== undefined;
+    const callerHeaders = hasBody
+      ? { ...options?.headers, "Content-Type": "application/json" }
+      : options?.headers;
+    const headers = this.buildHeaders(callerHeaders);
+
+    const response = await this.doFetch({
+      method,
+      url,
+      headers,
+      body: hasBody ? JSON.stringify(options.body) : undefined,
+      signal: options?.signal,
+      timeoutMs: this.timeout,
+      label: `${method} ${path}`,
+    });
 
     if (!response.ok) {
       throw await ApiError.fromResponse(response);
     }
 
     return (await response.json()) as T;
+  }
+
+  /**
+   * Perform an HTTP request and return the raw Response without parsing or
+   * throwing on non-2xx. Used by ProxyResource where the response body format
+   * is determined by the upstream service, not Agent Vault.
+   */
+  async raw(
+    method: string,
+    path: string,
+    options?: RawRequestOptions,
+  ): Promise<Response> {
+    const url = this.buildUrl(path, options?.query);
+    const headers = this.buildHeaders(options?.headers);
+    const timeoutMs = options?.timeout ?? this.timeout;
+
+    return this.doFetch({
+      method,
+      url,
+      headers,
+      body: options?.body,
+      signal: options?.signal,
+      timeoutMs,
+      label: `${method} ${path}`,
+    });
   }
 
   async get<T>(path: string, options?: Omit<RequestOptions, "body">): Promise<T> {

--- a/sdks/sdk-typescript/src/index.ts
+++ b/sdks/sdk-typescript/src/index.ts
@@ -3,7 +3,8 @@ export { AgentVault } from "./client.js";
 export { VaultClient } from "./vault.js";
 
 // Errors
-export { AgentVaultError, ApiError } from "./errors.js";
+export { AgentVaultError, ApiError, ProxyForbiddenError } from "./errors.js";
+export type { ProposalHint } from "./errors.js";
 
 // Config types
 export type { AgentVaultConfig, VaultClientConfig, ClientConfig } from "./types.js";
@@ -22,6 +23,12 @@ export type {
   SetCredentialsResult,
   DeleteCredentialsResult,
 } from "./resources/credentials.js";
+
+// Proxy resource types
+export type {
+  ProxyRequestOptions,
+  ProxyResponse,
+} from "./resources/proxy.js";
 
 // Service resource types
 export type {

--- a/sdks/sdk-typescript/src/resources/proxy.ts
+++ b/sdks/sdk-typescript/src/resources/proxy.ts
@@ -1,0 +1,217 @@
+import type { HttpClient, RawRequestBody } from "../http.js";
+import { AgentVaultError, ApiError } from "../errors.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ProxyRequestOptions {
+  /** Path appended after the host (default: "/"). */
+  path?: string;
+  /** Query parameters appended to the upstream URL. */
+  query?: Record<string, string | number | boolean>;
+  /**
+   * Headers forwarded to the upstream service.
+   * Only headers in the server's allowlist are actually forwarded:
+   * Content-Type, Accept, User-Agent, Idempotency-Key, X-Request-Id, etc.
+   * The `Authorization` header is always stripped by the broker and replaced
+   * with credentials from the vault's service configuration.
+   */
+  headers?: Record<string, string>;
+  /**
+   * Request body. Plain objects and arrays are JSON-stringified with
+   * `Content-Type: application/json` set automatically. Strings and Buffers
+   * are passed through — set Content-Type yourself if needed.
+   */
+  body?: RawRequestBody | Record<string, unknown> | unknown[];
+  /** AbortSignal for cancellation. */
+  signal?: AbortSignal;
+  /** Per-request timeout in milliseconds. 0 disables timeout. */
+  timeout?: number;
+}
+
+export interface ProxyResponse {
+  /** HTTP status code from the upstream service. */
+  status: number;
+  /** HTTP status text from the upstream service. */
+  statusText: string;
+  /** True if status is in the 200–299 range. */
+  ok: boolean;
+  /** Response headers from the upstream service. */
+  headers: Headers;
+  /** Parse the response body as JSON. */
+  json<T = unknown>(): Promise<T>;
+  /** Read the response body as text. */
+  text(): Promise<string>;
+  /** Read the response body as an ArrayBuffer. */
+  arrayBuffer(): Promise<ArrayBuffer>;
+  /** Raw response body stream (null if already consumed). */
+  body: ReadableStream<Uint8Array> | null;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+const INVALID_HOST_CHARS = /[@?#/\\\s%]/;
+const CONTROL_CHAR = /[\x00-\x1f\x7f]/;
+
+function validateHost(host: string): void {
+  if (!host) {
+    throw new AgentVaultError("Proxy host must not be empty");
+  }
+
+  let hostname = host;
+  const colonIdx = host.lastIndexOf(":");
+  if (colonIdx !== -1) {
+    hostname = host.slice(0, colonIdx);
+    const port = host.slice(colonIdx + 1);
+    if (!/^\d+$/.test(port)) {
+      throw new AgentVaultError(`Invalid port in proxy host: ${host}`);
+    }
+  }
+
+  if (!hostname) {
+    throw new AgentVaultError("Proxy host must not be empty");
+  }
+
+  if (INVALID_HOST_CHARS.test(hostname) || CONTROL_CHAR.test(hostname)) {
+    throw new AgentVaultError(
+      `Invalid proxy host "${host}": contains forbidden characters`,
+    );
+  }
+}
+
+function validatePath(path: string): void {
+  const segments = path.split("/");
+  for (const segment of segments) {
+    if (segment === "..") {
+      throw new AgentVaultError(
+        'Proxy path must not contain ".." segments (path traversal)',
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BROKER_ERROR_HEADER = "X-Agent-Vault-Proxy-Error";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) return false;
+  if (typeof ReadableStream !== "undefined" && value instanceof ReadableStream) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function wrapResponse(response: Response): ProxyResponse {
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    ok: response.ok,
+    headers: response.headers,
+    json: <T = unknown>() => response.json() as Promise<T>,
+    text: () => response.text(),
+    arrayBuffer: () => response.arrayBuffer(),
+    body: response.body,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Resource
+// ---------------------------------------------------------------------------
+
+export class ProxyResource {
+  private readonly httpClient: HttpClient;
+
+  constructor(httpClient: HttpClient) {
+    this.httpClient = httpClient;
+  }
+
+  /**
+   * Send an HTTP request through the Agent Vault proxy.
+   *
+   * The broker matches the target host against configured services, injects
+   * credentials, and forwards the request to `https://{host}/{path}`.
+   *
+   * Upstream responses (including non-2xx) resolve normally as a `ProxyResponse`.
+   * Broker-level errors (no matching service, missing credentials, auth failures)
+   * throw `ApiError` or `ProxyForbiddenError`.
+   */
+  async request(
+    method: string,
+    host: string,
+    options?: ProxyRequestOptions,
+  ): Promise<ProxyResponse> {
+    validateHost(host);
+
+    const path = options?.path ?? "/";
+    validatePath(path);
+
+    const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+    const proxyPath = `/proxy/${host}${normalizedPath}`;
+
+    let body: RawRequestBody | null | undefined;
+    let headers = options?.headers;
+
+    if (options?.body !== undefined) {
+      if (Array.isArray(options.body) || isPlainObject(options.body)) {
+        body = JSON.stringify(options.body);
+        if (!headers?.["Content-Type"]) {
+          headers = { ...headers, "Content-Type": "application/json" };
+        }
+      } else {
+        body = options.body as RawRequestBody;
+      }
+    }
+
+    const response = await this.httpClient.raw(method, proxyPath, {
+      headers,
+      query: options?.query,
+      body,
+      signal: options?.signal,
+      timeout: options?.timeout,
+    });
+
+    if (
+      !response.ok &&
+      response.headers.get(BROKER_ERROR_HEADER) === "true"
+    ) {
+      throw await ApiError.fromResponse(response);
+    }
+
+    return wrapResponse(response);
+  }
+
+  private _verb(
+    method: string,
+    host: string,
+    path?: string,
+    options?: Omit<ProxyRequestOptions, "path">,
+  ): Promise<ProxyResponse> {
+    return this.request(method, host, { ...options, path });
+  }
+
+  async get(host: string, path?: string, options?: Omit<ProxyRequestOptions, "path">) {
+    return this._verb("GET", host, path, options);
+  }
+
+  async post(host: string, path?: string, options?: Omit<ProxyRequestOptions, "path">) {
+    return this._verb("POST", host, path, options);
+  }
+
+  async put(host: string, path?: string, options?: Omit<ProxyRequestOptions, "path">) {
+    return this._verb("PUT", host, path, options);
+  }
+
+  async patch(host: string, path?: string, options?: Omit<ProxyRequestOptions, "path">) {
+    return this._verb("PATCH", host, path, options);
+  }
+
+  async delete(host: string, path?: string, options?: Omit<ProxyRequestOptions, "path">) {
+    return this._verb("DELETE", host, path, options);
+  }
+}

--- a/sdks/sdk-typescript/src/vault.ts
+++ b/sdks/sdk-typescript/src/vault.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from "./http.js";
 import { CredentialsResource } from "./resources/credentials.js";
+import { ProxyResource } from "./resources/proxy.js";
 import { ServicesResource } from "./resources/services.js";
 import { SessionsResource } from "./resources/sessions.js";
 import type { VaultClientConfig } from "./types.js";
@@ -56,6 +57,13 @@ export class VaultClient {
    */
   readonly credentials: CredentialsResource;
 
+  /**
+   * Proxy resource for sending HTTP requests through the Agent Vault proxy.
+   * The broker matches the target host against configured services, injects
+   * credentials, and forwards the request to the upstream service.
+   */
+  readonly proxy: ProxyResource;
+
   constructor(config?: VaultClientConfig | InternalArgs) {
     if (config && "marker" in config && config.marker === INTERNAL) {
       this._httpClient = config.httpClient;
@@ -63,12 +71,14 @@ export class VaultClient {
       this.sessions = new SessionsResource(config.httpClient, config.vaultName);
       this.services = new ServicesResource(config.httpClient, config.vaultName);
       this.credentials = new CredentialsResource(config.httpClient, config.vaultName);
+      this.proxy = new ProxyResource(config.httpClient);
     } else {
       this._httpClient = HttpClient.fromConfig(config as VaultClientConfig | undefined);
       this.name = undefined;
       this.sessions = undefined;
       this.services = undefined;
       this.credentials = new CredentialsResource(this._httpClient, undefined);
+      this.proxy = new ProxyResource(this._httpClient);
     }
   }
 

--- a/sdks/sdk-typescript/tests/helpers.ts
+++ b/sdks/sdk-typescript/tests/helpers.ts
@@ -5,14 +5,21 @@ export function createMockFetch(response: {
   status?: number;
   statusText?: string;
   body?: unknown;
+  headers?: Record<string, string>;
 }) {
   const ok = response.ok ?? true;
   const status = response.status ?? (ok ? 200 : 400);
+  const headers = new Headers(response.headers);
+  const bodyText = JSON.stringify(response.body ?? {});
   return vi.fn<typeof globalThis.fetch>().mockResolvedValue({
     ok,
     status,
-    statusText: response.statusText ?? "OK",
-    headers: new Headers(),
+    statusText: response.statusText ?? (ok ? "OK" : "Bad Request"),
+    headers,
     json: () => Promise.resolve(response.body ?? {}),
+    text: () => Promise.resolve(bodyText),
+    arrayBuffer: () =>
+      Promise.resolve(new TextEncoder().encode(bodyText).buffer),
+    body: null,
   } as Response);
 }

--- a/sdks/sdk-typescript/tests/proxy.test.ts
+++ b/sdks/sdk-typescript/tests/proxy.test.ts
@@ -1,0 +1,496 @@
+import { describe, it, expect } from "vitest";
+import { AgentVault } from "../src/client.js";
+import { VaultClient } from "../src/vault.js";
+import { AgentVaultError, ProxyForbiddenError, ApiError } from "../src/errors.js";
+import { createMockFetch } from "./helpers.js";
+
+describe("ProxyResource", () => {
+  // -------------------------------------------------------------------------
+  // URL construction
+  // -------------------------------------------------------------------------
+
+  describe("URL construction", () => {
+    it("builds /proxy/{host}/{path} URL", async () => {
+      const mockFetch = createMockFetch({ body: { ok: true } });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await vault.proxy.get("api.stripe.com", "/v1/charges");
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("http://localhost:14321/proxy/api.stripe.com/v1/charges");
+      expect(init?.method).toBe("GET");
+    });
+
+    it("defaults path to / when omitted", async () => {
+      const mockFetch = createMockFetch({ body: {} });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await vault.proxy.get("api.stripe.com");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("http://localhost:14321/proxy/api.stripe.com/");
+    });
+
+    it("normalizes path without leading slash", async () => {
+      const mockFetch = createMockFetch({ body: {} });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await vault.proxy.get("api.stripe.com", "v1/charges");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe("http://localhost:14321/proxy/api.stripe.com/v1/charges");
+    });
+
+    it("appends query parameters", async () => {
+      const mockFetch = createMockFetch({ body: {} });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await vault.proxy.get("api.stripe.com", "/v1/charges", {
+        query: { limit: 10, active: true },
+      });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toContain("/proxy/api.stripe.com/v1/charges?");
+      expect(url).toContain("limit=10");
+      expect(url).toContain("active=true");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // HTTP methods
+  // -------------------------------------------------------------------------
+
+  describe("HTTP methods", () => {
+    it.each([
+      ["get", "GET"],
+      ["post", "POST"],
+      ["put", "PUT"],
+      ["patch", "PATCH"],
+      ["delete", "DELETE"],
+    ] as const)(".%s() sends %s method", async (method, httpMethod) => {
+      const mockFetch = createMockFetch({ body: {} });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await (vault.proxy[method] as Function)("api.example.com", "/path");
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init?.method).toBe(httpMethod);
+    });
+
+    it("request() supports arbitrary HTTP methods", async () => {
+      const mockFetch = createMockFetch({ body: {} });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await vault.proxy.request("OPTIONS", "api.example.com", { path: "/v1" });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init?.method).toBe("OPTIONS");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Headers
+  // -------------------------------------------------------------------------
+
+  describe("headers", () => {
+    it("includes Authorization header for Agent Vault auth", async () => {
+      const mockFetch = createMockFetch({ body: {} });
+      const vault = new VaultClient({
+        token: "my-session-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await vault.proxy.get("api.example.com", "/");
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer my-session-token");
+    });
+
+    it("includes X-Vault header when created via AgentVault.vault()", async () => {
+      const mockFetch = createMockFetch({ body: {} });
+      const av = new AgentVault({
+        token: "agent-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await av.vault("production").proxy.get("api.stripe.com", "/v1/charges");
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["X-Vault"]).toBe("production");
+    });
+
+    it("forwards caller headers to the request", async () => {
+      const mockFetch = createMockFetch({ body: {} });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await vault.proxy.get("api.example.com", "/", {
+        headers: { "Idempotency-Key": "abc-123" },
+      });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["Idempotency-Key"]).toBe("abc-123");
+    });
+
+    it("protects Authorization header from caller override", async () => {
+      const mockFetch = createMockFetch({ body: {} });
+      const vault = new VaultClient({
+        token: "my-session-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await vault.proxy.get("api.example.com", "/", {
+        headers: { Authorization: "Bearer upstream-token" },
+      });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer my-session-token");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Body handling
+  // -------------------------------------------------------------------------
+
+  describe("body handling", () => {
+    it("JSON-stringifies plain object bodies", async () => {
+      const mockFetch = createMockFetch({ body: {} });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await vault.proxy.post("api.github.com", "/repos/o/r/issues", {
+        body: { title: "Bug", body: "steps" },
+      });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init?.body).toBe('{"title":"Bug","body":"steps"}');
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("application/json");
+    });
+
+    it("JSON-stringifies array bodies", async () => {
+      const mockFetch = createMockFetch({ body: {} });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await vault.proxy.post("api.example.com", "/batch", {
+        body: [{ id: 1 }, { id: 2 }],
+      });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init?.body).toBe('[{"id":1},{"id":2}]');
+    });
+
+    it("passes string bodies through without JSON-stringifying", async () => {
+      const mockFetch = createMockFetch({ body: {} });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await vault.proxy.post("api.example.com", "/raw", {
+        body: "raw-body-content",
+        headers: { "Content-Type": "text/plain" },
+      });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      expect(init?.body).toBe("raw-body-content");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Response handling
+  // -------------------------------------------------------------------------
+
+  describe("response handling", () => {
+    it("returns ProxyResponse with status and ok for success", async () => {
+      const mockFetch = createMockFetch({
+        ok: true,
+        status: 200,
+        body: { data: [{ id: "ch_1" }] },
+      });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      const res = await vault.proxy.get("api.stripe.com", "/v1/charges");
+
+      expect(res.ok).toBe(true);
+      expect(res.status).toBe(200);
+      const data = await res.json<{ data: { id: string }[] }>();
+      expect(data.data[0].id).toBe("ch_1");
+    });
+
+    it("returns ProxyResponse for upstream non-2xx (does not throw)", async () => {
+      const mockFetch = createMockFetch({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        body: { error: { message: "No such customer" } },
+      });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      const res = await vault.proxy.get("api.stripe.com", "/v1/customers/cus_missing");
+
+      expect(res.ok).toBe(false);
+      expect(res.status).toBe(404);
+      const data = await res.json();
+      expect(data).toEqual({ error: { message: "No such customer" } });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Broker error handling
+  // -------------------------------------------------------------------------
+
+  describe("broker error handling", () => {
+    it("throws ProxyForbiddenError for 403 with proposal_hint", async () => {
+      const mockFetch = createMockFetch({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        headers: { "X-Agent-Vault-Proxy-Error": "true" },
+        body: {
+          error: "forbidden",
+          message: 'No broker service matching host "api.unknown.com" in vault "default"',
+          proposal_hint: {
+            host: "api.unknown.com",
+            endpoint: "POST /v1/proposals",
+            supported_auth_types: ["bearer", "basic", "api-key", "custom"],
+          },
+        },
+      });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      try {
+        await vault.proxy.get("api.unknown.com", "/");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ProxyForbiddenError);
+        const e = err as ProxyForbiddenError;
+        expect(e.status).toBe(403);
+        expect(e.proposalHint.host).toBe("api.unknown.com");
+        expect(e.proposalHint.endpoint).toBe("POST /v1/proposals");
+        expect(e.proposalHint.supportedAuthTypes).toEqual([
+          "bearer",
+          "basic",
+          "api-key",
+          "custom",
+        ]);
+      }
+    });
+
+    it("throws ApiError for 502 broker error (credential_not_found)", async () => {
+      const mockFetch = createMockFetch({
+        ok: false,
+        status: 502,
+        statusText: "Bad Gateway",
+        headers: { "X-Agent-Vault-Proxy-Error": "true" },
+        body: {
+          error: "credential_not_found",
+          message: "A required credential could not be resolved; check vault configuration",
+        },
+      });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      try {
+        await vault.proxy.get("api.stripe.com", "/v1/charges");
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        const e = err as ApiError;
+        expect(e.status).toBe(502);
+        expect(e.code).toBe("credential_not_found");
+      }
+    });
+
+    it("throws ApiError for 400 broker error (bad_request)", async () => {
+      const mockFetch = createMockFetch({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        headers: { "X-Agent-Vault-Proxy-Error": "true" },
+        body: {
+          error: "bad_request",
+          message: "Missing target host in proxy URL",
+        },
+      });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      try {
+        await vault.proxy.request("GET", "example.com", { path: "/" });
+        expect.fail("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ApiError);
+        expect((err as ApiError).code).toBe("bad_request");
+      }
+    });
+
+    it("does NOT throw for upstream 403 without sentinel header", async () => {
+      const mockFetch = createMockFetch({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        body: { error: "forbidden", message: "Upstream denied" },
+      });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      const res = await vault.proxy.get("api.example.com", "/protected");
+      expect(res.ok).toBe(false);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Validation
+  // -------------------------------------------------------------------------
+
+  describe("validation", () => {
+    it("rejects empty host", async () => {
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: createMockFetch({ body: {} }),
+      });
+
+      await expect(vault.proxy.get("", "/")).rejects.toThrow(AgentVaultError);
+    });
+
+    it("rejects host with @ character", async () => {
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: createMockFetch({ body: {} }),
+      });
+
+      await expect(vault.proxy.get("user@evil.com", "/")).rejects.toThrow(
+        "forbidden characters",
+      );
+    });
+
+    it("rejects host with / character", async () => {
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: createMockFetch({ body: {} }),
+      });
+
+      await expect(vault.proxy.get("host/path", "/")).rejects.toThrow(
+        "forbidden characters",
+      );
+    });
+
+    it("rejects host with non-numeric port", async () => {
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: createMockFetch({ body: {} }),
+      });
+
+      await expect(vault.proxy.get("host:abc", "/")).rejects.toThrow(
+        "Invalid port",
+      );
+    });
+
+    it("allows host with numeric port", async () => {
+      const mockFetch = createMockFetch({ body: {} });
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: mockFetch,
+      });
+
+      await vault.proxy.get("api.example.com:8443", "/");
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toContain("/proxy/api.example.com:8443/");
+    });
+
+    it("rejects path with .. segments (path traversal)", async () => {
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: createMockFetch({ body: {} }),
+      });
+
+      await expect(
+        vault.proxy.get("api.example.com", "/../../../v1/credentials"),
+      ).rejects.toThrow("path traversal");
+    });
+
+    it("rejects path with .. in middle", async () => {
+      const vault = new VaultClient({
+        token: "test-token",
+        address: "http://localhost:14321",
+        fetch: createMockFetch({ body: {} }),
+      });
+
+      await expect(
+        vault.proxy.get("api.example.com", "/v1/../admin"),
+      ).rejects.toThrow("path traversal");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `ProxyResource` with `get/post/put/patch/delete/request` methods to the TypeScript SDK, exposed as `vault.proxy` on both `VaultClient` (vault-scoped token) and `AgentVault.vault(name)` (instance-level token with automatic `X-Vault` injection)
- Add `X-Agent-Vault-Proxy-Error` sentinel response header on broker-generated proxy errors (Go server), enabling the SDK to reliably distinguish broker errors (thrown as `ApiError`/`ProxyForbiddenError`) from upstream service errors (returned as `ProxyResponse` with `ok: false`)
- Add `raw()` method to `HttpClient` for non-JSON responses, refactor internals (`buildUrl`, `buildHeaders`, `doFetch` options object) for reuse and safety (protected `Authorization`/`User-Agent` headers, path traversal validation, host validation matching server rules)

## Key design decisions

- **No auto-JSON parsing**: `ProxyResponse` wraps fetch's `Response` — users call `.json()`, `.text()`, or `.arrayBuffer()` explicitly since proxied bodies may be binary, streaming, or non-JSON
- **Error model**: broker errors throw (so they surface like all other SDK errors), upstream non-2xx resolves normally (so users handle their own API semantics)
- **Client-side validation**: host validation mirrors `isValidProxyHost()` in Go, path traversal (`..` segments) is rejected to prevent URL normalization from bypassing the proxy path

## Files changed

| Area | Files |
|------|-------|
| Server | `internal/server/respond.go`, `internal/server/handle_proxy.go` |
| SDK core | `src/http.ts`, `src/errors.ts`, `src/vault.ts`, `src/index.ts` |
| SDK proxy | `src/resources/proxy.ts` (new) |
| Tests | `tests/proxy.test.ts` (new, 30 tests), `tests/helpers.ts` |
| Docs | `README.md` |

## Test plan

- [x] `npm run build` — TypeScript compiles with no errors (ESM, CJS, DTS)
- [x] `npx vitest run` — all 117 tests pass (30 new proxy tests + 87 existing)
- [x] `go build ./...` — Go compiles with no errors
- [ ] Manual e2e: start server, configure a service + credential, mint a scoped token, run `vault.proxy.get()` against the configured host, verify credential injection
- [ ] Manual e2e: test `ProxyForbiddenError` path with an unconfigured host

🤖 Generated with [Claude Code](https://claude.com/claude-code)