### PR TITLE
feat: add transparent MITM proxy loop for HTTPS_PROXY ingress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,16 @@ The server exposes a generic HTTP proxy at `/proxy/{target_host}/{path}[?query]`
 - Agent Vault validates the session, matches the target host against broker services, resolves auth config into headers, strips the agent's auth header, injects credentials, and forwards to `https://{target_host}/{path}`
 - Environment variables injected by `agent-vault vault run`: `AGENT_VAULT_ADDR` (server base URL), `AGENT_VAULT_SESSION_TOKEN`, `AGENT_VAULT_VAULT`
 
+## Transparent Proxy (MITM) — experimental
+
+Opt-in second ingress path for clients that respect `HTTPS_PROXY`. Off by default.
+
+- Enable with `agent-vault server --mitm-port 14322`. Binds to the same `--host` as the HTTP server (loopback by default).
+- Backed by `internal/mitm` (CONNECT + TLS termination) and `internal/ca` (software CA persisted under `~/.agent-vault/ca/`, root key encrypted with the master key). The CA is only initialized when `--mitm-port > 0`.
+- Upstream dials go through `netguard.SafeDialContext` (same SSRF protections as `/proxy`) with strict TLS verification against the system trust store.
+- **v1 scope**: HTTP/1.1 only (ALPN pinned), no credential injection, no audit hooks, no policy. Current behavior is a transparent pass-through that proves the TLS plumbing. Credential injection / audit unification are the next steps — plug into `internal/mitm/forward.go`.
+- Clients must trust the CA root (at `~/.agent-vault/ca/ca.crt.pem`) for the MITM handshake to succeed. An `install-ca` helper is a separate future initiative.
+
 ## Discovery Endpoint
 
 `GET /discover` -- returns the list of brokerable services and available credential key names for the session's vault. Requires a scoped session token. Response includes vault name, proxy URL, services (host + optional description), and `available_credentials` (credential key names only, values are never exposed). Agents use `available_credentials` to reference existing credentials in proposals.

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -15,7 +16,9 @@ import (
 	"time"
 
 	"github.com/Infisical/agent-vault/internal/auth"
+	"github.com/Infisical/agent-vault/internal/ca"
 	"github.com/Infisical/agent-vault/internal/crypto"
+	"github.com/Infisical/agent-vault/internal/mitm"
 	"github.com/Infisical/agent-vault/internal/notify"
 	"github.com/Infisical/agent-vault/internal/oauth"
 	"github.com/Infisical/agent-vault/internal/pidfile"
@@ -33,11 +36,12 @@ var serverCmd = &cobra.Command{
 		port, _ := cmd.Flags().GetInt("port")
 		host, _ := cmd.Flags().GetString("host")
 		detach, _ := cmd.Flags().GetBool("detach")
+		mitmPort, _ := cmd.Flags().GetInt("mitm-port")
 		addr := fmt.Sprintf("%s:%d", host, port)
 
 		// --- Detached child path: read master key + initialized flag from stdin pipe ---
 		if os.Getenv("_AGENT_VAULT_DETACHED") == "1" {
-			return runDetachedChild(addr)
+			return runDetachedChild(host, addr, mitmPort)
 		}
 
 		dbPath, err := store.DefaultDBPath()
@@ -77,7 +81,7 @@ var serverCmd = &cobra.Command{
 		}
 
 		if detach {
-			return spawnDetached(cmd, masterKey, initialized, host, port, addr)
+			return spawnDetached(cmd, masterKey, initialized, host, port, mitmPort, addr)
 		}
 
 		// --- Foreground path ---
@@ -92,8 +96,26 @@ var serverCmd = &cobra.Command{
 		oauthProviders := loadOAuthProviders(baseURL)
 		srv := server.New(addr, db, masterKey.Key(), notifier, initialized, baseURL, oauthProviders)
 		srv.SetSkills(skillCLI, skillHTTP)
+		if err := attachMITMIfEnabled(srv, host, mitmPort, masterKey.Key()); err != nil {
+			return err
+		}
 		return srv.Start()
 	},
+}
+
+// attachMITMIfEnabled initializes the CA and attaches a transparent MITM
+// proxy to srv when mitmPort > 0. The CA is loaded or created under the
+// standard ~/.agent-vault/ca/ directory, encrypted with the master key.
+func attachMITMIfEnabled(srv *server.Server, host string, mitmPort int, masterKey []byte) error {
+	if mitmPort <= 0 {
+		return nil
+	}
+	caProv, err := ca.New(masterKey, ca.Options{})
+	if err != nil {
+		return fmt.Errorf("init CA: %w", err)
+	}
+	srv.AttachMITM(mitm.New(net.JoinHostPort(host, strconv.Itoa(mitmPort)), caProv))
+	return nil
 }
 
 // promptOwnerSetup interactively creates the owner account.
@@ -276,7 +298,7 @@ func readPasswordFromStdin() ([]byte, error) {
 
 // runDetachedChild is the entry point for the detached child process.
 // It reads 33 bytes from stdin: 32-byte master key + 1-byte initialized flag.
-func runDetachedChild(addr string) error {
+func runDetachedChild(host, addr string, mitmPort int) error {
 	buf := make([]byte, 33)
 	if _, err := io.ReadFull(os.Stdin, buf); err != nil {
 		return fmt.Errorf("reading master key from pipe: %w", err)
@@ -305,11 +327,14 @@ func runDetachedChild(addr string) error {
 	oauthProviders := loadOAuthProviders(baseURL)
 	srv := server.New(addr, db, key, notifier, initialized, baseURL, oauthProviders)
 	srv.SetSkills(skillCLI, skillHTTP)
+	if err := attachMITMIfEnabled(srv, host, mitmPort, key); err != nil {
+		return err
+	}
 	return srv.Start()
 }
 
 // spawnDetached re-execs the server as a background process, passing the master key + initialized flag via a pipe.
-func spawnDetached(cmd *cobra.Command, masterKey *auth.MasterKey, initialized bool, host string, port int, addr string) error {
+func spawnDetached(cmd *cobra.Command, masterKey *auth.MasterKey, initialized bool, host string, port, mitmPort int, addr string) error {
 	defer masterKey.Wipe()
 
 	// Check if a server is already running.
@@ -342,7 +367,11 @@ func spawnDetached(cmd *cobra.Command, masterKey *auth.MasterKey, initialized bo
 		return fmt.Errorf("opening log file: %w", err)
 	}
 
-	child := exec.Command(exe, "server", "--port", strconv.Itoa(port), "--host", host)
+	childArgs := []string{"server", "--port", strconv.Itoa(port), "--host", host}
+	if mitmPort > 0 {
+		childArgs = append(childArgs, "--mitm-port", strconv.Itoa(mitmPort))
+	}
+	child := exec.Command(exe, childArgs...)
 	child.Stdin = pr
 	child.Stdout = logFile
 	child.Stderr = logFile
@@ -473,6 +502,7 @@ func init() {
 	serverCmd.Flags().String("host", DefaultHost, "host to bind to")
 	serverCmd.Flags().BoolP("detach", "d", false, "run server in background after unlocking")
 	serverCmd.Flags().Bool("password-stdin", false, "read master password from stdin (for non-interactive use)")
+	serverCmd.Flags().Int("mitm-port", 0, "enable transparent MITM proxy on this port (0 = disabled)")
 	serverCmd.AddCommand(stopCmd)
 	rootCmd.AddCommand(serverCmd)
 }

--- a/internal/mitm/connect.go
+++ b/internal/mitm/connect.go
@@ -59,7 +59,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	tlsConn := tls.Server(clientConn, tlsConf)
 	_ = tlsConn.SetDeadline(time.Now().Add(10 * time.Second))
 	if err := tlsConn.Handshake(); err != nil {
-		log.Printf("mitm: TLS handshake failed for %s: %v", target, err)
+		log.Printf("mitm: TLS handshake failed for %s: %v", host, err) // #nosec G706 -- host passes isValidHost, which rejects control chars and path separators
 		_ = tlsConn.Close()
 		return
 	}

--- a/internal/mitm/connect.go
+++ b/internal/mitm/connect.go
@@ -1,0 +1,137 @@
+package mitm
+
+import (
+	"crypto/tls"
+	"errors"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// handleConnect terminates a CONNECT tunnel and serves HTTP/1.1 off the
+// resulting TLS connection. The upstream target is taken from the
+// CONNECT request line (r.Host) and captured in a closure so subsequent
+// Host-header rewrites by the client cannot redirect the tunnel.
+func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
+	target := r.Host
+	host, _, err := net.SplitHostPort(target)
+	if err != nil {
+		http.Error(w, "CONNECT target must be host:port", http.StatusBadRequest)
+		return
+	}
+	if !isValidHost(host) {
+		http.Error(w, "invalid host", http.StatusBadRequest)
+		return
+	}
+
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+
+	clientConn, _, err := hj.Hijack()
+	if err != nil {
+		http.Error(w, "hijack failed", http.StatusInternalServerError)
+		return
+	}
+
+	if _, err := io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+		_ = clientConn.Close()
+		return
+	}
+
+	tlsConf := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"http/1.1"},
+		GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			sni := hello.ServerName
+			if sni == "" {
+				sni = host
+			}
+			return p.ca.MintLeaf(sni)
+		},
+	}
+
+	tlsConn := tls.Server(clientConn, tlsConf)
+	_ = tlsConn.SetDeadline(time.Now().Add(10 * time.Second))
+	if err := tlsConn.Handshake(); err != nil {
+		log.Printf("mitm: TLS handshake failed for %s: %v", target, err)
+		_ = tlsConn.Close()
+		return
+	}
+	_ = tlsConn.SetDeadline(time.Time{})
+
+	// Serve HTTP/1.1 requests off the terminated TLS connection. The
+	// listener yields the connection once, then blocks until Close so
+	// http.Serve stays alive while the connection goroutine is active.
+	// ConnState tracks when the connection leaves the hijacked state and
+	// closes the listener so Serve returns.
+	listener := newOneShotListener(tlsConn)
+	srv := &http.Server{
+		Handler:           p.forwardHandler(target),
+		ReadHeaderTimeout: 10 * time.Second,
+		ConnState: func(c net.Conn, state http.ConnState) {
+			if state == http.StateClosed || state == http.StateHijacked {
+				_ = listener.Close()
+			}
+		},
+	}
+	_ = srv.Serve(listener)
+}
+
+func isValidHost(h string) bool {
+	if h == "" || len(h) > 253 {
+		return false
+	}
+	for _, c := range h {
+		if c == '@' || c == '?' || c == '#' || c == '/' || c == '\\' || c == ' ' || c == '%' || c < 0x20 || c == 0x7f {
+			return false
+		}
+	}
+	return !strings.HasPrefix(h, ".") && !strings.HasSuffix(h, ".")
+}
+
+// oneShotListener yields a single net.Conn to http.Serve, then blocks
+// Accept until Close so Serve stays alive while the connection goroutine
+// handles requests.
+type oneShotListener struct {
+	conn   net.Conn
+	yield  chan net.Conn
+	closed chan struct{}
+}
+
+func newOneShotListener(c net.Conn) *oneShotListener {
+	l := &oneShotListener{
+		conn:   c,
+		yield:  make(chan net.Conn, 1),
+		closed: make(chan struct{}),
+	}
+	l.yield <- c
+	return l
+}
+
+var errListenerClosed = errors.New("mitm: one-shot listener closed")
+
+func (l *oneShotListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.yield:
+		return c, nil
+	case <-l.closed:
+		return nil, errListenerClosed
+	}
+}
+
+func (l *oneShotListener) Close() error {
+	select {
+	case <-l.closed:
+	default:
+		close(l.closed)
+	}
+	return l.conn.Close()
+}
+
+func (l *oneShotListener) Addr() net.Addr { return l.conn.LocalAddr() }

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -1,0 +1,85 @@
+package mitm
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+)
+
+// maxResponseBytes caps the body returned to the client. Matches the
+// limit used by the existing /proxy handler; credential injection work
+// in the next step should consolidate both constants.
+const maxResponseBytes = 100 << 20
+
+// hopByHopHeaders are HTTP/1.1 hop-by-hop headers that must not be
+// forwarded by a proxy. Duplicated from internal/server to avoid a
+// dependency cycle; if credential injection unifies both paths into a
+// shared package, this should be pulled up alongside it.
+var hopByHopHeaders = map[string]bool{
+	"Connection":          true,
+	"Keep-Alive":          true,
+	"Proxy-Authenticate":  true,
+	"Proxy-Authorization": true,
+	"Te":                  true,
+	"Trailer":             true,
+	"Transfer-Encoding":   true,
+	"Upgrade":             true,
+}
+
+// forwardHandler returns an http.Handler that forwards each request to
+// target (the host:port captured from the original CONNECT line). Using
+// a closed-over target rather than r.Host defeats post-tunnel host
+// rewriting.
+func (p *Proxy) forwardHandler(target string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		outURL := &url.URL{
+			Scheme:   "https",
+			Host:     target,
+			Path:     r.URL.Path,
+			RawPath:  r.URL.RawPath,
+			RawQuery: r.URL.RawQuery,
+		}
+
+		outReq, err := http.NewRequestWithContext(r.Context(), r.Method, outURL.String(), r.Body)
+		if err != nil {
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		if h, _, splitErr := net.SplitHostPort(target); splitErr == nil {
+			outReq.Host = h
+		} else {
+			outReq.Host = target
+		}
+		copyRequestHeaders(outReq.Header, r.Header)
+
+		resp, err := p.upstream.RoundTrip(outReq)
+		if err != nil {
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		for k, vv := range resp.Header {
+			if hopByHopHeaders[http.CanonicalHeaderKey(k)] {
+				continue
+			}
+			for _, v := range vv {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, io.LimitReader(resp.Body, maxResponseBytes))
+	})
+}
+
+func copyRequestHeaders(dst, src http.Header) {
+	for k, vv := range src {
+		if hopByHopHeaders[http.CanonicalHeaderKey(k)] {
+			continue
+		}
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}

--- a/internal/mitm/proxy.go
+++ b/internal/mitm/proxy.go
@@ -1,0 +1,93 @@
+// Package mitm implements a transparent TLS-intercepting HTTP proxy.
+//
+// A Proxy accepts HTTP CONNECT on a plain TCP listener, hijacks the
+// connection, terminates client-side TLS using a certificate minted on
+// demand by a ca.Provider, and forwards each HTTP/1.1 request to the
+// originally-requested upstream over a fresh TLS connection with strict
+// verification against the system trust store.
+//
+// v1 scope: HTTP/1.1 only (ALPN pinned), no credential injection, no
+// audit hooks. These are the next steps of the transparent-proxy
+// initiative; this package is deliberately shaped so they plug in at
+// well-defined points (forwardHandler in forward.go).
+package mitm
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/Infisical/agent-vault/internal/ca"
+	"github.com/Infisical/agent-vault/internal/netguard"
+)
+
+// Proxy is a transparent MITM proxy. It is safe to start at most once;
+// reuse across Shutdown is not supported.
+type Proxy struct {
+	ca         ca.Provider
+	httpServer *http.Server
+	upstream   *http.Transport
+}
+
+// New builds a Proxy bound to addr using caProv for leaf certificates.
+// The returned Proxy does not begin listening until ListenAndServe is
+// called.
+func New(addr string, caProv ca.Provider) *Proxy {
+	upstream := &http.Transport{
+		DialContext:           netguard.SafeDialContext(netguard.ModeFromEnv()),
+		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
+		ForceAttemptHTTP2:     false,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+	}
+
+	p := &Proxy{
+		ca:       caProv,
+		upstream: upstream,
+	}
+
+	p.httpServer = &http.Server{
+		Addr:              addr,
+		Handler:           http.HandlerFunc(p.dispatch),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	return p
+}
+
+// Addr returns the listener address the Proxy was configured with.
+func (p *Proxy) Addr() string { return p.httpServer.Addr }
+
+// ListenAndServe starts accepting connections. It blocks until Shutdown
+// is called, returning http.ErrServerClosed in that case.
+func (p *Proxy) ListenAndServe() error {
+	return p.httpServer.ListenAndServe()
+}
+
+// Serve accepts connections on the provided listener. It blocks until
+// Shutdown is called, returning http.ErrServerClosed in that case.
+// Useful for tests that need to bind :0 and learn the resulting port.
+func (p *Proxy) Serve(l net.Listener) error {
+	return p.httpServer.Serve(l)
+}
+
+// Shutdown gracefully stops the listener. In-flight CONNECT tunnels are
+// not tracked by http.Server's shutdown machinery (they detach from the
+// handler on Hijack), so callers should allow the process to exit after
+// Shutdown returns; the tunnels will die with it.
+func (p *Proxy) Shutdown(ctx context.Context) error {
+	p.upstream.CloseIdleConnections()
+	return p.httpServer.Shutdown(ctx)
+}
+
+func (p *Proxy) dispatch(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodConnect {
+		p.handleConnect(w, r)
+		return
+	}
+	http.Error(w, fmt.Sprintf("method %s not supported on transparent proxy", r.Method), http.StatusMethodNotAllowed)
+}

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -1,0 +1,185 @@
+package mitm
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Infisical/agent-vault/internal/ca"
+)
+
+// setupProxy starts a mitm.Proxy backed by a freshly-generated SoftCA on
+// a loopback :0 port. Returns the listening URL, the root-cert pool for
+// client-side trust, and the proxy instance (so the test can mutate its
+// upstream transport, e.g. to trust a test upstream's self-signed cert).
+func setupProxy(t *testing.T) (proxyURL *url.URL, clientRoots *x509.CertPool, p *Proxy) {
+	t.Helper()
+
+	// Default netguard mode is "public" which blocks loopback.
+	// httptest upstreams listen on 127.0.0.1, so switch to "private" for tests.
+	t.Setenv("AGENT_VAULT_NETWORK_MODE", "private")
+
+	masterKey := make([]byte, 32)
+	if _, err := rand.Read(masterKey); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	caProv, err := ca.New(masterKey, ca.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("ca.New: %v", err)
+	}
+
+	clientRoots = x509.NewCertPool()
+	if !clientRoots.AppendCertsFromPEM(caProv.RootPEM()) {
+		t.Fatal("failed to load CA root PEM into pool")
+	}
+
+	p = New("127.0.0.1:0", caProv)
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = p.Serve(l) }()
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = p.Shutdown(ctx)
+	})
+
+	proxyURL = &url.URL{Scheme: "http", Host: l.Addr().String()}
+	return proxyURL, clientRoots, p
+}
+
+// newTrustingClient returns an http.Client that routes HTTPS through
+// proxyURL and trusts the given roots for the terminated client-side TLS.
+func newTrustingClient(proxyURL *url.URL, roots *x509.CertPool) *http.Client {
+	return &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			Proxy:           http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{RootCAs: roots},
+		},
+	}
+}
+
+func TestProxyForwardsHTTPSRequest(t *testing.T) {
+	var sawAuth, sawProxyAuth string
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		sawProxyAuth = r.Header.Get("Proxy-Authorization")
+		w.Header().Set("X-Upstream", "hello")
+		_, _ = io.WriteString(w, "upstream-body")
+	}))
+	defer upstream.Close()
+
+	proxyURL, clientRoots, p := setupProxy(t)
+
+	// Teach the proxy's upstream transport to trust the httptest server's
+	// self-signed cert. In production this stays at system trust.
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    upstreamRoots,
+	}
+
+	client := newTrustingClient(proxyURL, clientRoots)
+	req, err := http.NewRequest("GET", upstream.URL+"/ping", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer client-token")
+	req.Header.Set("Proxy-Authorization", "Basic should-not-forward")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "upstream-body" {
+		t.Fatalf("body = %q, want upstream-body", body)
+	}
+	if got := resp.Header.Get("X-Upstream"); got != "hello" {
+		t.Fatalf("X-Upstream = %q, want hello", got)
+	}
+	if sawAuth != "Bearer client-token" {
+		t.Fatalf("upstream saw Authorization %q, want Bearer client-token", sawAuth)
+	}
+	if sawProxyAuth != "" {
+		t.Fatalf("upstream saw Proxy-Authorization %q, expected it to be stripped", sawProxyAuth)
+	}
+}
+
+func TestProxyReturns502WhenUpstreamCertUntrusted(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "should-not-reach")
+	}))
+	defer upstream.Close()
+
+	proxyURL, clientRoots, _ := setupProxy(t)
+	// NOTE: not adding the upstream's cert to p.upstream, so verification fails.
+
+	client := newTrustingClient(proxyURL, clientRoots)
+	resp, err := client.Get(upstream.URL + "/ping")
+	if err != nil {
+		t.Fatalf("client.Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	}
+}
+
+func TestProxyRejectsNonConnectRequests(t *testing.T) {
+	proxyURL, _, _ := setupProxy(t)
+
+	resp, err := http.Get(proxyURL.String() + "/anything")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestIsValidHost(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"example.com", true},
+		{"api.github.com", true},
+		{"localhost", true},
+		{"127.0.0.1", true},
+		{"", false},
+		{"has space.com", false},
+		{"has@at.com", false},
+		{"has/slash.com", false},
+		{"has?query.com", false},
+		{".leading-dot.com", false},
+		{"trailing-dot.", false},
+		{strings.Repeat("a", 254), false},
+	}
+	for _, c := range cases {
+		if got := isValidHost(c.in); got != c.want {
+			t.Errorf("isValidHost(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/Infisical/agent-vault/internal/crypto"
+	"github.com/Infisical/agent-vault/internal/mitm"
 	"github.com/Infisical/agent-vault/internal/notify"
 	"github.com/Infisical/agent-vault/internal/oauth"
 	"github.com/Infisical/agent-vault/internal/pidfile"
@@ -56,9 +57,15 @@ type Server struct {
 	initialized    bool   // true when at least one owner account exists
 	baseURL        string // externally-reachable base URL (e.g. "https://sb.example.com")
 	oauthProviders map[string]oauth.Provider
-	skillCLI       []byte // embedded CLI skill content (served at GET /v1/skills/cli)
-	skillHTTP      []byte // embedded HTTP skill content (served at GET /v1/skills/http)
+	skillCLI       []byte      // embedded CLI skill content (served at GET /v1/skills/cli)
+	skillHTTP      []byte      // embedded HTTP skill content (served at GET /v1/skills/http)
+	mitm           *mitm.Proxy // optional transparent MITM proxy, nil when --mitm-port unset
 }
+
+// AttachMITM registers an optional transparent MITM proxy whose lifecycle
+// is bound to this Server: Start launches it, and SIGINT/SIGTERM/Shutdown
+// stops it alongside the HTTP server.
+func (s *Server) AttachMITM(p *mitm.Proxy) { s.mitm = p }
 
 // Store is the persistence interface used by the server.
 type Store interface {
@@ -665,7 +672,7 @@ func (s *Server) Start() error {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
-	errCh := make(chan error, 1)
+	errCh := make(chan error, 2)
 	go func() {
 		fmt.Printf("Agent Vault server listening on %s\n", s.baseURL)
 		if !s.initialized {
@@ -674,8 +681,16 @@ func (s *Server) Start() error {
 		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			errCh <- err
 		}
-		close(errCh)
 	}()
+
+	if s.mitm != nil {
+		go func() {
+			fmt.Printf("Agent Vault transparent proxy listening on %s\n", s.mitm.Addr())
+			if err := s.mitm.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				errCh <- fmt.Errorf("mitm proxy: %w", err)
+			}
+		}()
+	}
 
 	if err := pidfile.Write(os.Getpid()); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not write PID file: %v\n", err)
@@ -692,6 +707,11 @@ func (s *Server) Start() error {
 	defer cancel()
 
 	fmt.Println("shutting down server...")
+	if s.mitm != nil {
+		if err := s.mitm.Shutdown(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: mitm proxy shutdown: %v\n", err)
+		}
+	}
 	if err := s.httpServer.Shutdown(ctx); err != nil {
 		return fmt.Errorf("server shutdown: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Second step of the transparent-proxy initiative. The CA scaffolding shipped in #69; this adds the MITM loop that consumes it.
- New `internal/mitm` package accepts HTTP `CONNECT`, terminates client TLS with a leaf minted on demand by `ca.Provider`, and forwards HTTP/1.1 to the originally-requested upstream over a fresh TLS connection with strict verification against the system trust store.
- Opt-in via `agent-vault server --mitm-port 14322` (default `0` = disabled). Off-by-default means existing deployments see no change.
- Upstream dials go through `netguard.SafeDialContext` — same SSRF protections as the existing `/proxy` endpoint (metadata-IP blocking, `AGENT_VAULT_NETWORK_MODE` controls).
- Lifecycle is bound to the HTTP server via a new `Server.AttachMITM` hook: SIGINT/SIGTERM shuts both listeners down in the same handler.

## Scope

In:
- CONNECT → hijack → TLS termination (ALPN pinned to `http/1.1`).
- Per-request upstream forwarding with hop-by-hop header stripping and a 100 MB response cap.
- Server integration (flag + lifecycle wiring) across the foreground and detached (daemon) paths.
- Unit tests with `httptest.NewTLSServer` covering: happy-path forwarding + hop-by-hop stripping, `502` on untrusted upstream cert, `405` for non-CONNECT, host-validation table.

Explicitly out of scope for v1 (each is a follow-up):
- Credential injection — current behavior is a transparent pass-through. The `forwardHandler` in `internal/mitm/forward.go` is the plug point.
- HTTP/2, WebSocket, HTTP/3.
- `install-ca` helper subcommand.
- Audit logging integration.
- Policy / host allowlist on the MITM path.

## Security posture
- MITM listener binds to the same `--host` as the HTTP server (loopback by default).
- Upstream TLS: system trust, no `InsecureSkipVerify`, `MinVersion` TLS 1.2.
- Upstream target is captured from the CONNECT line, not re-read from the post-TLS `Host` header — defeats SNI/Host mismatch smuggling.
- Hijacked conns are closed on every error path.

## Test plan
- [x] `go test ./internal/mitm/...` — 4 tests pass.
- [x] `go test ./...` — no regressions elsewhere.
- [x] `go vet ./...` clean.
- [ ] Manual: `./agent-vault server --mitm-port 14322`, `curl -x http://127.0.0.1:14322 --cacert ~/.agent-vault/ca/ca.crt.pem https://example.com/` → 200. Without `--cacert` → TLS verification failure (confirms leaf is signed by our CA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)