### PR TITLE
feat: add software-backed CA package for transparent proxy groundwork

### DIFF
--- a/internal/ca/lru.go
+++ b/internal/ca/lru.go
@@ -1,0 +1,59 @@
+package ca
+
+import (
+	"container/list"
+	"crypto/tls"
+)
+
+// lru is a small, non-thread-safe LRU cache of *tls.Certificate keyed by SNI.
+// The enclosing *SoftCA serializes access via its own mutex.
+type lru struct {
+	cap   int
+	ll    *list.List
+	items map[string]*list.Element
+}
+
+type lruEntry struct {
+	key   string
+	value *tls.Certificate
+}
+
+func newLRU(capacity int) *lru {
+	if capacity < 1 {
+		capacity = 1
+	}
+	return &lru{
+		cap:   capacity,
+		ll:    list.New(),
+		items: make(map[string]*list.Element, capacity),
+	}
+}
+
+func (c *lru) get(key string) (*tls.Certificate, bool) {
+	el, ok := c.items[key]
+	if !ok {
+		return nil, false
+	}
+	c.ll.MoveToFront(el)
+	return el.Value.(*lruEntry).value, true
+}
+
+func (c *lru) add(key string, value *tls.Certificate) {
+	if el, ok := c.items[key]; ok {
+		c.ll.MoveToFront(el)
+		el.Value.(*lruEntry).value = value
+		return
+	}
+	el := c.ll.PushFront(&lruEntry{key: key, value: value})
+	c.items[key] = el
+	if c.ll.Len() > c.cap {
+		if oldest := c.ll.Back(); oldest != nil {
+			c.ll.Remove(oldest)
+			delete(c.items, oldest.Value.(*lruEntry).key)
+		}
+	}
+}
+
+func (c *lru) len() int {
+	return c.ll.Len()
+}

--- a/internal/ca/lru.go
+++ b/internal/ca/lru.go
@@ -53,7 +53,3 @@ func (c *lru) add(key string, value *tls.Certificate) {
 		}
 	}
 }
-
-func (c *lru) len() int {
-	return c.ll.Len()
-}

--- a/internal/ca/provider.go
+++ b/internal/ca/provider.go
@@ -1,0 +1,15 @@
+package ca
+
+import "crypto/tls"
+
+// Provider issues TLS server certificates for arbitrary SNIs.
+// Implementations must be safe for concurrent use.
+type Provider interface {
+	// MintLeaf returns a leaf certificate whose SAN covers sni,
+	// signed by this CA's root. Implementations may cache results.
+	MintLeaf(sni string) (*tls.Certificate, error)
+
+	// RootPEM returns the root CA certificate in PEM form.
+	// It is safe to expose publicly.
+	RootPEM() []byte
+}

--- a/internal/ca/soft.go
+++ b/internal/ca/soft.go
@@ -1,0 +1,349 @@
+package ca
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Infisical/agent-vault/internal/crypto"
+)
+
+const (
+	rootCertFile     = "ca.crt.pem"
+	rootKeyFile      = "ca.key.enc"
+	defaultDirName   = "ca"
+	defaultLeafTTL   = 24 * time.Hour
+	defaultCacheSize = 1024
+	rootValidity     = 10 * 365 * 24 * time.Hour
+	clockSkew        = 5 * time.Minute
+	rootCommonName   = "Agent Vault Root CA"
+)
+
+var serialLimit = new(big.Int).Lsh(big.NewInt(1), 128)
+
+// Options configures a SoftCA. Zero values pick sensible defaults.
+type Options struct {
+	Dir       string           // default: ~/.agent-vault/ca
+	LeafTTL   time.Duration    // default: 24h
+	CacheSize int              // default: 1024
+	Clock     func() time.Time // default: time.Now
+}
+
+// SoftCA is a software-backed CA that persists its root to disk (with the
+// private key encrypted by the caller-supplied master key) and mints
+// short-lived ECDSA P-256 leaves on demand, cached by SNI.
+type SoftCA struct {
+	mu       sync.Mutex
+	dir      string
+	leafTTL  time.Duration
+	clock    func() time.Time
+	rootCert *x509.Certificate
+	rootKey  *ecdsa.PrivateKey
+	rootPEM  []byte
+	cache    *lru
+}
+
+type encryptedKeyFile struct {
+	Nonce      string `json:"nonce"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+// New loads an existing CA from opts.Dir or generates a new one.
+// masterKey must be 32 bytes (AES-256-GCM); it encrypts/decrypts the root
+// private key at rest.
+func New(masterKey []byte, opts Options) (*SoftCA, error) {
+	if len(masterKey) != 32 {
+		return nil, fmt.Errorf("masterKey must be 32 bytes, got %d", len(masterKey))
+	}
+
+	dir := opts.Dir
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolving home dir: %w", err)
+		}
+		dir = filepath.Join(home, ".agent-vault", defaultDirName)
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("creating ca dir: %w", err)
+	}
+
+	leafTTL := opts.LeafTTL
+	if leafTTL <= 0 {
+		leafTTL = defaultLeafTTL
+	}
+	cacheSize := opts.CacheSize
+	if cacheSize <= 0 {
+		cacheSize = defaultCacheSize
+	}
+	clock := opts.Clock
+	if clock == nil {
+		clock = time.Now
+	}
+
+	ca := &SoftCA{
+		dir:     dir,
+		leafTTL: leafTTL,
+		clock:   clock,
+		cache:   newLRU(cacheSize),
+	}
+
+	certPath := filepath.Join(dir, rootCertFile)
+	keyPath := filepath.Join(dir, rootKeyFile)
+
+	_, certErr := os.Stat(certPath)
+	_, keyErr := os.Stat(keyPath)
+	switch {
+	case certErr == nil && keyErr == nil:
+		if err := ca.load(certPath, keyPath, masterKey); err != nil {
+			return nil, fmt.Errorf("loading existing CA: %w", err)
+		}
+	case os.IsNotExist(certErr) && os.IsNotExist(keyErr):
+		if err := ca.generate(certPath, keyPath, masterKey); err != nil {
+			return nil, fmt.Errorf("generating new CA: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("inconsistent CA state in %s (cert: %v, key: %v)", dir, certErr, keyErr)
+	}
+	return ca, nil
+}
+
+func (c *SoftCA) load(certPath, keyPath string, masterKey []byte) error {
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return fmt.Errorf("reading root cert: %w", err)
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return fmt.Errorf("invalid root cert PEM at %s", certPath)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parsing root cert: %w", err)
+	}
+
+	raw, err := os.ReadFile(keyPath)
+	if err != nil {
+		return fmt.Errorf("reading root key: %w", err)
+	}
+	var enc encryptedKeyFile
+	if err := json.Unmarshal(raw, &enc); err != nil {
+		return fmt.Errorf("parsing root key file: %w", err)
+	}
+	nonce, err := base64.StdEncoding.DecodeString(enc.Nonce)
+	if err != nil {
+		return fmt.Errorf("decoding nonce: %w", err)
+	}
+	ciphertext, err := base64.StdEncoding.DecodeString(enc.Ciphertext)
+	if err != nil {
+		return fmt.Errorf("decoding ciphertext: %w", err)
+	}
+	keyDER, err := crypto.Decrypt(ciphertext, nonce, masterKey)
+	if err != nil {
+		return fmt.Errorf("decrypting root key: %w", err)
+	}
+	key, err := x509.ParseECPrivateKey(keyDER)
+	if err != nil {
+		return fmt.Errorf("parsing root key: %w", err)
+	}
+
+	c.setRoot(cert, key, certPEM)
+	return nil
+}
+
+func (c *SoftCA) generate(certPath, keyPath string, masterKey []byte) error {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generating root key: %w", err)
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return err
+	}
+	now := c.clock()
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: rootCommonName},
+		NotBefore:             now.Add(-clockSkew),
+		NotAfter:              now.Add(rootValidity),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return fmt.Errorf("creating root cert: %w", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return fmt.Errorf("parsing freshly created root cert: %w", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := writeAtomic(certPath, certPEM, 0644); err != nil {
+		return fmt.Errorf("writing root cert: %w", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return fmt.Errorf("marshaling root key: %w", err)
+	}
+	ciphertext, nonce, err := crypto.Encrypt(keyDER, masterKey)
+	if err != nil {
+		return fmt.Errorf("encrypting root key: %w", err)
+	}
+	blob, err := json.Marshal(encryptedKeyFile{
+		Nonce:      base64.StdEncoding.EncodeToString(nonce),
+		Ciphertext: base64.StdEncoding.EncodeToString(ciphertext),
+	})
+	if err != nil {
+		return fmt.Errorf("marshaling encrypted key: %w", err)
+	}
+	if err := writeAtomic(keyPath, blob, 0600); err != nil {
+		return fmt.Errorf("writing root key: %w", err)
+	}
+
+	c.setRoot(cert, key, certPEM)
+	return nil
+}
+
+func (c *SoftCA) setRoot(cert *x509.Certificate, key *ecdsa.PrivateKey, pemBytes []byte) {
+	c.rootCert = cert
+	c.rootKey = key
+	c.rootPEM = pemBytes
+}
+
+// RootPEM returns a copy of the root CA certificate in PEM form.
+func (c *SoftCA) RootPEM() []byte {
+	out := make([]byte, len(c.rootPEM))
+	copy(out, c.rootPEM)
+	return out
+}
+
+// MintLeaf returns a leaf certificate for the given SNI. Results are cached;
+// cached entries are returned only if they remain valid beyond a clock-skew
+// buffer, so the caller never receives a cert that may expire mid-handshake.
+func (c *SoftCA) MintLeaf(sni string) (*tls.Certificate, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.clock()
+	if existing, ok := c.cache.get(sni); ok {
+		if existing.Leaf != nil && existing.Leaf.NotAfter.After(now.Add(clockSkew)) {
+			return existing, nil
+		}
+	}
+
+	isIP, err := validateSNI(sni)
+	if err != nil {
+		return nil, err
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating leaf key: %w", err)
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: sni},
+		NotBefore:    now.Add(-clockSkew),
+		NotAfter:     now.Add(c.leafTTL),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	if isIP {
+		tmpl.IPAddresses = []net.IP{net.ParseIP(sni)}
+	} else {
+		tmpl.DNSNames = []string{sni}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, c.rootCert, &leafKey.PublicKey, c.rootKey)
+	if err != nil {
+		return nil, fmt.Errorf("creating leaf cert: %w", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, fmt.Errorf("parsing leaf cert: %w", err)
+	}
+	tlsCert := &tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  leafKey,
+		Leaf:        leaf,
+	}
+	c.cache.add(sni, tlsCert)
+	return tlsCert, nil
+}
+
+func validateSNI(sni string) (bool, error) {
+	if sni == "" {
+		return false, errors.New("empty SNI")
+	}
+	if len(sni) > 253 {
+		return false, errors.New("SNI exceeds 253 bytes")
+	}
+	if ip := net.ParseIP(sni); ip != nil {
+		return true, nil
+	}
+	for _, label := range strings.Split(sni, ".") {
+		if len(label) == 0 || len(label) > 63 {
+			return false, fmt.Errorf("invalid SNI label length: %d", len(label))
+		}
+		if label[0] == '-' || label[len(label)-1] == '-' {
+			return false, fmt.Errorf("SNI label cannot start or end with hyphen: %q", label)
+		}
+		for _, r := range label {
+			switch {
+			case r >= 'a' && r <= 'z':
+			case r >= 'A' && r <= 'Z':
+			case r >= '0' && r <= '9':
+			case r == '-':
+			default:
+				return false, fmt.Errorf("invalid SNI character %q", r)
+			}
+		}
+	}
+	return false, nil
+}
+
+func randomSerial() (*big.Int, error) {
+	n, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return nil, fmt.Errorf("generating serial: %w", err)
+	}
+	return n, nil
+}
+
+func writeAtomic(path string, data []byte, mode os.FileMode) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, mode); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmp, mode); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+var _ Provider = (*SoftCA)(nil)

--- a/internal/ca/soft_test.go
+++ b/internal/ca/soft_test.go
@@ -1,0 +1,263 @@
+package ca
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testMasterKey() []byte {
+	k := make([]byte, 32)
+	for i := range k {
+		k[i] = byte(i + 1)
+	}
+	return k
+}
+
+func newTestCA(t *testing.T, opts Options) *SoftCA {
+	t.Helper()
+	if opts.Dir == "" {
+		opts.Dir = t.TempDir()
+	}
+	ca, err := New(testMasterKey(), opts)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return ca
+}
+
+func TestNew_FreshInit_WritesFilesWithExpectedPerms(t *testing.T) {
+	caDir := filepath.Join(t.TempDir(), "ca")
+	ca := newTestCA(t, Options{Dir: caDir})
+	if len(ca.RootPEM()) == 0 {
+		t.Fatal("RootPEM is empty")
+	}
+
+	certInfo, err := os.Stat(filepath.Join(caDir, rootCertFile))
+	if err != nil {
+		t.Fatalf("stat cert: %v", err)
+	}
+	if certInfo.Mode().Perm() != 0644 {
+		t.Errorf("cert perm = %o, want 0644", certInfo.Mode().Perm())
+	}
+	keyInfo, err := os.Stat(filepath.Join(caDir, rootKeyFile))
+	if err != nil {
+		t.Fatalf("stat key: %v", err)
+	}
+	if keyInfo.Mode().Perm() != 0600 {
+		t.Errorf("key perm = %o, want 0600", keyInfo.Mode().Perm())
+	}
+}
+
+func TestNew_Reload_YieldsSameRoot(t *testing.T) {
+	caDir := t.TempDir()
+	key := testMasterKey()
+	ca1, err := New(key, Options{Dir: caDir})
+	if err != nil {
+		t.Fatalf("first New: %v", err)
+	}
+	ca2, err := New(key, Options{Dir: caDir})
+	if err != nil {
+		t.Fatalf("second New: %v", err)
+	}
+	if !bytes.Equal(ca1.RootPEM(), ca2.RootPEM()) {
+		t.Error("RootPEM differs between instances")
+	}
+	leaf, err := ca1.MintLeaf("verify.example.com")
+	if err != nil {
+		t.Fatalf("MintLeaf: %v", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(ca2.RootPEM()) {
+		t.Fatal("AppendCertsFromPEM failed")
+	}
+	if _, err := leaf.Leaf.Verify(x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSName:   "verify.example.com",
+	}); err != nil {
+		t.Errorf("verify leaf against reloaded root: %v", err)
+	}
+}
+
+func TestNew_WrongMasterKey_Fails(t *testing.T) {
+	caDir := t.TempDir()
+	if _, err := New(testMasterKey(), Options{Dir: caDir}); err != nil {
+		t.Fatalf("first New: %v", err)
+	}
+	wrong := make([]byte, 32)
+	wrong[0] = 0xFF
+	if _, err := New(wrong, Options{Dir: caDir}); err == nil {
+		t.Error("expected error with wrong master key, got nil")
+	}
+}
+
+func TestMintLeaf_VerifiesAgainstRoot(t *testing.T) {
+	ca := newTestCA(t, Options{LeafTTL: time.Hour})
+	cert, err := ca.MintLeaf("example.com")
+	if err != nil {
+		t.Fatalf("MintLeaf: %v", err)
+	}
+	if cert.Leaf == nil {
+		t.Fatal("Leaf is nil")
+	}
+	if cert.Leaf.Subject.CommonName != "example.com" {
+		t.Errorf("CN = %q, want example.com", cert.Leaf.Subject.CommonName)
+	}
+	if len(cert.Leaf.DNSNames) != 1 || cert.Leaf.DNSNames[0] != "example.com" {
+		t.Errorf("DNSNames = %v, want [example.com]", cert.Leaf.DNSNames)
+	}
+	if _, ok := cert.PrivateKey.(*ecdsa.PrivateKey); !ok {
+		t.Errorf("PrivateKey is not *ecdsa.PrivateKey")
+	}
+
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(ca.RootPEM()) {
+		t.Fatal("AppendCertsFromPEM failed")
+	}
+	if _, err := cert.Leaf.Verify(x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSName:   "example.com",
+	}); err != nil {
+		t.Errorf("Verify: %v", err)
+	}
+
+	now := time.Now()
+	if cert.Leaf.NotAfter.Before(now.Add(55*time.Minute)) || cert.Leaf.NotAfter.After(now.Add(65*time.Minute)) {
+		t.Errorf("NotAfter = %v, expected ~1h from %v", cert.Leaf.NotAfter, now)
+	}
+}
+
+func TestMintLeaf_CacheHit_ReturnsSamePointer(t *testing.T) {
+	ca := newTestCA(t, Options{})
+	a, err := ca.MintLeaf("example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := ca.MintLeaf("example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != b {
+		t.Error("cache hit returned different pointers")
+	}
+}
+
+func TestMintLeaf_DifferentSNI_DifferentCerts(t *testing.T) {
+	ca := newTestCA(t, Options{})
+	a, err := ca.MintLeaf("a.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := ca.MintLeaf("b.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Error("different SNIs returned same pointer")
+	}
+	if a.Leaf.DNSNames[0] == b.Leaf.DNSNames[0] {
+		t.Error("DNSNames match despite different SNIs")
+	}
+}
+
+func TestMintLeaf_LRUEvictsLeastRecent(t *testing.T) {
+	ca := newTestCA(t, Options{CacheSize: 2})
+	a1, err := ca.MintLeaf("a.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ca.MintLeaf("b.com"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ca.MintLeaf("c.com"); err != nil {
+		t.Fatal(err)
+	}
+	a2, err := ca.MintLeaf("a.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a1 == a2 {
+		t.Error("a.com should have been evicted and regenerated")
+	}
+}
+
+func TestMintLeaf_RegeneratesWhenNearExpiry(t *testing.T) {
+	current := time.Now()
+	ca := newTestCA(t, Options{
+		LeafTTL: time.Hour,
+		Clock:   func() time.Time { return current },
+	})
+	first, err := ca.MintLeaf("example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current = first.Leaf.NotAfter.Add(-1 * time.Minute)
+	second, err := ca.MintLeaf("example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Error("near-expiry cached leaf should have been regenerated")
+	}
+}
+
+func TestMintLeaf_InvalidSNI(t *testing.T) {
+	ca := newTestCA(t, Options{})
+	cases := []string{
+		"",
+		"foo bar",
+		"has/slash",
+		strings.Repeat("a", 254),
+		"-leading.com",
+		"trailing-.com",
+		".leading-dot.com",
+		"double..dot.com",
+		strings.Repeat("a", 64) + ".com",
+	}
+	for _, sni := range cases {
+		if _, err := ca.MintLeaf(sni); err == nil {
+			t.Errorf("MintLeaf(%q) = nil error, want error", sni)
+		}
+	}
+}
+
+func TestMintLeaf_IPAddressPopulatesIPSAN(t *testing.T) {
+	ca := newTestCA(t, Options{})
+	cert, err := ca.MintLeaf("127.0.0.1")
+	if err != nil {
+		t.Fatalf("MintLeaf: %v", err)
+	}
+	if len(cert.Leaf.IPAddresses) != 1 || !cert.Leaf.IPAddresses[0].Equal(net.ParseIP("127.0.0.1")) {
+		t.Errorf("IPAddresses = %v, want [127.0.0.1]", cert.Leaf.IPAddresses)
+	}
+	if len(cert.Leaf.DNSNames) != 0 {
+		t.Errorf("DNSNames = %v, want empty", cert.Leaf.DNSNames)
+	}
+}
+
+func TestRootPEM_IsValidCACert(t *testing.T) {
+	ca := newTestCA(t, Options{})
+	block, _ := pem.Decode(ca.RootPEM())
+	if block == nil {
+		t.Fatal("failed to decode root PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse root: %v", err)
+	}
+	if !cert.IsCA {
+		t.Error("root cert is not marked as CA")
+	}
+	if cert.Subject.CommonName != rootCommonName {
+		t.Errorf("CN = %q, want %q", cert.Subject.CommonName, rootCommonName)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/ca` with a `Provider` interface and a `SoftCA` implementation: self-signed ECDSA P-256 root persisted to `~/.agent-vault/ca/` (private key AES-256-GCM-wrapped with the master key), short-lived leaves signed on demand and cached by SNI via a small LRU.
- First compositional brick toward the upcoming `HTTPS_PROXY` MITM ingress mode. Ships as a standalone package with unit tests — no wiring into `cmd/server.go` or `internal/server/` yet, so existing deployments are unchanged.
- Later increments (MITM loop, `install-ca` subcommand, audit sink) will consume `ca.Provider` without having to revisit any of this.

## Design notes
- `Options{Dir, LeafTTL, CacheSize, Clock}` — zero values pick sensible defaults (`~/.agent-vault/ca`, 24h, 1024, `time.Now`); `Clock` is overridable for tests.
- Leaves include a 5-minute clock-skew buffer on cache reuse so callers never receive a cert that may expire mid-handshake.
- `validateSNI` runs only on cache miss and enforces RFC-1123 labels (length, leading/trailing hyphens, allowed chars); IP SNIs populate `IPAddresses` instead of `DNSNames`.
- No new Go dependencies — stdlib only, reusing `internal/crypto` for the AES-GCM wrap.

## Test plan
- [x] `go test ./internal/ca/...` — 11 tests pass (fresh init, reload, wrong master key, leaf verifies against root, cache hit/miss, LRU eviction, near-expiry regeneration, invalid SNIs incl. hyphen boundaries & oversized labels, IP SAN, root is a valid CA cert).
- [x] `go vet ./internal/ca/...` and `go build ./...` clean.
- [ ] Manual smoke: pipe a minted leaf into `openssl x509 -text -noout` and confirm issuer/subject/SAN/signature algorithm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)