### PR TITLE
docs+test: address passthrough PR #76 review feedback

### DIFF
--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -1,20 +1,20 @@
 ---
 name: agent-vault-cli
 description: >-
-  Agent Vault CLI: manage authenticated HTTP proxy access to external services
-  (Linear, GitHub, Stripe, Slack, Jira, etc.) using the agent-vault binary.
-  Use when the task involves interacting with any third-party API or service
-  that requires credentials, or when writing code that needs environment
-  variables for secrets/API keys.
+  Agent Vault CLI: manage transparent credential injection for external
+  services (Linear, GitHub, Stripe, Slack, Jira, etc.) using the agent-vault
+  binary. Use when the task involves interacting with any third-party API or
+  service that requires credentials, or when writing code that needs
+  environment variables for secrets/API keys.
 compatibility: Requires a running Agent Vault server, the agent-vault binary on $PATH, and AGENT_VAULT_SESSION_TOKEN environment variable
 metadata:
   author: dangtony98
-  version: "0.2.0"
+  version: "0.3.0"
 ---
 
 # Agent Vault (CLI)
 
-You have access to Agent Vault, an HTTP proxy that attaches credentials to your outbound requests. You never see or handle credentials directly -- route authenticated requests through Agent Vault and it authenticates on your behalf.
+You have access to Agent Vault, a transparent HTTPS proxy that injects credentials into your outbound calls. You never see or handle credentials directly -- make API calls to the real host as normal and Agent Vault attaches the real credentials at the proxy boundary.
 
 ## CRITICAL: Always Check Agent Vault First
 
@@ -22,45 +22,62 @@ You have access to Agent Vault, an HTTP proxy that attaches credentials to your 
 
 **Your workflow for ANY external service interaction:**
 1. Check that `AGENT_VAULT_SESSION_TOKEN` is set (it should be if you were launched via `agent-vault vault run`)
-2. Run `agent-vault vault discover --json` to see what services are available
-3. If the service is listed, route your request through the Agent Vault proxy -- done
-4. If the service is NOT listed, create a proposal via CLI (the user can approve and provide credentials)
+2. Run `agent-vault vault discover --json` to see which hosts have credentials configured
+3. If the host is listed, **just make the request to the real API URL** -- Agent Vault transparently injects the credential
+4. If the host is NOT listed, create a proposal via CLI (the user approves and provides credentials)
 5. Only tell the user you cannot access a service if Agent Vault is not available at all (no session token)
 
 **Never say "I don't have access to X" without checking discover first.** Agent Vault may already have credentials configured for the service you need.
 
-**Not every HTTP request needs to go through Agent Vault.** Unauthenticated requests or requests to services not configured in Agent Vault should be made directly.
+**Not every HTTP request needs Agent Vault credentials.** Unauthenticated requests or requests to hosts not configured in Agent Vault still pass through the proxy unmodified -- no special handling required.
 
 ## Environment Variables
 
 | Variable | Description |
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
-| `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault |
+| `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault's control-plane endpoints (`discover`, proposals, etc.) |
 | `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`; instance-level agent tokens use `X-Vault` header instead) |
+
+`vault run` also pre-configures `HTTPS_PROXY`, `NO_PROXY`, and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`) so HTTPS calls from your process route through the broker transparently. You don't manage these yourself.
 
 ## Discover Available Services (Start Here)
 
-**Always run this first** to learn which services have credentials configured:
+**Always run this first** to learn which hosts have credentials configured:
 
 ```bash
 agent-vault vault discover --json
 ```
 
-Response includes `vault`, `proxy_url`, `services` (host + description), and `available_credentials` (key names only, values are never exposed). Use `available_credentials` to reference existing credentials in proposals instead of creating duplicate slots.
+Response includes `vault`, `services` (host + description), `available_credentials` (key names only, values are never exposed), and `proxy_url` (only needed for the explicit-proxy fallback below). Use `available_credentials` to reference existing credentials in proposals instead of creating duplicate slots.
 
 **Browse service templates:** `agent-vault catalog --json` lists built-in service templates with suggested credential keys and auth types. No auth needed.
 
-## Making Requests Through Agent Vault
+## Making Requests
 
-For hosts returned by discover, route requests through Agent Vault's proxy:
+**Just call the real API URL.** When you were launched via `agent-vault vault run`, your HTTPS traffic already routes through Agent Vault transparently — `HTTPS_PROXY` and the broker's CA cert are pre-configured in your environment. Agent Vault intercepts the call, looks up the host in the vault's services, injects the credential, and forwards over HTTPS.
+
+```bash
+curl https://api.stripe.com/v1/charges
+curl https://api.github.com/user
+```
+
+Your code can leave the upstream auth header blank or set it to a placeholder — Agent Vault attaches the real credential at the proxy boundary, so the value in your env can be anything (or absent). Standard HTTP clients (curl, fetch, requests, axios, the Go stdlib, etc.) honor `HTTPS_PROXY` automatically.
+
+### Fallback: explicit `/proxy/{host}/{path}`
+
+Use the explicit proxy URL only when transparent MITM isn't viable:
+
+- The HTTP client doesn't honor `HTTPS_PROXY` (rare)
+- You weren't launched via `vault run`, so your environment lacks the broker's CA trust
+- The operator started the server with `--mitm-port 0`, or you with `--no-mitm`
 
 ```
 {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
 Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
 ```
 
-Agent Vault strips your auth header, injects the real credentials, and forwards the request over HTTPS.
+Agent Vault strips your `Authorization` header (it carried your session token), injects the real credentials, and forwards over HTTPS. Same credential injection as the transparent path — just URL-rewritten.
 
 ## Managing Services Directly
 
@@ -114,8 +131,8 @@ Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic
 
 Header handling on passthrough depends on the ingress the client uses:
 
-- **Explicit `/proxy/{host}/{path}` ingress:** hop-by-hop, `X-Vault`, **and** `Authorization` are stripped before the request is forwarded. `Authorization` carries the Agent Vault session token on this ingress, so clients cannot use it to carry an upstream credential. Client headers the target accepts via `Cookie` or a custom header still flow through.
-- **MITM (`HTTPS_PROXY`) ingress:** hop-by-hop and `Proxy-Authorization` are stripped. `Authorization` and all other client headers flow through unchanged — use this ingress if you need to forward an upstream `Authorization: Bearer <target-token>` through a passthrough service.
+- **Transparent MITM (`HTTPS_PROXY`, the default under `vault run`):** hop-by-hop and `Proxy-Authorization` are stripped. `Authorization` and all other client headers flow through unchanged — use this ingress if you need to forward an upstream `Authorization: Bearer <target-token>` through a passthrough service.
+- **Explicit `/proxy/{host}/{path}` fallback:** hop-by-hop, `X-Vault`, **and** `Authorization` are stripped before the request is forwarded. `Authorization` carries the Agent Vault session token on this ingress, so clients cannot use it to carry an upstream credential. Client headers the target accepts via `Cookie` or a custom header still flow through.
 
 ### Creating a Proposal
 

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -110,7 +110,12 @@ passthrough -- forward client headers, inject nothing  {"auth": {"type": "passth
 
 Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic -- API key as username), Jira (basic -- email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
 
-**Passthrough** allowlists a host but does not store or inject a credential — the client's `Authorization` and other request headers flow through unchanged. Use it only when the operator has decided their client already holds the credential and wants netguard / audit / MITM coverage without putting the secret in the vault. For the default case (agent needs the credential from the vault), use one of the credentialed types above.
+**Passthrough** allowlists a host but does not store or inject a credential. Use it only when the operator has decided their client already holds the credential and wants netguard / audit / MITM coverage without putting the secret in the vault. For the default case (agent needs the credential from the vault), use one of the credentialed types above.
+
+Header handling on passthrough depends on the ingress the client uses:
+
+- **Explicit `/proxy/{host}/{path}` ingress:** hop-by-hop, `X-Vault`, **and** `Authorization` are stripped before the request is forwarded. `Authorization` carries the Agent Vault session token on this ingress, so clients cannot use it to carry an upstream credential. Client headers the target accepts via `Cookie` or a custom header still flow through.
+- **MITM (`HTTPS_PROXY`) ingress:** hop-by-hop and `Proxy-Authorization` are stripped. `Authorization` and all other client headers flow through unchanged — use this ingress if you need to forward an upstream `Authorization: Bearer <target-token>` through a passthrough service.
 
 ### Creating a Proposal
 
@@ -148,7 +153,7 @@ Other flags: `--description` (service description), `--user-message` (shown on b
 
 Key fields (JSON mode):
 - `services[].action` -- `"set"` (upsert, needs `host` + `auth`) or `"delete"` (needs `host` only)
-- `services[].auth` -- authentication config. Types: `bearer` (`token`), `basic` (`username`, optional `password`), `api-key` (`key` + `header`, optional `prefix`), `custom` (`headers` map with `{{ KEY }}` templates)
+- `services[].auth` -- authentication config. Types: `bearer` (`token`), `basic` (`username`, optional `password`), `api-key` (`key` + `header`, optional `prefix`), `custom` (`headers` map with `{{ KEY }}` templates), `passthrough` (no credential fields)
 - `credentials[].action` -- `"set"` (omit `value` for human to supply; include `value` to store back) or `"delete"`
 - `credentials` -- only declare credentials not already in `available_credentials`. Every credential referenced in auth configs must resolve to a slot or existing credential (400 otherwise)
 - `message` -- developer-facing explanation; `user_message` -- shown on the browser approval page

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -1,20 +1,19 @@
 ---
 name: agent-vault-http
 description: >-
-  Agent Vault HTTP: interact with Agent Vault's authenticated HTTP proxy for
-  external services (Linear, GitHub, Stripe, Slack, Jira, etc.) using only
-  HTTP requests. Use when the task involves any third-party API or service
-  that requires credentials, or when writing code that needs environment
-  variables for secrets/API keys.
+  Agent Vault HTTP: a transparent HTTPS proxy that injects credentials for
+  external services (Linear, GitHub, Stripe, Slack, Jira, etc.). Use when the
+  task involves any third-party API or service that requires credentials, or
+  when writing code that needs environment variables for secrets/API keys.
 compatibility: Requires a running Agent Vault server and AGENT_VAULT_SESSION_TOKEN environment variable
 metadata:
   author: dangtony98
-  version: "0.2.0"
+  version: "0.3.0"
 ---
 
 # Agent Vault (HTTP)
 
-You have access to Agent Vault, an HTTP proxy that attaches credentials to your outbound requests. You never see or handle credentials directly -- route authenticated requests through Agent Vault and it authenticates on your behalf.
+You have access to Agent Vault, a transparent HTTPS proxy that injects credentials into your outbound calls. You never see or handle credentials directly -- make API calls to the real host as normal and Agent Vault attaches the real credentials at the proxy boundary.
 
 ## CRITICAL: Always Check Agent Vault First
 
@@ -22,26 +21,28 @@ You have access to Agent Vault, an HTTP proxy that attaches credentials to your 
 
 **Your workflow for ANY external service interaction:**
 1. Check that `AGENT_VAULT_SESSION_TOKEN` is set
-2. Call `GET {AGENT_VAULT_ADDR}/discover` to see what services are available
-3. If the service is listed, route your request through the Agent Vault proxy -- done
-4. If the service is NOT listed, create a proposal (the user can approve and provide credentials)
+2. Call `GET {AGENT_VAULT_ADDR}/discover` to see which hosts have credentials configured
+3. If the host is listed, **just make the request to the real API URL** -- Agent Vault transparently injects the credential
+4. If the host is NOT listed, create a proposal (the user approves and provides credentials)
 5. Only tell the user you cannot access a service if Agent Vault is not available at all (no session token)
 
 **Never say "I don't have access to X" without checking /discover first.** Agent Vault may already have credentials configured for the service you need.
 
-**Not every HTTP request needs to go through Agent Vault.** Unauthenticated requests or requests to services not configured in Agent Vault should be made directly.
+**Not every HTTP request needs Agent Vault credentials.** Unauthenticated requests or requests to hosts not configured in Agent Vault still pass through the proxy unmodified -- no special handling required.
 
 ## Environment Variables
 
 | Variable | Description |
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
-| `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault |
+| `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault's control-plane endpoints (`/discover`, proposals, etc.) |
 | `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`; for instance-level agent tokens, use the `X-Vault` header instead) |
+
+`vault run` also pre-configures `HTTPS_PROXY`, `NO_PROXY`, and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`) so HTTPS calls from your process route through the broker transparently. You don't manage these yourself.
 
 ## Discover Available Services (Start Here)
 
-**Always call this first** to learn which services have credentials configured:
+**Always call this first** to learn which hosts have credentials configured:
 
 ```
 GET {AGENT_VAULT_ADDR}/discover
@@ -51,7 +52,7 @@ X-Vault: {vault_name}
 
 **Note:** If `AGENT_VAULT_VAULT` is set, the server uses it automatically. Instance-level agent tokens (persistent agents) must include the `X-Vault` header on all vault-scoped requests.
 
-Response includes `vault`, `proxy_url`, `services` (host + description), and `available_credentials` (key names only, values are never exposed). Use `available_credentials` to reference existing credentials in proposals instead of creating duplicate slots.
+Response includes `vault`, `services` (host + description), `available_credentials` (key names only, values are never exposed), and `proxy_url` (only needed for the explicit-proxy fallback below). Use `available_credentials` to reference existing credentials in proposals instead of creating duplicate slots.
 
 **Browse service templates:**
 
@@ -61,16 +62,31 @@ GET {AGENT_VAULT_ADDR}/v1/service-catalog
 
 Returns built-in service templates with suggested credential keys and auth types. No auth required.
 
-## Making Requests Through Agent Vault
+## Making Requests
 
-For hosts returned by `/discover`, route requests through Agent Vault's proxy:
+**Just call the real API URL.** When you were launched via `agent-vault vault run`, your HTTPS traffic already routes through Agent Vault transparently — `HTTPS_PROXY` and the broker's CA cert are pre-configured in your environment. Agent Vault intercepts the call, looks up the host in the vault's services, injects the credential, and forwards over HTTPS.
+
+```
+GET https://api.stripe.com/v1/charges
+GET https://api.github.com/user
+```
+
+Your code can leave the upstream auth header blank or set it to a placeholder — Agent Vault attaches the real credential at the proxy boundary, so the value in your env can be anything (or absent). Standard HTTP clients (curl, fetch, requests, axios, the Go stdlib, etc.) honor `HTTPS_PROXY` automatically.
+
+### Fallback: explicit `/proxy/{host}/{path}`
+
+Use the explicit proxy URL only when transparent MITM isn't viable:
+
+- The HTTP client doesn't honor `HTTPS_PROXY` (rare)
+- You weren't launched via `vault run`, so your environment lacks the broker's CA trust
+- The operator started the server with `--mitm-port 0`, or you with `--no-mitm`
 
 ```
 {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
 Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
 ```
 
-Agent Vault strips your auth header, injects the real credentials, and forwards the request over HTTPS.
+Agent Vault strips your `Authorization` header (it carried your session token), injects the real credentials, and forwards over HTTPS. Same credential injection as the transparent path — just URL-rewritten.
 
 ## Managing Services Directly
 
@@ -133,8 +149,8 @@ Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic
 
 Header handling on passthrough depends on the ingress:
 
-- **Explicit `/proxy/{host}/{path}` (this doc):** hop-by-hop, `X-Vault`, **and** `Authorization` are stripped before the request is forwarded. `Authorization` carries your session token on this ingress, so it cannot be repurposed to carry an upstream credential. Any client headers the target accepts via `Cookie` or a custom header (e.g. `X-Api-Key`) still flow through. **If you need to forward an upstream `Authorization: Bearer <target-token>` through passthrough, you must use the MITM ingress (`HTTPS_PROXY=http://localhost:14322`) instead** — there, `Proxy-Authorization` is the broker-scoped credential and `Authorization` passes through unchanged.
-- **MITM (`HTTPS_PROXY`) ingress:** hop-by-hop and `Proxy-Authorization` are stripped. `Authorization` and all other client headers flow through unchanged.
+- **Transparent MITM (`HTTPS_PROXY`, the default under `vault run`):** hop-by-hop and `Proxy-Authorization` are stripped. `Authorization` and all other client headers flow through unchanged — use this ingress if you need to forward an upstream `Authorization: Bearer <target-token>`.
+- **Explicit `/proxy/{host}/{path}` fallback:** hop-by-hop, `X-Vault`, **and** `Authorization` are stripped before the request is forwarded. `Authorization` carries your session token on this ingress, so it cannot be repurposed to carry an upstream credential. Client headers the target accepts via `Cookie` or a custom header (e.g. `X-Api-Key`) still flow through.
 
 ### Creating a Proposal
 

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -129,7 +129,12 @@ passthrough -- forward client headers, inject nothing  {"auth": {"type": "passth
 
 Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic -- API key as username), Jira (basic -- email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
 
-**Passthrough** allowlists a host but does not store or inject a credential — the client's `Authorization` and other request headers flow through unchanged (hop-by-hop headers, `X-Vault`, and `Proxy-Authorization` are still stripped). Use it only when the operator has decided their client already holds the credential and wants netguard / audit / MITM coverage without putting the secret in the vault. For the default case (agent needs the credential from the vault), use one of the credentialed types above. Passthrough auth entries reject all credential fields (`token`, `username`, `password`, `key`, `header`, `prefix`, `headers`).
+**Passthrough** allowlists a host but does not store or inject a credential. Use it only when the operator has decided their client already holds the credential and wants netguard / audit / MITM coverage without putting the secret in the vault. For the default case (agent needs the credential from the vault), use one of the credentialed types above. Passthrough auth entries reject all credential fields (`token`, `username`, `password`, `key`, `header`, `prefix`, `headers`).
+
+Header handling on passthrough depends on the ingress:
+
+- **Explicit `/proxy/{host}/{path}` (this doc):** hop-by-hop, `X-Vault`, **and** `Authorization` are stripped before the request is forwarded. `Authorization` carries your session token on this ingress, so it cannot be repurposed to carry an upstream credential. Any client headers the target accepts via `Cookie` or a custom header (e.g. `X-Api-Key`) still flow through. **If you need to forward an upstream `Authorization: Bearer <target-token>` through passthrough, you must use the MITM ingress (`HTTPS_PROXY=http://localhost:14322`) instead** — there, `Proxy-Authorization` is the broker-scoped credential and `Authorization` passes through unchanged.
+- **MITM (`HTTPS_PROXY`) ingress:** hop-by-hop and `Proxy-Authorization` are stripped. `Authorization` and all other client headers flow through unchanged.
 
 ### Creating a Proposal
 

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -239,6 +239,11 @@ func TestMITMPassthroughForwardsClientAuthorization(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer upstream-token")
 	req.Header.Set("Cookie", "session=abc")
 	req.Header.Set("X-Trace-Id", "trace-123")
+	// Set Proxy-Authorization on the tunneled request explicitly. Go's
+	// http.Transport only emits Proxy-Authorization on the CONNECT
+	// handshake (via url.User), not on in-tunnel requests, so without
+	// this assignment the strip assertion below would be vacuous.
+	req.Header.Set("Proxy-Authorization", "Basic c2hvdWxkLWJlLXN0cmlwcGVk")
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Three follow-ups from [review feedback on PR #76](https://github.com/Infisical/agent-vault/pull/76#pullrequestreview-4125428912), which merged the passthrough auth type.

## Summary

1. **skill_http.md + skill_cli.md** — the passthrough paragraph read *"the client's `Authorization` and other request headers flow through unchanged"*, which is only true for the MITM ingress. On the explicit `/proxy` ingress, `Authorization` carries the Agent Vault session token and is always stripped before the request is forwarded. Agents reading the skills and following that guidance would set `Authorization: Bearer <target-token>`, have it silently dropped, and get an unexplained 401 from the upstream. Split the passthrough header-handling guidance per-ingress in both skill files so the ingress-specific behavior is documented alongside the code.

2. **skill_cli.md JSON-mode Key fields list** — the `services[].auth` enumeration was missing `passthrough`. The equivalent line in `skill_http.md` had been updated; the skill pair must stay in lockstep per the [CLAUDE.md convention](CLAUDE.md). Added `passthrough` (no credential fields) to the list in `skill_cli.md`.

3. **`TestMITMPassthroughForwardsClientAuthorization`** — the `Proxy-Authorization` strip assertion was vacuous. Go's `http.Transport` emits `Proxy-Authorization` only on the CONNECT handshake (via `url.User`), not on in-tunnel requests, so the upstream handler always saw an empty value regardless of whether `CopyPassthroughRequestHeaders` stripped it. Set `Proxy-Authorization` explicitly on the inner tunneled request so the strip is actually exercised.

No production code changed — the implementation was already correct and the brokercore unit test (`TestCopyPassthroughRequestHeaders_StripsBrokerScoped`) already covered the strip directly. This closes the documentation/test-coverage gaps the review surfaced.

## Test plan

- [x] `make test` — all packages green, including `TestMITMPassthroughForwardsClientAuthorization` with the now-meaningful `Proxy-Authorization` assertion.
- [x] `make build` — frontend + Go binary build clean.
- [ ] Spot-check the rendered Mintlify preview to confirm the per-ingress bullets render correctly in the skill docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)