### PR TITLE
feat: route `vault run` child HTTPS through the MITM proxy by default

### DIFF
--- a/cmd/ca.go
+++ b/cmd/ca.go
@@ -6,33 +6,43 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 // fetchMITMCA requests the transparent-proxy root CA from the local server.
-// Returns (pem, true, nil) on 200, (nil, false, nil) on 404 (MITM disabled),
-// or an error for any other failure. Body is always drained before returning
-// so the underlying connection can be pooled.
-func fetchMITMCA(addr string) ([]byte, bool, error) {
+// Returns (pem, port, true, nil) on 200 where port is the MITM listener
+// port advertised by the server (0 if the server omitted the header, e.g.
+// an older build — callers should fall back to DefaultMITMPort in that
+// case). Returns (nil, 0, false, nil) on 404 (MITM disabled), or an error
+// for any other failure. Body is always drained before returning so the
+// underlying connection can be pooled.
+func fetchMITMCA(addr string) ([]byte, int, bool, error) {
 	resp, err := httpClient.Get(addr + "/v1/mitm/ca.pem")
 	if err != nil {
-		return nil, false, fmt.Errorf("could not reach server at %s: %w", addr, err)
+		return nil, 0, false, fmt.Errorf("could not reach server at %s: %w", addr, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, false, fmt.Errorf("reading response: %w", err)
+		return nil, 0, false, fmt.Errorf("reading response: %w", err)
 	}
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return body, true, nil
+		port := 0
+		if raw := resp.Header.Get("X-MITM-Port"); raw != "" {
+			if n, err := strconv.Atoi(raw); err == nil && n > 0 && n < 65536 {
+				port = n
+			}
+		}
+		return body, port, true, nil
 	case http.StatusNotFound:
-		return nil, false, nil
+		return nil, 0, false, nil
 	default:
-		return nil, false, fmt.Errorf("server returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, 0, false, fmt.Errorf("server returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 }
 
@@ -62,7 +72,7 @@ Examples:
 		addr := resolveAddress(cmd)
 		output, _ := cmd.Flags().GetString("output")
 
-		pem, enabled, err := fetchMITMCA(addr)
+		pem, _, enabled, err := fetchMITMCA(addr)
 		if err != nil {
 			return err
 		}

--- a/cmd/ca.go
+++ b/cmd/ca.go
@@ -11,6 +11,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// fetchMITMCA requests the transparent-proxy root CA from the local server.
+// Returns (pem, true, nil) on 200, (nil, false, nil) on 404 (MITM disabled),
+// or an error for any other failure. Body is always drained before returning
+// so the underlying connection can be pooled.
+func fetchMITMCA(addr string) ([]byte, bool, error) {
+	resp, err := httpClient.Get(addr + "/v1/mitm/ca.pem")
+	if err != nil {
+		return nil, false, fmt.Errorf("could not reach server at %s: %w", addr, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, false, fmt.Errorf("reading response: %w", err)
+	}
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return body, true, nil
+	case http.StatusNotFound:
+		return nil, false, nil
+	default:
+		return nil, false, fmt.Errorf("server returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+}
+
 var caCmd = &cobra.Command{
 	Use:   "ca",
 	Short: "Manage the transparent-proxy root CA certificate",
@@ -37,33 +62,22 @@ Examples:
 		addr := resolveAddress(cmd)
 		output, _ := cmd.Flags().GetString("output")
 
-		url := fmt.Sprintf("%s/v1/mitm/ca.pem", addr)
-		resp, err := httpClient.Get(url)
+		pem, enabled, err := fetchMITMCA(addr)
 		if err != nil {
-			return fmt.Errorf("could not reach server at %s: %w", addr, err)
+			return err
 		}
-		defer func() { _ = resp.Body.Close() }()
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("reading response: %w", err)
-		}
-
-		if resp.StatusCode == http.StatusNotFound {
-			return errors.New(strings.TrimSpace(string(body)))
-		}
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("server returned %d: %s", resp.StatusCode, string(body))
+		if !enabled {
+			return errors.New("MITM proxy is not enabled on this server")
 		}
 
 		if output != "" {
-			if err := os.WriteFile(output, body, 0o600); err != nil {
+			if err := os.WriteFile(output, pem, 0o600); err != nil {
 				return fmt.Errorf("writing %s: %w", output, err)
 			}
 			fmt.Fprintf(cmd.ErrOrStderr(), "%s Wrote CA cert to %s\n", successText("✓"), output)
 			return nil
 		}
-		_, _ = cmd.OutOrStdout().Write(body)
+		_, _ = cmd.OutOrStdout().Write(pem)
 		return nil
 	},
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,12 +38,13 @@ Environment variables always set on the child:
   AGENT_VAULT_VAULT          — vault the session is scoped to
 
 When the server's transparent MITM proxy is reachable (default), the child
-also inherits HTTPS_PROXY / HTTP_PROXY / NO_PROXY plus the root CA trust
-variables (SSL_CERT_FILE, NODE_EXTRA_CA_CERTS, REQUESTS_CA_BUNDLE,
-CURL_CA_BUNDLE, GIT_SSL_CAINFO) so standard HTTPS clients transparently
-route through the broker. The root CA PEM is written to
-~/.agent-vault/mitm-ca.pem. Pass --no-mitm to disable injection and rely
-solely on the explicit /proxy/{host}/{path} endpoint.
+also inherits HTTPS_PROXY / NO_PROXY plus the root CA trust variables
+(SSL_CERT_FILE, NODE_EXTRA_CA_CERTS, REQUESTS_CA_BUNDLE, CURL_CA_BUNDLE,
+GIT_SSL_CAINFO) so standard HTTPS clients transparently route through the
+broker. HTTP_PROXY is intentionally not set — the MITM proxy only handles
+HTTPS (CONNECT) and would 405 any plain http:// request. The root CA PEM
+is written to ~/.agent-vault/mitm-ca.pem. Pass --no-mitm to disable
+injection and rely solely on the explicit /proxy/{host}/{path} endpoint.
 
 Example:
   agent-vault vault run -- claude
@@ -94,7 +95,7 @@ Example:
 		// 6. Route the child's HTTPS traffic through the transparent MITM
 		//    proxy. Explicit /proxy stays available as a fallback.
 		if noMITM, _ := cmd.Flags().GetBool("no-mitm"); !noMITM {
-			newEnv, ok, err := augmentEnvWithMITM(env, addr, scopedToken, vault, "")
+			newEnv, mitmPort, ok, err := augmentEnvWithMITM(env, addr, scopedToken, vault, "")
 			switch {
 			case err != nil:
 				fmt.Fprintf(os.Stderr, "agent-vault: MITM setup failed (%v); continuing with explicit proxy only\n", err)
@@ -102,7 +103,7 @@ Example:
 				fmt.Fprintln(os.Stderr, "agent-vault: MITM proxy disabled on server; using explicit proxy only")
 			default:
 				env = newEnv
-				fmt.Fprintf(os.Stderr, "%s routing HTTPS through MITM proxy (127.0.0.1:%d)\n", successText("agent-vault:"), DefaultMITMPort)
+				fmt.Fprintf(os.Stderr, "%s routing HTTPS through MITM proxy (127.0.0.1:%d)\n", successText("agent-vault:"), mitmPort)
 			}
 		}
 
@@ -277,30 +278,76 @@ func fetchUserVaults(addr, token string) ([]string, error) {
 	return names, nil
 }
 
+// mitmInjectedKeys is the set of env keys augmentEnvWithMITM manages on
+// the child. Any pre-existing occurrence inherited from os.Environ() must
+// be stripped before the new values are appended — POSIX getenv returns
+// the *first* match in C code paths (glibc, curl, libcurl-backed Python),
+// so a stale corporate HTTPS_PROXY from the parent shell would otherwise
+// silently win and the MITM route would be bypassed entirely.
+var mitmInjectedKeys = map[string]struct{}{
+	"HTTPS_PROXY":         {},
+	"NO_PROXY":            {},
+	"SSL_CERT_FILE":       {},
+	"NODE_EXTRA_CA_CERTS": {},
+	"REQUESTS_CA_BUNDLE":  {},
+	"CURL_CA_BUNDLE":      {},
+	"GIT_SSL_CAINFO":      {},
+}
+
+// stripEnvKeys returns env with every entry whose key (the part before
+// '=') appears in keys removed. Case-sensitive, matching how the kernel
+// stores envp and how POSIX getenv looks keys up.
+func stripEnvKeys(env []string, keys map[string]struct{}) []string {
+	out := env[:0:len(env)]
+	for _, kv := range env {
+		i := strings.IndexByte(kv, '=')
+		if i < 0 {
+			out = append(out, kv)
+			continue
+		}
+		if _, drop := keys[kv[:i]]; drop {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
 // augmentEnvWithMITM extends env so the child transparently routes HTTPS
-// through the broker. Returns (env, false, nil) when the server has MITM
-// disabled. caPath is a test seam — pass "" for the default location.
-func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]string, bool, error) {
-	pem, enabled, err := fetchMITMCA(addr)
+// through the broker. Returns (env, 0, false, nil) when the server has
+// MITM disabled. The second return value is the port the server reported;
+// callers log it so operators see the actual listen port (not a constant).
+// caPath is a test seam — pass "" for the default location.
+//
+// Only HTTPS_PROXY is injected — not HTTP_PROXY. The MITM proxy handles
+// HTTP CONNECT only and returns 405 for every other method, so setting
+// HTTP_PROXY would route plain http:// requests into a dead end.
+func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]string, int, bool, error) {
+	pem, port, enabled, err := fetchMITMCA(addr)
 	if err != nil {
-		return env, false, err
+		return env, 0, false, err
 	}
 	if !enabled {
-		return env, false, nil
+		return env, 0, false, nil
+	}
+	if port == 0 {
+		// Older server that didn't advertise X-MITM-Port. Fall back to
+		// the compile-time default so upgrade paths don't hard-break.
+		port = DefaultMITMPort
 	}
 
 	if caPath == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return env, false, fmt.Errorf("resolve home dir: %w", err)
+			return env, 0, false, fmt.Errorf("resolve home dir: %w", err)
 		}
 		caPath = filepath.Join(home, ".agent-vault", "mitm-ca.pem")
 	}
 	if err := os.MkdirAll(filepath.Dir(caPath), 0o700); err != nil {
-		return env, false, fmt.Errorf("create CA dir: %w", err)
+		return env, 0, false, fmt.Errorf("create CA dir: %w", err)
 	}
 	if err := os.WriteFile(caPath, pem, 0o644); err != nil {
-		return env, false, fmt.Errorf("write CA: %w", err)
+		return env, 0, false, fmt.Errorf("write CA: %w", err)
 	}
 
 	mitmHost := "127.0.0.1"
@@ -312,12 +359,12 @@ func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]stri
 	proxyURL := (&url.URL{
 		Scheme: "http",
 		User:   url.UserPassword(token, vault),
-		Host:   fmt.Sprintf("%s:%d", mitmHost, DefaultMITMPort),
+		Host:   fmt.Sprintf("%s:%d", mitmHost, port),
 	}).String()
 
+	env = stripEnvKeys(env, mitmInjectedKeys)
 	env = append(env,
 		"HTTPS_PROXY="+proxyURL,
-		"HTTP_PROXY="+proxyURL,
 		"NO_PROXY=localhost,127.0.0.1",
 		"SSL_CERT_FILE="+caPath,
 		"NODE_EXTRA_CA_CERTS="+caPath,
@@ -325,7 +372,7 @@ func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]stri
 		"CURL_CA_BUNDLE="+caPath,
 		"GIT_SSL_CAINFO="+caPath,
 	)
-	return env, true, nil
+	return env, port, true, nil
 }
 
 // requestScopedSession calls the server to create a vault-scoped session

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -346,7 +346,10 @@ func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]stri
 	if err := os.MkdirAll(filepath.Dir(caPath), 0o700); err != nil {
 		return env, 0, false, fmt.Errorf("create CA dir: %w", err)
 	}
-	if err := os.WriteFile(caPath, pem, 0o644); err != nil {
+	// The parent directory is already 0o700 so anyone with read access to
+	// the file is also the file owner — 0o600 adds no real restriction,
+	// but keeps gosec G306 happy.
+	if err := os.WriteFile(caPath, pem, 0o600); err != nil {
 		return env, 0, false, fmt.Errorf("write CA: %w", err)
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -31,14 +32,23 @@ var runCmd = &cobra.Command{
 	Long: `Start an agent process (e.g. claude, agent, codex) with an Agent Vault session.
 Everything after -- is treated as the command to execute.
 
-The following environment variables are set on the child process:
+Environment variables always set on the child:
   AGENT_VAULT_SESSION_TOKEN  — vault-scoped bearer token for the Agent Vault server
-  AGENT_VAULT_ADDR           — base URL of the Agent Vault proxy endpoint
+  AGENT_VAULT_ADDR           — base URL of the Agent Vault HTTP control server
   AGENT_VAULT_VAULT          — vault the session is scoped to
+
+When the server's transparent MITM proxy is reachable (default), the child
+also inherits HTTPS_PROXY / HTTP_PROXY / NO_PROXY plus the root CA trust
+variables (SSL_CERT_FILE, NODE_EXTRA_CA_CERTS, REQUESTS_CA_BUNDLE,
+CURL_CA_BUNDLE, GIT_SSL_CAINFO) so standard HTTPS clients transparently
+route through the broker. The root CA PEM is written to
+~/.agent-vault/mitm-ca.pem. Pass --no-mitm to disable injection and rely
+solely on the explicit /proxy/{host}/{path} endpoint.
 
 Example:
   agent-vault vault run -- claude
-  agent-vault vault run --vault myproject -- claude`,
+  agent-vault vault run --vault myproject -- claude
+  agent-vault vault run --no-mitm -- claude`,
 	Args:                  cobra.MinimumNArgs(1),
 	DisableFlagsInUseLine: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -80,7 +90,23 @@ Example:
 			"AGENT_VAULT_ADDR="+addr,
 			"AGENT_VAULT_VAULT="+vault,
 		)
-		// 6. If the target command is a supported agent, offer to install the
+
+		// 6. Route the child's HTTPS traffic through the transparent MITM
+		//    proxy. Explicit /proxy stays available as a fallback.
+		if noMITM, _ := cmd.Flags().GetBool("no-mitm"); !noMITM {
+			newEnv, ok, err := augmentEnvWithMITM(env, addr, scopedToken, vault, "")
+			switch {
+			case err != nil:
+				fmt.Fprintf(os.Stderr, "agent-vault: MITM setup failed (%v); continuing with explicit proxy only\n", err)
+			case !ok:
+				fmt.Fprintln(os.Stderr, "agent-vault: MITM proxy disabled on server; using explicit proxy only")
+			default:
+				env = newEnv
+				fmt.Fprintf(os.Stderr, "%s routing HTTPS through MITM proxy (127.0.0.1:%d)\n", successText("agent-vault:"), DefaultMITMPort)
+			}
+		}
+
+		// 7. If the target command is a supported agent, offer to install the
 		//    Agent Vault skill (only when not already present).
 		if isClaudeCommand(args[0]) {
 			maybeInstallSkills("Claude Code", ".claude")
@@ -90,7 +116,7 @@ Example:
 			maybeInstallSkills("Codex", ".agents")
 		}
 
-		// 7. Confirm, then exec — replaces this process entirely so the child
+		// 8. Confirm, then exec — replaces this process entirely so the child
 		//    (e.g. Claude Code) gets direct terminal control.
 		fmt.Fprintf(os.Stderr, "%s agent-vault connected. Starting %s...\n\n", successText("agent-vault:"), boldText(args[0]))
 		return syscall.Exec(binary, args, env)
@@ -251,6 +277,57 @@ func fetchUserVaults(addr, token string) ([]string, error) {
 	return names, nil
 }
 
+// augmentEnvWithMITM extends env so the child transparently routes HTTPS
+// through the broker. Returns (env, false, nil) when the server has MITM
+// disabled. caPath is a test seam — pass "" for the default location.
+func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]string, bool, error) {
+	pem, enabled, err := fetchMITMCA(addr)
+	if err != nil {
+		return env, false, err
+	}
+	if !enabled {
+		return env, false, nil
+	}
+
+	if caPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return env, false, fmt.Errorf("resolve home dir: %w", err)
+		}
+		caPath = filepath.Join(home, ".agent-vault", "mitm-ca.pem")
+	}
+	if err := os.MkdirAll(filepath.Dir(caPath), 0o700); err != nil {
+		return env, false, fmt.Errorf("create CA dir: %w", err)
+	}
+	if err := os.WriteFile(caPath, pem, 0o644); err != nil {
+		return env, false, fmt.Errorf("write CA: %w", err)
+	}
+
+	mitmHost := "127.0.0.1"
+	if u, err := url.Parse(addr); err == nil {
+		if h := u.Hostname(); h != "" {
+			mitmHost = h
+		}
+	}
+	proxyURL := (&url.URL{
+		Scheme: "http",
+		User:   url.UserPassword(token, vault),
+		Host:   fmt.Sprintf("%s:%d", mitmHost, DefaultMITMPort),
+	}).String()
+
+	env = append(env,
+		"HTTPS_PROXY="+proxyURL,
+		"HTTP_PROXY="+proxyURL,
+		"NO_PROXY=localhost,127.0.0.1",
+		"SSL_CERT_FILE="+caPath,
+		"NODE_EXTRA_CA_CERTS="+caPath,
+		"REQUESTS_CA_BUNDLE="+caPath,
+		"CURL_CA_BUNDLE="+caPath,
+		"GIT_SSL_CAINFO="+caPath,
+	)
+	return env, true, nil
+}
+
 // requestScopedSession calls the server to create a vault-scoped session
 // and returns the scoped token.
 func requestScopedSession(addr, adminToken, vault, role string, ttlSeconds int) (string, error) {
@@ -303,6 +380,7 @@ func init() {
 	runCmd.Flags().String("address", "", "Agent Vault server address (defaults to session address)")
 	runCmd.Flags().String("role", "", "Vault role for the agent session (proxy, member, admin; default: proxy)")
 	runCmd.Flags().Int("ttl", 0, "Session TTL in seconds (300–604800; default: server default 24h)")
+	runCmd.Flags().Bool("no-mitm", false, "Skip HTTPS_PROXY/CA env injection for the child (explicit /proxy only)")
 
 	vaultCmd.AddCommand(runCmd)
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -42,12 +42,15 @@ func TestAugmentEnvWithMITM_Disabled(t *testing.T) {
 	caPath := filepath.Join(t.TempDir(), "mitm-ca.pem")
 	baseEnv := []string{"FOO=bar"}
 
-	env, ok, err := augmentEnvWithMITM(baseEnv, srv.URL, "av_sess_abc", "default", caPath)
+	env, port, ok, err := augmentEnvWithMITM(baseEnv, srv.URL, "av_sess_abc", "default", caPath)
 	if err != nil {
 		t.Fatalf("expected nil err on 404, got %v", err)
 	}
 	if ok {
 		t.Fatal("expected ok=false when server 404s")
+	}
+	if port != 0 {
+		t.Errorf("expected port=0 when disabled, got %d", port)
 	}
 	if len(env) != len(baseEnv) || env[0] != "FOO=bar" {
 		t.Errorf("env should be unchanged on 404, got %v", env)
@@ -57,21 +60,35 @@ func TestAugmentEnvWithMITM_Disabled(t *testing.T) {
 	}
 }
 
+// fakeMITMServer returns an httptest server that mimics the real
+// /v1/mitm/ca.pem endpoint. advertisedPort, when non-zero, is written
+// into the X-MITM-Port response header.
+func fakeMITMServer(t *testing.T, pem string, advertisedPort int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if advertisedPort > 0 {
+			w.Header().Set("X-MITM-Port", fmt.Sprintf("%d", advertisedPort))
+		}
+		w.Header().Set("Content-Type", "application/x-pem-file")
+		_, _ = w.Write([]byte(pem))
+	}))
+}
+
 func TestAugmentEnvWithMITM_Enabled(t *testing.T) {
 	const fakePEM = "-----BEGIN CERTIFICATE-----\nMIIFAKE\n-----END CERTIFICATE-----\n"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/x-pem-file")
-		_, _ = w.Write([]byte(fakePEM))
-	}))
+	srv := fakeMITMServer(t, fakePEM, 9001)
 	defer srv.Close()
 
 	caPath := filepath.Join(t.TempDir(), "mitm-ca.pem")
-	env, ok, err := augmentEnvWithMITM(nil, srv.URL, "av_sess_abc", "default", caPath)
+	env, port, ok, err := augmentEnvWithMITM(nil, srv.URL, "av_sess_abc", "default", caPath)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	if !ok {
 		t.Fatal("expected ok=true on 200")
+	}
+	if port != 9001 {
+		t.Errorf("port = %d, want 9001 (from X-MITM-Port header)", port)
 	}
 
 	got, err := os.ReadFile(caPath)
@@ -83,8 +100,7 @@ func TestAugmentEnvWithMITM_Enabled(t *testing.T) {
 	}
 
 	want := map[string]string{
-		"HTTP_PROXY":          "", // checked separately below
-		"HTTPS_PROXY":         "",
+		"HTTPS_PROXY":         "", // checked separately below
 		"NO_PROXY":            "localhost,127.0.0.1",
 		"SSL_CERT_FILE":       caPath,
 		"NODE_EXTRA_CA_CERTS": caPath,
@@ -104,13 +120,16 @@ func TestAugmentEnvWithMITM_Enabled(t *testing.T) {
 		}
 	}
 
+	// HTTP_PROXY must NOT be set — the MITM proxy is HTTPS-only and would
+	// return 405 for plain http:// requests routed through it.
+	if v, ok := vars["HTTP_PROXY"]; ok {
+		t.Errorf("HTTP_PROXY should not be set (MITM is HTTPS-only), got %q", v)
+	}
+
 	// Proxy URL must parse cleanly and carry token:vault userinfo.
 	proxyURL := vars["HTTPS_PROXY"]
 	if proxyURL == "" {
 		t.Fatal("HTTPS_PROXY not set")
-	}
-	if proxyURL != vars["HTTP_PROXY"] {
-		t.Errorf("HTTP_PROXY and HTTPS_PROXY should match, got %q vs %q", vars["HTTP_PROXY"], proxyURL)
 	}
 	u, err := url.Parse(proxyURL)
 	if err != nil {
@@ -128,13 +147,91 @@ func TestAugmentEnvWithMITM_Enabled(t *testing.T) {
 	if pw, _ := u.User.Password(); pw != "default" {
 		t.Errorf("proxy password (vault) = %q, want default", pw)
 	}
-	wantHost := fmt.Sprintf("127.0.0.1:%d", DefaultMITMPort)
-	if !strings.HasSuffix(u.Host, fmt.Sprintf(":%d", DefaultMITMPort)) {
-		t.Errorf("proxy host = %q, want suffix :%d", u.Host, DefaultMITMPort)
-	}
-	// httptest servers bind to 127.0.0.1, so the derived host should match.
+	// Host should use the advertised X-MITM-Port (9001), not the compile-time
+	// default — this guards the regression where --mitm-port 9000 produced
+	// a URL pointing at 14322.
+	wantHost := "127.0.0.1:9001"
 	if u.Host != wantHost {
 		t.Errorf("proxy host = %q, want %q", u.Host, wantHost)
+	}
+}
+
+// TestAugmentEnvWithMITM_PortFallback verifies that a server which does
+// not advertise X-MITM-Port (e.g. pre-v0.8 build) is still usable — the
+// client falls back to DefaultMITMPort rather than emitting a URL with
+// port 0.
+func TestAugmentEnvWithMITM_PortFallback(t *testing.T) {
+	const fakePEM = "-----BEGIN CERTIFICATE-----\nMIIFAKE\n-----END CERTIFICATE-----\n"
+	srv := fakeMITMServer(t, fakePEM, 0) // no header
+	defer srv.Close()
+
+	caPath := filepath.Join(t.TempDir(), "mitm-ca.pem")
+	_, port, ok, err := augmentEnvWithMITM(nil, srv.URL, "tok", "v", caPath)
+	if err != nil || !ok {
+		t.Fatalf("augmentEnvWithMITM: ok=%v err=%v", ok, err)
+	}
+	if port != DefaultMITMPort {
+		t.Errorf("port = %d, want fallback to DefaultMITMPort (%d)", port, DefaultMITMPort)
+	}
+}
+
+// TestAugmentEnvWithMITM_DedupesParentEnv guards the corporate-proxy
+// regression: if the parent shell already has HTTPS_PROXY / SSL_CERT_FILE
+// etc. set, C tooling (curl, libcurl-backed Python, git) reads the FIRST
+// matching envp entry via getenv — so the stale parent value would win
+// over the injected MITM value and bypass credential injection entirely.
+// The fix strips the parent entries before appending the new ones.
+func TestAugmentEnvWithMITM_DedupesParentEnv(t *testing.T) {
+	const fakePEM = "-----BEGIN CERTIFICATE-----\nMIIFAKE\n-----END CERTIFICATE-----\n"
+	srv := fakeMITMServer(t, fakePEM, 14322)
+	defer srv.Close()
+
+	caPath := filepath.Join(t.TempDir(), "mitm-ca.pem")
+	parentEnv := []string{
+		"FOO=bar",
+		"HTTPS_PROXY=http://corp-proxy:3128",
+		"NO_PROXY=internal.example.com",
+		"SSL_CERT_FILE=/etc/ssl/corp-ca.pem",
+		"NODE_EXTRA_CA_CERTS=/etc/ssl/corp-ca.pem",
+		"REQUESTS_CA_BUNDLE=/etc/ssl/corp-ca.pem",
+		"CURL_CA_BUNDLE=/etc/ssl/corp-ca.pem",
+		"GIT_SSL_CAINFO=/etc/ssl/corp-ca.pem",
+		"UNRELATED=keep-me",
+	}
+	env, _, ok, err := augmentEnvWithMITM(parentEnv, srv.URL, "tok", "v", caPath)
+	if err != nil || !ok {
+		t.Fatalf("augmentEnvWithMITM: ok=%v err=%v", ok, err)
+	}
+
+	// Each managed key must appear exactly once, and that single value
+	// must be the injected MITM value — not the stale parent value.
+	counts := map[string]int{}
+	for _, kv := range env {
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			counts[kv[:i]]++
+		}
+	}
+	for _, k := range []string{"HTTPS_PROXY", "NO_PROXY", "SSL_CERT_FILE", "NODE_EXTRA_CA_CERTS", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE", "GIT_SSL_CAINFO"} {
+		if counts[k] != 1 {
+			t.Errorf("%s appears %d times in env, want exactly 1 (POSIX getenv returns first match)", k, counts[k])
+		}
+	}
+
+	vars := envMap(env)
+	if vars["HTTPS_PROXY"] == "http://corp-proxy:3128" {
+		t.Error("HTTPS_PROXY still carries the parent corp-proxy value")
+	}
+	if !strings.Contains(vars["HTTPS_PROXY"], "127.0.0.1:14322") {
+		t.Errorf("HTTPS_PROXY = %q, want the MITM URL", vars["HTTPS_PROXY"])
+	}
+	if vars["SSL_CERT_FILE"] != caPath {
+		t.Errorf("SSL_CERT_FILE = %q, want %q", vars["SSL_CERT_FILE"], caPath)
+	}
+	if vars["UNRELATED"] != "keep-me" {
+		t.Error("unrelated parent env vars must be preserved")
+	}
+	if vars["FOO"] != "bar" {
+		t.Error("unrelated parent env vars must be preserved")
 	}
 }
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunFlagsRegistered(t *testing.T) {
+	vCmd := findSubcommand(rootCmd, "vault")
+	if vCmd == nil {
+		t.Fatal("vault command not found")
+	}
+	rCmd := findSubcommand(vCmd, "run")
+	if rCmd == nil {
+		t.Fatal("vault run subcommand not found")
+	}
+
+	for _, name := range []string{"address", "role", "ttl", "no-mitm"} {
+		if rCmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected vault run flag --%s to be registered", name)
+		}
+	}
+}
+
+func TestAugmentEnvWithMITM_Disabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/mitm/ca.pem" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("MITM proxy is not enabled on this server\n"))
+	}))
+	defer srv.Close()
+
+	caPath := filepath.Join(t.TempDir(), "mitm-ca.pem")
+	baseEnv := []string{"FOO=bar"}
+
+	env, ok, err := augmentEnvWithMITM(baseEnv, srv.URL, "av_sess_abc", "default", caPath)
+	if err != nil {
+		t.Fatalf("expected nil err on 404, got %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false when server 404s")
+	}
+	if len(env) != len(baseEnv) || env[0] != "FOO=bar" {
+		t.Errorf("env should be unchanged on 404, got %v", env)
+	}
+	if _, err := os.Stat(caPath); !os.IsNotExist(err) {
+		t.Errorf("expected no CA file on 404, stat err=%v", err)
+	}
+}
+
+func TestAugmentEnvWithMITM_Enabled(t *testing.T) {
+	const fakePEM = "-----BEGIN CERTIFICATE-----\nMIIFAKE\n-----END CERTIFICATE-----\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-pem-file")
+		_, _ = w.Write([]byte(fakePEM))
+	}))
+	defer srv.Close()
+
+	caPath := filepath.Join(t.TempDir(), "mitm-ca.pem")
+	env, ok, err := augmentEnvWithMITM(nil, srv.URL, "av_sess_abc", "default", caPath)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true on 200")
+	}
+
+	got, err := os.ReadFile(caPath)
+	if err != nil {
+		t.Fatalf("reading CA file: %v", err)
+	}
+	if string(got) != fakePEM {
+		t.Errorf("CA file contents mismatch:\nwant %q\n got %q", fakePEM, string(got))
+	}
+
+	want := map[string]string{
+		"HTTP_PROXY":          "", // checked separately below
+		"HTTPS_PROXY":         "",
+		"NO_PROXY":            "localhost,127.0.0.1",
+		"SSL_CERT_FILE":       caPath,
+		"NODE_EXTRA_CA_CERTS": caPath,
+		"REQUESTS_CA_BUNDLE":  caPath,
+		"CURL_CA_BUNDLE":      caPath,
+		"GIT_SSL_CAINFO":      caPath,
+	}
+	vars := envMap(env)
+	for k, v := range want {
+		got, ok := vars[k]
+		if !ok {
+			t.Errorf("missing env var %s", k)
+			continue
+		}
+		if v != "" && got != v {
+			t.Errorf("%s = %q, want %q", k, got, v)
+		}
+	}
+
+	// Proxy URL must parse cleanly and carry token:vault userinfo.
+	proxyURL := vars["HTTPS_PROXY"]
+	if proxyURL == "" {
+		t.Fatal("HTTPS_PROXY not set")
+	}
+	if proxyURL != vars["HTTP_PROXY"] {
+		t.Errorf("HTTP_PROXY and HTTPS_PROXY should match, got %q vs %q", vars["HTTP_PROXY"], proxyURL)
+	}
+	u, err := url.Parse(proxyURL)
+	if err != nil {
+		t.Fatalf("parse HTTPS_PROXY: %v", err)
+	}
+	if u.Scheme != "http" {
+		t.Errorf("proxy scheme = %q, want http", u.Scheme)
+	}
+	if u.User == nil {
+		t.Fatal("proxy URL missing userinfo")
+	}
+	if u.User.Username() != "av_sess_abc" {
+		t.Errorf("proxy username = %q, want av_sess_abc", u.User.Username())
+	}
+	if pw, _ := u.User.Password(); pw != "default" {
+		t.Errorf("proxy password (vault) = %q, want default", pw)
+	}
+	wantHost := fmt.Sprintf("127.0.0.1:%d", DefaultMITMPort)
+	if !strings.HasSuffix(u.Host, fmt.Sprintf(":%d", DefaultMITMPort)) {
+		t.Errorf("proxy host = %q, want suffix :%d", u.Host, DefaultMITMPort)
+	}
+	// httptest servers bind to 127.0.0.1, so the derived host should match.
+	if u.Host != wantHost {
+		t.Errorf("proxy host = %q, want %q", u.Host, wantHost)
+	}
+}
+
+func envMap(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, kv := range env {
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			m[kv[:i]] = kv[i+1:]
+		}
+	}
+	return m
+}

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -233,13 +233,14 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault run [flags] -- <command>
     ```
 
-    Wrap a process with Agent Vault environment variables. The child process receives `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT` in its environment.
+    Wrap a process with Agent Vault environment variables. The child process always receives `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT`. When the server's transparent MITM proxy is reachable (default), it also receives `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` plus CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`) pointing at `~/.agent-vault/mitm-ca.pem`, so standard HTTPS clients transparently route through the broker.
 
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--address` | | Server address override |
     | `--role` | `proxy` | Vault role for the session: `proxy`, `member`, or `admin` |
     | `--ttl` | `0` | Session TTL in seconds (300–604800). Default: server default (24h). |
+    | `--no-mitm` | `false` | Skip HTTPS_PROXY/CA env injection; rely solely on the explicit `/proxy/{host}/{path}` endpoint. |
   </Accordion>
 
   <Accordion title="agent-vault vault token">

--- a/internal/server/handle_mitm.go
+++ b/internal/server/handle_mitm.go
@@ -1,6 +1,9 @@
 package server
 
-import "net/http"
+import (
+	"net"
+	"net/http"
+)
 
 // handleMITMCA serves the transparent-proxy root CA certificate in PEM form.
 // Public (no auth): the CA is world-readable by design — clients install it
@@ -11,12 +14,19 @@ import "net/http"
 // nothing is accepting connections. Returning a PEM in that state would
 // lead operators to install a cert and configure HTTPS_PROXY for a port
 // that silently refuses connections.
+//
+// The X-MITM-Port response header advertises the port the proxy is bound
+// to. Clients (e.g. `agent-vault vault run`) use this instead of a
+// hardcoded default so non-standard --mitm-port values actually work.
 func (s *Server) handleMITMCA(w http.ResponseWriter, _ *http.Request) {
 	if s.mitm == nil || !s.mitm.IsListening() {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte("MITM proxy is not enabled on this server\n"))
 		return
+	}
+	if _, port, err := net.SplitHostPort(s.mitm.Addr()); err == nil && port != "" && port != "0" {
+		w.Header().Set("X-MITM-Port", port)
 	}
 	w.Header().Set("Content-Type", "application/x-pem-file")
 	w.Header().Set("Content-Disposition", `attachment; filename="agent-vault-ca.pem"`)

--- a/internal/server/handle_mitm_test.go
+++ b/internal/server/handle_mitm_test.go
@@ -80,6 +80,55 @@ func TestHandleMITMCA(t *testing.T) {
 		}
 	})
 
+	// Guards the contract relied on by `vault run`: the listening port must
+	// be advertised so clients can build HTTPS_PROXY pointing at the *real*
+	// port (not the compile-time default) when --mitm-port is non-standard.
+	t.Run("mitm_port_header", func(t *testing.T) {
+		srv := newTestServer()
+
+		masterKey := make([]byte, 32)
+		if _, err := rand.Read(masterKey); err != nil {
+			t.Fatalf("rand: %v", err)
+		}
+		caProv, err := ca.New(masterKey, ca.Options{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("ca.New: %v", err)
+		}
+		// Bind to an explicit non-default port so we can assert the
+		// header reflects the configured Addr rather than any constant.
+		p := mitm.New("127.0.0.1:19322", caProv, srv.SessionResolver(), srv.CredentialProvider(), srv.Logger())
+		srv.AttachMITM(p)
+
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = p.Serve(l)
+		}()
+		t.Cleanup(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			_ = p.Shutdown(ctx)
+			wg.Wait()
+		})
+		waitForListening(t, p)
+
+		req := httptest.NewRequest(http.MethodGet, "/v1/mitm/ca.pem", nil)
+		rec := httptest.NewRecorder()
+		srv.httpServer.Handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		if got := rec.Header().Get("X-MITM-Port"); got != "19322" {
+			t.Errorf("X-MITM-Port = %q, want 19322", got)
+		}
+	})
+
 	t.Run("mitm_disabled", func(t *testing.T) {
 		srv := newTestServer()
 


### PR DESCRIPTION
## Summary

- `vault run` now fetches the server's root CA via `/v1/mitm/ca.pem`, writes it to `~/.agent-vault/mitm-ca.pem`, and exports `HTTPS_PROXY` + standard CA-trust env vars (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`) so standard HTTPS clients in the child transparently route through the broker with credential injection — no per-service agent code needed.
- If the server returned 404 (MITM disabled via `--mitm-port 0`), the run degrades cleanly to today's explicit-proxy-only behavior. Opt out at will with `--no-mitm`.
- `/v1/mitm/ca.pem` GET + 404 handling is now a shared `fetchMITMCA` helper in [`cmd/ca.go`](cmd/ca.go), reused by the existing `ca fetch` command.

The original `AGENT_VAULT_SESSION_TOKEN` / `AGENT_VAULT_ADDR` / `AGENT_VAULT_VAULT` vars still ship, so explicit `/proxy/{host}/{path}` remains available as a fallback.

## Test plan

- [ ] `go test ./...` passes locally (cmd + server suites green).
- [ ] Default path: `./agent-vault server` (MITM on) + `./agent-vault vault run -- bash` → child env contains `HTTPS_PROXY`, `SSL_CERT_FILE`, etc. `curl https://api.github.com/user` inside the child gets credential injection.
- [ ] Opt-out: `./agent-vault vault run --no-mitm -- bash` → child has no `HTTPS_PROXY`, retains `AGENT_VAULT_*`.
- [ ] MITM disabled: `./agent-vault server --mitm-port 0` + `vault run -- bash` → stderr prints "MITM proxy disabled on server; using explicit proxy only", child has no `HTTPS_PROXY`.
- [ ] `agent-vault ca fetch` still works unchanged (uses the new shared helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)