### PR TITLE
feat: enable transparent MITM proxy by default on port 14322

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ make docker       # Multi-stage Docker image; data persisted at /data/.agent-vau
 
 - **Two ingress paths into the broker**:
   - Explicit proxy: `GET/POST /proxy/{target_host}/{path}` with a vault-scoped session token. Agent Vault matches the host against broker services, strips client auth, and injects credentials from the vault.
-  - Transparent MITM (opt-in, `agent-vault server --mitm-port 14322`): HTTPS_PROXY-compatible ingress backed by [internal/mitm](internal/mitm/) + [internal/ca](internal/ca/) (software CA, root key encrypted with the master key). Same credential-injection code path as `/proxy` via `brokercore`. HTTP/1.1 only today.
+  - Transparent MITM (on by default, port 14322, disable with `--mitm-port 0`): HTTPS_PROXY-compatible ingress backed by [internal/mitm](internal/mitm/) + [internal/ca](internal/ca/) (software CA, root key encrypted with the master key). Same credential-injection code path as `/proxy` via `brokercore`. HTTP/1.1 only today. Bind failures are non-fatal — the core HTTP server keeps running.
 - **Proposals = GitHub-PR-style change requests.** Agents cannot edit services or credentials directly; they create proposals, a human approves in CLI or browser, and apply merges atomically. Per-vault sequential IDs. 7-day TTL.
 - **Two independent permission axes**:
   - Instance role: `owner` vs `member` (applies to both users and agents).

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ Supports macOS (Intel + Apple Silicon) and Linux (x86_64 + ARM64).
 ### [Docker](https://docs.agent-vault.dev/self-hosting/docker)
 
 ```bash
-docker run -it -p 14321:14321 -v agent-vault-data:/data infisical/agent-vault
+docker run -it -p 14321:14321 -p 14322:14322 -v agent-vault-data:/data infisical/agent-vault
 ```
+
+Port `14322` exposes the transparent HTTPS proxy (on by default) — omit the mapping or pass `--mitm-port 0` to the server if you only need the explicit `/proxy/{host}/{path}` API on `14321`.
 
 ### From source
 
@@ -63,7 +65,7 @@ sudo mv agent-vault /usr/local/bin/
 ## Quickstart
 
 ```bash
-# Start the server (runs on localhost:14321 by default)
+# Start the server (HTTP on 14321, transparent HTTPS proxy on 14322)
 agent-vault server -d
 
 # Add a credential
@@ -75,6 +77,8 @@ agent-vault vault service add \
   --auth-type bearer \
   --token-key GITHUB_TOKEN
 ```
+
+The transparent MITM proxy binds `127.0.0.1:14322` by default so clients configured with `HTTPS_PROXY=http://localhost:14322` route through Agent Vault without code changes — install the root CA with `agent-vault ca fetch`, or disable the proxy entirely with `--mitm-port 0`.
 
 Any command that needs authentication will walk you through setup automatically. Just run it and follow the prompts. You can also run `agent-vault vault service set` interactively, load from YAML with `agent-vault vault service set -f services.yaml`, or browse templates with `agent-vault catalog`.
 

--- a/cmd/ca.go
+++ b/cmd/ca.go
@@ -23,8 +23,9 @@ var caFetchCmd = &cobra.Command{
 proxy. Install the returned PEM into your client trust store so HTTPS
 traffic routed through the proxy validates cleanly.
 
-The server must be running with --mitm-port set. The endpoint is public —
-no authentication required.
+The transparent proxy is enabled by default. The endpoint is public —
+no authentication required. If the server was started with --mitm-port 0,
+this command returns an error.
 
 Examples:
   agent-vault ca fetch > ca.pem

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -1,7 +1,8 @@
 package cmd
 
 const (
-	DefaultPort    = 14321
-	DefaultHost    = "127.0.0.1"
-	DefaultAddress = "http://127.0.0.1:14321"
+	DefaultPort     = 14321
+	DefaultHost     = "127.0.0.1"
+	DefaultAddress  = "http://127.0.0.1:14321"
+	DefaultMITMPort = 14322
 )

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -372,10 +372,7 @@ func spawnDetached(cmd *cobra.Command, masterKey *auth.MasterKey, initialized bo
 		return fmt.Errorf("opening log file: %w", err)
 	}
 
-	childArgs := []string{"server", "--port", strconv.Itoa(port), "--host", host}
-	if mitmPort > 0 {
-		childArgs = append(childArgs, "--mitm-port", strconv.Itoa(mitmPort))
-	}
+	childArgs := []string{"server", "--port", strconv.Itoa(port), "--host", host, "--mitm-port", strconv.Itoa(mitmPort)}
 	child := exec.Command(exe, childArgs...)
 	child.Stdin = pr
 	child.Stdout = logFile
@@ -507,7 +504,7 @@ func init() {
 	serverCmd.Flags().String("host", DefaultHost, "host to bind to")
 	serverCmd.Flags().BoolP("detach", "d", false, "run server in background after unlocking")
 	serverCmd.Flags().Bool("password-stdin", false, "read master password from stdin (for non-interactive use)")
-	serverCmd.Flags().Int("mitm-port", 0, "enable transparent MITM proxy on this port (0 = disabled)")
+	serverCmd.Flags().Int("mitm-port", DefaultMITMPort, "port for the transparent MITM proxy (0 = disabled)")
 	serverCmd.AddCommand(stopCmd)
 	rootCmd.AddCommand(serverCmd)
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -106,13 +106,19 @@ var serverCmd = &cobra.Command{
 // attachMITMIfEnabled initializes the CA and attaches a transparent MITM
 // proxy to srv when mitmPort > 0. The CA is loaded or created under the
 // standard ~/.agent-vault/ca/ directory, encrypted with the master key.
+//
+// CA init failures are non-fatal, matching the behavior for bind failures
+// in server.Start: since the MITM proxy is default-on, environments that
+// cannot create ~/.agent-vault/ca/ (read-only FS, containers without HOME,
+// corrupted state) must still be able to run the core HTTP server.
 func attachMITMIfEnabled(srv *server.Server, host string, mitmPort int, masterKey []byte) error {
 	if mitmPort <= 0 {
 		return nil
 	}
 	caProv, err := ca.New(masterKey, ca.Options{})
 	if err != nil {
-		return fmt.Errorf("init CA: %w", err)
+		fmt.Fprintf(os.Stderr, "warning: transparent proxy disabled (CA init failed: %v); pass --mitm-port 0 to suppress\n", err)
+		return nil
 	}
 	srv.AttachMITM(mitm.New(
 		net.JoinHostPort(host, strconv.Itoa(mitmPort)),

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -21,7 +21,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `--port` | `14321` | Port to listen on |
     | `-d`, `--detach` | `false` | Run in background (detached) mode |
     | `--password-stdin` | `false` | Read master password from stdin |
-    | `--mitm-port` | `0` | Port for the transparent MITM proxy (experimental). When `> 0`, enables the proxy and initializes the root CA. Clients fetch the root cert with [`agent-vault ca fetch`](#ca). |
+    | `--mitm-port` | `14322` | Port for the transparent MITM proxy. Enabled by default; set to `0` to disable. On first launch the root CA is created under `~/.agent-vault/ca/` — clients fetch it with [`agent-vault ca fetch`](#ca). Bind failures are non-fatal. |
 
     **Environment variables:**
 
@@ -60,7 +60,7 @@ description: "Complete reference for all Agent Vault CLI commands."
 
     Fetch the root CA certificate used by Agent Vault's transparent MITM proxy, in PEM form. Install the output into your client trust store so HTTPS traffic routed through the proxy validates cleanly.
 
-    The server must be running with `--mitm-port` set. The endpoint is public — no authentication required. Returns an error if MITM is not enabled on the target server.
+    The transparent proxy is enabled by default, so this command works out of the box. The endpoint is public — no authentication required. Returns an error only if the server was started with `--mitm-port 0`.
 
     | Flag | Default | Description |
     |------|---------|-------------|

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -17,7 +17,7 @@ description: "Complete reference for all Agent Vault CLI commands."
 
     | Flag | Default | Description |
     |------|---------|-------------|
-    | `--host` | `localhost` | Host to bind to |
+    | `--host` | `127.0.0.1` | Host to bind to |
     | `--port` | `14321` | Port to listen on |
     | `-d`, `--detach` | `false` | Run in background (detached) mode |
     | `--password-stdin` | `false` | Read master password from stdin |

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -72,16 +72,17 @@ Any CLI command that needs authentication will walk you through registration and
 
 Subsequent users can self-register via `agent-vault auth register`, the web registration page, or be [invited to a vault](/learn/vaults#invite-users-to-a-vault) by a vault admin.
 
-## Transparent proxy (optional)
+## Transparent proxy
 
 <Warning>
-  Experimental. HTTP/1.1 only, and credential injection is not yet wired into this path — the MITM proxy currently proves the TLS plumbing without adding auth headers on the way through. Use the regular `/proxy` endpoint for brokered requests.
+  HTTP/1.1 only today. Clients that negotiate HTTP/2 end-to-end will not proxy through this path — use the explicit `/proxy` endpoint instead.
 </Warning>
 
-Agent Vault can expose a second ingress as a transparent `HTTPS_PROXY`. This lets clients that respect the proxy environment variable (but can't be pointed at a custom base URL) route through Agent Vault. Start the server with `--mitm-port`:
+Agent Vault exposes a second ingress as a transparent `HTTPS_PROXY`. This lets clients that respect the proxy environment variable (but can't be pointed at a custom base URL) route through Agent Vault. It listens on port `14322` by default; pass `--mitm-port 0` to disable, or a different port to change it:
 
 ```bash
-agent-vault server --mitm-port 14322
+agent-vault server               # transparent proxy on 14322 (default)
+agent-vault server --mitm-port 0 # disable
 ```
 
 A software-backed root CA is created on first launch under `~/.agent-vault/ca/` (private key encrypted with the master key). Clients must trust this root before the proxied TLS handshake will succeed.

--- a/internal/mitm/proxy.go
+++ b/internal/mitm/proxy.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/Infisical/agent-vault/internal/brokercore"
@@ -25,11 +26,12 @@ import (
 // Proxy is a transparent MITM proxy. It is safe to start at most once;
 // reuse across Shutdown is not supported.
 type Proxy struct {
-	ca         ca.Provider
-	sessions   brokercore.SessionResolver
-	creds      brokercore.CredentialProvider
-	httpServer *http.Server
-	upstream   *http.Transport
+	ca          ca.Provider
+	sessions    brokercore.SessionResolver
+	creds       brokercore.CredentialProvider
+	httpServer  *http.Server
+	upstream    *http.Transport
+	isListening atomic.Bool
 }
 
 // New builds a Proxy bound to addr using caProv for leaf certificates and
@@ -70,16 +72,31 @@ func (p *Proxy) Addr() string { return p.httpServer.Addr }
 // leaves minted on demand during CONNECT.
 func (p *Proxy) RootPEM() []byte { return p.ca.RootPEM() }
 
-// ListenAndServe starts accepting connections. It blocks until Shutdown
-// is called, returning http.ErrServerClosed in that case.
+// IsListening reports whether the Proxy has successfully bound its
+// listener and is accepting connections. Callers that gate operator-
+// visible behavior (like advertising the root CA) on proxy reachability
+// should check this rather than nil-checking the Proxy itself — a bind
+// failure leaves the Proxy value alive but unreachable.
+func (p *Proxy) IsListening() bool { return p.isListening.Load() }
+
+// ListenAndServe starts accepting connections. It binds the listener
+// eagerly so callers can detect bind failures; on success, IsListening
+// reports true for the lifetime of the accept loop. Blocks until
+// Shutdown, returning http.ErrServerClosed in that case.
 func (p *Proxy) ListenAndServe() error {
-	return p.httpServer.ListenAndServe()
+	l, err := net.Listen("tcp", p.httpServer.Addr)
+	if err != nil {
+		return err
+	}
+	return p.Serve(l)
 }
 
 // Serve accepts connections on the provided listener. It blocks until
 // Shutdown is called, returning http.ErrServerClosed in that case.
 // Useful for tests that need to bind :0 and learn the resulting port.
 func (p *Proxy) Serve(l net.Listener) error {
+	p.isListening.Store(true)
+	defer p.isListening.Store(false)
 	return p.httpServer.Serve(l)
 }
 

--- a/internal/server/handle_mitm.go
+++ b/internal/server/handle_mitm.go
@@ -5,8 +5,14 @@ import "net/http"
 // handleMITMCA serves the transparent-proxy root CA certificate in PEM form.
 // Public (no auth): the CA is world-readable by design — clients install it
 // into local trust stores to validate proxy-minted leaves.
+//
+// Gated on IsListening, not just non-nil: when the proxy fails to bind
+// (port conflict with default-on MITM), s.mitm is still attached but
+// nothing is accepting connections. Returning a PEM in that state would
+// lead operators to install a cert and configure HTTPS_PROXY for a port
+// that silently refuses connections.
 func (s *Server) handleMITMCA(w http.ResponseWriter, _ *http.Request) {
-	if s.mitm == nil {
+	if s.mitm == nil || !s.mitm.IsListening() {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte("MITM proxy is not enabled on this server\n"))

--- a/internal/server/handle_mitm_test.go
+++ b/internal/server/handle_mitm_test.go
@@ -1,13 +1,17 @@
 package server
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/Infisical/agent-vault/internal/ca"
 	"github.com/Infisical/agent-vault/internal/mitm"
@@ -27,6 +31,27 @@ func TestHandleMITMCA(t *testing.T) {
 		}
 		p := mitm.New("127.0.0.1:0", caProv, srv.SessionResolver(), srv.CredentialProvider())
 		srv.AttachMITM(p)
+
+		// Start the proxy so IsListening() reports true. The handler gates
+		// the PEM response on listener state to avoid advertising a CA cert
+		// for a proxy that failed to bind.
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = p.Serve(l)
+		}()
+		t.Cleanup(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			_ = p.Shutdown(ctx)
+			wg.Wait()
+		})
+		waitForListening(t, p)
 
 		req := httptest.NewRequest(http.MethodGet, "/v1/mitm/ca.pem", nil)
 		rec := httptest.NewRecorder()
@@ -72,4 +97,45 @@ func TestHandleMITMCA(t *testing.T) {
 			t.Fatal("expected non-empty plaintext error body")
 		}
 	})
+
+	// Guards the regression where a bind failure left s.mitm non-nil and
+	// the endpoint kept serving a PEM for a proxy that was not listening.
+	t.Run("mitm_attached_but_not_listening", func(t *testing.T) {
+		srv := newTestServer()
+
+		masterKey := make([]byte, 32)
+		if _, err := rand.Read(masterKey); err != nil {
+			t.Fatalf("rand: %v", err)
+		}
+		caProv, err := ca.New(masterKey, ca.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("ca.New: %v", err)
+		}
+		p := mitm.New("127.0.0.1:0", caProv, srv.SessionResolver(), srv.CredentialProvider())
+		srv.AttachMITM(p)
+		// Intentionally do not call Serve — simulates a bind failure.
+
+		req := httptest.NewRequest(http.MethodGet, "/v1/mitm/ca.pem", nil)
+		rec := httptest.NewRecorder()
+		srv.httpServer.Handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("expected 404 while proxy not listening, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+// waitForListening spins until the Proxy reports it has bound its listener,
+// or fails the test after a short timeout. Needed because Serve flips the
+// atomic flag on a background goroutine.
+func waitForListening(t *testing.T, p *mitm.Proxy) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.IsListening() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("proxy did not report IsListening within timeout")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -703,11 +703,16 @@ func (s *Server) Start() error {
 
 	if s.mitm != nil {
 		go func() {
-			fmt.Printf("Agent Vault transparent proxy listening on %s\n", s.mitm.Addr())
-			if err := s.mitm.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			l, err := net.Listen("tcp", s.mitm.Addr())
+			if err != nil {
 				// MITM is best-effort (e.g. default-on port conflict shouldn't
 				// kill the core HTTP server). Log and let the goroutine exit.
 				fmt.Fprintf(os.Stderr, "warning: transparent proxy unavailable: %v\n", err)
+				return
+			}
+			fmt.Printf("Agent Vault transparent proxy listening on %s\n", s.mitm.Addr())
+			if err := s.mitm.Serve(l); err != nil && err != http.ErrServerClosed {
+				fmt.Fprintf(os.Stderr, "warning: transparent proxy stopped: %v\n", err)
 			}
 		}()
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -60,7 +60,7 @@ type Server struct {
 	oauthProviders map[string]oauth.Provider
 	skillCLI       []byte      // embedded CLI skill content (served at GET /v1/skills/cli)
 	skillHTTP      []byte      // embedded HTTP skill content (served at GET /v1/skills/http)
-	mitm           *mitm.Proxy // optional transparent MITM proxy, nil when --mitm-port unset
+	mitm           *mitm.Proxy // transparent MITM proxy; nil only when --mitm-port 0
 }
 
 // AttachMITM registers an optional transparent MITM proxy whose lifecycle
@@ -690,7 +690,7 @@ func (s *Server) Start() error {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
-	errCh := make(chan error, 2)
+	errCh := make(chan error, 1)
 	go func() {
 		fmt.Printf("Agent Vault server listening on %s\n", s.baseURL)
 		if !s.initialized {
@@ -705,7 +705,9 @@ func (s *Server) Start() error {
 		go func() {
 			fmt.Printf("Agent Vault transparent proxy listening on %s\n", s.mitm.Addr())
 			if err := s.mitm.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				errCh <- fmt.Errorf("mitm proxy: %w", err)
+				// MITM is best-effort (e.g. default-on port conflict shouldn't
+				// kill the core HTTP server). Log and let the goroutine exit.
+				fmt.Fprintf(os.Stderr, "warning: transparent proxy unavailable: %v\n", err)
 			}
 		}()
 	}


### PR DESCRIPTION
## Summary

- Flip `--mitm-port` default from `0` (disabled) to `14322`. The transparent `HTTPS_PROXY` ingress is now the out-of-the-box experience; `agent-vault ca fetch` works immediately on a fresh `agent-vault server`.
- Make MITM bind failures non-fatal — a port conflict on 14322 now logs a warning and leaves the core HTTP server running, instead of killing the whole process.
- Fix a latent bug in `server -d --mitm-port 0`: `spawnDetached` only forwarded the flag when `> 0`, so the detached child would silently inherit the new default and re-enable MITM. Always pass the flag through.
- Add `DefaultMITMPort` constant alongside the existing `DefaultPort` / `DefaultHost` defaults.
- Update CLAUDE.md mental model, cmd/ca.go help text, and docs to reflect default-on.

## Why

Transparent MITM is significantly easier than the explicit `/proxy/{host}/{path}` path — set `HTTPS_PROXY` once, any SDK or opaque tool routes through Agent Vault without code changes. Leaving it behind an opt-in flag turned it into a second-class feature that most operators never found.

End-to-end usage still requires installing the root CA into a client trust store (out-of-band step, unchanged) and supplying credentials via `HTTPS_PROXY=http://<token>:<vault>@host:port` — the [CONNECT auth path in internal/mitm/connect.go](https://github.com/Infisical/agent-vault/blob/main/internal/mitm/connect.go) validates via the same `brokercore.ResolveForProxy` that the explicit `/proxy` ingress uses. No new auth surface.

## Opt-out

```
agent-vault server --mitm-port 0
```

## Test plan

- [ ] `go test ./...` passes (verified locally).
- [ ] `agent-vault server` (no flags) prints both `Agent Vault server listening on ...` and `Agent Vault transparent proxy listening on 127.0.0.1:14322`.
- [ ] `agent-vault ca fetch` returns the PEM without `--mitm-port` being set.
- [ ] `agent-vault server --mitm-port 0` starts with only the core HTTP server; `agent-vault ca fetch` returns the "MITM proxy is not enabled" error.
- [ ] `agent-vault server -d --mitm-port 0` + `agent-vault ca fetch` returns the disabled error (confirms the spawnDetached fix).
- [ ] Start a second `agent-vault server` instance → first still running holds 14321 and 14322; second logs `warning: transparent proxy unavailable: ...` but the core HTTP server error still causes exit cleanly (only 14321 conflict is fatal now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)