### PR TITLE
feat: add --log-level flag + structured per-request proxy logs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,11 @@
       "Bash(go build:*)",
       "Bash(go vet:*)",
       "Bash(npm test:*)",
-      "Bash(npm run:*)"
+      "Bash(npm run:*)",
+      "Bash(command -v golangci-lint)",
+      "Bash(grep -n \"os.WriteFile\\\\|WriteFile\" cmd/*.go)",
+      "Bash(grep -n \"handleSkill\\\\|handleService\\\\|handleHealth\\\\|writePlaintext\\\\|writeMarkdown\" /Users/tuandang/Desktop/Projects/agent-vault/agent-vault/internal/server/handler*.go)",
+      "WebFetch(domain:www.humanlayer.dev)"
     ]
   },
   "enabledPlugins": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,11 +7,7 @@
       "Bash(go build:*)",
       "Bash(go vet:*)",
       "Bash(npm test:*)",
-      "Bash(npm run:*)",
-      "Bash(command -v golangci-lint)",
-      "Bash(grep -n \"os.WriteFile\\\\|WriteFile\" cmd/*.go)",
-      "Bash(grep -n \"handleSkill\\\\|handleService\\\\|handleHealth\\\\|writePlaintext\\\\|writeMarkdown\" /Users/tuandang/Desktop/Projects/agent-vault/agent-vault/internal/server/handler*.go)",
-      "WebFetch(domain:www.humanlayer.dev)"
+      "Bash(npm run:*)"
     ]
   },
   "enabledPlugins": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,11 +39,14 @@ make docker       # Multi-stage Docker image; data persisted at /data/.agent-vau
 - **Types & validation** — broker service/auth shapes in [internal/broker/](internal/broker/); proposal shapes in [internal/proposal/](internal/proposal/).
 - **User-facing operator docs** — [README.md](README.md).
 - **Environment variables** — [.env.example](.env.example) is the canonical list.
+- **Public docs site** — Mintlify source lives under [docs/](docs/). Flag reference: [docs/reference/cli.mdx](docs/reference/cli.mdx). Env var reference: [docs/self-hosting/environment-variables.mdx](docs/self-hosting/environment-variables.mdx).
 - **Go module**: `github.com/Infisical/agent-vault`. CLI framework: [spf13/cobra](https://github.com/spf13/cobra).
 
 ## Conventions
 
 - When the agent-facing surface changes (endpoints, request/response fields, auth behavior), update **both** [cmd/skill_cli.md](cmd/skill_cli.md) and [cmd/skill_http.md](cmd/skill_http.md) together — they are versioned as a pair.
-- When adding an environment variable, update [.env.example](.env.example).
+- When adding an environment variable, update [.env.example](.env.example) **and** the server-config table in [docs/self-hosting/environment-variables.mdx](docs/self-hosting/environment-variables.mdx).
+- When adding or changing a CLI flag, update the flag table in [docs/reference/cli.mdx](docs/reference/cli.mdx) for the affected command.
 - When a change affects operator-facing behavior, update [README.md](README.md).
+- Whenever a new feature lands, scan [docs/](docs/) for pages that need a matching update — quickstart, guides, self-hosting, learn, and reference all mirror runtime behavior and drift fast.
 - When the *mental model* in this file drifts (new core concept, renamed ingress path, changed permission axes), update this file — but don't re-bloat it with reference material that belongs in the skill files or `--help`.

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,16 @@ build: web
 # Hot-reload dev: Go backend (air) + React frontend (Vite HMR)
 # Env vars can come from .env file OR `infisical run -- make dev`.
 # Open http://localhost:5173/app/ in browser
+# Defaults AGENT_VAULT_LOG_LEVEL=debug for per-request proxy visibility; an
+# explicit value in the shell env or .env file wins.
 dev: web
 	@echo ""
 	@echo "  ➜ Open http://localhost:5173 in your browser (not 14321)"
 	@echo ""
 	@trap 'kill 0' EXIT; \
+	export AGENT_VAULT_LOG_LEVEL=$${AGENT_VAULT_LOG_LEVEL:-debug}; \
 	if [ -f .env ]; then set -a; . ./.env; set +a; echo "  ✓ Loaded .env"; fi; \
+	echo "  ✓ Log level: $$AGENT_VAULT_LOG_LEVEL"; \
 	$(AIR) & (cd web && npm run dev) & wait
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,18 @@ build: web
 # Hot-reload dev: Go backend (air) + React frontend (Vite HMR)
 # Env vars can come from .env file OR `infisical run -- make dev`.
 # Open http://localhost:5173/app/ in browser
-# Defaults AGENT_VAULT_LOG_LEVEL=debug for per-request proxy visibility; an
-# explicit value in the shell env or .env file wins.
+# Precedence for AGENT_VAULT_LOG_LEVEL: shell env > .env file > default (debug).
+# The shell value is captured before sourcing .env so a plain assignment in
+# .env cannot overwrite an explicit `AGENT_VAULT_LOG_LEVEL=... make dev`.
 dev: web
 	@echo ""
 	@echo "  ➜ Open http://localhost:5173 in your browser (not 14321)"
 	@echo ""
 	@trap 'kill 0' EXIT; \
-	export AGENT_VAULT_LOG_LEVEL=$${AGENT_VAULT_LOG_LEVEL:-debug}; \
+	_shell_log_level="$$AGENT_VAULT_LOG_LEVEL"; \
 	if [ -f .env ]; then set -a; . ./.env; set +a; echo "  ✓ Loaded .env"; fi; \
+	if [ -n "$$_shell_log_level" ]; then export AGENT_VAULT_LOG_LEVEL="$$_shell_log_level"; fi; \
+	export AGENT_VAULT_LOG_LEVEL=$${AGENT_VAULT_LOG_LEVEL:-debug}; \
 	echo "  ✓ Log level: $$AGENT_VAULT_LOG_LEVEL"; \
 	$(AIR) & (cd web && npm run dev) & wait
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ agent-vault vault service add \
 
 The transparent MITM proxy binds `127.0.0.1:14322` by default so clients configured with `HTTPS_PROXY=http://localhost:14322` route through Agent Vault without code changes — install the root CA with `agent-vault ca fetch`, or disable the proxy entirely with `--mitm-port 0`.
 
+For local debugging, start the server with `--log-level debug` (or set `AGENT_VAULT_LOG_LEVEL=debug`) to emit one structured line per proxied request on stderr — method, host, path, matched broker service, injected credential key names, upstream status, duration. Credential *values* are never logged.
+
 Any command that needs authentication will walk you through setup automatically. Just run it and follow the prompts. You can also run `agent-vault vault service set` interactively, load from YAML with `agent-vault vault service set -f services.yaml`, or browse templates with `agent-vault catalog`.
 
 The server includes a web UI at `http://localhost:14321` for managing services, credentials, approving proposals, and inviting users and agents.

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -731,3 +731,83 @@ func TestCatalogFlagsRegistered(t *testing.T) {
 		t.Error("expected --address flag on catalog command")
 	}
 }
+
+func TestServerLogLevelFlag(t *testing.T) {
+	srvCmd := findSubcommand(rootCmd, "server")
+	if srvCmd == nil {
+		t.Fatal("server command not found")
+	}
+	f := srvCmd.Flags().Lookup("log-level")
+	if f == nil {
+		t.Fatal("expected --log-level flag on server command")
+	}
+	if f.DefValue != "info" {
+		t.Errorf("expected --log-level default to be info, got %q", f.DefValue)
+	}
+	if f.Shorthand != "" {
+		t.Errorf("expected no shorthand for --log-level, got %q", f.Shorthand)
+	}
+}
+
+func TestResolveLogLevel(t *testing.T) {
+	// Isolate from any ambient env var in the developer's shell.
+	t.Setenv("AGENT_VAULT_LOG_LEVEL", "")
+
+	cases := []struct {
+		name        string
+		flag        string
+		changed     bool
+		env         string
+		wantLevel   string // "info" | "debug"
+		wantErr     bool
+	}{
+		{name: "default", flag: "info", changed: false, wantLevel: "info"},
+		{name: "flag_debug", flag: "debug", changed: true, wantLevel: "debug"},
+		{name: "flag_info_explicit", flag: "info", changed: true, wantLevel: "info"},
+		{name: "env_debug_no_flag", flag: "info", changed: false, env: "debug", wantLevel: "debug"},
+		{name: "env_info_no_flag", flag: "info", changed: false, env: "info", wantLevel: "info"},
+		{name: "flag_wins_over_env", flag: "info", changed: true, env: "debug", wantLevel: "info"},
+		{name: "case_insensitive", flag: "info", changed: false, env: "DEBUG", wantLevel: "debug"},
+		{name: "invalid_flag", flag: "verbose", changed: true, wantErr: true},
+		{name: "invalid_env", flag: "info", changed: false, env: "trace", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AGENT_VAULT_LOG_LEVEL", tc.env)
+			got, err := resolveLogLevel(tc.flag, tc.changed)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got level=%v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			gotName := "info"
+			if got.String() == "DEBUG" {
+				gotName = "debug"
+			}
+			if gotName != tc.wantLevel {
+				t.Errorf("got level %s, want %s", gotName, tc.wantLevel)
+			}
+		})
+	}
+}
+
+// Verify the cobra-level --log-level validation surfaces the error before
+// the command tries to open the DB or touch the master key.
+func TestServerLogLevelInvalidSurface(t *testing.T) {
+	_, err := executeCommand("server", "--log-level", "verbose")
+	if err == nil {
+		t.Fatal("expected error for invalid --log-level")
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("log level")) {
+		t.Errorf("expected error to mention log level, got %v", err)
+	}
+	// Reset cobra state for the next test; the rootCmd retains flag values.
+	if sc := findSubcommand(rootCmd, "server"); sc != nil {
+		_ = sc.Flags().Set("log-level", "info")
+	}
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -29,6 +30,33 @@ import (
 
 const maxPasswordAttempts = 3
 
+// resolveLogLevel turns the --log-level flag (or AGENT_VAULT_LOG_LEVEL env
+// fallback) into a slog.Level. Flag wins if explicitly set. Accepts "info"
+// and "debug" only — anything else is rejected with a clear error.
+// flagChanged indicates whether the user passed --log-level explicitly.
+func resolveLogLevel(flagValue string, flagChanged bool) (slog.Level, error) {
+	value := flagValue
+	if !flagChanged {
+		if env := os.Getenv("AGENT_VAULT_LOG_LEVEL"); env != "" {
+			value = env
+		}
+	}
+	switch strings.ToLower(value) {
+	case "", "info":
+		return slog.LevelInfo, nil
+	case "debug":
+		return slog.LevelDebug, nil
+	default:
+		return 0, fmt.Errorf("invalid log level %q (accepted: info, debug)", value)
+	}
+}
+
+// buildLogger constructs the process-wide slog logger. Text handler to
+// stderr keeps it readable in a terminal without a dependency bump.
+func buildLogger(level slog.Level) *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+}
+
 var serverCmd = &cobra.Command{
 	Use:   "server",
 	Short: "Start an Agent Vault server",
@@ -37,11 +65,19 @@ var serverCmd = &cobra.Command{
 		host, _ := cmd.Flags().GetString("host")
 		detach, _ := cmd.Flags().GetBool("detach")
 		mitmPort, _ := cmd.Flags().GetInt("mitm-port")
+		logLevelFlag, _ := cmd.Flags().GetString("log-level")
+		logLevelChanged := cmd.Flags().Changed("log-level")
 		addr := fmt.Sprintf("%s:%d", host, port)
+
+		logLevel, err := resolveLogLevel(logLevelFlag, logLevelChanged)
+		if err != nil {
+			return err
+		}
+		logger := buildLogger(logLevel)
 
 		// --- Detached child path: read master key + initialized flag from stdin pipe ---
 		if os.Getenv("_AGENT_VAULT_DETACHED") == "1" {
-			return runDetachedChild(host, addr, mitmPort)
+			return runDetachedChild(host, addr, mitmPort, logger)
 		}
 
 		dbPath, err := store.DefaultDBPath()
@@ -81,7 +117,11 @@ var serverCmd = &cobra.Command{
 		}
 
 		if detach {
-			return spawnDetached(cmd, masterKey, initialized, host, port, mitmPort, addr)
+			var explicitLogLevel *string
+			if logLevelChanged {
+				explicitLogLevel = &logLevelFlag
+			}
+			return spawnDetached(cmd, masterKey, initialized, host, port, mitmPort, addr, explicitLogLevel)
 		}
 
 		// --- Foreground path ---
@@ -94,7 +134,7 @@ var serverCmd = &cobra.Command{
 		_ = os.Unsetenv("AGENT_VAULT_SMTP_PASSWORD")
 		notifier := notify.New(smtpCfg)
 		oauthProviders := loadOAuthProviders(baseURL)
-		srv := server.New(addr, db, masterKey.Key(), notifier, initialized, baseURL, oauthProviders)
+		srv := server.New(addr, db, masterKey.Key(), notifier, initialized, baseURL, oauthProviders, logger)
 		srv.SetSkills(skillCLI, skillHTTP)
 		if err := attachMITMIfEnabled(srv, host, mitmPort, masterKey.Key()); err != nil {
 			return err
@@ -125,6 +165,7 @@ func attachMITMIfEnabled(srv *server.Server, host string, mitmPort int, masterKe
 		caProv,
 		srv.SessionResolver(),
 		srv.CredentialProvider(),
+		srv.Logger(),
 	))
 	return nil
 }
@@ -309,7 +350,7 @@ func readPasswordFromStdin() ([]byte, error) {
 
 // runDetachedChild is the entry point for the detached child process.
 // It reads 33 bytes from stdin: 32-byte master key + 1-byte initialized flag.
-func runDetachedChild(host, addr string, mitmPort int) error {
+func runDetachedChild(host, addr string, mitmPort int, logger *slog.Logger) error {
 	buf := make([]byte, 33)
 	if _, err := io.ReadFull(os.Stdin, buf); err != nil {
 		return fmt.Errorf("reading master key from pipe: %w", err)
@@ -336,7 +377,7 @@ func runDetachedChild(host, addr string, mitmPort int) error {
 	_ = os.Unsetenv("AGENT_VAULT_SMTP_PASSWORD")
 	notifier := notify.New(smtpCfg)
 	oauthProviders := loadOAuthProviders(baseURL)
-	srv := server.New(addr, db, key, notifier, initialized, baseURL, oauthProviders)
+	srv := server.New(addr, db, key, notifier, initialized, baseURL, oauthProviders, logger)
 	srv.SetSkills(skillCLI, skillHTTP)
 	if err := attachMITMIfEnabled(srv, host, mitmPort, key); err != nil {
 		return err
@@ -345,7 +386,9 @@ func runDetachedChild(host, addr string, mitmPort int) error {
 }
 
 // spawnDetached re-execs the server as a background process, passing the master key + initialized flag via a pipe.
-func spawnDetached(cmd *cobra.Command, masterKey *auth.MasterKey, initialized bool, host string, port, mitmPort int, addr string) error {
+// explicitLogLevel, when non-nil, forwards the parent's --log-level flag to the child so a flag-only
+// invocation (no env var) still takes effect after re-exec.
+func spawnDetached(cmd *cobra.Command, masterKey *auth.MasterKey, initialized bool, host string, port, mitmPort int, addr string, explicitLogLevel *string) error {
 	defer masterKey.Wipe()
 
 	// Check if a server is already running.
@@ -379,6 +422,9 @@ func spawnDetached(cmd *cobra.Command, masterKey *auth.MasterKey, initialized bo
 	}
 
 	childArgs := []string{"server", "--port", strconv.Itoa(port), "--host", host, "--mitm-port", strconv.Itoa(mitmPort)}
+	if explicitLogLevel != nil {
+		childArgs = append(childArgs, "--log-level", *explicitLogLevel)
+	}
 	child := exec.Command(exe, childArgs...)
 	child.Stdin = pr
 	child.Stdout = logFile
@@ -511,6 +557,7 @@ func init() {
 	serverCmd.Flags().BoolP("detach", "d", false, "run server in background after unlocking")
 	serverCmd.Flags().Bool("password-stdin", false, "read master password from stdin (for non-interactive use)")
 	serverCmd.Flags().Int("mitm-port", DefaultMITMPort, "port for the transparent MITM proxy (0 = disabled)")
+	serverCmd.Flags().String("log-level", "info", "log level: info (default) or debug (per-request proxy logs)")
 	serverCmd.AddCommand(stopCmd)
 	rootCmd.AddCommand(serverCmd)
 }

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -22,12 +22,14 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `-d`, `--detach` | `false` | Run in background (detached) mode |
     | `--password-stdin` | `false` | Read master password from stdin |
     | `--mitm-port` | `14322` | Port for the transparent MITM proxy. Enabled by default; set to `0` to disable. On first launch the root CA is created under `~/.agent-vault/ca/` — clients fetch it with [`agent-vault ca fetch`](#ca). Bind failures are non-fatal. |
+    | `--log-level` | `info` | Log level: `info` (default) or `debug`. At `debug`, emits one structured line per proxied request on stderr covering method, host, path, matched service, injected credential key names, upstream status, and duration. Credential **values** are never logged. |
 
     **Environment variables:**
 
     | Variable | Description |
     |----------|-------------|
     | `AGENT_VAULT_MASTER_PASSWORD` | Master password for encrypting credentials at rest |
+    | `AGENT_VAULT_LOG_LEVEL` | Fallback for `--log-level` when the flag is not set. Accepts `info` or `debug`. |
     | `AGENT_VAULT_ADDR` | Externally-reachable base URL (e.g. `https://agent-vault.example.com`). Used for links in emails, invites, and discovery. Falls back to `http://{host}:{port}` if unset. |
     | `AGENT_VAULT_OAUTH_GOOGLE_CLIENT_ID` | Google OAuth client ID. When both this and the client secret are set, Google OAuth is enabled. |
     | `AGENT_VAULT_OAUTH_GOOGLE_CLIENT_SECRET` | Google OAuth client secret |

--- a/docs/self-hosting/environment-variables.mdx
+++ b/docs/self-hosting/environment-variables.mdx
@@ -11,6 +11,7 @@ description: "All environment variables used to configure Agent Vault"
 | `AGENT_VAULT_ADDR` | `http://{host}:{port}` | Externally-reachable base URL. Used for generating links in emails, invites, and discovery responses. |
 | `AGENT_VAULT_NETWORK_MODE` | `public` | Proxy network restriction mode. `public` blocks connections to private/reserved IP ranges (RFC-1918, link-local, cloud metadata). `private` allows all outbound connections including private ranges — use this for local/private deployments where the proxy needs to reach internal services. |
 | `AGENT_VAULT_TRUSTED_PROXIES` | (unset) | Comma-separated CIDR ranges of trusted reverse proxies (e.g. `10.0.0.0/8,172.16.0.0/12`). When set, `X-Forwarded-For` is only trusted if the direct connection comes from a listed proxy. Used for rate limiting and audit logging behind a load balancer. |
+| `AGENT_VAULT_LOG_LEVEL` | `info` | Log level for the server. `info` (default) keeps startup banners and warnings only. `debug` adds one structured line per proxied request (ingress path, method, host, path, matched service, injected credential **key names**, upstream status, duration). Credential values are never logged. The `--log-level` flag takes precedence when set. |
 
 Master password resolution order:
 

--- a/internal/brokercore/credential.go
+++ b/internal/brokercore/credential.go
@@ -16,8 +16,18 @@ import (
 type InjectResult struct {
 	// Headers is the map of header name → value to overlay on the outbound
 	// request. Caller must Set (not Add) to ensure injected values win over
-	// any client-supplied duplicates.
+	// any client-supplied duplicates. Values are SECRET — never log.
 	Headers map[string]string
+
+	// MatchedHost is the broker service host pattern that matched the
+	// target (e.g. "api.github.com"). Safe to log.
+	MatchedHost string
+
+	// CredentialKeys are the upper-snake-case credential key names the
+	// matched service references. These are names, not values — safe to
+	// log. Populated before credential resolution, so a credential-missing
+	// failure still carries this metadata.
+	CredentialKeys []string
 }
 
 // CredentialProvider resolves a broker service for targetHost inside vaultID
@@ -69,6 +79,13 @@ func (p *StoreCredentialProvider) Inject(ctx context.Context, vaultID, targetHos
 		return nil, ErrServiceNotFound
 	}
 
+	// Capture non-secret metadata up front so a downstream credential-missing
+	// error still carries it for the caller (e.g. for debug logging).
+	result := &InjectResult{
+		MatchedHost:    matched.Host,
+		CredentialKeys: matched.Auth.CredentialKeys(),
+	}
+
 	headers, err := matched.Auth.Resolve(func(key string) (string, error) {
 		cred, err := p.Store.GetCredential(ctx, vaultID, key)
 		if err != nil || cred == nil {
@@ -81,8 +98,9 @@ func (p *StoreCredentialProvider) Inject(ctx context.Context, vaultID, targetHos
 		return string(plaintext), nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrCredentialMissing, err)
+		return result, fmt.Errorf("%w: %v", ErrCredentialMissing, err)
 	}
 
-	return &InjectResult{Headers: headers}, nil
+	result.Headers = headers
+	return result, nil
 }

--- a/internal/brokercore/logging.go
+++ b/internal/brokercore/logging.go
@@ -1,0 +1,67 @@
+package brokercore
+
+import (
+	"log/slog"
+	"time"
+)
+
+// ProxyEvent is the shape of a single structured per-request log line
+// emitted by both the explicit /proxy/ handler and the transparent MITM
+// forward handler. It is intentionally shallow and contains only
+// non-secret metadata — no header values, no bodies, no query strings.
+type ProxyEvent struct {
+	Ingress        string   // "explicit" | "mitm"
+	Method         string   // HTTP method from the agent request
+	Host           string   // target host (with port if present)
+	Path           string   // r.URL.Path only — no query, no fragment
+	MatchedService string   // broker service host that matched, or "" if none
+	CredentialKeys []string // upper-snake credential key names only
+	Status         int      // upstream status; 0 if never dispatched
+	TotalMs        int64    // handler entry → emit, in milliseconds
+	Err            string   // short error code, or "" on success
+}
+
+// Emit fills in the terminal fields (Status, Err, TotalMs measured from
+// start) and writes the event at Debug level. Shared by both ingress
+// paths so the log-line shape stays consistent.
+func (e *ProxyEvent) Emit(logger *slog.Logger, start time.Time, status int, errCode string) {
+	e.Status = status
+	e.Err = errCode
+	e.TotalMs = time.Since(start).Milliseconds()
+	LogProxyEvent(logger, *e)
+}
+
+// LogProxyEvent emits e at Debug level on logger. Handler-level filtering
+// in slog means info-level runs drop these lines at effectively zero cost.
+// Safe to call with a nil logger (no-op) so handlers don't have to guard.
+func LogProxyEvent(logger *slog.Logger, e ProxyEvent) {
+	if logger == nil {
+		return
+	}
+	logger.Debug("proxy_request",
+		slog.String("ingress", e.Ingress),
+		slog.String("method", e.Method),
+		slog.String("host", e.Host),
+		slog.String("path", e.Path),
+		slog.String("matched_service", e.MatchedService),
+		slog.Any("credential_keys", e.CredentialKeys),
+		slog.Int("status", e.Status),
+		slog.Int64("total_ms", e.TotalMs),
+		slog.String("err", e.Err),
+	)
+}
+
+// LogCredentialMissing emits the operator-visible Warn line when a host
+// matched a service but the referenced credential couldn't be resolved.
+// Kept at info-level (Warn) because it's a user-actionable misconfig, not
+// a debug signal. Secret-free: only vault id, service host, and key names.
+func LogCredentialMissing(logger *slog.Logger, vaultID, service string, keys []string) {
+	if logger == nil {
+		return
+	}
+	logger.Warn("credential resolution failed",
+		"vault", vaultID,
+		"service", service,
+		"credential_keys", keys,
+	)
+}

--- a/internal/brokercore/logging_test.go
+++ b/internal/brokercore/logging_test.go
@@ -1,0 +1,221 @@
+package brokercore
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/Infisical/agent-vault/internal/broker"
+)
+
+// randomSentinel returns a long, lowercase, hyphen-prefixed token whose
+// character class cannot collide with UPPER_SNAKE_CASE credential key
+// names. This matters for the redaction assertion: a naive sentinel like
+// "SECRET_12345" could be a substring of a key name and produce a false
+// positive when the log contains the key.
+func randomSentinel(t *testing.T) string {
+	t.Helper()
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return "sentinel-" + strings.ToLower(base64.RawURLEncoding.EncodeToString(b))
+}
+
+// TestLogProxyEvent_NoSecretLeak proves the debug log line never contains
+// the resolved credential value across all four broker auth types — the
+// core redaction guardrail called out in the plan.
+func TestLogProxyEvent_NoSecretLeak(t *testing.T) {
+	encKey := make32(0xAB)
+
+	cases := []struct {
+		name         string
+		auth         broker.Auth
+		expectedKeys []string
+	}{
+		{
+			name:         "bearer",
+			auth:         broker.Auth{Type: "bearer", Token: "BEARER_TOKEN"},
+			expectedKeys: []string{"BEARER_TOKEN"},
+		},
+		{
+			name:         "basic",
+			auth:         broker.Auth{Type: "basic", Username: "BASIC_USER", Password: "BASIC_PASS"},
+			expectedKeys: []string{"BASIC_USER", "BASIC_PASS"},
+		},
+		{
+			name:         "api_key",
+			auth:         broker.Auth{Type: "api-key", Key: "APIKEY_SECRET", Header: "X-Api-Key"},
+			expectedKeys: []string{"APIKEY_SECRET"},
+		},
+		{
+			name: "custom",
+			auth: broker.Auth{
+				Type: "custom",
+				Headers: map[string]string{
+					"X-Token":  "Bearer {{ CUSTOM_TOKEN }}",
+					"X-Second": "{{ CUSTOM_SECOND }}",
+				},
+			},
+			expectedKeys: []string{"CUSTOM_TOKEN", "CUSTOM_SECOND"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeCredStore()
+			f.setServices(t, "v1", []broker.Service{{Host: "api.example.com", Auth: tc.auth}})
+
+			sentinels := make(map[string]string, len(tc.expectedKeys))
+			for _, k := range tc.expectedKeys {
+				s := randomSentinel(t)
+				sentinels[k] = s
+				f.setCred(t, encKey, "v1", k, s)
+			}
+
+			provider := NewStoreCredentialProvider(f, encKey)
+			result, err := provider.Inject(context.Background(), "v1", "api.example.com")
+			if err != nil {
+				t.Fatalf("Inject: %v", err)
+			}
+			if result.MatchedHost != "api.example.com" {
+				t.Errorf("MatchedHost = %q, want api.example.com", result.MatchedHost)
+			}
+
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+			LogProxyEvent(logger, ProxyEvent{
+				Ingress:        "explicit",
+				Method:         "GET",
+				Host:           "api.example.com",
+				Path:           "/v1/users",
+				MatchedService: result.MatchedHost,
+				CredentialKeys: result.CredentialKeys,
+				Status:         200,
+				TotalMs:        42,
+			})
+
+			out := buf.String()
+			if len(out) == 0 {
+				t.Fatal("expected log output, got empty buffer (log path did not fire)")
+			}
+			for key, sentinel := range sentinels {
+				if strings.Contains(out, sentinel) {
+					t.Errorf("credential value for %s leaked into log output: %q\nfull log: %s", key, sentinel, out)
+				}
+				if !strings.Contains(out, key) {
+					t.Errorf("expected key name %s in log output, got: %s", key, out)
+				}
+			}
+		})
+	}
+}
+
+// TestLogProxyEvent_CredentialMissingCarriesMetadata verifies that even
+// when credential resolution fails, the InjectResult still carries the
+// matched service + credential key names so the log line remains useful.
+func TestLogProxyEvent_CredentialMissingCarriesMetadata(t *testing.T) {
+	encKey := make32(0xCD)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.example.com",
+		Auth: broker.Auth{Type: "bearer", Token: "MISSING_TOKEN"},
+	}})
+	// Deliberately don't seed MISSING_TOKEN — Resolve will fail.
+
+	provider := NewStoreCredentialProvider(f, encKey)
+	result, err := provider.Inject(context.Background(), "v1", "api.example.com")
+	if err == nil {
+		t.Fatal("expected ErrCredentialMissing, got nil")
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result even on credential miss")
+	}
+	if result.MatchedHost != "api.example.com" {
+		t.Errorf("MatchedHost = %q, want api.example.com", result.MatchedHost)
+	}
+	if len(result.CredentialKeys) != 1 || result.CredentialKeys[0] != "MISSING_TOKEN" {
+		t.Errorf("CredentialKeys = %v, want [MISSING_TOKEN]", result.CredentialKeys)
+	}
+}
+
+// TestLogProxyEvent_Shape verifies the structured field shape of the
+// emitted line, including empty-match and mitm-ingress variants.
+func TestLogProxyEvent_Shape(t *testing.T) {
+	cases := []struct {
+		name  string
+		event ProxyEvent
+		want  []string
+	}{
+		{
+			name: "explicit_success",
+			event: ProxyEvent{
+				Ingress: "explicit", Method: "GET", Host: "api.example.com",
+				Path: "/v1/users", MatchedService: "api.example.com",
+				CredentialKeys: []string{"API_KEY"}, Status: 200, TotalMs: 17,
+			},
+			want: []string{
+				"ingress=explicit",
+				"method=GET",
+				"status=200",
+				"matched_service=api.example.com",
+				"API_KEY",
+			},
+		},
+		{
+			name: "mitm_no_match",
+			event: ProxyEvent{
+				Ingress: "mitm", Method: "POST", Host: "unknown.example.com",
+				Path: "/", Status: 403, TotalMs: 3, Err: "no_match",
+			},
+			want: []string{
+				"ingress=mitm",
+				"err=no_match",
+				"status=403",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			LogProxyEvent(logger, tc.event)
+			out := buf.String()
+			if !strings.Contains(out, "proxy_request") {
+				t.Errorf("missing proxy_request message in %q", out)
+			}
+			for _, needle := range tc.want {
+				if !strings.Contains(out, needle) {
+					t.Errorf("missing %q in log output: %s", needle, out)
+				}
+			}
+		})
+	}
+}
+
+// TestLogProxyEvent_InfoLevelSuppressed confirms that the default
+// info-level handler filters out the per-request debug line entirely.
+func TestLogProxyEvent_InfoLevelSuppressed(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	LogProxyEvent(logger, ProxyEvent{Ingress: "explicit", Status: 200})
+	if buf.Len() != 0 {
+		t.Errorf("expected zero output at info level, got: %s", buf.String())
+	}
+}
+
+// TestLogProxyEvent_NilLoggerSafe guards handlers passing a nil logger.
+func TestLogProxyEvent_NilLoggerSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic: %v", r)
+		}
+	}()
+	LogProxyEvent(nil, ProxyEvent{Ingress: "explicit"})
+}

--- a/internal/mitm/connect.go
+++ b/internal/mitm/connect.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"time"
@@ -74,7 +73,8 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	tlsConn := tls.Server(clientConn, tlsConf)
 	_ = tlsConn.SetDeadline(time.Now().Add(10 * time.Second))
 	if err := tlsConn.Handshake(); err != nil {
-		log.Printf("mitm: TLS handshake failed for %s: %v", host, err) // #nosec G706 -- host passes isValidHost, which rejects control chars and path separators
+		// err may carry TLS alert detail from the client — diagnostic, not secret.
+		p.logger.Warn("mitm TLS handshake failed", "host", host, "err", err.Error())
 		_ = tlsConn.Close()
 		return
 	}

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -39,7 +39,7 @@ func (p *Proxy) forwardHandler(target, host string, scope *brokercore.ProxyScope
 		outReq, err := http.NewRequestWithContext(r.Context(), r.Method, outURL.String(), r.Body)
 		if err != nil {
 			http.Error(w, "bad gateway", http.StatusBadGateway)
-			emit(http.StatusBadGateway, "bad_request")
+			emit(http.StatusBadGateway, "internal")
 			return
 		}
 		outReq.Host = host

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -1,9 +1,11 @@
 package mitm
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/Infisical/agent-vault/internal/brokercore"
 )
@@ -15,6 +17,17 @@ import (
 // handleConnect; scope is the vault context resolved at CONNECT time.
 func (p *Proxy) forwardHandler(target, host string, scope *brokercore.ProxyScope) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		event := brokercore.ProxyEvent{
+			Ingress: "mitm",
+			Method:  r.Method,
+			Host:    target,
+			Path:    r.URL.Path,
+		}
+		emit := func(status int, errCode string) {
+			event.Emit(p.logger, start, status, errCode)
+		}
+
 		outURL := &url.URL{
 			Scheme:   "https",
 			Host:     target,
@@ -26,6 +39,7 @@ func (p *Proxy) forwardHandler(target, host string, scope *brokercore.ProxyScope
 		outReq, err := http.NewRequestWithContext(r.Context(), r.Method, outURL.String(), r.Body)
 		if err != nil {
 			http.Error(w, "bad gateway", http.StatusBadGateway)
+			emit(http.StatusBadGateway, "bad_request")
 			return
 		}
 		outReq.Host = host
@@ -40,8 +54,20 @@ func (p *Proxy) forwardHandler(target, host string, scope *brokercore.ProxyScope
 		}
 
 		inject, err := p.creds.Inject(r.Context(), scope.VaultID, host)
+		if inject != nil {
+			event.MatchedService = inject.MatchedHost
+			event.CredentialKeys = inject.CredentialKeys
+		}
 		if err != nil {
+			errCode := "no_match"
+			status := http.StatusForbidden
+			if errors.Is(err, brokercore.ErrCredentialMissing) {
+				errCode = "credential_not_found"
+				status = http.StatusBadGateway
+				brokercore.LogCredentialMissing(p.logger, scope.VaultID, event.MatchedService, event.CredentialKeys)
+			}
 			brokercore.WriteInjectError(w, err, host, scope.VaultName)
+			emit(status, errCode)
 			return
 		}
 		for k, v := range inject.Headers {
@@ -51,6 +77,7 @@ func (p *Proxy) forwardHandler(target, host string, scope *brokercore.ProxyScope
 		resp, err := p.upstream.RoundTrip(outReq)
 		if err != nil {
 			http.Error(w, "bad gateway", http.StatusBadGateway)
+			emit(http.StatusBadGateway, "upstream_error")
 			return
 		}
 		defer func() { _ = resp.Body.Close() }()
@@ -65,5 +92,6 @@ func (p *Proxy) forwardHandler(target, host string, scope *brokercore.ProxyScope
 		}
 		w.WriteHeader(resp.StatusCode)
 		_, _ = io.Copy(w, io.LimitReader(resp.Body, brokercore.MaxResponseBytes))
+		emit(resp.StatusCode, "")
 	})
 }

--- a/internal/mitm/proxy.go
+++ b/internal/mitm/proxy.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"sync/atomic"
@@ -32,13 +33,14 @@ type Proxy struct {
 	httpServer  *http.Server
 	upstream    *http.Transport
 	isListening atomic.Bool
+	logger      *slog.Logger
 }
 
 // New builds a Proxy bound to addr using caProv for leaf certificates and
 // the brokercore sessions/creds for authentication and credential injection.
 // The returned Proxy does not begin listening until ListenAndServe is
-// called.
-func New(addr string, caProv ca.Provider, sessions brokercore.SessionResolver, creds brokercore.CredentialProvider) *Proxy {
+// called. logger must be non-nil; tests can pass slog.New(slog.DiscardHandler).
+func New(addr string, caProv ca.Provider, sessions brokercore.SessionResolver, creds brokercore.CredentialProvider, logger *slog.Logger) *Proxy {
 	upstream := &http.Transport{
 		DialContext:           netguard.SafeDialContext(netguard.ModeFromEnv()),
 		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
@@ -54,6 +56,7 @@ func New(addr string, caProv ca.Provider, sessions brokercore.SessionResolver, c
 		sessions: sessions,
 		creds:    creds,
 		upstream: upstream,
+		logger:   logger,
 	}
 
 	p.httpServer = &http.Server{

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -96,7 +97,7 @@ func setupProxy(t *testing.T, sr brokercore.SessionResolver, cp brokercore.Crede
 		t.Fatal("failed to load CA root PEM into pool")
 	}
 
-	p = New("127.0.0.1:0", caProv, sr, cp)
+	p = New("127.0.0.1:0", caProv, sr, cp, slog.New(slog.DiscardHandler))
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/server/handle_mitm_test.go
+++ b/internal/server/handle_mitm_test.go
@@ -29,7 +29,7 @@ func TestHandleMITMCA(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ca.New: %v", err)
 		}
-		p := mitm.New("127.0.0.1:0", caProv, srv.SessionResolver(), srv.CredentialProvider())
+		p := mitm.New("127.0.0.1:0", caProv, srv.SessionResolver(), srv.CredentialProvider(), srv.Logger())
 		srv.AttachMITM(p)
 
 		// Start the proxy so IsListening() reports true. The handler gates
@@ -111,7 +111,7 @@ func TestHandleMITMCA(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ca.New: %v", err)
 		}
-		p := mitm.New("127.0.0.1:0", caProv, srv.SessionResolver(), srv.CredentialProvider())
+		p := mitm.New("127.0.0.1:0", caProv, srv.SessionResolver(), srv.CredentialProvider(), srv.Logger())
 		srv.AttachMITM(p)
 		// Intentionally do not call Serve — simulates a bind failure.
 

--- a/internal/server/handle_proxy.go
+++ b/internal/server/handle_proxy.go
@@ -129,6 +129,9 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	event.Host = targetHost
+	// Log the upstream path, not the /proxy/{host}/... ingress path, so this
+	// field is directly comparable to the MITM ingress log line.
+	event.Path = "/" + remainingPath
 
 	// Validate targetHost is a safe hostname (no @, ?, #, spaces, control chars).
 	// This prevents userinfo injection (e.g. host@evil.com) in the outbound URL.

--- a/internal/server/handle_proxy.go
+++ b/internal/server/handle_proxy.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -105,23 +104,37 @@ func (s *Server) resolveVaultForSession(w http.ResponseWriter, r *http.Request, 
 }
 
 func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	event := brokercore.ProxyEvent{
+		Ingress: "explicit",
+		Method:  r.Method,
+		Path:    r.URL.Path,
+	}
+	emit := func(status int, errCode string) {
+		event.Emit(s.logger, start, status, errCode)
+	}
+
 	// 1. Parse target host and path from /proxy/{target_host}/{path...}
 	trimmed := strings.TrimPrefix(r.URL.Path, "/proxy/")
 	if trimmed == "" {
 		proxyError(w, http.StatusBadRequest, "bad_request", "Missing target host in proxy URL")
+		emit(http.StatusBadRequest, "bad_request")
 		return
 	}
 	// Split into host and remaining path.
 	targetHost, remainingPath, _ := strings.Cut(trimmed, "/")
 	if targetHost == "" {
 		proxyError(w, http.StatusBadRequest, "bad_request", "Missing target host in proxy URL")
+		emit(http.StatusBadRequest, "bad_request")
 		return
 	}
+	event.Host = targetHost
 
 	// Validate targetHost is a safe hostname (no @, ?, #, spaces, control chars).
 	// This prevents userinfo injection (e.g. host@evil.com) in the outbound URL.
 	if !isValidProxyHost(targetHost) {
 		proxyError(w, http.StatusBadRequest, "bad_request", "Invalid target host")
+		emit(http.StatusBadRequest, "bad_request")
 		return
 	}
 
@@ -131,20 +144,31 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 	sess := sessionFromContext(ctx)
 	if sess == nil {
 		proxyError(w, http.StatusForbidden, "forbidden", "Proxy requires an authenticated session")
+		emit(http.StatusForbidden, "forbidden")
 		return
 	}
 	ns, _, err := s.resolveVaultForSession(w, r, sess)
 	if err != nil {
+		emit(0, "vault_error")
 		return // error already written
 	}
 
 	// Resolve broker service + inject credentials.
 	inject, err := s.CredentialProvider().Inject(ctx, ns.ID, targetHost)
+	if inject != nil {
+		event.MatchedService = inject.MatchedHost
+		event.CredentialKeys = inject.CredentialKeys
+	}
 	if err != nil {
+		errCode := "no_match"
+		status := http.StatusForbidden
 		if errors.Is(err, brokercore.ErrCredentialMissing) {
-			fmt.Fprintf(os.Stderr, "[agent-vault] credential resolution failed for vault %s: %v\n", ns.ID, err)
+			errCode = "credential_not_found"
+			status = http.StatusBadGateway
+			brokercore.LogCredentialMissing(s.logger, ns.ID, event.MatchedService, event.CredentialKeys)
 		}
 		brokercore.WriteInjectError(w, err, targetHost, ns.Name)
+		emit(status, errCode)
 		return
 	}
 	resolved := inject.Headers
@@ -162,6 +186,7 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 	outReq, err := http.NewRequestWithContext(ctx, r.Method, targetURL, r.Body)
 	if err != nil {
 		proxyError(w, http.StatusInternalServerError, "internal", "Failed to create outbound request")
+		emit(http.StatusInternalServerError, "internal")
 		return
 	}
 
@@ -186,6 +211,7 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 		// Sanitize error — do not leak internal IPs or hostnames to the agent.
 		proxyError(w, http.StatusBadGateway, "upstream_error",
 			fmt.Sprintf("Failed to reach %s", targetHost))
+		emit(http.StatusBadGateway, "upstream_error")
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -203,4 +229,5 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(resp.StatusCode)
 	// Limit response body to prevent resource exhaustion.
 	_, _ = io.Copy(w, io.LimitReader(resp.Body, brokercore.MaxResponseBytes))
+	emit(resp.StatusCode, "")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -58,9 +59,10 @@ type Server struct {
 	initialized    bool   // true when at least one owner account exists
 	baseURL        string // externally-reachable base URL (e.g. "https://sb.example.com")
 	oauthProviders map[string]oauth.Provider
-	skillCLI       []byte      // embedded CLI skill content (served at GET /v1/skills/cli)
-	skillHTTP      []byte      // embedded HTTP skill content (served at GET /v1/skills/http)
-	mitm           *mitm.Proxy // transparent MITM proxy; nil only when --mitm-port 0
+	skillCLI       []byte       // embedded CLI skill content (served at GET /v1/skills/cli)
+	skillHTTP      []byte       // embedded HTTP skill content (served at GET /v1/skills/http)
+	mitm           *mitm.Proxy  // transparent MITM proxy; nil only when --mitm-port 0
+	logger         *slog.Logger // structured logger for per-request observability
 }
 
 // AttachMITM registers an optional transparent MITM proxy whose lifecycle
@@ -79,6 +81,11 @@ func (s *Server) SessionResolver() brokercore.SessionResolver {
 func (s *Server) CredentialProvider() brokercore.CredentialProvider {
 	return brokercore.NewStoreCredentialProvider(s.store, s.encKey)
 }
+
+// Logger returns the server's structured logger. Callers (e.g. the MITM
+// proxy constructed outside the server) use this to share a single logger
+// across ingress paths.
+func (s *Server) Logger() *slog.Logger { return s.logger }
 
 // Store is the persistence interface used by the server.
 type Store interface {
@@ -504,7 +511,8 @@ func limitBody(next http.HandlerFunc) http.HandlerFunc {
 // New creates a new Server listening on the given address.
 // The initialized parameter indicates whether at least one owner account exists.
 // When false, all endpoints except /health and POST /v1/init return 503.
-func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, initialized bool, baseURL string, oauthProviders map[string]oauth.Provider) *Server {
+// logger must be non-nil; tests can pass slog.New(slog.DiscardHandler).
+func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, initialized bool, baseURL string, oauthProviders map[string]oauth.Provider, logger *slog.Logger) *Server {
 	mux := http.NewServeMux()
 
 	// Initialize proxy client once (reads AGENT_VAULT_NETWORK_MODE after env is configured).
@@ -527,6 +535,7 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 		initialized:    initialized,
 		baseURL:        strings.TrimRight(baseURL, "/"),
 		oauthProviders: oauthProviders,
+		logger:         logger,
 	}
 
 	// Always available (no initialization required)

--- a/internal/server/testutil_test.go
+++ b/internal/server/testutil_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"log/slog"
+
 	"github.com/Infisical/agent-vault/internal/notify"
 )
 
@@ -15,7 +17,7 @@ type testServerOption func(*Server)
 //
 // Use option functions (withStore, withEncKey, etc.) to override defaults.
 func newTestServer(opts ...testServerOption) *Server {
-	srv := New("127.0.0.1:0", newMockStore(), make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil)
+	srv := New("127.0.0.1:0", newMockStore(), make([]byte, 32), nil, true, "http://127.0.0.1:14321", nil, slog.New(slog.DiscardHandler))
 	for _, opt := range opts {
 		opt(srv)
 	}


### PR DESCRIPTION
## Summary
- Adds `--log-level` (info|debug) + `AGENT_VAULT_LOG_LEVEL` env fallback on `agent-vault server`.
- At debug level, both ingress paths (explicit `/proxy/` and transparent MITM) emit one structured slog line per request: ingress, method, host, path, matched broker service, injected credential **key names**, upstream status, duration.
- Credential values never reach the logger — enforced by a redaction test that seeds random sentinels and asserts they are absent from the log output across all four broker auth types (bearer, basic, api-key, custom).
- `make dev` now defaults `AGENT_VAULT_LOG_LEVEL=debug` for local visibility; explicit shell/.env values still win.

## Notes
- Shared logger plumbed through `server.Server` and `mitm.Proxy` so the two ingress paths emit from a single handler.
- `--log-level` is forwarded to the detached child re-exec only when the user set the flag explicitly, so env-var-only setups keep working.
- Docs updated: [docs/reference/cli.mdx](docs/reference/cli.mdx), [docs/self-hosting/environment-variables.mdx](docs/self-hosting/environment-variables.mdx), [README.md](README.md), [CLAUDE.md](CLAUDE.md).

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] Redaction test covers all four auth types
- [ ] Manual: `agent-vault server --log-level debug`, issue a request through `/proxy/` and via `HTTPS_PROXY=http://localhost:14322`, confirm a debug line is emitted with no credential values
- [ ] Manual: invalid `--log-level verbose` surfaces a clear error before the DB is touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)