### PR TITLE
feat: add credential injection + auth to MITM proxy via shared brokercore

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -114,7 +114,12 @@ func attachMITMIfEnabled(srv *server.Server, host string, mitmPort int, masterKe
 	if err != nil {
 		return fmt.Errorf("init CA: %w", err)
 	}
-	srv.AttachMITM(mitm.New(net.JoinHostPort(host, strconv.Itoa(mitmPort)), caProv))
+	srv.AttachMITM(mitm.New(
+		net.JoinHostPort(host, strconv.Itoa(mitmPort)),
+		caProv,
+		srv.SessionResolver(),
+		srv.CredentialProvider(),
+	))
 	return nil
 }
 

--- a/internal/brokercore/brokercore.go
+++ b/internal/brokercore/brokercore.go
@@ -1,0 +1,141 @@
+// Package brokercore is the runtime glue shared by both Agent Vault ingress
+// paths: the explicit /proxy HTTP endpoint and the transparent MITM proxy.
+//
+// It extracts the credential-resolution pipeline from the server handler
+// behind a CredentialProvider interface and the session+vault resolution
+// behind a SessionResolver interface. Both ingresses call the same code;
+// audit hooks will plug in here next.
+//
+// brokercore depends on broker, store, and crypto. broker stays a pure
+// config library with no runtime coupling.
+package brokercore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Infisical/agent-vault/internal/broker"
+)
+
+// MaxResponseBytes caps response bodies streamed back to agents. Shared by
+// both ingresses so resource limits are unified.
+const MaxResponseBytes = 100 << 20
+
+// ProxyErrorHeader is the response header Agent Vault sets on broker-layer
+// error responses so SDK clients can distinguish them from upstream
+// responses that happen to share the same status code.
+const ProxyErrorHeader = "X-Agent-Vault-Proxy-Error"
+
+// HopByHopHeaders are HTTP/1.1 hop-by-hop headers that must not be
+// forwarded by a proxy.
+var HopByHopHeaders = map[string]bool{
+	"Connection":          true,
+	"Keep-Alive":          true,
+	"Proxy-Authenticate":  true,
+	"Proxy-Authorization": true,
+	"Te":                  true,
+	"Trailer":             true,
+	"Transfer-Encoding":   true,
+	"Upgrade":             true,
+}
+
+// IsHopByHop reports whether the given header name is hop-by-hop.
+func IsHopByHop(name string) bool {
+	return HopByHopHeaders[http.CanonicalHeaderKey(name)]
+}
+
+// IsValidHost reports whether h is a safe hostname for use in an outbound
+// URL or CONNECT target. Rejects characters that could cause URL parsing
+// issues (userinfo injection, path separators, whitespace, control chars)
+// and enforces DNS length + no leading/trailing dot. h must NOT include a
+// port — strip it first with net.SplitHostPort if applicable.
+func IsValidHost(h string) bool {
+	if h == "" || len(h) > 253 {
+		return false
+	}
+	for _, c := range h {
+		if c == '@' || c == '?' || c == '#' || c == '/' || c == '\\' || c == ' ' || c == '%' || c < 0x20 || c == 0x7f {
+			return false
+		}
+	}
+	return !strings.HasPrefix(h, ".") && !strings.HasSuffix(h, ".")
+}
+
+// PassthroughHeaders is the allowlist of headers forwarded from agent
+// requests to upstream services. All other agent headers are dropped;
+// in particular Authorization is NOT on this list so injected credentials
+// always win over any client-supplied value.
+var PassthroughHeaders = []string{
+	"Content-Type",
+	"Content-Encoding",
+	"Accept",
+	"Accept-Encoding",
+	"Accept-Language",
+	"User-Agent",
+	"Idempotency-Key",
+	"X-Request-Id",
+}
+
+// ForbiddenHintBody returns the JSON-shaped body for a 403 response when
+// the target host is not matched by any broker service in the vault. Both
+// ingresses emit identical bytes so agents can uniformly parse the hint.
+func ForbiddenHintBody(targetHost, vaultName string) map[string]interface{} {
+	return map[string]interface{}{
+		"error":   "forbidden",
+		"message": fmt.Sprintf("No broker service matching host %q in vault %q", targetHost, vaultName),
+		"proposal_hint": map[string]interface{}{
+			"host":                 targetHost,
+			"endpoint":             "POST /v1/proposals",
+			"supported_auth_types": broker.SupportedAuthTypes,
+		},
+	}
+}
+
+// ShouldStripResponseHeader reports whether an upstream response header
+// must not be forwarded to the agent: hop-by-hop headers plus Set-Cookie.
+// Stripping Set-Cookie prevents the upstream from planting cookies in the
+// agent's jar.
+func ShouldStripResponseHeader(name string) bool {
+	return IsHopByHop(name) || strings.EqualFold(name, "Set-Cookie")
+}
+
+// WriteProxyError writes a JSON error response with Content-Type, the
+// X-Agent-Vault-Proxy-Error header (so SDKs can distinguish broker-layer
+// errors from upstream status codes that happen to match), and a
+// {error, message} body.
+func WriteProxyError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(ProxyErrorHeader, "true")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": code, "message": message})
+}
+
+// WriteForbiddenHint writes a 403 with the shared proposal_hint body so
+// both ingress paths emit identical bytes for the "host not brokerable"
+// case.
+func WriteForbiddenHint(w http.ResponseWriter, targetHost, vaultName string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(ProxyErrorHeader, "true")
+	w.WriteHeader(http.StatusForbidden)
+	_ = json.NewEncoder(w).Encode(ForbiddenHintBody(targetHost, vaultName))
+}
+
+// WriteInjectError maps a CredentialProvider.Inject error to the standard
+// HTTP response for both ingress paths. Callers that want to log before
+// responding (e.g. the /proxy path logs credential-resolution failures)
+// should do so before calling this helper.
+func WriteInjectError(w http.ResponseWriter, err error, targetHost, vaultName string) {
+	switch {
+	case errors.Is(err, ErrServiceNotFound):
+		WriteForbiddenHint(w, targetHost, vaultName)
+	case errors.Is(err, ErrCredentialMissing):
+		WriteProxyError(w, http.StatusBadGateway, "credential_not_found",
+			"A required credential could not be resolved; check vault configuration")
+	default:
+		WriteProxyError(w, http.StatusInternalServerError, "internal",
+			"Failed to resolve broker services")
+	}
+}

--- a/internal/brokercore/brokercore_test.go
+++ b/internal/brokercore/brokercore_test.go
@@ -1,0 +1,60 @@
+package brokercore
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestIsHopByHop(t *testing.T) {
+	cases := map[string]bool{
+		"Proxy-Authorization": true,
+		"proxy-authorization": true,
+		"Connection":          true,
+		"Upgrade":             true,
+		"Content-Type":        false,
+		"Authorization":       false,
+	}
+	for name, want := range cases {
+		if got := IsHopByHop(name); got != want {
+			t.Errorf("IsHopByHop(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestPassthroughHeadersExcludesAuthorization(t *testing.T) {
+	for _, h := range PassthroughHeaders {
+		if strings.EqualFold(h, "Authorization") {
+			t.Fatalf("PassthroughHeaders must not include Authorization; clients must not be able to shadow injected credentials")
+		}
+		if strings.EqualFold(h, "Proxy-Authorization") {
+			t.Fatalf("PassthroughHeaders must not include Proxy-Authorization")
+		}
+	}
+}
+
+func TestForbiddenHintBody(t *testing.T) {
+	body := ForbiddenHintBody("api.example.com", "default")
+	if body["error"] != "forbidden" {
+		t.Fatalf("error = %v", body["error"])
+	}
+	msg, ok := body["message"].(string)
+	if !ok || !strings.Contains(msg, `"api.example.com"`) || !strings.Contains(msg, `"default"`) {
+		t.Fatalf("message = %v", body["message"])
+	}
+	hint, ok := body["proposal_hint"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("proposal_hint type = %T", body["proposal_hint"])
+	}
+	if hint["host"] != "api.example.com" {
+		t.Fatalf("hint host = %v", hint["host"])
+	}
+	if hint["endpoint"] != "POST /v1/proposals" {
+		t.Fatalf("hint endpoint = %v", hint["endpoint"])
+	}
+
+	// Must be JSON-serializable (used by both ingresses as response body).
+	if _, err := json.Marshal(body); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+}

--- a/internal/brokercore/credential.go
+++ b/internal/brokercore/credential.go
@@ -1,0 +1,88 @@
+package brokercore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/Infisical/agent-vault/internal/broker"
+	"github.com/Infisical/agent-vault/internal/crypto"
+	"github.com/Infisical/agent-vault/internal/store"
+)
+
+// InjectResult is the outcome of matching a target host and resolving
+// credentials to ready-to-attach HTTP headers.
+type InjectResult struct {
+	// Headers is the map of header name → value to overlay on the outbound
+	// request. Caller must Set (not Add) to ensure injected values win over
+	// any client-supplied duplicates.
+	Headers map[string]string
+}
+
+// CredentialProvider resolves a broker service for targetHost inside vaultID
+// and returns the HTTP headers required to authenticate the outbound request.
+type CredentialProvider interface {
+	Inject(ctx context.Context, vaultID, targetHost string) (*InjectResult, error)
+}
+
+// CredentialStore is the minimal store surface used by StoreCredentialProvider.
+type CredentialStore interface {
+	GetBrokerConfig(ctx context.Context, vaultID string) (*store.BrokerConfig, error)
+	GetCredential(ctx context.Context, vaultID, key string) (*store.Credential, error)
+}
+
+// StoreCredentialProvider injects credentials using a CredentialStore and a
+// 32-byte AES-256-GCM key held in memory for the lifetime of the process.
+type StoreCredentialProvider struct {
+	Store  CredentialStore
+	EncKey []byte
+}
+
+// NewStoreCredentialProvider constructs a provider. encKey must be 32 bytes.
+func NewStoreCredentialProvider(s CredentialStore, encKey []byte) *StoreCredentialProvider {
+	return &StoreCredentialProvider{Store: s, EncKey: encKey}
+}
+
+// Inject matches targetHost against the vault's broker services, resolves
+// the matched service's auth config into HTTP headers, and returns them.
+//
+// targetHost may include a port; the port is stripped before matching so
+// services configured as bare hostnames match `api.github.com:443`.
+func (p *StoreCredentialProvider) Inject(ctx context.Context, vaultID, targetHost string) (*InjectResult, error) {
+	cfg, err := p.Store.GetBrokerConfig(ctx, vaultID)
+	if err != nil || cfg == nil {
+		return nil, ErrServiceNotFound
+	}
+
+	var services []broker.Service
+	if err := json.Unmarshal([]byte(cfg.ServicesJSON), &services); err != nil {
+		return nil, fmt.Errorf("brokercore: parsing broker services: %w", err)
+	}
+
+	matchHost := targetHost
+	if h, _, err := net.SplitHostPort(targetHost); err == nil {
+		matchHost = h
+	}
+	matched := broker.MatchHost(matchHost, services)
+	if matched == nil {
+		return nil, ErrServiceNotFound
+	}
+
+	headers, err := matched.Auth.Resolve(func(key string) (string, error) {
+		cred, err := p.Store.GetCredential(ctx, vaultID, key)
+		if err != nil || cred == nil {
+			return "", fmt.Errorf("credential %q not found", key)
+		}
+		plaintext, err := crypto.Decrypt(cred.Ciphertext, cred.Nonce, p.EncKey)
+		if err != nil {
+			return "", fmt.Errorf("failed to decrypt credential %q", key)
+		}
+		return string(plaintext), nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCredentialMissing, err)
+	}
+
+	return &InjectResult{Headers: headers}, nil
+}

--- a/internal/brokercore/credential_test.go
+++ b/internal/brokercore/credential_test.go
@@ -1,0 +1,255 @@
+package brokercore
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Infisical/agent-vault/internal/broker"
+	"github.com/Infisical/agent-vault/internal/crypto"
+	"github.com/Infisical/agent-vault/internal/store"
+)
+
+// fakeCredStore satisfies CredentialStore for tests.
+type fakeCredStore struct {
+	brokerCfg map[string]*store.BrokerConfig // vaultID → config
+	creds     map[string]*store.Credential   // key = vaultID+"|"+key
+	missKey   string                          // if set, GetCredential for this key returns nil/err
+}
+
+func newFakeCredStore() *fakeCredStore {
+	return &fakeCredStore{
+		brokerCfg: map[string]*store.BrokerConfig{},
+		creds:     map[string]*store.Credential{},
+	}
+}
+
+func (f *fakeCredStore) GetBrokerConfig(_ context.Context, vaultID string) (*store.BrokerConfig, error) {
+	c, ok := f.brokerCfg[vaultID]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return c, nil
+}
+func (f *fakeCredStore) GetCredential(_ context.Context, vaultID, key string) (*store.Credential, error) {
+	if key == f.missKey {
+		return nil, errors.New("missing")
+	}
+	c, ok := f.creds[vaultID+"|"+key]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return c, nil
+}
+
+// make32 returns a deterministic 32-byte key for tests.
+func make32(b byte) []byte {
+	k := make([]byte, 32)
+	for i := range k {
+		k[i] = b
+	}
+	return k
+}
+
+func (f *fakeCredStore) setCred(t *testing.T, key32 []byte, vaultID, key, plaintext string) {
+	t.Helper()
+	ct, nonce, err := crypto.Encrypt([]byte(plaintext), key32)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	f.creds[vaultID+"|"+key] = &store.Credential{
+		VaultID: vaultID, Key: key, Ciphertext: ct, Nonce: nonce,
+	}
+}
+
+func (f *fakeCredStore) setServices(t *testing.T, vaultID string, svcs []broker.Service) {
+	t.Helper()
+	b, err := json.Marshal(svcs)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	f.brokerCfg[vaultID] = &store.BrokerConfig{VaultID: vaultID, ServicesJSON: string(b)}
+}
+
+func TestInject_BearerHappyPath(t *testing.T) {
+	key32 := make32(0x11)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.example.com",
+		Auth: broker.Auth{Type: "bearer", Token: "MY_TOKEN"},
+	}})
+	f.setCred(t, key32, "v1", "MY_TOKEN", "s3cret")
+
+	p := NewStoreCredentialProvider(f, key32)
+	res, err := p.Inject(context.Background(), "v1", "api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res.Headers["Authorization"] != "Bearer s3cret" {
+		t.Fatalf("got Authorization=%q", res.Headers["Authorization"])
+	}
+}
+
+func TestInject_BasicHappyPath(t *testing.T) {
+	key32 := make32(0x22)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.example.com",
+		Auth: broker.Auth{Type: "basic", Username: "USER", Password: "PASS"},
+	}})
+	f.setCred(t, key32, "v1", "USER", "alice")
+	f.setCred(t, key32, "v1", "PASS", "wonderland")
+
+	p := NewStoreCredentialProvider(f, key32)
+	res, err := p.Inject(context.Background(), "v1", "api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("alice:wonderland"))
+	if res.Headers["Authorization"] != want {
+		t.Fatalf("got %q want %q", res.Headers["Authorization"], want)
+	}
+}
+
+func TestInject_APIKeyCustomHeader(t *testing.T) {
+	key32 := make32(0x33)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.example.com",
+		Auth: broker.Auth{Type: "api-key", Key: "STRIPE_KEY", Header: "X-API-Key", Prefix: "sk_"},
+	}})
+	f.setCred(t, key32, "v1", "STRIPE_KEY", "live123")
+
+	p := NewStoreCredentialProvider(f, key32)
+	res, err := p.Inject(context.Background(), "v1", "api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res.Headers["X-API-Key"] != "sk_live123" {
+		t.Fatalf("got X-API-Key=%q", res.Headers["X-API-Key"])
+	}
+}
+
+func TestInject_CustomHeaders(t *testing.T) {
+	key32 := make32(0x44)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.example.com",
+		Auth: broker.Auth{Type: "custom", Headers: map[string]string{
+			"X-Api-Key": "{{ API_KEY }}",
+			"X-Tenant":  "acme-{{ TENANT }}",
+		}},
+	}})
+	f.setCred(t, key32, "v1", "API_KEY", "abc")
+	f.setCred(t, key32, "v1", "TENANT", "42")
+
+	p := NewStoreCredentialProvider(f, key32)
+	res, err := p.Inject(context.Background(), "v1", "api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res.Headers["X-Api-Key"] != "abc" {
+		t.Fatalf("got X-Api-Key=%q", res.Headers["X-Api-Key"])
+	}
+	if res.Headers["X-Tenant"] != "acme-42" {
+		t.Fatalf("got X-Tenant=%q", res.Headers["X-Tenant"])
+	}
+}
+
+func TestInject_StripsPortForMatching(t *testing.T) {
+	key32 := make32(0x55)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.example.com",
+		Auth: broker.Auth{Type: "bearer", Token: "TOK"},
+	}})
+	f.setCred(t, key32, "v1", "TOK", "v")
+
+	p := NewStoreCredentialProvider(f, key32)
+	res, err := p.Inject(context.Background(), "v1", "api.example.com:443")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res.Headers["Authorization"] != "Bearer v" {
+		t.Fatalf("got %q", res.Headers["Authorization"])
+	}
+}
+
+func TestInject_WildcardMatch(t *testing.T) {
+	key32 := make32(0x66)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "*.github.com",
+		Auth: broker.Auth{Type: "bearer", Token: "GH"},
+	}})
+	f.setCred(t, key32, "v1", "GH", "ghp_abc")
+
+	p := NewStoreCredentialProvider(f, key32)
+	res, err := p.Inject(context.Background(), "v1", "api.github.com")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res.Headers["Authorization"] != "Bearer ghp_abc" {
+		t.Fatalf("got %q", res.Headers["Authorization"])
+	}
+}
+
+func TestInject_ServiceNotFound_NoConfig(t *testing.T) {
+	f := newFakeCredStore()
+	p := NewStoreCredentialProvider(f, make32(0x77))
+	_, err := p.Inject(context.Background(), "v1", "api.example.com")
+	if !errors.Is(err, ErrServiceNotFound) {
+		t.Fatalf("expected ErrServiceNotFound, got %v", err)
+	}
+}
+
+func TestInject_ServiceNotFound_HostMiss(t *testing.T) {
+	key32 := make32(0x88)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.example.com",
+		Auth: broker.Auth{Type: "bearer", Token: "T"},
+	}})
+	f.setCred(t, key32, "v1", "T", "x")
+
+	p := NewStoreCredentialProvider(f, key32)
+	_, err := p.Inject(context.Background(), "v1", "other.example.com")
+	if !errors.Is(err, ErrServiceNotFound) {
+		t.Fatalf("expected ErrServiceNotFound, got %v", err)
+	}
+}
+
+func TestInject_CredentialMissing(t *testing.T) {
+	key32 := make32(0x99)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.example.com",
+		Auth: broker.Auth{Type: "bearer", Token: "MISSING"},
+	}})
+
+	p := NewStoreCredentialProvider(f, key32)
+	_, err := p.Inject(context.Background(), "v1", "api.example.com")
+	if !errors.Is(err, ErrCredentialMissing) {
+		t.Fatalf("expected ErrCredentialMissing, got %v", err)
+	}
+}
+
+func TestInject_DecryptFails(t *testing.T) {
+	// Encrypt with one key, try to decrypt with another → ErrCredentialMissing wrapping decrypt error.
+	encKey := make32(0xAA)
+	wrongKey := make32(0xBB)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.example.com",
+		Auth: broker.Auth{Type: "bearer", Token: "TOK"},
+	}})
+	f.setCred(t, encKey, "v1", "TOK", "secret")
+
+	p := NewStoreCredentialProvider(f, wrongKey)
+	_, err := p.Inject(context.Background(), "v1", "api.example.com")
+	if !errors.Is(err, ErrCredentialMissing) {
+		t.Fatalf("expected ErrCredentialMissing, got %v", err)
+	}
+}

--- a/internal/brokercore/errors.go
+++ b/internal/brokercore/errors.go
@@ -1,0 +1,39 @@
+package brokercore
+
+import "errors"
+
+var (
+	// ErrInvalidSession means the supplied session token is missing, unknown,
+	// or expired. Callers should return 401 (/proxy) or 407 (MITM).
+	ErrInvalidSession = errors.New("brokercore: invalid or expired session")
+
+	// ErrNoVaultContext means the session carries no vault scope and no hint
+	// was provided (e.g. an agent token with zero vault grants).
+	ErrNoVaultContext = errors.New("brokercore: session has no vault context")
+
+	// ErrAgentVaultAmbiguous means an instance-level agent token with access
+	// to multiple vaults did not specify which vault to use. Callers should
+	// tell the user to set vault via the token:vault Basic auth form.
+	ErrAgentVaultAmbiguous = errors.New("brokercore: agent has multiple vault grants; vault hint required")
+
+	// ErrVaultHintMismatch means a scoped session was accompanied by a vault
+	// hint that does not match the session's bound vault. Never silently
+	// retarget a scoped session to a different vault.
+	ErrVaultHintMismatch = errors.New("brokercore: vault hint does not match scoped session")
+
+	// ErrVaultNotFound means the requested vault name does not exist.
+	ErrVaultNotFound = errors.New("brokercore: vault not found")
+
+	// ErrVaultAccessDenied means the actor exists but has no grant on the
+	// requested vault.
+	ErrVaultAccessDenied = errors.New("brokercore: actor has no access to vault")
+
+	// ErrServiceNotFound means no configured broker service in the resolved
+	// vault matches the target host. Callers surface 403 with a proposal hint.
+	ErrServiceNotFound = errors.New("brokercore: no broker service matches target host")
+
+	// ErrCredentialMissing means a credential referenced by the matched
+	// service's auth config is not set or could not be decrypted. Callers
+	// surface 502 so agents retry only after the credential is provisioned.
+	ErrCredentialMissing = errors.New("brokercore: referenced credential missing or undecryptable")
+)

--- a/internal/brokercore/proxyauth.go
+++ b/internal/brokercore/proxyauth.go
@@ -1,0 +1,67 @@
+package brokercore
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+)
+
+// ParseProxyAuth extracts an Agent Vault session token and optional vault
+// hint from a Proxy-Authorization header.
+//
+// Supported forms:
+//   - Bearer <token>                        — token only, no vault hint
+//   - Basic base64(<token>)                 — token only, no vault hint
+//   - Basic base64(<token>:<vault-name>)    — token + vault hint
+//
+// The Basic form maps directly to HTTPS_PROXY URLs:
+//
+//	HTTPS_PROXY=http://<token>@host:port          (scoped session)
+//	HTTPS_PROXY=http://<token>:<vault>@host:port  (instance-level agent token)
+//
+// Vault names are config-validated as UPPER/lowercase alphanumeric + hyphens,
+// so they cannot contain a colon; splitting on the first colon in the decoded
+// userinfo is unambiguous.
+//
+// Returns ErrInvalidSession when the header is missing, malformed, or of an
+// unsupported scheme. Higher-level handlers map this to 407.
+func ParseProxyAuth(r *http.Request) (token, vaultHint string, err error) {
+	h := r.Header.Get("Proxy-Authorization")
+	if h == "" {
+		return "", "", ErrInvalidSession
+	}
+
+	scheme, rest, ok := strings.Cut(h, " ")
+	if !ok || rest == "" {
+		return "", "", ErrInvalidSession
+	}
+	rest = strings.TrimSpace(rest)
+
+	switch strings.ToLower(scheme) {
+	case "bearer":
+		if rest == "" {
+			return "", "", ErrInvalidSession
+		}
+		return rest, "", nil
+	case "basic":
+		decoded, derr := base64.StdEncoding.DecodeString(rest)
+		if derr != nil {
+			return "", "", ErrInvalidSession
+		}
+		userinfo := string(decoded)
+		if userinfo == "" {
+			return "", "", ErrInvalidSession
+		}
+		if idx := strings.Index(userinfo, ":"); idx >= 0 {
+			tok := userinfo[:idx]
+			hint := userinfo[idx+1:]
+			if tok == "" {
+				return "", "", ErrInvalidSession
+			}
+			return tok, hint, nil
+		}
+		return userinfo, "", nil
+	default:
+		return "", "", ErrInvalidSession
+	}
+}

--- a/internal/brokercore/proxyauth_test.go
+++ b/internal/brokercore/proxyauth_test.go
@@ -1,0 +1,108 @@
+package brokercore
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func reqWithProxyAuth(v string) *http.Request {
+	r := httptest.NewRequest(http.MethodConnect, "api.example.com:443", nil)
+	if v != "" {
+		r.Header.Set("Proxy-Authorization", v)
+	}
+	return r
+}
+
+func basic(userinfo string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(userinfo))
+}
+
+func TestParseProxyAuth_BearerOnly(t *testing.T) {
+	tok, hint, err := ParseProxyAuth(reqWithProxyAuth("Bearer av_sess_abc"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "av_sess_abc" || hint != "" {
+		t.Fatalf("got token=%q hint=%q", tok, hint)
+	}
+}
+
+func TestParseProxyAuth_BasicTokenOnly(t *testing.T) {
+	tok, hint, err := ParseProxyAuth(reqWithProxyAuth(basic("av_sess_abc")))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "av_sess_abc" || hint != "" {
+		t.Fatalf("got token=%q hint=%q", tok, hint)
+	}
+}
+
+func TestParseProxyAuth_BasicTokenAndVault(t *testing.T) {
+	tok, hint, err := ParseProxyAuth(reqWithProxyAuth(basic("av_agt_xyz:default")))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "av_agt_xyz" || hint != "default" {
+		t.Fatalf("got token=%q hint=%q", tok, hint)
+	}
+}
+
+func TestParseProxyAuth_BasicEmptyVault(t *testing.T) {
+	// Trailing colon with empty vault name — treat as empty hint.
+	tok, hint, err := ParseProxyAuth(reqWithProxyAuth(basic("av_sess_abc:")))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "av_sess_abc" || hint != "" {
+		t.Fatalf("got token=%q hint=%q", tok, hint)
+	}
+}
+
+func TestParseProxyAuth_MissingHeader(t *testing.T) {
+	_, _, err := ParseProxyAuth(reqWithProxyAuth(""))
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("expected ErrInvalidSession, got %v", err)
+	}
+}
+
+func TestParseProxyAuth_UnsupportedScheme(t *testing.T) {
+	_, _, err := ParseProxyAuth(reqWithProxyAuth("Digest whatever"))
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("expected ErrInvalidSession, got %v", err)
+	}
+}
+
+func TestParseProxyAuth_MalformedBasic(t *testing.T) {
+	_, _, err := ParseProxyAuth(reqWithProxyAuth("Basic not-base64!@#"))
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("expected ErrInvalidSession, got %v", err)
+	}
+}
+
+func TestParseProxyAuth_EmptyToken(t *testing.T) {
+	// Basic base64(":vault") — empty token.
+	_, _, err := ParseProxyAuth(reqWithProxyAuth(basic(":default")))
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("expected ErrInvalidSession, got %v", err)
+	}
+}
+
+func TestParseProxyAuth_EmptyBearer(t *testing.T) {
+	_, _, err := ParseProxyAuth(reqWithProxyAuth("Bearer "))
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("expected ErrInvalidSession, got %v", err)
+	}
+}
+
+func TestParseProxyAuth_CaseInsensitiveScheme(t *testing.T) {
+	tok, _, err := ParseProxyAuth(reqWithProxyAuth("bearer av_sess_abc"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "av_sess_abc" {
+		t.Fatalf("got token=%q", tok)
+	}
+}

--- a/internal/brokercore/session.go
+++ b/internal/brokercore/session.go
@@ -1,0 +1,131 @@
+package brokercore
+
+import (
+	"context"
+	"time"
+
+	"github.com/Infisical/agent-vault/internal/store"
+)
+
+// ProxyScope is the resolved identity + vault context for a proxy request.
+// It is produced once per ingress (per request for /proxy, per CONNECT for
+// MITM) and carried through to credential injection.
+type ProxyScope struct {
+	AgentID   string // non-empty for agent tokens
+	UserID    string // non-empty for user sessions
+	VaultID   string
+	VaultName string
+	VaultRole string
+}
+
+// SessionResolver collapses bearer-token validation and vault selection into
+// one call. Both ingresses use the same resolver; MITM passes a vault hint
+// parsed from Proxy-Authorization, /proxy passes r.Header.Get("X-Vault").
+// An empty hint means "infer from session".
+type SessionResolver interface {
+	ResolveForProxy(ctx context.Context, token, vaultHint string) (*ProxyScope, error)
+}
+
+// SessionStore is the minimal store surface used by StoreSessionResolver.
+// Kept narrow so tests can supply fakes without stubbing the full store.
+type SessionStore interface {
+	GetSession(ctx context.Context, rawToken string) (*store.Session, error)
+	GetVault(ctx context.Context, name string) (*store.Vault, error)
+	GetVaultByID(ctx context.Context, id string) (*store.Vault, error)
+	GetVaultRole(ctx context.Context, actorID, vaultID string) (string, error)
+	ListActorGrants(ctx context.Context, actorID string) ([]store.VaultGrant, error)
+}
+
+// StoreSessionResolver resolves sessions through a SessionStore. Now is
+// injectable so tests can control expiry without wall-clock flake.
+type StoreSessionResolver struct {
+	Store SessionStore
+	Now   func() time.Time
+}
+
+// NewStoreSessionResolver constructs a resolver backed by s. If s is nil
+// the returned resolver will panic on use; the constructor is permissive
+// to match existing server construction patterns.
+func NewStoreSessionResolver(s SessionStore) *StoreSessionResolver {
+	return &StoreSessionResolver{Store: s, Now: time.Now}
+}
+
+// ResolveForProxy validates token, applies the vault hint, and returns a
+// ProxyScope. See the sentinel errors in errors.go for the full taxonomy.
+func (r *StoreSessionResolver) ResolveForProxy(ctx context.Context, token, vaultHint string) (*ProxyScope, error) {
+	if token == "" {
+		return nil, ErrInvalidSession
+	}
+	sess, err := r.Store.GetSession(ctx, token)
+	if err != nil || sess == nil {
+		return nil, ErrInvalidSession
+	}
+	now := r.Now
+	if now == nil {
+		now = time.Now
+	}
+	if sess.ExpiresAt != nil && now().After(*sess.ExpiresAt) {
+		return nil, ErrInvalidSession
+	}
+
+	// Scoped session: vault is baked into the session. A hint must match
+	// the session's vault name; never silently retarget.
+	if sess.VaultID != "" {
+		v, err := r.Store.GetVaultByID(ctx, sess.VaultID)
+		if err != nil || v == nil {
+			return nil, ErrVaultNotFound
+		}
+		if vaultHint != "" && vaultHint != v.Name {
+			return nil, ErrVaultHintMismatch
+		}
+		return &ProxyScope{
+			UserID:    sess.UserID,
+			AgentID:   sess.AgentID,
+			VaultID:   v.ID,
+			VaultName: v.Name,
+			VaultRole: sess.VaultRole,
+		}, nil
+	}
+
+	// Instance-level agent token: resolve vault from hint, or from the
+	// agent's unique grant if any.
+	if sess.AgentID == "" {
+		return nil, ErrNoVaultContext
+	}
+
+	if vaultHint != "" {
+		v, err := r.Store.GetVault(ctx, vaultHint)
+		if err != nil || v == nil {
+			return nil, ErrVaultNotFound
+		}
+		role, err := r.Store.GetVaultRole(ctx, sess.AgentID, v.ID)
+		if err != nil || role == "" {
+			return nil, ErrVaultAccessDenied
+		}
+		return &ProxyScope{
+			AgentID:   sess.AgentID,
+			VaultID:   v.ID,
+			VaultName: v.Name,
+			VaultRole: role,
+		}, nil
+	}
+
+	grants, err := r.Store.ListActorGrants(ctx, sess.AgentID)
+	if err != nil {
+		return nil, ErrNoVaultContext
+	}
+	switch len(grants) {
+	case 0:
+		return nil, ErrNoVaultContext
+	case 1:
+		g := grants[0]
+		return &ProxyScope{
+			AgentID:   sess.AgentID,
+			VaultID:   g.VaultID,
+			VaultName: g.VaultName,
+			VaultRole: g.Role,
+		}, nil
+	default:
+		return nil, ErrAgentVaultAmbiguous
+	}
+}

--- a/internal/brokercore/session_test.go
+++ b/internal/brokercore/session_test.go
@@ -1,0 +1,235 @@
+package brokercore
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Infisical/agent-vault/internal/store"
+)
+
+// fakeSessionStore satisfies SessionStore for tests without a real DB.
+type fakeSessionStore struct {
+	sessions map[string]*store.Session
+	vaults   map[string]*store.Vault // keyed by name
+	byID     map[string]*store.Vault
+	roles    map[string]string // key = actorID+"|"+vaultID → role
+	grants   map[string][]store.VaultGrant
+}
+
+func newFakeSessionStore() *fakeSessionStore {
+	return &fakeSessionStore{
+		sessions: map[string]*store.Session{},
+		vaults:   map[string]*store.Vault{},
+		byID:     map[string]*store.Vault{},
+		roles:    map[string]string{},
+		grants:   map[string][]store.VaultGrant{},
+	}
+}
+
+func (f *fakeSessionStore) GetSession(_ context.Context, token string) (*store.Session, error) {
+	s, ok := f.sessions[token]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return s, nil
+}
+func (f *fakeSessionStore) GetVault(_ context.Context, name string) (*store.Vault, error) {
+	v, ok := f.vaults[name]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return v, nil
+}
+func (f *fakeSessionStore) GetVaultByID(_ context.Context, id string) (*store.Vault, error) {
+	v, ok := f.byID[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return v, nil
+}
+func (f *fakeSessionStore) GetVaultRole(_ context.Context, actorID, vaultID string) (string, error) {
+	r, ok := f.roles[actorID+"|"+vaultID]
+	if !ok {
+		return "", errors.New("no role")
+	}
+	return r, nil
+}
+func (f *fakeSessionStore) ListActorGrants(_ context.Context, actorID string) ([]store.VaultGrant, error) {
+	return f.grants[actorID], nil
+}
+
+func (f *fakeSessionStore) putVault(id, name string) {
+	v := &store.Vault{ID: id, Name: name}
+	f.vaults[name] = v
+	f.byID[id] = v
+}
+
+func TestResolveForProxy_ScopedSession_NoHint(t *testing.T) {
+	f := newFakeSessionStore()
+	f.putVault("v1", "default")
+	f.sessions["tok"] = &store.Session{ID: "tok", UserID: "u1", VaultID: "v1", VaultRole: "admin"}
+
+	r := NewStoreSessionResolver(f)
+	scope, err := r.ResolveForProxy(context.Background(), "tok", "")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if scope.VaultID != "v1" || scope.VaultName != "default" || scope.VaultRole != "admin" || scope.UserID != "u1" {
+		t.Fatalf("scope = %+v", scope)
+	}
+}
+
+func TestResolveForProxy_ScopedSession_MatchingHint(t *testing.T) {
+	f := newFakeSessionStore()
+	f.putVault("v1", "default")
+	f.sessions["tok"] = &store.Session{UserID: "u1", VaultID: "v1", VaultRole: "member"}
+
+	r := NewStoreSessionResolver(f)
+	scope, err := r.ResolveForProxy(context.Background(), "tok", "default")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if scope.VaultName != "default" {
+		t.Fatalf("vault = %q", scope.VaultName)
+	}
+}
+
+func TestResolveForProxy_ScopedSession_MismatchedHint(t *testing.T) {
+	f := newFakeSessionStore()
+	f.putVault("v1", "default")
+	f.putVault("v2", "prod")
+	f.sessions["tok"] = &store.Session{UserID: "u1", VaultID: "v1", VaultRole: "member"}
+
+	r := NewStoreSessionResolver(f)
+	_, err := r.ResolveForProxy(context.Background(), "tok", "prod")
+	if !errors.Is(err, ErrVaultHintMismatch) {
+		t.Fatalf("expected ErrVaultHintMismatch, got %v", err)
+	}
+}
+
+func TestResolveForProxy_AgentSingleGrant_NoHint(t *testing.T) {
+	f := newFakeSessionStore()
+	f.putVault("v1", "default")
+	f.sessions["tok"] = &store.Session{AgentID: "a1"}
+	f.grants["a1"] = []store.VaultGrant{{ActorID: "a1", VaultID: "v1", VaultName: "default", Role: "proxy"}}
+
+	r := NewStoreSessionResolver(f)
+	scope, err := r.ResolveForProxy(context.Background(), "tok", "")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if scope.VaultID != "v1" || scope.VaultName != "default" || scope.VaultRole != "proxy" {
+		t.Fatalf("scope = %+v", scope)
+	}
+}
+
+func TestResolveForProxy_AgentWithHint(t *testing.T) {
+	f := newFakeSessionStore()
+	f.putVault("v1", "default")
+	f.putVault("v2", "prod")
+	f.sessions["tok"] = &store.Session{AgentID: "a1"}
+	f.roles["a1|v2"] = "member"
+
+	r := NewStoreSessionResolver(f)
+	scope, err := r.ResolveForProxy(context.Background(), "tok", "prod")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if scope.VaultID != "v2" || scope.VaultRole != "member" {
+		t.Fatalf("scope = %+v", scope)
+	}
+}
+
+func TestResolveForProxy_AgentZeroGrants(t *testing.T) {
+	f := newFakeSessionStore()
+	f.sessions["tok"] = &store.Session{AgentID: "a1"}
+
+	r := NewStoreSessionResolver(f)
+	_, err := r.ResolveForProxy(context.Background(), "tok", "")
+	if !errors.Is(err, ErrNoVaultContext) {
+		t.Fatalf("expected ErrNoVaultContext, got %v", err)
+	}
+}
+
+func TestResolveForProxy_AgentMultipleGrantsAmbiguous(t *testing.T) {
+	f := newFakeSessionStore()
+	f.sessions["tok"] = &store.Session{AgentID: "a1"}
+	f.grants["a1"] = []store.VaultGrant{
+		{ActorID: "a1", VaultID: "v1", VaultName: "a", Role: "proxy"},
+		{ActorID: "a1", VaultID: "v2", VaultName: "b", Role: "proxy"},
+	}
+
+	r := NewStoreSessionResolver(f)
+	_, err := r.ResolveForProxy(context.Background(), "tok", "")
+	if !errors.Is(err, ErrAgentVaultAmbiguous) {
+		t.Fatalf("expected ErrAgentVaultAmbiguous, got %v", err)
+	}
+}
+
+func TestResolveForProxy_AgentHintUnknownVault(t *testing.T) {
+	f := newFakeSessionStore()
+	f.sessions["tok"] = &store.Session{AgentID: "a1"}
+
+	r := NewStoreSessionResolver(f)
+	_, err := r.ResolveForProxy(context.Background(), "tok", "nope")
+	if !errors.Is(err, ErrVaultNotFound) {
+		t.Fatalf("expected ErrVaultNotFound, got %v", err)
+	}
+}
+
+func TestResolveForProxy_AgentHintNoAccess(t *testing.T) {
+	f := newFakeSessionStore()
+	f.putVault("v1", "default")
+	f.sessions["tok"] = &store.Session{AgentID: "a1"}
+
+	r := NewStoreSessionResolver(f)
+	_, err := r.ResolveForProxy(context.Background(), "tok", "default")
+	if !errors.Is(err, ErrVaultAccessDenied) {
+		t.Fatalf("expected ErrVaultAccessDenied, got %v", err)
+	}
+}
+
+func TestResolveForProxy_InvalidToken(t *testing.T) {
+	f := newFakeSessionStore()
+	r := NewStoreSessionResolver(f)
+	_, err := r.ResolveForProxy(context.Background(), "missing", "")
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("expected ErrInvalidSession, got %v", err)
+	}
+}
+
+func TestResolveForProxy_EmptyToken(t *testing.T) {
+	r := NewStoreSessionResolver(newFakeSessionStore())
+	_, err := r.ResolveForProxy(context.Background(), "", "")
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("expected ErrInvalidSession, got %v", err)
+	}
+}
+
+func TestResolveForProxy_ExpiredSession(t *testing.T) {
+	f := newFakeSessionStore()
+	past := time.Now().Add(-1 * time.Hour)
+	f.putVault("v1", "default")
+	f.sessions["tok"] = &store.Session{UserID: "u1", VaultID: "v1", VaultRole: "admin", ExpiresAt: &past}
+
+	r := &StoreSessionResolver{Store: f, Now: func() time.Time { return time.Now() }}
+	_, err := r.ResolveForProxy(context.Background(), "tok", "")
+	if !errors.Is(err, ErrInvalidSession) {
+		t.Fatalf("expected ErrInvalidSession, got %v", err)
+	}
+}
+
+func TestResolveForProxy_UserSessionNoVaultNoAgent(t *testing.T) {
+	// User login session with no vault scope (global login) is not valid for
+	// proxying — treat as no vault context.
+	f := newFakeSessionStore()
+	f.sessions["tok"] = &store.Session{UserID: "u1"}
+
+	r := NewStoreSessionResolver(f)
+	_, err := r.ResolveForProxy(context.Background(), "tok", "")
+	if !errors.Is(err, ErrNoVaultContext) {
+		t.Fatalf("expected ErrNoVaultContext, got %v", err)
+	}
+}

--- a/internal/brokercore/session_test.go
+++ b/internal/brokercore/session_test.go
@@ -214,7 +214,7 @@ func TestResolveForProxy_ExpiredSession(t *testing.T) {
 	f.putVault("v1", "default")
 	f.sessions["tok"] = &store.Session{UserID: "u1", VaultID: "v1", VaultRole: "admin", ExpiresAt: &past}
 
-	r := &StoreSessionResolver{Store: f, Now: func() time.Time { return time.Now() }}
+	r := &StoreSessionResolver{Store: f, Now: time.Now}
 	_, err := r.ResolveForProxy(context.Background(), "tok", "")
 	if !errors.Is(err, ErrInvalidSession) {
 		t.Fatalf("expected ErrInvalidSession, got %v", err)

--- a/internal/mitm/connect.go
+++ b/internal/mitm/connect.go
@@ -7,8 +7,9 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"strings"
 	"time"
+
+	"github.com/Infisical/agent-vault/internal/brokercore"
 )
 
 // handleConnect terminates a CONNECT tunnel and serves HTTP/1.1 off the
@@ -24,6 +25,20 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	}
 	if !isValidHost(host) {
 		http.Error(w, "invalid host", http.StatusBadRequest)
+		return
+	}
+
+	// Authenticate the CONNECT request via Proxy-Authorization and resolve
+	// the target vault. All error responses must be written BEFORE the
+	// connection is hijacked — once hijacked, no HTTP status can be sent.
+	token, hint, err := brokercore.ParseProxyAuth(r)
+	if err != nil {
+		writeProxyAuthChallenge(w, "Proxy-Authorization required")
+		return
+	}
+	scope, err := p.sessions.ResolveForProxy(r.Context(), token, hint)
+	if err != nil {
+		writeAuthError(w, err)
 		return
 	}
 
@@ -72,7 +87,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// closes the listener so Serve returns.
 	listener := newOneShotListener(tlsConn)
 	srv := &http.Server{
-		Handler:           p.forwardHandler(target),
+		Handler:           p.forwardHandler(target, host, scope),
 		ReadHeaderTimeout: 10 * time.Second,
 		ConnState: func(c net.Conn, state http.ConnState) {
 			if state == http.StateClosed || state == http.StateHijacked {
@@ -83,17 +98,35 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	_ = srv.Serve(listener)
 }
 
-func isValidHost(h string) bool {
-	if h == "" || len(h) > 253 {
-		return false
-	}
-	for _, c := range h {
-		if c == '@' || c == '?' || c == '#' || c == '/' || c == '\\' || c == ' ' || c == '%' || c < 0x20 || c == 0x7f {
-			return false
-		}
-	}
-	return !strings.HasPrefix(h, ".") && !strings.HasSuffix(h, ".")
+// writeProxyAuthChallenge writes a 407 with a Proxy-Authenticate header so
+// well-behaved clients re-issue the CONNECT with credentials.
+func writeProxyAuthChallenge(w http.ResponseWriter, msg string) {
+	w.Header().Set("Proxy-Authenticate", `Basic realm="agent-vault"`)
+	http.Error(w, msg, http.StatusProxyAuthRequired)
 }
+
+// writeAuthError maps a brokercore session-resolution error to an HTTP
+// response. All writes happen before the connection is hijacked.
+func writeAuthError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, brokercore.ErrInvalidSession):
+		writeProxyAuthChallenge(w, "invalid or expired session")
+	case errors.Is(err, brokercore.ErrAgentVaultAmbiguous),
+		errors.Is(err, brokercore.ErrNoVaultContext):
+		http.Error(w, "set vault via HTTPS_PROXY=http://<token>:<vault>@host:port", http.StatusBadRequest)
+	case errors.Is(err, brokercore.ErrVaultHintMismatch),
+		errors.Is(err, brokercore.ErrVaultAccessDenied):
+		http.Error(w, "forbidden", http.StatusForbidden)
+	case errors.Is(err, brokercore.ErrVaultNotFound):
+		http.Error(w, "vault not found", http.StatusNotFound)
+	default:
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}
+}
+
+// isValidHost is a local alias for brokercore.IsValidHost so existing
+// callers and the #nosec G706 justification below stay readable.
+func isValidHost(h string) bool { return brokercore.IsValidHost(h) }
 
 // oneShotListener yields a single net.Conn to http.Serve, then blocks
 // Accept until Close so Serve stays alive while the connection goroutine

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -2,36 +2,18 @@ package mitm
 
 import (
 	"io"
-	"net"
 	"net/http"
 	"net/url"
+
+	"github.com/Infisical/agent-vault/internal/brokercore"
 )
-
-// maxResponseBytes caps the body returned to the client. Matches the
-// limit used by the existing /proxy handler; credential injection work
-// in the next step should consolidate both constants.
-const maxResponseBytes = 100 << 20
-
-// hopByHopHeaders are HTTP/1.1 hop-by-hop headers that must not be
-// forwarded by a proxy. Duplicated from internal/server to avoid a
-// dependency cycle; if credential injection unifies both paths into a
-// shared package, this should be pulled up alongside it.
-var hopByHopHeaders = map[string]bool{
-	"Connection":          true,
-	"Keep-Alive":          true,
-	"Proxy-Authenticate":  true,
-	"Proxy-Authorization": true,
-	"Te":                  true,
-	"Trailer":             true,
-	"Transfer-Encoding":   true,
-	"Upgrade":             true,
-}
 
 // forwardHandler returns an http.Handler that forwards each request to
 // target (the host:port captured from the original CONNECT line). Using
 // a closed-over target rather than r.Host defeats post-tunnel host
-// rewriting.
-func (p *Proxy) forwardHandler(target string) http.Handler {
+// rewriting. host is the port-stripped form, already validated in
+// handleConnect; scope is the vault context resolved at CONNECT time.
+func (p *Proxy) forwardHandler(target, host string, scope *brokercore.ProxyScope) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		outURL := &url.URL{
 			Scheme:   "https",
@@ -46,12 +28,25 @@ func (p *Proxy) forwardHandler(target string) http.Handler {
 			http.Error(w, "bad gateway", http.StatusBadGateway)
 			return
 		}
-		if h, _, splitErr := net.SplitHostPort(target); splitErr == nil {
-			outReq.Host = h
-		} else {
-			outReq.Host = target
+		outReq.Host = host
+
+		// Allowlist passthrough: Authorization and Proxy-Authorization are
+		// not on the list, so injected credentials always win and the
+		// client cannot shadow them.
+		for _, k := range brokercore.PassthroughHeaders {
+			for _, v := range r.Header.Values(k) {
+				outReq.Header.Add(k, v)
+			}
 		}
-		copyRequestHeaders(outReq.Header, r.Header)
+
+		inject, err := p.creds.Inject(r.Context(), scope.VaultID, host)
+		if err != nil {
+			brokercore.WriteInjectError(w, err, host, scope.VaultName)
+			return
+		}
+		for k, v := range inject.Headers {
+			outReq.Header.Set(k, v)
+		}
 
 		resp, err := p.upstream.RoundTrip(outReq)
 		if err != nil {
@@ -61,7 +56,7 @@ func (p *Proxy) forwardHandler(target string) http.Handler {
 		defer func() { _ = resp.Body.Close() }()
 
 		for k, vv := range resp.Header {
-			if hopByHopHeaders[http.CanonicalHeaderKey(k)] {
+			if brokercore.ShouldStripResponseHeader(k) {
 				continue
 			}
 			for _, v := range vv {
@@ -69,17 +64,6 @@ func (p *Proxy) forwardHandler(target string) http.Handler {
 			}
 		}
 		w.WriteHeader(resp.StatusCode)
-		_, _ = io.Copy(w, io.LimitReader(resp.Body, maxResponseBytes))
+		_, _ = io.Copy(w, io.LimitReader(resp.Body, brokercore.MaxResponseBytes))
 	})
-}
-
-func copyRequestHeaders(dst, src http.Header) {
-	for k, vv := range src {
-		if hopByHopHeaders[http.CanonicalHeaderKey(k)] {
-			continue
-		}
-		for _, v := range vv {
-			dst.Add(k, v)
-		}
-	}
 }

--- a/internal/mitm/proxy.go
+++ b/internal/mitm/proxy.go
@@ -6,10 +6,7 @@
 // originally-requested upstream over a fresh TLS connection with strict
 // verification against the system trust store.
 //
-// v1 scope: HTTP/1.1 only (ALPN pinned), no credential injection, no
-// audit hooks. These are the next steps of the transparent-proxy
-// initiative; this package is deliberately shaped so they plug in at
-// well-defined points (forwardHandler in forward.go).
+// v1 scope: HTTP/1.1 only (ALPN pinned).
 package mitm
 
 import (
@@ -20,6 +17,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Infisical/agent-vault/internal/brokercore"
 	"github.com/Infisical/agent-vault/internal/ca"
 	"github.com/Infisical/agent-vault/internal/netguard"
 )
@@ -28,14 +26,17 @@ import (
 // reuse across Shutdown is not supported.
 type Proxy struct {
 	ca         ca.Provider
+	sessions   brokercore.SessionResolver
+	creds      brokercore.CredentialProvider
 	httpServer *http.Server
 	upstream   *http.Transport
 }
 
-// New builds a Proxy bound to addr using caProv for leaf certificates.
+// New builds a Proxy bound to addr using caProv for leaf certificates and
+// the brokercore sessions/creds for authentication and credential injection.
 // The returned Proxy does not begin listening until ListenAndServe is
 // called.
-func New(addr string, caProv ca.Provider) *Proxy {
+func New(addr string, caProv ca.Provider, sessions brokercore.SessionResolver, creds brokercore.CredentialProvider) *Proxy {
 	upstream := &http.Transport{
 		DialContext:           netguard.SafeDialContext(netguard.ModeFromEnv()),
 		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
@@ -48,6 +49,8 @@ func New(addr string, caProv ca.Provider) *Proxy {
 
 	p := &Proxy{
 		ca:       caProv,
+		sessions: sessions,
+		creds:    creds,
 		upstream: upstream,
 	}
 

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -1,10 +1,14 @@
 package mitm
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -14,18 +18,68 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Infisical/agent-vault/internal/brokercore"
 	"github.com/Infisical/agent-vault/internal/ca"
 )
 
-// setupProxy starts a mitm.Proxy backed by a freshly-generated SoftCA on
-// a loopback :0 port. Returns the listening URL, the root-cert pool for
-// client-side trust, and the proxy instance (so the test can mutate its
-// upstream transport, e.g. to trust a test upstream's self-signed cert).
-func setupProxy(t *testing.T) (proxyURL *url.URL, clientRoots *x509.CertPool, p *Proxy) {
+// fakeSessionResolver delegates to a per-test closure. Tests supply
+// whatever policy they need without adding fields to the struct.
+type fakeSessionResolver struct {
+	resolve func(token, hint string) (*brokercore.ProxyScope, error)
+}
+
+func (f *fakeSessionResolver) ResolveForProxy(_ context.Context, token, hint string) (*brokercore.ProxyScope, error) {
+	return f.resolve(token, hint)
+}
+
+// validTokenResolver returns a resolver that succeeds with scope when
+// token matches expected, and returns ErrInvalidSession otherwise.
+func validTokenResolver(expected string, scope *brokercore.ProxyScope) *fakeSessionResolver {
+	return &fakeSessionResolver{resolve: func(token, _ string) (*brokercore.ProxyScope, error) {
+		if token != expected {
+			return nil, brokercore.ErrInvalidSession
+		}
+		return scope, nil
+	}}
+}
+
+// errResolver returns a resolver that always fails with err.
+func errResolver(err error) *fakeSessionResolver {
+	return &fakeSessionResolver{resolve: func(string, string) (*brokercore.ProxyScope, error) {
+		return nil, err
+	}}
+}
+
+// fakeCredProvider returns a canned InjectResult or error.
+type fakeCredProvider struct {
+	// byHost maps target host (without port) to the injection outcome.
+	byHost map[string]fakeInjectResult
+}
+
+type fakeInjectResult struct {
+	result *brokercore.InjectResult
+	err    error
+}
+
+func (f *fakeCredProvider) Inject(_ context.Context, _, targetHost string) (*brokercore.InjectResult, error) {
+	// Mirror StoreCredentialProvider: accept host:port and strip internally.
+	host := targetHost
+	if h, _, err := net.SplitHostPort(targetHost); err == nil {
+		host = h
+	}
+	res, ok := f.byHost[host]
+	if !ok {
+		return nil, brokercore.ErrServiceNotFound
+	}
+	return res.result, res.err
+}
+
+// setupProxy starts a mitm.Proxy backed by a freshly-generated SoftCA and
+// the given session + credential stubs. Returns the listening URL, the
+// root-cert pool for client-side trust, and the proxy instance.
+func setupProxy(t *testing.T, sr brokercore.SessionResolver, cp brokercore.CredentialProvider) (proxyURL *url.URL, clientRoots *x509.CertPool, p *Proxy) {
 	t.Helper()
 
-	// Default netguard mode is "public" which blocks loopback.
-	// httptest upstreams listen on 127.0.0.1, so switch to "private" for tests.
 	t.Setenv("AGENT_VAULT_NETWORK_MODE", "private")
 
 	masterKey := make([]byte, 32)
@@ -42,7 +96,7 @@ func setupProxy(t *testing.T) (proxyURL *url.URL, clientRoots *x509.CertPool, p 
 		t.Fatal("failed to load CA root PEM into pool")
 	}
 
-	p = New("127.0.0.1:0", caProv)
+	p = New("127.0.0.1:0", caProv, sr, cp)
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -61,31 +115,43 @@ func setupProxy(t *testing.T) (proxyURL *url.URL, clientRoots *x509.CertPool, p 
 }
 
 // newTrustingClient returns an http.Client that routes HTTPS through
-// proxyURL and trusts the given roots for the terminated client-side TLS.
-func newTrustingClient(proxyURL *url.URL, roots *x509.CertPool) *http.Client {
+// proxyURL (with the given userinfo encoded as Basic Proxy-Authorization)
+// and trusts the given roots for the terminated client-side TLS.
+func newTrustingClient(proxyURL *url.URL, userInfo *url.Userinfo, roots *x509.CertPool) *http.Client {
+	u := *proxyURL
+	u.User = userInfo
 	return &http.Client{
 		Timeout: 5 * time.Second,
 		Transport: &http.Transport{
-			Proxy:           http.ProxyURL(proxyURL),
+			Proxy:           http.ProxyURL(&u),
 			TLSClientConfig: &tls.Config{RootCAs: roots},
 		},
 	}
 }
 
-func TestProxyForwardsHTTPSRequest(t *testing.T) {
-	var sawAuth, sawProxyAuth string
+func TestMITMInjectsCredentials(t *testing.T) {
+	var sawAuth, sawClientAuth, sawProxyAuth string
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sawAuth = r.Header.Get("Authorization")
+		sawClientAuth = r.Header.Get("X-Client-Auth")
 		sawProxyAuth = r.Header.Get("Proxy-Authorization")
 		w.Header().Set("X-Upstream", "hello")
 		_, _ = io.WriteString(w, "upstream-body")
 	}))
 	defer upstream.Close()
 
-	proxyURL, clientRoots, p := setupProxy(t)
+	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
 
-	// Teach the proxy's upstream transport to trust the httptest server's
-	// self-signed cert. In production this stays at system trust.
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{
+			Headers: map[string]string{"Authorization": "Bearer injected-secret"},
+		}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+
 	upstreamRoots := x509.NewCertPool()
 	upstreamRoots.AddCert(upstream.Certificate())
 	p.upstream.TLSClientConfig = &tls.Config{
@@ -93,13 +159,16 @@ func TestProxyForwardsHTTPSRequest(t *testing.T) {
 		RootCAs:    upstreamRoots,
 	}
 
-	client := newTrustingClient(proxyURL, clientRoots)
+	client := newTrustingClient(proxyURL, url.User("av_sess_ok"), clientRoots)
+
 	req, err := http.NewRequest("GET", upstream.URL+"/ping", nil)
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
-	req.Header.Set("Authorization", "Bearer client-token")
-	req.Header.Set("Proxy-Authorization", "Basic should-not-forward")
+	// Client-supplied Authorization must be dropped and replaced by injection.
+	req.Header.Set("Authorization", "Bearer client-should-not-win")
+	// Arbitrary non-allowlisted header must also be dropped.
+	req.Header.Set("X-Client-Auth", "leaked")
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -114,27 +183,181 @@ func TestProxyForwardsHTTPSRequest(t *testing.T) {
 	if string(body) != "upstream-body" {
 		t.Fatalf("body = %q, want upstream-body", body)
 	}
-	if got := resp.Header.Get("X-Upstream"); got != "hello" {
-		t.Fatalf("X-Upstream = %q, want hello", got)
+	if sawAuth != "Bearer injected-secret" {
+		t.Fatalf("upstream saw Authorization %q, want injected value", sawAuth)
 	}
-	if sawAuth != "Bearer client-token" {
-		t.Fatalf("upstream saw Authorization %q, want Bearer client-token", sawAuth)
+	if sawClientAuth != "" {
+		t.Fatalf("upstream saw X-Client-Auth %q; non-allowlisted header must be dropped", sawClientAuth)
 	}
 	if sawProxyAuth != "" {
-		t.Fatalf("upstream saw Proxy-Authorization %q, expected it to be stripped", sawProxyAuth)
+		t.Fatalf("upstream saw Proxy-Authorization %q; must be stripped", sawProxyAuth)
 	}
 }
 
-func TestProxyReturns502WhenUpstreamCertUntrusted(t *testing.T) {
-	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func TestMITMMissingProxyAuth(t *testing.T) {
+	sr := errResolver(brokercore.ErrInvalidSession)
+	cp := &fakeCredProvider{}
+	proxyURL, _, _ := setupProxy(t, sr, cp)
+
+	// Speak CONNECT manually so we can inspect the response without client
+	// retries masking it.
+	conn, err := net.Dial("tcp", proxyURL.Host)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	_, _ = fmt.Fprintf(conn, "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusProxyAuthRequired {
+		t.Fatalf("status = %d, want 407", resp.StatusCode)
+	}
+	if ch := resp.Header.Get("Proxy-Authenticate"); !strings.Contains(ch, "Basic") {
+		t.Fatalf("Proxy-Authenticate = %q, want a Basic challenge", ch)
+	}
+}
+
+func TestMITMInvalidSession(t *testing.T) {
+	sr := validTokenResolver("not-this-one", nil)
+	cp := &fakeCredProvider{}
+	proxyURL, _, _ := setupProxy(t, sr, cp)
+
+	auth := base64.StdEncoding.EncodeToString([]byte("bad-token:"))
+	conn, err := net.Dial("tcp", proxyURL.Host)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	_, _ = fmt.Fprintf(conn,
+		"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nProxy-Authorization: Basic %s\r\n\r\n",
+		auth)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusProxyAuthRequired {
+		t.Fatalf("status = %d, want 407", resp.StatusCode)
+	}
+}
+
+func TestMITMAmbiguousAgentVault(t *testing.T) {
+	sr := errResolver(brokercore.ErrAgentVaultAmbiguous)
+	cp := &fakeCredProvider{}
+	proxyURL, _, _ := setupProxy(t, sr, cp)
+
+	auth := base64.StdEncoding.EncodeToString([]byte("av_agt_multi:"))
+	conn, err := net.Dial("tcp", proxyURL.Host)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	_, _ = fmt.Fprintf(conn,
+		"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nProxy-Authorization: Basic %s\r\n\r\n",
+		auth)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "HTTPS_PROXY=http://<token>:<vault>@") {
+		t.Fatalf("body = %q, missing vault-hint message", body)
+	}
+}
+
+func TestMITMVaultHintMismatch(t *testing.T) {
+	sr := errResolver(brokercore.ErrVaultHintMismatch)
+	cp := &fakeCredProvider{}
+	proxyURL, _, _ := setupProxy(t, sr, cp)
+
+	auth := base64.StdEncoding.EncodeToString([]byte("scoped-token:prod"))
+	conn, err := net.Dial("tcp", proxyURL.Host)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	_, _ = fmt.Fprintf(conn,
+		"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\nProxy-Authorization: Basic %s\r\n\r\n",
+		auth)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestMITMUnknownHostInTunnel(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, "should-not-reach")
 	}))
 	defer upstream.Close()
 
-	proxyURL, clientRoots, _ := setupProxy(t)
-	// NOTE: not adding the upstream's cert to p.upstream, so verification fails.
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	// byHost empty → every Inject returns ErrServiceNotFound.
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{}}
 
-	client := newTrustingClient(proxyURL, clientRoots)
+	proxyURL, clientRoots, _ := setupProxy(t, sr, cp)
+	client := newTrustingClient(proxyURL, url.User("av_sess_ok"), clientRoots)
+
+	resp, err := client.Get(upstream.URL + "/ping")
+	if err != nil {
+		t.Fatalf("client.Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if resp.Header.Get(brokercore.ProxyErrorHeader) != "true" {
+		t.Fatalf("missing %s header", brokercore.ProxyErrorHeader)
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["error"] != "forbidden" {
+		t.Fatalf("body.error = %v", body["error"])
+	}
+	hint, ok := body["proposal_hint"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("missing proposal_hint")
+	}
+	if hint["endpoint"] != "POST /v1/proposals" {
+		t.Fatalf("hint.endpoint = %v", hint["endpoint"])
+	}
+}
+
+func TestMITMUpstreamCertUntrusted(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "should-not-reach")
+	}))
+	defer upstream.Close()
+	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
+
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{
+			Headers: map[string]string{"Authorization": "Bearer whatever"},
+		}},
+	}}
+
+	proxyURL, clientRoots, _ := setupProxy(t, sr, cp)
+	// NOTE: not adding upstream's cert to p.upstream; verification fails.
+
+	client := newTrustingClient(proxyURL, url.User("av_sess_ok"), clientRoots)
 	resp, err := client.Get(upstream.URL + "/ping")
 	if err != nil {
 		t.Fatalf("client.Get: %v", err)
@@ -146,8 +369,8 @@ func TestProxyReturns502WhenUpstreamCertUntrusted(t *testing.T) {
 	}
 }
 
-func TestProxyRejectsNonConnectRequests(t *testing.T) {
-	proxyURL, _, _ := setupProxy(t)
+func TestMITMRejectsNonConnectRequests(t *testing.T) {
+	proxyURL, _, _ := setupProxy(t, errResolver(brokercore.ErrInvalidSession), &fakeCredProvider{})
 
 	resp, err := http.Get(proxyURL.String() + "/anything")
 	if err != nil {
@@ -183,3 +406,4 @@ func TestIsValidHost(t *testing.T) {
 		}
 	}
 }
+

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -212,6 +212,7 @@ func TestMITMMissingProxyAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read response: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusProxyAuthRequired {
 		t.Fatalf("status = %d, want 407", resp.StatusCode)
 	}
@@ -239,6 +240,7 @@ func TestMITMInvalidSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read response: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusProxyAuthRequired {
 		t.Fatalf("status = %d, want 407", resp.StatusCode)
 	}
@@ -263,6 +265,7 @@ func TestMITMAmbiguousAgentVault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read response: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", resp.StatusCode)
 	}
@@ -291,6 +294,7 @@ func TestMITMVaultHintMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read response: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403", resp.StatusCode)
 	}

--- a/internal/server/handle_proxy.go
+++ b/internal/server/handle_proxy.go
@@ -1,17 +1,15 @@
 package server
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/Infisical/agent-vault/internal/broker"
-	"github.com/Infisical/agent-vault/internal/crypto"
+	"github.com/Infisical/agent-vault/internal/brokercore"
 	"github.com/Infisical/agent-vault/internal/netguard"
 	"github.com/Infisical/agent-vault/internal/store"
 )
@@ -27,79 +25,19 @@ func isSecureRequest(r *http.Request, baseURL string) bool {
 	return strings.HasPrefix(baseURL, "https://")
 }
 
-// proxyForbiddenWithHint writes a 403 with a proposal_hint so agents can
-// programmatically construct a proposal from a denied proxy request.
-func proxyForbiddenWithHint(w http.ResponseWriter, targetHost, nsName string) {
-	w.Header().Set(proxyErrorHeader, "true")
-	jsonStatus(w, http.StatusForbidden, map[string]interface{}{
-		"error":   "forbidden",
-		"message": fmt.Sprintf("No broker service matching host %q in vault %q", targetHost, nsName),
-		"proposal_hint": map[string]interface{}{
-			"host":                 targetHost,
-			"endpoint":             "POST /v1/proposals",
-			"supported_auth_types": broker.SupportedAuthTypes,
-		},
-	})
-}
-
-// hopByHopHeaders are HTTP/1.1 hop-by-hop headers that must not be forwarded by proxies.
-var hopByHopHeaders = map[string]bool{
-	"Connection":          true,
-	"Keep-Alive":          true,
-	"Proxy-Authenticate":  true,
-	"Proxy-Authorization": true,
-	"Te":                  true,
-	"Trailer":             true,
-	"Transfer-Encoding":   true,
-	"Upgrade":             true,
-}
-
-// isHopByHopHeader returns true if the header is a hop-by-hop header.
-func isHopByHopHeader(name string) bool {
-	return hopByHopHeaders[http.CanonicalHeaderKey(name)]
-}
-
 // isValidProxyHost validates that a target host is a safe hostname or host:port.
-// Rejects characters that could cause URL parsing issues (userinfo injection, etc.).
 func isValidProxyHost(host string) bool {
-	if host == "" {
-		return false
-	}
-	// Strip optional port suffix for hostname validation.
 	h := host
 	if idx := strings.LastIndex(host, ":"); idx != -1 {
 		h = host[:idx]
 		port := host[idx+1:]
-		// Port must be numeric.
 		for _, c := range port {
 			if c < '0' || c > '9' {
 				return false
 			}
 		}
 	}
-	if h == "" {
-		return false
-	}
-	// Reject any character that could cause URL parsing issues.
-	for _, c := range h {
-		if c == '@' || c == '?' || c == '#' || c == '/' || c == '\\' || c == ' ' || c == '%' || c < 0x20 || c == 0x7f {
-			return false
-		}
-	}
-	return true
-}
-
-// proxyPassthroughHeaders is the allowlist of headers forwarded from agent
-// requests to upstream services. All other agent headers are dropped.
-var proxyPassthroughHeaders = []string{
-	"Content-Type",
-	"Content-Encoding",
-	"Accept",
-	"Accept-Encoding",
-	"Accept-Language",
-	"User-Agent",
-	"Idempotency-Key",
-	"X-Request-Id",
+	return brokercore.IsValidHost(h)
 }
 
 // newProxyClient creates an HTTP client for outbound proxy requests.
@@ -200,48 +138,16 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 		return // error already written
 	}
 
-	// 4. Load broker config for this vault.
-	brokerCfg, err := s.store.GetBrokerConfig(ctx, ns.ID)
-	if err != nil || brokerCfg == nil {
-		proxyForbiddenWithHint(w, targetHost, ns.Name)
-		return
-	}
-
-	var services []broker.Service
-	if err := json.Unmarshal([]byte(brokerCfg.ServicesJSON), &services); err != nil {
-		proxyError(w, http.StatusInternalServerError, "internal", "Failed to parse broker services")
-		return
-	}
-
-	// 5. Match host against broker services.
-	// Strip port for matching (services use bare hostnames).
-	matchHost := targetHost
-	if h, _, err := net.SplitHostPort(targetHost); err == nil {
-		matchHost = h
-	}
-	matched := broker.MatchHost(matchHost, services)
-	if matched == nil {
-		proxyForbiddenWithHint(w, targetHost, ns.Name)
-		return
-	}
-
-	// 6. Resolve credentials from matched service's auth config.
-	resolved, err := matched.Auth.Resolve(func(key string) (string, error) {
-		cred, err := s.store.GetCredential(ctx, ns.ID, key)
-		if err != nil {
-			return "", fmt.Errorf("credential %q not found", key)
-		}
-		plaintext, err := crypto.Decrypt(cred.Ciphertext, cred.Nonce, s.encKey)
-		if err != nil {
-			return "", fmt.Errorf("failed to decrypt credential %q", key)
-		}
-		return string(plaintext), nil
-	})
+	// Resolve broker service + inject credentials.
+	inject, err := s.CredentialProvider().Inject(ctx, ns.ID, targetHost)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[agent-vault] credential resolution failed for vault %s: %v\n", ns.ID, err)
-		proxyError(w, http.StatusBadGateway, "credential_not_found", "A required credential could not be resolved; check vault configuration")
+		if errors.Is(err, brokercore.ErrCredentialMissing) {
+			fmt.Fprintf(os.Stderr, "[agent-vault] credential resolution failed for vault %s: %v\n", ns.ID, err)
+		}
+		brokercore.WriteInjectError(w, err, targetHost, ns.Name)
 		return
 	}
+	resolved := inject.Headers
 
 	// 7. Build outbound URL.
 	targetURL := "https://" + targetHost
@@ -260,7 +166,7 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Copy only safe headers from the agent request (allowlist approach).
-	for _, k := range proxyPassthroughHeaders {
+	for _, k := range brokercore.PassthroughHeaders {
 		if vv := r.Header.Values(k); len(vv) > 0 {
 			for _, v := range vv {
 				outReq.Header.Add(k, v)
@@ -287,7 +193,7 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// 10. Stream response back to agent (filter unsafe headers).
 	for k, vv := range resp.Header {
 		// Skip hop-by-hop and security-sensitive headers from upstream.
-		if isHopByHopHeader(k) || strings.EqualFold(k, "Set-Cookie") {
+		if brokercore.ShouldStripResponseHeader(k) {
 			continue
 		}
 		for _, v := range vv {
@@ -295,6 +201,6 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	w.WriteHeader(resp.StatusCode)
-	// Limit response body to 100 MB to prevent resource exhaustion.
-	_, _ = io.Copy(w, io.LimitReader(resp.Body, 100<<20))
+	// Limit response body to prevent resource exhaustion.
+	_, _ = io.Copy(w, io.LimitReader(resp.Body, brokercore.MaxResponseBytes))
 }

--- a/internal/server/respond.go
+++ b/internal/server/respond.go
@@ -7,8 +7,6 @@ import (
 	"github.com/Infisical/agent-vault/internal/brokercore"
 )
 
-const proxyErrorHeader = brokercore.ProxyErrorHeader
-
 // jsonOK writes a 200 JSON response.
 func jsonOK(w http.ResponseWriter, data any) {
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/server/respond.go
+++ b/internal/server/respond.go
@@ -3,9 +3,11 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/Infisical/agent-vault/internal/brokercore"
 )
 
-const proxyErrorHeader = "X-Agent-Vault-Proxy-Error"
+const proxyErrorHeader = brokercore.ProxyErrorHeader
 
 // jsonOK writes a 200 JSON response.
 func jsonOK(w http.ResponseWriter, data any) {
@@ -37,8 +39,5 @@ func jsonError(w http.ResponseWriter, status int, message string) {
 // Sets X-Agent-Vault-Proxy-Error so SDK clients can distinguish broker errors
 // from upstream responses that happen to share the same status code.
 func proxyError(w http.ResponseWriter, status int, code, message string) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set(proxyErrorHeader, "true")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": code, "message": message})
+	brokercore.WriteProxyError(w, status, code, message)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"sync"
 
+	"github.com/Infisical/agent-vault/internal/brokercore"
 	"github.com/Infisical/agent-vault/internal/crypto"
 	"github.com/Infisical/agent-vault/internal/mitm"
 	"github.com/Infisical/agent-vault/internal/notify"
@@ -66,6 +67,18 @@ type Server struct {
 // is bound to this Server: Start launches it, and SIGINT/SIGTERM/Shutdown
 // stops it alongside the HTTP server.
 func (s *Server) AttachMITM(p *mitm.Proxy) { s.mitm = p }
+
+// SessionResolver returns a brokercore.SessionResolver backed by this
+// server's store.
+func (s *Server) SessionResolver() brokercore.SessionResolver {
+	return brokercore.NewStoreSessionResolver(s.store)
+}
+
+// CredentialProvider returns a brokercore.CredentialProvider backed by
+// this server's store and encryption key.
+func (s *Server) CredentialProvider() brokercore.CredentialProvider {
+	return brokercore.NewStoreCredentialProvider(s.store, s.encKey)
+}
 
 // Store is the persistence interface used by the server.
 type Store interface {


### PR DESCRIPTION
## Summary
- Extract a new `internal/brokercore` package that shares credential injection and session/vault resolution between the `/proxy` HTTP endpoint and the transparent MITM proxy.
- Wire `Proxy-Authorization` (with optional vault hint via Basic userinfo `token:vault`) and credential injection into MITM CONNECT. Auth happens BEFORE hijack, so 407/400/403/404 can be returned cleanly.
- Forward path drops client-supplied `Authorization` via allowlist so injected credentials always win; `Set-Cookie` and hop-by-hop headers are stripped on the response.
- `/proxy` handler now routes through `brokercore.Inject`, removing ~100 lines of duplicated logic.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — new unit tests for `brokercore` (proxyauth, session, credential) + revamped `mitm` tests covering 407 on missing auth, 407 on invalid session, 400 on ambiguous agent vaults, 403 on vault hint mismatch, 403+proposal_hint on unknown host, 502 on upstream cert failure, allowlist passthrough + credential injection end-to-end.
- [ ] Manual smoke: `HTTPS_PROXY=http://<scoped-token>@127.0.0.1:14322 curl ...` against a configured service.
- [ ] Manual smoke: instance-agent token form `HTTPS_PROXY=http://<agent-token>:<vault>@127.0.0.1:14322 curl ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)