### PR TITLE
feat: add passthrough auth type for allowlisting without credential injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Agents should not possess credentials. Agent Vault eliminates credential exfiltr
 
 Secret managers return credentials directly to the caller. This breaks down with AI agents, which are non-deterministic systems vulnerable to prompt injection that can be tricked into exfiltrating secrets.
 
-Agent Vault takes a different approach: **agents never see credentials at all**. Instead, they route HTTP requests through a local proxy that injects the right credentials at the network layer.
+Agent Vault takes a different approach: **Agent Vault never reveals vault-stored credentials to agents**. Instead, agents route HTTP requests through a local proxy that injects the right credentials at the network layer.
 
-- **Brokered access, not retrieval** - Your agent gets a token and a proxy URL. It sends requests to `proxy/{host}/{path}` and Agent Vault authenticates them. There is nothing to leak. [Learn more](https://docs.agent-vault.dev/learn/security)
+- **Brokered access, not retrieval** - Your agent gets a token and a proxy URL. It sends requests to `proxy/{host}/{path}` and Agent Vault authenticates them. Credentials stored in the vault are never returned to the agent. [Learn more](https://docs.agent-vault.dev/learn/security)
 - **Works with any agent** - Custom Python/TypeScript agents, sandboxed processes, coding agents (Claude Code, Cursor, Codex), anything that can make HTTP requests. [Learn more](https://docs.agent-vault.dev/quickstart)
 - **Self-service access** - Agents discover available services at runtime and [propose access](https://docs.agent-vault.dev/learn/proposals) for anything missing. You review and approve in your browser with one click.
 - **Encrypted at rest** - Credentials are encrypted with AES-256-GCM using an Argon2id-derived key. The master password never touches disk. [Learn more](https://docs.agent-vault.dev/learn/credentials)

--- a/cmd/proposal_create.go
+++ b/cmd/proposal_create.go
@@ -229,11 +229,35 @@ func buildAuthFromFlags(cmd *cobra.Command, authType string) (*broker.Auth, erro
 	case "custom":
 		return nil, fmt.Errorf("custom auth type requires JSON mode (-f); use flags for bearer, basic, or api-key")
 
+	case "passthrough":
+		if err := rejectCredentialFlags(cmd, "passthrough"); err != nil {
+			return nil, err
+		}
+
 	default:
 		return nil, fmt.Errorf("unsupported auth type %q (supported: %s)", authType, strings.Join(broker.SupportedAuthTypes, ", "))
 	}
 
 	return a, nil
+}
+
+// rejectCredentialFlags returns an error if any credential-related flag was
+// provided. Used by auth types like passthrough that accept no credentials.
+func rejectCredentialFlags(cmd *cobra.Command, authType string) error {
+	credFlags := []string{
+		"token-key",
+		"username-key",
+		"password-key",
+		"api-key-key",
+		"api-key-header",
+		"api-key-prefix",
+	}
+	for _, f := range credFlags {
+		if v, _ := cmd.Flags().GetString(f); v != "" {
+			return fmt.Errorf("--%s is not accepted for %s auth (no credential is injected)", f, authType)
+		}
+	}
+	return nil
 }
 
 func init() {
@@ -243,7 +267,7 @@ func init() {
 	// Flag-driven mode.
 	proposalCreateCmd.Flags().String("host", "", "target service host (e.g. api.stripe.com)")
 	proposalCreateCmd.Flags().String("description", "", "service description")
-	proposalCreateCmd.Flags().String("auth-type", "", "auth type: bearer, basic, api-key")
+	proposalCreateCmd.Flags().String("auth-type", "", "auth type: bearer, basic, api-key, passthrough")
 	proposalCreateCmd.Flags().String("token-key", "", "credential key for bearer auth")
 	proposalCreateCmd.Flags().String("username-key", "", "credential key for basic auth username")
 	proposalCreateCmd.Flags().String("password-key", "", "credential key for basic auth password")

--- a/cmd/proposal_create_test.go
+++ b/cmd/proposal_create_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newAuthFlagCmd returns a cobra.Command with all the auth-related flags
+// that proposal_create / service add define, so buildAuthFromFlags has
+// something to read from.
+func newAuthFlagCmd() *cobra.Command {
+	c := &cobra.Command{Use: "test"}
+	c.Flags().String("token-key", "", "")
+	c.Flags().String("username-key", "", "")
+	c.Flags().String("password-key", "", "")
+	c.Flags().String("api-key-key", "", "")
+	c.Flags().String("api-key-header", "", "")
+	c.Flags().String("api-key-prefix", "", "")
+	return c
+}
+
+func TestBuildAuthFromFlags_Passthrough(t *testing.T) {
+	cmd := newAuthFlagCmd()
+	auth, err := buildAuthFromFlags(cmd, "passthrough")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if auth.Type != "passthrough" {
+		t.Fatalf("type = %q, want passthrough", auth.Type)
+	}
+	// Every credential field must be empty.
+	if auth.Token != "" || auth.Username != "" || auth.Password != "" ||
+		auth.Key != "" || auth.Header != "" || auth.Prefix != "" ||
+		len(auth.Headers) > 0 {
+		t.Fatalf("passthrough auth should have no credential fields, got %+v", auth)
+	}
+}
+
+func TestBuildAuthFromFlags_PassthroughRejectsCredentialFlags(t *testing.T) {
+	cases := []struct {
+		flag  string
+		value string
+	}{
+		{"token-key", "FOO"},
+		{"username-key", "FOO"},
+		{"password-key", "FOO"},
+		{"api-key-key", "FOO"},
+		{"api-key-header", "X-Foo"},
+		{"api-key-prefix", "Bearer "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.flag, func(t *testing.T) {
+			cmd := newAuthFlagCmd()
+			if err := cmd.Flags().Set(tc.flag, tc.value); err != nil {
+				t.Fatalf("flag set: %v", err)
+			}
+			_, err := buildAuthFromFlags(cmd, "passthrough")
+			if err == nil {
+				t.Fatalf("expected error for --%s on passthrough", tc.flag)
+			}
+			if !strings.Contains(err.Error(), tc.flag) {
+				t.Fatalf("error should mention --%s, got %q", tc.flag, err.Error())
+			}
+		})
+	}
+}

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -317,7 +317,7 @@ func init() {
 	serviceAddCmd.Flags().StringP("file", "f", "", "Path to services YAML file (upsert mode)")
 	serviceAddCmd.Flags().String("host", "", "Target service host (e.g. api.stripe.com)")
 	serviceAddCmd.Flags().String("description", "", "Service description")
-	serviceAddCmd.Flags().String("auth-type", "", "Auth type: bearer, basic, api-key, custom")
+	serviceAddCmd.Flags().String("auth-type", "", "Auth type: bearer, basic, api-key, custom, passthrough")
 	serviceAddCmd.Flags().String("token-key", "", "Credential key for bearer auth")
 	serviceAddCmd.Flags().String("username-key", "", "Credential key for basic auth username")
 	serviceAddCmd.Flags().String("password-key", "", "Credential key for basic auth password")

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -101,13 +101,16 @@ When you get a `403` for a host not in discover, the response includes a `propos
 Agent Vault auth types:
 
 ```
-bearer    -- Authorization: Bearer <token>          {"auth": {"type": "bearer", "token": "SECRET_KEY"}}
-basic     -- HTTP Basic (user, optional password)    {"auth": {"type": "basic", "username": "API_KEY"}}
-api-key   -- key in a named header, optional prefix  {"auth": {"type": "api-key", "key": "SECRET", "header": "x-api-key"}}
-custom    -- freeform header templates               {"auth": {"type": "custom", "headers": {"X-Key": "{{ SECRET }}"}}}
+bearer      -- Authorization: Bearer <token>          {"auth": {"type": "bearer", "token": "SECRET_KEY"}}
+basic       -- HTTP Basic (user, optional password)    {"auth": {"type": "basic", "username": "API_KEY"}}
+api-key     -- key in a named header, optional prefix  {"auth": {"type": "api-key", "key": "SECRET", "header": "x-api-key"}}
+custom      -- freeform header templates               {"auth": {"type": "custom", "headers": {"X-Key": "{{ SECRET }}"}}}
+passthrough -- forward client headers, inject nothing  {"auth": {"type": "passthrough"}}
 ```
 
 Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic -- API key as username), Jira (basic -- email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
+
+**Passthrough** allowlists a host but does not store or inject a credential — the client's `Authorization` and other request headers flow through unchanged. Use it only when the operator has decided their client already holds the credential and wants netguard / audit / MITM coverage without putting the secret in the vault. For the default case (agent needs the credential from the vault), use one of the credentialed types above.
 
 ### Creating a Proposal
 
@@ -139,6 +142,7 @@ Flag-driven auth flags by type:
 - **bearer**: `--auth-type bearer --token-key CREDENTIAL_KEY`
 - **basic**: `--auth-type basic --username-key USER_KEY [--password-key PASS_KEY]`
 - **api-key**: `--auth-type api-key --api-key-key KEY [--api-key-header x-api-key] [--api-key-prefix "ApiKey "]`
+- **passthrough**: `--auth-type passthrough` (no credential flags; any credential flag is rejected)
 
 Other flags: `--description` (service description), `--user-message` (shown on browser approval page), `--credential KEY=description` (repeatable).
 

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -120,13 +120,16 @@ When you get a `403` for a host not in `/discover`, the response includes a `pro
 Agent Vault auth types:
 
 ```
-bearer    -- Authorization: Bearer <token>          {"auth": {"type": "bearer", "token": "SECRET_KEY"}}
-basic     -- HTTP Basic (user, optional password)    {"auth": {"type": "basic", "username": "API_KEY"}}
-api-key   -- key in a named header, optional prefix  {"auth": {"type": "api-key", "key": "SECRET", "header": "x-api-key"}}
-custom    -- freeform header templates               {"auth": {"type": "custom", "headers": {"X-Key": "{{ SECRET }}"}}}
+bearer      -- Authorization: Bearer <token>          {"auth": {"type": "bearer", "token": "SECRET_KEY"}}
+basic       -- HTTP Basic (user, optional password)    {"auth": {"type": "basic", "username": "API_KEY"}}
+api-key     -- key in a named header, optional prefix  {"auth": {"type": "api-key", "key": "SECRET", "header": "x-api-key"}}
+custom      -- freeform header templates               {"auth": {"type": "custom", "headers": {"X-Key": "{{ SECRET }}"}}}
+passthrough -- forward client headers, inject nothing  {"auth": {"type": "passthrough"}}
 ```
 
 Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic -- API key as username), Jira (basic -- email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
+
+**Passthrough** allowlists a host but does not store or inject a credential — the client's `Authorization` and other request headers flow through unchanged (hop-by-hop headers, `X-Vault`, and `Proxy-Authorization` are still stripped). Use it only when the operator has decided their client already holds the credential and wants netguard / audit / MITM coverage without putting the secret in the vault. For the default case (agent needs the credential from the vault), use one of the credentialed types above. Passthrough auth entries reject all credential fields (`token`, `username`, `password`, `key`, `header`, `prefix`, `headers`).
 
 ### Creating a Proposal
 
@@ -145,7 +148,7 @@ Content-Type: application/json
 
 Key fields:
 - `services[].action` -- `"set"` (upsert, needs `host` + `auth`) or `"delete"` (needs `host` only)
-- `services[].auth` -- authentication config. Types: `bearer` (`token`), `basic` (`username`, optional `password`), `api-key` (`key` + `header`, optional `prefix`), `custom` (`headers` map with `{{ KEY }}` templates)
+- `services[].auth` -- authentication config. Types: `bearer` (`token`), `basic` (`username`, optional `password`), `api-key` (`key` + `header`, optional `prefix`), `custom` (`headers` map with `{{ KEY }}` templates), `passthrough` (no credential fields)
 - `credentials[].action` -- `"set"` (omit `value` for human to supply; include `value` to store back) or `"delete"`
 - `credentials` -- only declare credentials not already in `available_credentials`. Every credential referenced in auth configs must resolve to a slot or existing credential (400 otherwise)
 - `message` -- developer-facing explanation; `user_message` -- shown on the browser approval page

--- a/docs/learn/security.mdx
+++ b/docs/learn/security.mdx
@@ -3,9 +3,19 @@ title: "Security"
 description: "How Agent Vault protects credentials at rest, in transit, and across the network."
 ---
 
-Agent Vault is designed around a single principle: **agents never see credentials**. Credentials are encrypted at rest, decrypted only in memory at proxy time, and injected into outbound requests server-side. No credential value is ever returned in an API response or written to a log.
+Agent Vault is designed around a single principle: **Agent Vault never reveals vault-stored credentials to agents**. Credentials are encrypted at rest, decrypted only in memory at proxy time, and injected into outbound requests server-side. No credential value stored in the vault is ever returned in an API response or written to a log.
 
 This page covers the cryptographic primitives, token model, network protections, and operational safeguards that make this possible.
+
+<Note>
+  [Passthrough services](/learn/services#passthrough) are an operator-chosen
+  exception: they allowlist a host without storing or injecting any credential,
+  so the client's own request headers flow through unchanged. The guarantees
+  below apply to credentials *stored in the vault* — a credential the client
+  holds outside the vault is not protected by Agent Vault, but the host
+  allowlist, [netguard](#network-security), TLS interception, and audit
+  logging still apply.
+</Note>
 
 ## Encryption at rest
 

--- a/docs/learn/services.mdx
+++ b/docs/learn/services.mdx
@@ -8,7 +8,7 @@ A `Service` is a per-[vault](/learn/vaults) configuration that defines which hos
 Each service contains:
 
 - **Host**: The target hostname. Supports exact match (e.g. `api.stripe.com`) or wildcard patterns (e.g. `*.github.com`).
-- **Auth config**: How Agent Vault authenticates to the host. Four types are supported: `bearer`, `basic`, `api-key`, and `custom`.
+- **Auth config**: How Agent Vault authenticates to the host. Five types are supported: `bearer`, `basic`, `api-key`, `custom`, and `passthrough` (opt out of injection).
 - **Description**: An optional human-readable label shown in `/discover` responses.
 
 <Tip>
@@ -39,7 +39,7 @@ services:
 agent-vault vault service set -f stripe-services.yaml --vault my-vault
 ```
 
-The `host` tells Agent Vault which requests this service applies to. The `auth` block tells Agent Vault how to authenticate, referencing [credential](/learn/credentials) keys by name (not the actual credential values). The following section covers all four auth types.
+The `host` tells Agent Vault which requests this service applies to. The `auth` block tells Agent Vault how to authenticate, referencing [credential](/learn/credentials) keys by name (not the actual credential values). The following section covers all five auth types.
 
 ## Auth types
 
@@ -126,11 +126,34 @@ services:
         X-Tenant-ID: "{{ ACME_TENANT }}"
 ```
 
+### Passthrough
+
+Allowlists the host without injecting a credential. The client's request headers (including `Authorization` and `Cookie`) flow through to the target unchanged; Agent Vault strips only hop-by-hop headers and broker-scoped headers (`X-Vault`, `Proxy-Authorization`). No credential is stored, read, or attached.
+
+```yaml
+services:
+  - host: api.example.com
+    description: Client already holds the credential
+    auth:
+      type: passthrough
+```
+
+Use passthrough when the operator has decided their client already holds the credential (for example, an existing tool that manages its own token) and wants Agent Vault to provide the host allowlist, [netguard](/learn/security), TLS interception, and audit logging without putting the secret in the vault. All the other auth types are the default — reach for passthrough only when you explicitly want Agent Vault *not* to broker the credential.
+
+<Warning>
+  Passthrough auth configs reject every credential field (`token`, `username`,
+  `password`, `key`, `header`, `prefix`, `headers`). Setting any of them
+  returns a validation error — if you want Agent Vault to inject a credential,
+  use one of the credentialed auth types instead.
+</Warning>
+
 <Warning>
   Every credential key referenced in an auth config (whether directly or via `
   {{ KEY }}` templates) must resolve to either an existing
   [credential](/learn/credentials) in the vault or a credential slot in the same
   [proposal](/learn/proposals). Agent Vault returns `400` if a key is missing.
+  This does not apply to `passthrough` services, which reference no
+  credentials.
 </Warning>
 
 ## Host matching

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -413,13 +413,15 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `-f` | | Path to a YAML services file (upsert mode) |
     | `--host` | | Target service host (e.g. `api.stripe.com`) |
     | `--description` | | Service description |
-    | `--auth-type` | | Auth type: `bearer`, `basic`, `api-key`, `custom` |
+    | `--auth-type` | | Auth type: `bearer`, `basic`, `api-key`, `custom`, `passthrough` |
     | `--token-key` | | Credential key for bearer auth |
     | `--username-key` | | Credential key for basic auth username |
     | `--password-key` | | Credential key for basic auth password |
     | `--api-key-key` | | Credential key for api-key auth |
     | `--api-key-header` | `Authorization` | Header name for api-key |
     | `--api-key-prefix` | | Prefix for api-key value |
+
+    The `passthrough` auth type accepts no credential flags; Agent Vault allowlists the host and forwards the client's request headers unchanged, stripping only hop-by-hop and broker-scoped headers (`X-Vault`, `Proxy-Authorization`).
   </Accordion>
 
   <Accordion title="agent-vault vault service remove">
@@ -543,7 +545,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `-f`, `--file` | | Path to JSON proposal file (use `-` for stdin) |
     | `--host` | | Target service host (e.g. `api.stripe.com`) |
     | `--description` | | Service description |
-    | `--auth-type` | | Auth type: `bearer`, `basic`, or `api-key` |
+    | `--auth-type` | | Auth type: `bearer`, `basic`, `api-key`, or `passthrough` |
     | `--token-key` | | Credential key for bearer auth |
     | `--username-key` | | Credential key for basic auth username |
     | `--password-key` | | Credential key for basic auth password |

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -23,8 +23,13 @@ type Service struct {
 
 // Auth describes how credentials are attached for a broker service.
 // Each service must specify a Type and the fields relevant to that type.
+//
+// The "passthrough" type is a special case: no credential is looked up
+// and no credential is injected. The host is allowlisted, and the
+// client's request headers flow through (minus broker-scoped headers
+// like X-Vault and Proxy-Authorization, and hop-by-hop headers).
 type Auth struct {
-	Type string `yaml:"type" json:"type"` // "bearer", "basic", "api-key", "custom"
+	Type string `yaml:"type" json:"type"` // "bearer", "basic", "api-key", "custom", "passthrough"
 
 	// type: bearer — token credential key
 	Token string `yaml:"token,omitempty" json:"token,omitempty"`
@@ -43,7 +48,7 @@ type Auth struct {
 }
 
 // SupportedAuthTypes lists the valid auth type values.
-var SupportedAuthTypes = []string{"bearer", "basic", "api-key", "custom"}
+var SupportedAuthTypes = []string{"bearer", "basic", "api-key", "custom", "passthrough"}
 
 // CredentialKeyPattern validates credential key names: UPPER_SNAKE_CASE.
 var CredentialKeyPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
@@ -116,6 +121,11 @@ func (a *Auth) Validate() error {
 		}
 		return nil
 
+	case "passthrough":
+		// Passthrough forwards client headers unchanged and injects nothing.
+		// No credential fields are permitted.
+		return checkUnexpectedFields(a, "passthrough")
+
 	default:
 		return fmt.Errorf("auth: unsupported type %q (supported: %s)", a.Type, strings.Join(SupportedAuthTypes, ", "))
 	}
@@ -152,6 +162,10 @@ func checkUnexpectedFields(a *Auth, authType string, allowed ...string) error {
 
 	for _, c := range checks {
 		if c.isSet && !allowedSet[c.name] {
+			if len(allowed) == 0 {
+				return fmt.Errorf("auth: unexpected field %q for %s auth (no credential fields are permitted)",
+					c.name, authType)
+			}
 			return fmt.Errorf("auth: unexpected field %q for %s auth (only %s)",
 				c.name, authType, strings.Join(allowed, ", "))
 		}
@@ -160,6 +174,7 @@ func checkUnexpectedFields(a *Auth, authType string, allowed ...string) error {
 }
 
 // CredentialKeys returns all credential key names referenced by this auth config.
+// Passthrough services reference no credentials and return nil.
 func (a *Auth) CredentialKeys() []string {
 	switch a.Type {
 	case "bearer":
@@ -174,6 +189,8 @@ func (a *Auth) CredentialKeys() []string {
 		return []string{a.Key}
 	case "custom":
 		return credentialKeysFromHeaders(a.Headers)
+	case "passthrough":
+		return nil
 	default:
 		return nil
 	}
@@ -234,6 +251,11 @@ func (a *Auth) Resolve(getCredential func(key string) (string, error)) (map[stri
 
 	case "custom":
 		return resolveHeaders(a.Headers, getCredential)
+
+	case "passthrough":
+		// Passthrough injects nothing. Callers should branch on the service
+		// type before reaching Resolve; this return is defensive.
+		return nil, nil
 
 	default:
 		return nil, fmt.Errorf("unsupported auth type %q", a.Type)

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -350,3 +350,67 @@ func TestValidateConfigInvalidAuth(t *testing.T) {
 		t.Fatal("expected error for invalid auth")
 	}
 }
+
+// --- Passthrough tests ---
+
+func TestAuthValidatePassthrough(t *testing.T) {
+	a := Auth{Type: "passthrough"}
+	if err := a.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAuthValidatePassthroughRejectsCredentialFields(t *testing.T) {
+	cases := []struct {
+		name string
+		auth Auth
+	}{
+		{"token", Auth{Type: "passthrough", Token: "FOO"}},
+		{"username", Auth{Type: "passthrough", Username: "FOO"}},
+		{"password", Auth{Type: "passthrough", Password: "FOO"}},
+		{"key", Auth{Type: "passthrough", Key: "FOO"}},
+		{"header", Auth{Type: "passthrough", Header: "X-Foo"}},
+		{"prefix", Auth{Type: "passthrough", Prefix: "Bearer "}},
+		{"headers", Auth{Type: "passthrough", Headers: map[string]string{"X-Foo": "bar"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.auth.Validate(); err == nil {
+				t.Fatalf("expected error for %s on passthrough auth", tc.name)
+			}
+		})
+	}
+}
+
+func TestAuthCredentialKeysPassthrough(t *testing.T) {
+	a := Auth{Type: "passthrough"}
+	if keys := a.CredentialKeys(); keys != nil {
+		t.Fatalf("expected nil, got %v", keys)
+	}
+}
+
+func TestAuthResolvePassthrough(t *testing.T) {
+	a := Auth{Type: "passthrough"}
+	resolved, err := a.Resolve(func(key string) (string, error) {
+		t.Fatalf("getCredential should not be called for passthrough, got %q", key)
+		return "", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved != nil {
+		t.Fatalf("expected nil headers, got %v", resolved)
+	}
+}
+
+func TestValidateConfigPassthrough(t *testing.T) {
+	cfg := &Config{
+		Vault: "default",
+		Services: []Service{
+			{Host: "api.example.com", Auth: Auth{Type: "passthrough"}},
+		},
+	}
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/brokercore/brokercore.go
+++ b/internal/brokercore/brokercore.go
@@ -65,9 +65,14 @@ func IsValidHost(h string) bool {
 }
 
 // PassthroughHeaders is the allowlist of headers forwarded from agent
-// requests to upstream services. All other agent headers are dropped;
-// in particular Authorization is NOT on this list so injected credentials
-// always win over any client-supplied value.
+// requests to upstream services for credentialed (non-passthrough) auth
+// types. All other agent headers are dropped; in particular Authorization
+// is NOT on this list so injected credentials always win over any
+// client-supplied value.
+//
+// Passthrough services use CopyPassthroughRequestHeaders instead, which
+// is a denylist — the client's request is forwarded unchanged apart from
+// hop-by-hop headers and broker-scoped headers.
 var PassthroughHeaders = []string{
 	"Content-Type",
 	"Content-Encoding",
@@ -77,6 +82,64 @@ var PassthroughHeaders = []string{
 	"User-Agent",
 	"Idempotency-Key",
 	"X-Request-Id",
+}
+
+// brokerScopedRequestHeaders are headers that authenticate the client to
+// Agent Vault itself (explicit /proxy ingress uses X-Vault;
+// HTTPS_PROXY-compatible ingress uses Proxy-Authorization). They must
+// never traverse the broker → target hop, even on passthrough services.
+var brokerScopedRequestHeaders = map[string]bool{
+	"X-Vault":             true,
+	"Proxy-Authorization": true,
+}
+
+// IsBrokerScopedRequestHeader reports whether a request header
+// authenticates the client to Agent Vault itself and must be stripped
+// before forwarding to the target service.
+func IsBrokerScopedRequestHeader(name string) bool {
+	return brokerScopedRequestHeaders[http.CanonicalHeaderKey(name)]
+}
+
+// CopyPassthroughRequestHeaders forwards headers from src to dst for
+// passthrough services: everything except hop-by-hop, broker-scoped
+// (X-Vault, Proxy-Authorization), and any extra names in extraStrip.
+// Callers pass the header that authenticates the client to Agent Vault
+// on their ingress so that credential never reaches the target.
+func CopyPassthroughRequestHeaders(src, dst http.Header, extraStrip ...string) {
+	strip := make(map[string]bool, len(extraStrip))
+	for _, s := range extraStrip {
+		strip[http.CanonicalHeaderKey(s)] = true
+	}
+	for k, vv := range src {
+		ck := http.CanonicalHeaderKey(k)
+		if IsHopByHop(ck) || IsBrokerScopedRequestHeader(ck) || strip[ck] {
+			continue
+		}
+		for _, v := range vv {
+			dst.Add(ck, v)
+		}
+	}
+}
+
+// ApplyInjection writes the outbound request headers for a resolved
+// InjectResult. Passthrough services forward client headers via the
+// denylist (hop-by-hop + broker-scoped + extraStrip); credentialed
+// services copy the PassthroughHeaders allowlist and then overlay
+// injected credentials. Used by both ingress paths so header handling
+// for the two branches stays in lockstep.
+func ApplyInjection(src, dst http.Header, inject *InjectResult, extraStrip ...string) {
+	if inject.Passthrough {
+		CopyPassthroughRequestHeaders(src, dst, extraStrip...)
+		return
+	}
+	for _, k := range PassthroughHeaders {
+		for _, v := range src.Values(k) {
+			dst.Add(k, v)
+		}
+	}
+	for k, v := range inject.Headers {
+		dst.Set(k, v)
+	}
 }
 
 // ForbiddenHintBody returns the JSON-shaped body for a 403 response when

--- a/internal/brokercore/brokercore_test.go
+++ b/internal/brokercore/brokercore_test.go
@@ -2,6 +2,7 @@ package brokercore
 
 import (
 	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -30,6 +31,100 @@ func TestPassthroughHeadersExcludesAuthorization(t *testing.T) {
 		if strings.EqualFold(h, "Proxy-Authorization") {
 			t.Fatalf("PassthroughHeaders must not include Proxy-Authorization")
 		}
+	}
+}
+
+func TestIsBrokerScopedRequestHeader(t *testing.T) {
+	cases := map[string]bool{
+		"X-Vault":             true,
+		"x-vault":             true,
+		"Proxy-Authorization": true,
+		"proxy-authorization": true,
+		"Authorization":       false,
+		"Cookie":              false,
+		"Content-Type":        false,
+		"X-Request-Id":        false,
+	}
+	for name, want := range cases {
+		if got := IsBrokerScopedRequestHeader(name); got != want {
+			t.Errorf("IsBrokerScopedRequestHeader(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestCopyPassthroughRequestHeaders_ForwardsClientCredentials(t *testing.T) {
+	src := http.Header{}
+	src.Set("Authorization", "Bearer client-token")
+	src.Set("Cookie", "session=abc")
+	src.Set("X-Trace-Id", "trace-123")
+	src.Set("Content-Type", "application/json")
+	src.Set("User-Agent", "client/1.0")
+
+	dst := http.Header{}
+	CopyPassthroughRequestHeaders(src, dst)
+
+	for _, h := range []string{"Authorization", "Cookie", "X-Trace-Id", "Content-Type", "User-Agent"} {
+		if dst.Get(h) != src.Get(h) {
+			t.Errorf("header %q: got %q, want %q", h, dst.Get(h), src.Get(h))
+		}
+	}
+}
+
+func TestCopyPassthroughRequestHeaders_StripsBrokerScoped(t *testing.T) {
+	src := http.Header{}
+	src.Set("Authorization", "Bearer client-token")
+	src.Set("X-Vault", "default")
+	src.Set("Proxy-Authorization", "Basic xxx")
+	src.Set("Connection", "keep-alive")
+	src.Set("Te", "trailers")
+
+	dst := http.Header{}
+	CopyPassthroughRequestHeaders(src, dst)
+
+	if dst.Get("Authorization") == "" {
+		t.Error("Authorization should be forwarded on passthrough")
+	}
+	for _, h := range []string{"X-Vault", "Proxy-Authorization", "Connection", "Te"} {
+		if dst.Get(h) != "" {
+			t.Errorf("header %q should have been stripped, got %q", h, dst.Get(h))
+		}
+	}
+}
+
+func TestCopyPassthroughRequestHeaders_PreservesMultipleValues(t *testing.T) {
+	src := http.Header{}
+	src.Add("X-Multi", "a")
+	src.Add("X-Multi", "b")
+	src.Add("X-Multi", "c")
+
+	dst := http.Header{}
+	CopyPassthroughRequestHeaders(src, dst)
+
+	got := dst.Values("X-Multi")
+	if len(got) != 3 || got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Fatalf("X-Multi values = %v, want [a b c]", got)
+	}
+}
+
+func TestCopyPassthroughRequestHeaders_ExtraStrip(t *testing.T) {
+	// Explicit /proxy ingress passes "Authorization" as extra strip so the
+	// Agent Vault session token never leaks upstream.
+	src := http.Header{}
+	src.Set("Authorization", "Bearer session-token")
+	src.Set("Cookie", "session=abc")
+	src.Set("X-Trace-Id", "trace-123")
+
+	dst := http.Header{}
+	CopyPassthroughRequestHeaders(src, dst, "Authorization")
+
+	if got := dst.Get("Authorization"); got != "" {
+		t.Errorf("Authorization should be stripped when listed in extraStrip, got %q", got)
+	}
+	if dst.Get("Cookie") != "session=abc" {
+		t.Error("Cookie should still pass through")
+	}
+	if dst.Get("X-Trace-Id") != "trace-123" {
+		t.Error("X-Trace-Id should still pass through")
 	}
 }
 

--- a/internal/brokercore/credential.go
+++ b/internal/brokercore/credential.go
@@ -17,6 +17,7 @@ type InjectResult struct {
 	// Headers is the map of header name → value to overlay on the outbound
 	// request. Caller must Set (not Add) to ensure injected values win over
 	// any client-supplied duplicates. Values are SECRET — never log.
+	// Nil for passthrough services.
 	Headers map[string]string
 
 	// MatchedHost is the broker service host pattern that matched the
@@ -26,8 +27,15 @@ type InjectResult struct {
 	// CredentialKeys are the upper-snake-case credential key names the
 	// matched service references. These are names, not values — safe to
 	// log. Populated before credential resolution, so a credential-missing
-	// failure still carries this metadata.
+	// failure still carries this metadata. Empty for passthrough services.
 	CredentialKeys []string
+
+	// Passthrough indicates the matched service opts out of credential
+	// injection. The ingress should forward client request headers via
+	// the denylist (CopyPassthroughRequestHeaders) rather than the
+	// PassthroughHeaders allowlist, and must not perform the injection
+	// merge step.
+	Passthrough bool
 }
 
 // CredentialProvider resolves a broker service for targetHost inside vaultID
@@ -77,6 +85,16 @@ func (p *StoreCredentialProvider) Inject(ctx context.Context, vaultID, targetHos
 	matched := broker.MatchHost(matchHost, services)
 	if matched == nil {
 		return nil, ErrServiceNotFound
+	}
+
+	// Passthrough services opt out of credential injection entirely. No
+	// vault read, no CredentialKeys (nothing to resolve). The ingress
+	// branches on Passthrough to forward client headers via the denylist.
+	if matched.Auth.Type == "passthrough" {
+		return &InjectResult{
+			MatchedHost: matched.Host,
+			Passthrough: true,
+		}, nil
 	}
 
 	// Capture non-secret metadata up front so a downstream credential-missing

--- a/internal/brokercore/credential_test.go
+++ b/internal/brokercore/credential_test.go
@@ -16,7 +16,9 @@ import (
 type fakeCredStore struct {
 	brokerCfg map[string]*store.BrokerConfig // vaultID → config
 	creds     map[string]*store.Credential   // key = vaultID+"|"+key
-	missKey   string                          // if set, GetCredential for this key returns nil/err
+	missKey   string                         // if set, GetCredential for this key returns nil/err
+
+	getCredentialCalls int // call count — used by passthrough tests to assert no lookup
 }
 
 func newFakeCredStore() *fakeCredStore {
@@ -34,6 +36,7 @@ func (f *fakeCredStore) GetBrokerConfig(_ context.Context, vaultID string) (*sto
 	return c, nil
 }
 func (f *fakeCredStore) GetCredential(_ context.Context, vaultID, key string) (*store.Credential, error) {
+	f.getCredentialCalls++
 	if key == f.missKey {
 		return nil, errors.New("missing")
 	}
@@ -251,5 +254,50 @@ func TestInject_DecryptFails(t *testing.T) {
 	_, err := p.Inject(context.Background(), "v1", "api.example.com")
 	if !errors.Is(err, ErrCredentialMissing) {
 		t.Fatalf("expected ErrCredentialMissing, got %v", err)
+	}
+}
+
+func TestInject_Passthrough(t *testing.T) {
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.example.com",
+		Auth: broker.Auth{Type: "passthrough"},
+	}})
+
+	p := NewStoreCredentialProvider(f, make32(0xCC))
+	res, err := p.Inject(context.Background(), "v1", "api.example.com")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !res.Passthrough {
+		t.Fatal("expected Passthrough=true")
+	}
+	if res.Headers != nil {
+		t.Fatalf("expected nil Headers, got %v", res.Headers)
+	}
+	if res.MatchedHost != "api.example.com" {
+		t.Fatalf("MatchedHost = %q, want %q", res.MatchedHost, "api.example.com")
+	}
+	if len(res.CredentialKeys) != 0 {
+		t.Fatalf("expected no CredentialKeys, got %v", res.CredentialKeys)
+	}
+	if f.getCredentialCalls != 0 {
+		t.Fatalf("expected GetCredential to NOT be called, got %d calls", f.getCredentialCalls)
+	}
+}
+
+func TestInject_PassthroughPortStripped(t *testing.T) {
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.example.com",
+		Auth: broker.Auth{Type: "passthrough"},
+	}})
+	p := NewStoreCredentialProvider(f, make32(0xDD))
+	res, err := p.Inject(context.Background(), "v1", "api.example.com:443")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !res.Passthrough {
+		t.Fatal("expected Passthrough=true for host:port match")
 	}
 }

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -44,15 +44,6 @@ func (p *Proxy) forwardHandler(target, host string, scope *brokercore.ProxyScope
 		}
 		outReq.Host = host
 
-		// Allowlist passthrough: Authorization and Proxy-Authorization are
-		// not on the list, so injected credentials always win and the
-		// client cannot shadow them.
-		for _, k := range brokercore.PassthroughHeaders {
-			for _, v := range r.Header.Values(k) {
-				outReq.Header.Add(k, v)
-			}
-		}
-
 		inject, err := p.creds.Inject(r.Context(), scope.VaultID, host)
 		if inject != nil {
 			event.MatchedService = inject.MatchedHost
@@ -70,9 +61,11 @@ func (p *Proxy) forwardHandler(target, host string, scope *brokercore.ProxyScope
 			emit(status, errCode)
 			return
 		}
-		for k, v := range inject.Headers {
-			outReq.Header.Set(k, v)
-		}
+
+		// No extraStrip: Proxy-Authorization (the broker-scoped credential
+		// on this ingress) is already filtered by the denylist, and
+		// Authorization is the client's own upstream header.
+		brokercore.ApplyInjection(r.Header, outReq.Header, inject)
 
 		resp, err := p.upstream.RoundTrip(outReq)
 		if err != nil {

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -195,6 +195,78 @@ func TestMITMInjectsCredentials(t *testing.T) {
 	}
 }
 
+func TestMITMPassthroughForwardsClientAuthorization(t *testing.T) {
+	// On the MITM ingress, Proxy-Authorization is the broker-scoped credential
+	// and Authorization is the client's own upstream header — it must flow
+	// through unchanged for passthrough services. Proxy-Authorization and
+	// hop-by-hop headers must still be stripped.
+	var sawAuth, sawCookie, sawTrace, sawProxyAuth string
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		sawCookie = r.Header.Get("Cookie")
+		sawTrace = r.Header.Get("X-Trace-Id")
+		sawProxyAuth = r.Header.Get("Proxy-Authorization")
+		_, _ = io.WriteString(w, "passthrough-ok")
+	}))
+	defer upstream.Close()
+
+	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
+
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{
+			MatchedHost: upstreamHost,
+			Passthrough: true,
+		}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    upstreamRoots,
+	}
+
+	client := newTrustingClient(proxyURL, url.User("av_sess_ok"), clientRoots)
+
+	req, err := http.NewRequest("GET", upstream.URL+"/data", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer upstream-token")
+	req.Header.Set("Cookie", "session=abc")
+	req.Header.Set("X-Trace-Id", "trace-123")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "passthrough-ok" {
+		t.Fatalf("body = %q", body)
+	}
+	if sawAuth != "Bearer upstream-token" {
+		t.Fatalf("upstream Authorization = %q, want passthrough of client value", sawAuth)
+	}
+	if sawCookie != "session=abc" {
+		t.Fatalf("upstream Cookie = %q, want passthrough", sawCookie)
+	}
+	if sawTrace != "trace-123" {
+		t.Fatalf("upstream X-Trace-Id = %q, want passthrough", sawTrace)
+	}
+	if sawProxyAuth != "" {
+		t.Fatalf("upstream saw Proxy-Authorization %q; must be stripped on passthrough", sawProxyAuth)
+	}
+}
+
 func TestMITMMissingProxyAuth(t *testing.T) {
 	sr := errResolver(brokercore.ErrInvalidSession)
 	cp := &fakeCredProvider{}

--- a/internal/server/handle_proxy.go
+++ b/internal/server/handle_proxy.go
@@ -174,8 +174,6 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 		emit(status, errCode)
 		return
 	}
-	resolved := inject.Headers
-
 	// 7. Build outbound URL.
 	targetURL := "https://" + targetHost
 	if remainingPath != "" {
@@ -192,21 +190,13 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 		emit(http.StatusInternalServerError, "internal")
 		return
 	}
-
-	// Copy only safe headers from the agent request (allowlist approach).
-	for _, k := range brokercore.PassthroughHeaders {
-		if vv := r.Header.Values(k); len(vv) > 0 {
-			for _, v := range vv {
-				outReq.Header.Add(k, v)
-			}
-		}
-	}
 	outReq.Host = targetHost
 
-	// Merge injected headers (injected wins on conflict).
-	for k, v := range resolved {
-		outReq.Header.Set(k, v)
-	}
+	// Authorization carries the Agent Vault session token on this ingress;
+	// strip it on passthrough so the session credential never reaches the
+	// target. Clients needing to forward an upstream Authorization should
+	// use the MITM ingress, where Proxy-Authorization is broker-scoped.
+	brokercore.ApplyInjection(r.Header, outReq.Header, inject, "Authorization")
 
 	// 9. Forward request to target.
 	resp, err := proxyClient.Do(outReq)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2084,6 +2084,95 @@ func TestProxyNoMatchingRule(t *testing.T) {
 	}
 }
 
+func TestProxyPassthroughForwardsClientHeaders(t *testing.T) {
+	// Upstream asserts: client-supplied Cookie and X-Trace-Id flow through,
+	// but broker-scoped X-Vault and the session-token Authorization are
+	// stripped (the session token must never reach the target).
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("Authorization on explicit /proxy ingress should be stripped (it is the session token), got %q", got)
+		}
+		if got := r.Header.Get("Cookie"); got != "session=abc" {
+			t.Errorf("Cookie: got %q, want %q", got, "session=abc")
+		}
+		if got := r.Header.Get("X-Trace-Id"); got != "trace-123" {
+			t.Errorf("X-Trace-Id: got %q, want %q", got, "trace-123")
+		}
+		if got := r.Header.Get("X-Vault"); got != "" {
+			t.Errorf("X-Vault should have been stripped, got %q", got)
+		}
+		w.Header().Set("X-Upstream", "true")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`passthrough-ok`))
+	}))
+	defer upstream.Close()
+
+	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
+	serviceHost, _, _ := net.SplitHostPort(upstreamHost)
+	services := fmt.Sprintf(`[{"host":"%s","auth":{"type":"passthrough"}}]`, serviceHost)
+	ms, token, encKey := setupProxyTest(t, services)
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+
+	origClient := proxyClient
+	proxyClient = upstream.Client()
+	defer func() { proxyClient = origClient }()
+
+	req := httptest.NewRequest(http.MethodGet, "/proxy/"+upstreamHost+"/data", nil)
+	req.Header.Set("Authorization", "Bearer "+token) // session auth — must not leak
+	req.Header.Set("Cookie", "session=abc")
+	req.Header.Set("X-Trace-Id", "trace-123")
+	req.Header.Set("X-Vault", "should-be-stripped")
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("X-Upstream") != "true" {
+		t.Fatal("expected X-Upstream header from upstream")
+	}
+	body, _ := io.ReadAll(rec.Body)
+	if string(body) != "passthrough-ok" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestProxyPassthroughDoesNotReadCredentials(t *testing.T) {
+	// Passthrough must not perform any credential lookup, even if the service
+	// name collides with a stored credential key. Use a credential provider
+	// that explodes on any read to catch it.
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
+	serviceHost, _, _ := net.SplitHostPort(upstreamHost)
+	services := fmt.Sprintf(`[{"host":"%s","auth":{"type":"passthrough"}}]`, serviceHost)
+	ms, token, encKey := setupProxyTest(t, services)
+
+	// Sabotage: mark the only credential as unreachable. If the handler ever
+	// tried to read it, decryption or lookup would fail and the request
+	// would return 502.
+	delete(ms.credentials, "root-ns-id:STRIPE_KEY")
+
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+	origClient := proxyClient
+	proxyClient = upstream.Client()
+	defer func() { proxyClient = origClient }()
+
+	req := httptest.NewRequest(http.MethodGet, "/proxy/"+upstreamHost+"/data", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 (no credential lookup for passthrough), got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestProxyMissingCredential(t *testing.T) {
 	services := `[{"host":"api.stripe.com","auth":{"type":"bearer","token":"nonexistent_key"}}]`
 	ms, token, encKey := setupProxyTest(t, services)

--- a/web/src/components/ProposalPreview.tsx
+++ b/web/src/components/ProposalPreview.tsx
@@ -62,6 +62,7 @@ export const AUTH_TYPE_LABELS: Record<string, string> = {
   basic: "HTTP Basic Auth",
   "api-key": "API key",
   custom: "Custom headers",
+  passthrough: "Passthrough",
 };
 
 function AuthDisplay({ auth }: { auth: Auth }) {
@@ -73,6 +74,11 @@ function AuthDisplay({ auth }: { auth: Auth }) {
         Authentication
       </div>
       <div className="text-xs font-mono text-text mb-1">{label}</div>
+      {auth.type === "passthrough" && (
+        <div className="text-xs text-text-muted leading-relaxed">
+          No credential injected — client headers are forwarded unchanged.
+        </div>
+      )}
       {auth.type === "custom" &&
         auth.headers &&
         Object.keys(auth.headers).length > 0 && (

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -24,6 +24,7 @@ const AUTH_TYPE_OPTIONS: { value: string; label: string }[] = [
   { value: "basic", label: "HTTP Basic Auth" },
   { value: "api-key", label: "API key" },
   { value: "custom", label: "Custom headers" },
+  { value: "passthrough", label: "Passthrough (no credential injected)" },
 ];
 
 export default function ServicesTab() {
@@ -115,6 +116,14 @@ export default function ServicesTab() {
       header: "Auth",
       render: (service) => {
         const label = AUTH_TYPE_LABELS[service.auth?.type] || service.auth?.type || "\u2014";
+        if (service.auth?.type === "passthrough") {
+          return (
+            <span className="inline-flex items-center gap-1 rounded-full border border-border bg-surface-raised px-2 py-0.5 text-xs font-medium text-text-muted">
+              <span className="h-1.5 w-1.5 rounded-full bg-text-muted/70" />
+              {label}
+            </span>
+          );
+        }
         return (
           <div className="text-sm text-text">
             {label}
@@ -288,6 +297,8 @@ function ServiceModal({
         return !!apiKey.trim();
       case "custom":
         return customHeaders.length > 0 && customHeaders.every((h) => h.name.trim() && h.value.trim());
+      case "passthrough":
+        return true;
       default:
         return false;
     }
@@ -315,6 +326,8 @@ function ServiceModal({
         }
         return { type: "custom", headers };
       }
+      case "passthrough":
+        return { type: "passthrough" };
       default:
         return { type: authType };
     }
@@ -469,6 +482,17 @@ function ServiceModal({
               />
             </FormField>
           </>
+        )}
+
+        {authType === "passthrough" && (
+          <div className="rounded-lg border border-border bg-bg p-3 text-sm text-text-muted leading-relaxed">
+            Passthrough forwards your client's request headers unchanged to
+            the target. Agent Vault will not look up or inject a credential,
+            and will strip only hop-by-hop headers and broker-scoped headers
+            (<span className="font-mono">X-Vault</span>,{" "}
+            <span className="font-mono">Proxy-Authorization</span>). Use this
+            when the agent already holds the credential.
+          </div>
         )}
 
         {authType === "custom" && (

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -24,7 +24,7 @@ const AUTH_TYPE_OPTIONS: { value: string; label: string }[] = [
   { value: "basic", label: "HTTP Basic Auth" },
   { value: "api-key", label: "API key" },
   { value: "custom", label: "Custom headers" },
-  { value: "passthrough", label: "Passthrough (no credential injected)" },
+  { value: "passthrough", label: "Passthrough" },
 ];
 
 export default function ServicesTab() {

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -116,14 +116,6 @@ export default function ServicesTab() {
       header: "Auth",
       render: (service) => {
         const label = AUTH_TYPE_LABELS[service.auth?.type] || service.auth?.type || "\u2014";
-        if (service.auth?.type === "passthrough") {
-          return (
-            <span className="inline-flex items-center gap-1 rounded-full border border-border bg-surface-raised px-2 py-0.5 text-xs font-medium text-text-muted">
-              <span className="h-1.5 w-1.5 rounded-full bg-text-muted/70" />
-              {label}
-            </span>
-          );
-        }
         return (
           <div className="text-sm text-text">
             {label}


### PR DESCRIPTION
## Summary

- Adds a fifth auth type, `passthrough`, that allowlists a host without storing or injecting a credential — the client's request headers flow through to the target unchanged, minus broker-scoped and hop-by-hop headers.
- Both ingress paths (explicit `/proxy` and transparent MITM) share a new `brokercore.ApplyInjection` helper so the passthrough / credentialed branches stay in lockstep.
- Skill docs, Mintlify pages, CLI reference, and the "Agent Vault never reveals vault-stored credentials" security framing are updated alongside the code.

## Why

Services today conflate two responsibilities: allowlisting a host and brokering a credential. An operator whose agent already holds the upstream credential had no way to get netguard / audit / MITM coverage without duplicating the secret into the vault. Passthrough is the opt-in escape hatch for that case.

## Semantics

- **Matching** — identical to credentialed services (exact + wildcard host match).
- **Validation** — `passthrough` rejects every credential field (`token`, `username`, `password`, `key`, `header`, `prefix`, `headers`).
- **Credential lookup** — skipped entirely. No vault read, no CredentialKeys emitted in logs.
- **Headers**
  - Explicit `/proxy` ingress: strips hop-by-hop, `X-Vault`, `Proxy-Authorization`, **and** `Authorization` (the session token). Clients needing to forward an upstream `Authorization` should use the MITM ingress.
  - MITM ingress: strips hop-by-hop and `Proxy-Authorization`. `Authorization` and `Cookie` flow through to the target.
- **Response handling** — unchanged. `Set-Cookie` is still stripped on passthrough to keep the "no cookie planting" posture.

## Surface changes

- `broker.Auth` — new type constant + validation that rejects all credential fields (`internal/broker/broker.go`).
- `brokercore.InjectResult` — new `Passthrough bool`; `Inject` short-circuits without any credential lookup (`internal/brokercore/credential.go`).
- `brokercore` helpers — `IsBrokerScopedRequestHeader`, `CopyPassthroughRequestHeaders`, `ApplyInjection` (`internal/brokercore/brokercore.go`).
- CLI — `--auth-type passthrough` on `vault service add` and `vault proposal create`; errors if any credential flag is passed alongside it.
- Web UI — new dropdown option, inline note in the edit modal, distinct badge in the service list.
- Skill pair — `cmd/skill_cli.md` + `cmd/skill_http.md` updated together per the CLAUDE.md convention.
- Docs — `docs/learn/services.mdx` (new Passthrough section + warning), `docs/learn/security.mdx` (softened framing + carve-out note), `docs/reference/cli.mdx` (flag tables), `README.md`.

## Test plan

- [x] `make test` — unit + integration pass, including new:
  - `broker`: passthrough validation accept / per-field reject, `CredentialKeys` nil, `Resolve` nil.
  - `brokercore`: `IsBrokerScopedRequestHeader` truth table, `CopyPassthroughRequestHeaders` forwards / strips / preserves multi-value / honors `extraStrip`, `Inject` returns `Passthrough: true` and performs zero credential lookups.
  - `mitm`: end-to-end — client `Authorization: Bearer upstream-token` + `Cookie` reach upstream; `Proxy-Authorization` stripped.
  - `server`: end-to-end — on `/proxy`, `Cookie` / custom headers reach upstream; session-token `Authorization` + `X-Vault` stripped. Second test sabotages the stored credential to prove no lookup happens for passthrough.
  - `cmd`: `buildAuthFromFlags` builds `{Type: "passthrough"}` and rejects every `--*-key` flag.
- [x] `make build` — frontend + Go binary build clean.
- [ ] Manual smoke through both ingresses:
  - `./agent-vault vault service add --host httpbin.org --auth-type passthrough` succeeds; adding `--token-key FOO` fails with a clear error.
  - `curl -H "X-Vault: default" -H "Authorization: Bearer CLIENT" ${AGENT_VAULT_ADDR}/proxy/httpbin.org/headers` shows `X-Vault` stripped.
  - `HTTPS_PROXY=http://localhost:14322 curl -H "Authorization: Bearer CLIENT" https://httpbin.org/headers` (with the root CA trusted) shows `Authorization: Bearer CLIENT` echoed by httpbin.
- [ ] Web UI: open Services tab, add a passthrough service in the modal, confirm credential fields are hidden and the badge renders in the list.

## Non-goals

- Path-level allowlisting within a host.
- Per-request toggle between passthrough and injection for the same host.
- Letting client-supplied `Authorization` override an injected credential on credentialed services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)