### PR TITLE
feat: expose transparent-proxy root CA via public endpoint + `agent-vault ca fetch`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ Opt-in second ingress path for clients that respect `HTTPS_PROXY`. Off by defaul
 - Backed by `internal/mitm` (CONNECT + TLS termination) and `internal/ca` (software CA persisted under `~/.agent-vault/ca/`, root key encrypted with the master key). The CA is only initialized when `--mitm-port > 0`.
 - Upstream dials go through `netguard.SafeDialContext` (same SSRF protections as `/proxy`) with strict TLS verification against the system trust store.
 - **v1 scope**: HTTP/1.1 only (ALPN pinned), no credential injection, no audit hooks, no policy. Current behavior is a transparent pass-through that proves the TLS plumbing. Credential injection / audit unification are the next steps — plug into `internal/mitm/forward.go`.
-- Clients must trust the CA root (at `~/.agent-vault/ca/ca.crt.pem`) for the MITM handshake to succeed. An `install-ca` helper is a separate future initiative.
+- Clients must trust the CA root for the MITM handshake to succeed. Fetch it with `agent-vault ca fetch` (pipes raw PEM to stdout; `-o <file>` to save) or `curl -O http://localhost:14321/v1/mitm/ca.pem`. The endpoint `GET /v1/mitm/ca.pem` is public (the cert is safe to expose by design) and returns 404 with a plaintext body when `--mitm-port` is not set. Installing the fetched PEM into trust stores (`security add-trusted-cert`, `update-ca-certificates`, `keytool`) is currently a manual step — an `agent-vault ca install` helper is a future initiative.
 
 ## Discovery Endpoint
 

--- a/cmd/ca.go
+++ b/cmd/ca.go
@@ -56,7 +56,7 @@ Examples:
 		}
 
 		if output != "" {
-			if err := os.WriteFile(output, body, 0644); err != nil {
+			if err := os.WriteFile(output, body, 0o600); err != nil {
 				return fmt.Errorf("writing %s: %w", output, err)
 			}
 			fmt.Fprintf(cmd.ErrOrStderr(), "%s Wrote CA cert to %s\n", successText("✓"), output)

--- a/cmd/ca.go
+++ b/cmd/ca.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var caCmd = &cobra.Command{
+	Use:   "ca",
+	Short: "Manage the transparent-proxy root CA certificate",
+}
+
+var caFetchCmd = &cobra.Command{
+	Use:   "fetch",
+	Short: "Fetch the root CA certificate (PEM)",
+	Long: `Fetch the root CA certificate used by Agent Vault's transparent MITM
+proxy. Install the returned PEM into your client trust store so HTTPS
+traffic routed through the proxy validates cleanly.
+
+The server must be running with --mitm-port set. The endpoint is public —
+no authentication required.
+
+Examples:
+  agent-vault ca fetch > ca.pem
+  agent-vault ca fetch -o /etc/ssl/certs/agent-vault-ca.pem
+  agent-vault ca fetch | sudo security add-trusted-cert -d -r trustRoot \
+      -k /Library/Keychains/System.keychain /dev/stdin`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		addr := resolveAddress(cmd)
+		output, _ := cmd.Flags().GetString("output")
+
+		url := fmt.Sprintf("%s/v1/mitm/ca.pem", addr)
+		resp, err := httpClient.Get(url)
+		if err != nil {
+			return fmt.Errorf("could not reach server at %s: %w", addr, err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("reading response: %w", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return errors.New(strings.TrimSpace(string(body)))
+		}
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+		}
+
+		if output != "" {
+			if err := os.WriteFile(output, body, 0644); err != nil {
+				return fmt.Errorf("writing %s: %w", output, err)
+			}
+			fmt.Fprintf(cmd.ErrOrStderr(), "%s Wrote CA cert to %s\n", successText("✓"), output)
+			return nil
+		}
+		_, _ = cmd.OutOrStdout().Write(body)
+		return nil
+	},
+}
+
+func init() {
+	caFetchCmd.Flags().StringP("output", "o", "", "write PEM to file instead of stdout")
+	caFetchCmd.Flags().String("address", "", "server address (default: auto-detect)")
+	caCmd.AddCommand(caFetchCmd)
+	rootCmd.AddCommand(caCmd)
+}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -25,11 +25,50 @@ func TestCommandsRegistered(t *testing.T) {
 		registered[c.Name()] = true
 	}
 
-	expected := []string{"server", "auth", "vault", "owner", "account", "catalog", "user", "agent"}
+	expected := []string{"server", "auth", "vault", "owner", "account", "catalog", "user", "agent", "ca"}
 	for _, name := range expected {
 		if !registered[name] {
 			t.Errorf("expected command %q to be registered, but it was not", name)
 		}
+	}
+}
+
+func TestCASubcommandsRegistered(t *testing.T) {
+	caCmd := findSubcommand(rootCmd, "ca")
+	if caCmd == nil {
+		t.Fatal("ca command not found")
+	}
+
+	registered := make(map[string]bool)
+	for _, c := range caCmd.Commands() {
+		registered[c.Name()] = true
+	}
+
+	expected := []string{"fetch"}
+	for _, name := range expected {
+		if !registered[name] {
+			t.Errorf("expected ca subcommand %q to be registered, but it was not", name)
+		}
+	}
+}
+
+func TestCAFetchFlags(t *testing.T) {
+	caCmd := findSubcommand(rootCmd, "ca")
+	if caCmd == nil {
+		t.Fatal("ca command not found")
+	}
+	fetchCmd := findSubcommand(caCmd, "fetch")
+	if fetchCmd == nil {
+		t.Fatal("ca fetch subcommand not found")
+	}
+
+	for _, name := range []string{"output", "address"} {
+		if fetchCmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected ca fetch flag --%s to be registered", name)
+		}
+	}
+	if f := fetchCmd.Flags().ShorthandLookup("o"); f == nil {
+		t.Error("expected ca fetch flag -o shorthand to be registered")
 	}
 }
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -21,6 +21,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `--port` | `14321` | Port to listen on |
     | `-d`, `--detach` | `false` | Run in background (detached) mode |
     | `--password-stdin` | `false` | Read master password from stdin |
+    | `--mitm-port` | `0` | Port for the transparent MITM proxy (experimental). When `> 0`, enables the proxy and initializes the root CA. Clients fetch the root cert with [`agent-vault ca fetch`](#ca). |
 
     **Environment variables:**
 
@@ -46,6 +47,39 @@ description: "Complete reference for all Agent Vault CLI commands."
     ```
 
     Stop a running server. Reads the PID from `~/.agent-vault/agent-vault.pid` and sends SIGTERM.
+  </Accordion>
+</AccordionGroup>
+
+## CA
+
+<AccordionGroup>
+  <Accordion title="agent-vault ca fetch">
+    ```bash
+    agent-vault ca fetch [flags]
+    ```
+
+    Fetch the root CA certificate used by Agent Vault's transparent MITM proxy, in PEM form. Install the output into your client trust store so HTTPS traffic routed through the proxy validates cleanly.
+
+    The server must be running with `--mitm-port` set. The endpoint is public — no authentication required. Returns an error if MITM is not enabled on the target server.
+
+    | Flag | Default | Description |
+    |------|---------|-------------|
+    | `-o`, `--output` | | Write PEM to file instead of stdout |
+    | `--address` | | Server URL |
+
+    **Examples:**
+
+    ```bash
+    # Print to stdout
+    agent-vault ca fetch > ca.pem
+
+    # Save directly to a file
+    agent-vault ca fetch -o /etc/ssl/certs/agent-vault-ca.pem
+
+    # Pipe into the macOS system keychain
+    agent-vault ca fetch | sudo security add-trusted-cert -d -r trustRoot \
+        -k /Library/Keychains/System.keychain /dev/stdin
+    ```
   </Accordion>
 </AccordionGroup>
 

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -72,6 +72,42 @@ Any CLI command that needs authentication will walk you through registration and
 
 Subsequent users can self-register via `agent-vault auth register`, the web registration page, or be [invited to a vault](/learn/vaults#invite-users-to-a-vault) by a vault admin.
 
+## Transparent proxy (optional)
+
+<Warning>
+  Experimental. HTTP/1.1 only, and credential injection is not yet wired into this path — the MITM proxy currently proves the TLS plumbing without adding auth headers on the way through. Use the regular `/proxy` endpoint for brokered requests.
+</Warning>
+
+Agent Vault can expose a second ingress as a transparent `HTTPS_PROXY`. This lets clients that respect the proxy environment variable (but can't be pointed at a custom base URL) route through Agent Vault. Start the server with `--mitm-port`:
+
+```bash
+agent-vault server --mitm-port 14322
+```
+
+A software-backed root CA is created on first launch under `~/.agent-vault/ca/` (private key encrypted with the master key). Clients must trust this root before the proxied TLS handshake will succeed.
+
+Fetch the root certificate from any machine that can reach the server:
+
+```bash
+# From stdout (pipe into a trust-store installer)
+agent-vault ca fetch > agent-vault-ca.pem
+
+# Save to a file
+agent-vault ca fetch -o /etc/ssl/certs/agent-vault-ca.pem
+
+# Or with curl — the endpoint is public
+curl -O http://localhost:14321/v1/mitm/ca.pem
+```
+
+Then install into the relevant trust store. For example, on macOS:
+
+```bash
+agent-vault ca fetch | sudo security add-trusted-cert -d -r trustRoot \
+    -k /Library/Keychains/System.keychain /dev/stdin
+```
+
+See the [CLI reference](/reference/cli#ca) for all `agent-vault ca fetch` flags.
+
 ## Upgrade
 
 Re-run the same install command — the script detects your existing installation, stops the running server, backs up your database, and installs the latest version:

--- a/internal/mitm/proxy.go
+++ b/internal/mitm/proxy.go
@@ -65,6 +65,11 @@ func New(addr string, caProv ca.Provider, sessions brokercore.SessionResolver, c
 // Addr returns the listener address the Proxy was configured with.
 func (p *Proxy) Addr() string { return p.httpServer.Addr }
 
+// RootPEM returns the root CA certificate in PEM form. Safe for public
+// distribution — clients install this into trust stores to validate the
+// leaves minted on demand during CONNECT.
+func (p *Proxy) RootPEM() []byte { return p.ca.RootPEM() }
+
 // ListenAndServe starts accepting connections. It blocks until Shutdown
 // is called, returning http.ErrServerClosed in that case.
 func (p *Proxy) ListenAndServe() error {

--- a/internal/server/handle_mitm.go
+++ b/internal/server/handle_mitm.go
@@ -1,0 +1,18 @@
+package server
+
+import "net/http"
+
+// handleMITMCA serves the transparent-proxy root CA certificate in PEM form.
+// Public (no auth): the CA is world-readable by design — clients install it
+// into local trust stores to validate proxy-minted leaves.
+func (s *Server) handleMITMCA(w http.ResponseWriter, _ *http.Request) {
+	if s.mitm == nil {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("MITM proxy is not enabled on this server\n"))
+		return
+	}
+	w.Header().Set("Content-Type", "application/x-pem-file")
+	w.Header().Set("Content-Disposition", `attachment; filename="agent-vault-ca.pem"`)
+	_, _ = w.Write(s.mitm.RootPEM())
+}

--- a/internal/server/handle_mitm_test.go
+++ b/internal/server/handle_mitm_test.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Infisical/agent-vault/internal/ca"
+	"github.com/Infisical/agent-vault/internal/mitm"
+)
+
+func TestHandleMITMCA(t *testing.T) {
+	t.Run("mitm_enabled", func(t *testing.T) {
+		srv := newTestServer()
+
+		masterKey := make([]byte, 32)
+		if _, err := rand.Read(masterKey); err != nil {
+			t.Fatalf("rand: %v", err)
+		}
+		caProv, err := ca.New(masterKey, ca.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("ca.New: %v", err)
+		}
+		p := mitm.New("127.0.0.1:0", caProv, srv.SessionResolver(), srv.CredentialProvider())
+		srv.AttachMITM(p)
+
+		req := httptest.NewRequest(http.MethodGet, "/v1/mitm/ca.pem", nil)
+		rec := httptest.NewRecorder()
+		srv.httpServer.Handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "application/x-pem-file" {
+			t.Fatalf("Content-Type: got %q, want application/x-pem-file", ct)
+		}
+		if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, "agent-vault-ca.pem") {
+			t.Fatalf("Content-Disposition: got %q, want filename=agent-vault-ca.pem", cd)
+		}
+
+		block, _ := pem.Decode(rec.Body.Bytes())
+		if block == nil || block.Type != "CERTIFICATE" {
+			t.Fatal("response body did not decode as a CERTIFICATE PEM block")
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			t.Fatalf("x509.ParseCertificate: %v", err)
+		}
+		if !cert.IsCA {
+			t.Fatal("returned certificate is not a CA certificate")
+		}
+	})
+
+	t.Run("mitm_disabled", func(t *testing.T) {
+		srv := newTestServer()
+
+		req := httptest.NewRequest(http.MethodGet, "/v1/mitm/ca.pem", nil)
+		rec := httptest.NewRecorder()
+		srv.httpServer.Handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+			t.Fatalf("Content-Type: got %q, want text/plain*", ct)
+		}
+		if strings.TrimSpace(rec.Body.String()) == "" {
+			t.Fatal("expected non-empty plaintext error body")
+		}
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -611,6 +611,11 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("GET /v1/skills/cli", s.requireInitialized(s.handleSkillCLI))
 	mux.HandleFunc("GET /v1/skills/http", s.requireInitialized(s.handleSkillHTTP))
 
+	// Public: transparent-proxy root CA. Safe to expose; clients need it to
+	// trust the minted leaves. Not wrapped in requireInitialized — the CA
+	// lifecycle is tied to --mitm-port, not owner registration.
+	mux.HandleFunc("GET /v1/mitm/ca.pem", s.handleMITMCA)
+
 	// Instance-level user invites
 	mux.HandleFunc("POST /v1/users/invites", s.requireInitialized(s.requireAuth(limitBody(s.handleUserInviteCreate))))
 	mux.HandleFunc("GET /v1/users/invites", s.requireInitialized(s.requireAuth(s.handleUserInviteList)))


### PR DESCRIPTION
## Summary

- Adds `GET /v1/mitm/ca.pem` — public, unauthenticated endpoint that serves the transparent-proxy root CA in PEM form. Returns 404 with a plaintext body when the server is not running with `--mitm-port`.
- Adds `agent-vault ca fetch` CLI (new `ca` command group) that pipes PEM to stdout or writes it to `-o <file>`. Uses the shared `httpClient` (10s timeout) so it doesn't hang on unreachable servers.
- Scaffolds `ca` as a cobra group so the future `ca install` helper (called out in `CLAUDE.md`) slots in without a breaking rename.

## Why

The transparent MITM proxy (introduced in #69/#70/#71) needs clients to trust its root CA before HTTPS handshakes will succeed. Previously the only way to get the cert was to scrape `~/.agent-vault/ca/ca.crt.pem` off the server host, which breaks for remote/Dockerized deployments and anyone whose client lives on a different machine than the server.

## Design notes

- **Public endpoint**: the CA cert is world-readable by design (`ca.Provider.RootPEM()`'s docstring says so). Requiring auth would create a bootstrap chicken-and-egg — a fresh user on a new machine needs the CA *before* they can route through it. Matches convention from mitmproxy / Caddy / step-ca.
- **`.pem` URL suffix + `application/x-pem-file` content type**: makes `curl -O`, browser downloads, and `security add-trusted-cert` all work naturally.
- **Plaintext 404 (not JSON)**: keeps the error path pipe-friendly for `curl | installer`.
- **Not wrapped in `requireInitialized`**: the CA lifecycle is tied to `--mitm-port`, not owner registration. A server running MITM before anyone has registered should still be able to serve its CA.

## Test plan

- [x] `go test ./...` passes
- [x] New handler tests in `internal/server/handle_mitm_test.go` cover both the enabled (validates PEM parses as a CA cert, correct content-type/disposition) and disabled (404 + plaintext body) paths
- [x] New CLI smoke tests in `cmd/cmd_test.go` verify the `ca fetch` subcommand + flags are registered
- [x] End-to-end smoke:
  - `./agent-vault ca fetch | openssl x509 -noout -subject -issuer -dates` → prints the 10-year Agent Vault Root CA
  - `./agent-vault ca fetch -o /tmp/ca.pem` → file is byte-identical to `~/.agent-vault/ca/ca.crt.pem`
  - `curl http://localhost:14321/v1/mitm/ca.pem` → `200 application/x-pem-file`, same bytes as CLI
  - Against a server without `--mitm-port`: CLI exits 1 with `Error: MITM proxy is not enabled on this server`; curl gets `404 text/plain`

## Docs

- `CLAUDE.md` — updated the "Transparent Proxy (MITM)" section with the new fetch flow
- `docs/reference/cli.mdx` — added `--mitm-port` to the server flags table + new `## CA` section
- `docs/self-hosting/local.mdx` — added a "Transparent proxy (optional)" section with the fetch + trust-install workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)