### PR TITLE
feat: simplify agent skills to MITM-only + add help hints to proxy errors

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,7 +29,7 @@ var skillHTTP string
 var runCmd = &cobra.Command{
 	Use:   "run [flags] -- <command> [args...]",
 	Short: "Wrap an agent process with Agent Vault access",
-	Long: `Start an agent process (e.g. claude, agent, codex) with an Agent Vault session.
+	Long: `Start an agent process (e.g. claude, agent, codex, hermes) with an Agent Vault session.
 Everything after -- is treated as the command to execute.
 
 Environment variables always set on the child:
@@ -40,7 +40,7 @@ Environment variables always set on the child:
 When the server's transparent MITM proxy is reachable (default), the child
 also inherits HTTPS_PROXY / NO_PROXY plus the root CA trust variables
 (SSL_CERT_FILE, NODE_EXTRA_CA_CERTS, REQUESTS_CA_BUNDLE, CURL_CA_BUNDLE,
-GIT_SSL_CAINFO) so standard HTTPS clients transparently route through the
+GIT_SSL_CAINFO, DENO_CERT) so standard HTTPS clients transparently route through the
 broker. HTTP_PROXY is intentionally not set — the MITM proxy only handles
 HTTPS (CONNECT) and would 405 any plain http:// request. The root CA PEM
 is written to ~/.agent-vault/mitm-ca.pem. Pass --no-mitm to disable
@@ -109,12 +109,8 @@ Example:
 
 		// 7. If the target command is a supported agent, offer to install the
 		//    Agent Vault skill (only when not already present).
-		if isClaudeCommand(args[0]) {
-			maybeInstallSkills("Claude Code", ".claude")
-		} else if isCursorCommand(args[0]) {
-			maybeInstallSkills("Cursor", ".cursor")
-		} else if isCodexCommand(args[0]) {
-			maybeInstallSkills("Codex", ".agents")
+		if name, dir, ok := agentSkillDir(args[0]); ok {
+			maybeInstallSkills(name, dir)
 		}
 
 		// 8. Confirm, then exec — replaces this process entirely so the child
@@ -124,23 +120,32 @@ Example:
 	},
 }
 
-// isClaudeCommand returns true if the command name is "claude"
-// (ignoring any path prefix). args[0] is always the base command;
-// flags like --dangerously-skip-permissions are separate args.
-func isClaudeCommand(cmd string) bool {
-	return filepath.Base(cmd) == "claude"
+// knownAgents maps CLI binary base-names to the (agentName, skillsDir)
+// pair used by maybeInstallSkills. Multiple base-names can map to the
+// same entry (e.g. "cursor" and "agent" both target ".cursor").
+var knownAgents = []struct {
+	bases     []string
+	agentName string
+	baseDir   string
+}{
+	{[]string{"claude"}, "Claude Code", ".claude"},
+	{[]string{"cursor", "agent"}, "Cursor", ".cursor"},
+	{[]string{"codex"}, "Codex", ".agents"},
+	{[]string{"hermes"}, "Hermes", ".hermes"},
 }
 
-// isCursorCommand returns true if the command name is "cursor" or "agent"
-// (Cursor's CLI binary).
-func isCursorCommand(cmd string) bool {
+// agentSkillDir returns the display name and skills base directory for a
+// known agent command, or ok=false if the command is not recognized.
+func agentSkillDir(cmd string) (agentName, baseDir string, ok bool) {
 	base := filepath.Base(cmd)
-	return base == "cursor" || base == "agent"
-}
-
-// isCodexCommand returns true if the command name is "codex".
-func isCodexCommand(cmd string) bool {
-	return filepath.Base(cmd) == "codex"
+	for _, a := range knownAgents {
+		for _, b := range a.bases {
+			if base == b {
+				return a.agentName, a.baseDir, true
+			}
+		}
+	}
+	return "", "", false
 }
 
 // maybeInstallSkills installs both Agent Vault skills (CLI and HTTP) under
@@ -292,6 +297,7 @@ var mitmInjectedKeys = map[string]struct{}{
 	"REQUESTS_CA_BUNDLE":  {},
 	"CURL_CA_BUNDLE":      {},
 	"GIT_SSL_CAINFO":      {},
+	"DENO_CERT":           {},
 }
 
 // stripEnvKeys returns env with every entry whose key (the part before
@@ -374,6 +380,7 @@ func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]stri
 		"REQUESTS_CA_BUNDLE="+caPath,
 		"CURL_CA_BUNDLE="+caPath,
 		"GIT_SSL_CAINFO="+caPath,
+		"DENO_CERT="+caPath,
 	)
 	return env, port, true, nil
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -107,6 +107,7 @@ func TestAugmentEnvWithMITM_Enabled(t *testing.T) {
 		"REQUESTS_CA_BUNDLE":  caPath,
 		"CURL_CA_BUNDLE":      caPath,
 		"GIT_SSL_CAINFO":      caPath,
+		"DENO_CERT":           caPath,
 	}
 	vars := envMap(env)
 	for k, v := range want {
@@ -196,6 +197,7 @@ func TestAugmentEnvWithMITM_DedupesParentEnv(t *testing.T) {
 		"REQUESTS_CA_BUNDLE=/etc/ssl/corp-ca.pem",
 		"CURL_CA_BUNDLE=/etc/ssl/corp-ca.pem",
 		"GIT_SSL_CAINFO=/etc/ssl/corp-ca.pem",
+		"DENO_CERT=/etc/ssl/corp-ca.pem",
 		"UNRELATED=keep-me",
 	}
 	env, _, ok, err := augmentEnvWithMITM(parentEnv, srv.URL, "tok", "v", caPath)
@@ -211,7 +213,7 @@ func TestAugmentEnvWithMITM_DedupesParentEnv(t *testing.T) {
 			counts[kv[:i]]++
 		}
 	}
-	for _, k := range []string{"HTTPS_PROXY", "NO_PROXY", "SSL_CERT_FILE", "NODE_EXTRA_CA_CERTS", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE", "GIT_SSL_CAINFO"} {
+	for _, k := range []string{"HTTPS_PROXY", "NO_PROXY", "SSL_CERT_FILE", "NODE_EXTRA_CA_CERTS", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE", "GIT_SSL_CAINFO", "DENO_CERT"} {
 		if counts[k] != 1 {
 			t.Errorf("%s appears %d times in env, want exactly 1 (POSIX getenv returns first match)", k, counts[k])
 		}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -165,6 +165,7 @@ func attachMITMIfEnabled(srv *server.Server, host string, mitmPort int, masterKe
 		caProv,
 		srv.SessionResolver(),
 		srv.CredentialProvider(),
+		srv.BaseURL(),
 		srv.Logger(),
 	))
 	return nil

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -9,7 +9,7 @@ description: >-
 compatibility: Requires a running Agent Vault server, the agent-vault binary on $PATH, and AGENT_VAULT_SESSION_TOKEN environment variable
 metadata:
   author: dangtony98
-  version: "0.3.0"
+  version: "0.4.0"
 ---
 
 # Agent Vault (CLI)
@@ -37,9 +37,9 @@ You have access to Agent Vault, a transparent HTTPS proxy that injects credentia
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault's control-plane endpoints (`discover`, proposals, etc.) |
-| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`; instance-level agent tokens use `X-Vault` header instead) |
+| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`) |
 
-`vault run` also pre-configures `HTTPS_PROXY`, `NO_PROXY`, and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`) so HTTPS calls from your process route through the broker transparently. You don't manage these yourself.
+`vault run` also pre-configures `HTTPS_PROXY`, `NO_PROXY`, and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) so HTTPS calls from your process route through the broker transparently. You don't manage these yourself.
 
 ## Discover Available Services (Start Here)
 
@@ -49,7 +49,7 @@ You have access to Agent Vault, a transparent HTTPS proxy that injects credentia
 agent-vault vault discover --json
 ```
 
-Response includes `vault`, `services` (host + description), `available_credentials` (key names only, values are never exposed), and `proxy_url` (only needed for the explicit-proxy fallback below). Use `available_credentials` to reference existing credentials in proposals instead of creating duplicate slots.
+Response includes `vault`, `services` (host + description), and `available_credentials` (key names only, values are never exposed). Use `available_credentials` to reference existing credentials in proposals instead of creating duplicate slots.
 
 **Browse service templates:** `agent-vault catalog --json` lists built-in service templates with suggested credential keys and auth types. No auth needed.
 
@@ -63,43 +63,6 @@ curl https://api.github.com/user
 ```
 
 Your code can leave the upstream auth header blank or set it to a placeholder — Agent Vault attaches the real credential at the proxy boundary, so the value in your env can be anything (or absent). Standard HTTP clients (curl, fetch, requests, axios, the Go stdlib, etc.) honor `HTTPS_PROXY` automatically.
-
-### Fallback: explicit `/proxy/{host}/{path}`
-
-Use the explicit proxy URL only when transparent MITM isn't viable:
-
-- The HTTP client doesn't honor `HTTPS_PROXY` (rare)
-- You weren't launched via `vault run`, so your environment lacks the broker's CA trust
-- The operator started the server with `--mitm-port 0`, or you with `--no-mitm`
-
-```
-{AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-```
-
-Agent Vault strips your `Authorization` header (it carried your session token), injects the real credentials, and forwards over HTTPS. Same credential injection as the transparent path — just URL-rewritten.
-
-## Managing Services Directly
-
-If you have vault admin role, you can add or remove services directly without proposals:
-
-```bash
-# Add or update a service (upsert by host)
-agent-vault vault service add \
-  --host api.stripe.com --auth-type bearer --token-key STRIPE_KEY \
-  --description "Stripe API"
-
-# Add services from a YAML file (upsert, non-destructive)
-agent-vault vault service add -f services.yaml
-
-# Remove a specific service
-agent-vault vault service remove api.stripe.com --yes
-
-# List all configured services
-agent-vault vault service list
-```
-
-Use `service add` when you already have credentials stored and just need to configure the proxy rule. Use proposals when the human needs to provide new credentials.
 
 ## Proposals -- Requesting and Storing Credentials
 
@@ -128,11 +91,6 @@ passthrough -- forward client headers, inject nothing  {"auth": {"type": "passth
 Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic -- API key as username), Jira (basic -- email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
 
 **Passthrough** allowlists a host but does not store or inject a credential. Use it only when the operator has decided their client already holds the credential and wants netguard / audit / MITM coverage without putting the secret in the vault. For the default case (agent needs the credential from the vault), use one of the credentialed types above.
-
-Header handling on passthrough depends on the ingress the client uses:
-
-- **Transparent MITM (`HTTPS_PROXY`, the default under `vault run`):** hop-by-hop and `Proxy-Authorization` are stripped. `Authorization` and all other client headers flow through unchanged — use this ingress if you need to forward an upstream `Authorization: Bearer <target-token>` through a passthrough service.
-- **Explicit `/proxy/{host}/{path}` fallback:** hop-by-hop, `X-Vault`, **and** `Authorization` are stripped before the request is forwarded. `Authorization` carries the Agent Vault session token on this ingress, so clients cannot use it to carry an upstream credential. Client headers the target accepts via `Cookie` or a custom header still flow through.
 
 ### Creating a Proposal
 

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -8,7 +8,7 @@ description: >-
 compatibility: Requires a running Agent Vault server and AGENT_VAULT_SESSION_TOKEN environment variable
 metadata:
   author: dangtony98
-  version: "0.3.0"
+  version: "0.4.0"
 ---
 
 # Agent Vault (HTTP)
@@ -36,9 +36,9 @@ You have access to Agent Vault, a transparent HTTPS proxy that injects credentia
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault's control-plane endpoints (`/discover`, proposals, etc.) |
-| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`; for instance-level agent tokens, use the `X-Vault` header instead) |
+| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`) |
 
-`vault run` also pre-configures `HTTPS_PROXY`, `NO_PROXY`, and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`) so HTTPS calls from your process route through the broker transparently. You don't manage these yourself.
+`vault run` also pre-configures `HTTPS_PROXY`, `NO_PROXY`, and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) so HTTPS calls from your process route through the broker transparently. You don't manage these yourself.
 
 ## Discover Available Services (Start Here)
 
@@ -52,7 +52,7 @@ X-Vault: {vault_name}
 
 **Note:** If `AGENT_VAULT_VAULT` is set, the server uses it automatically. Instance-level agent tokens (persistent agents) must include the `X-Vault` header on all vault-scoped requests.
 
-Response includes `vault`, `services` (host + description), `available_credentials` (key names only, values are never exposed), and `proxy_url` (only needed for the explicit-proxy fallback below). Use `available_credentials` to reference existing credentials in proposals instead of creating duplicate slots.
+Response includes `vault`, `services` (host + description), and `available_credentials` (key names only, values are never exposed). Use `available_credentials` to reference existing credentials in proposals instead of creating duplicate slots.
 
 **Browse service templates:**
 
@@ -72,52 +72,6 @@ GET https://api.github.com/user
 ```
 
 Your code can leave the upstream auth header blank or set it to a placeholder — Agent Vault attaches the real credential at the proxy boundary, so the value in your env can be anything (or absent). Standard HTTP clients (curl, fetch, requests, axios, the Go stdlib, etc.) honor `HTTPS_PROXY` automatically.
-
-### Fallback: explicit `/proxy/{host}/{path}`
-
-Use the explicit proxy URL only when transparent MITM isn't viable:
-
-- The HTTP client doesn't honor `HTTPS_PROXY` (rare)
-- You weren't launched via `vault run`, so your environment lacks the broker's CA trust
-- The operator started the server with `--mitm-port 0`, or you with `--no-mitm`
-
-```
-{AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-```
-
-Agent Vault strips your `Authorization` header (it carried your session token), injects the real credentials, and forwards over HTTPS. Same credential injection as the transparent path — just URL-rewritten.
-
-## Managing Services Directly
-
-If you have vault admin role, you can add or remove services via HTTP without proposals:
-
-**Upsert services (add or replace by host):**
-
-```
-POST {AGENT_VAULT_ADDR}/v1/vaults/{vault_name}/services
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-Content-Type: application/json
-
-{
-  "services": [
-    {"host": "api.stripe.com", "description": "Stripe API", "auth": {"type": "bearer", "token": "STRIPE_KEY"}}
-  ]
-}
-```
-
-Returns: `{"vault": "...", "upserted": ["api.stripe.com"], "services_count": 5}`
-
-**Remove a service by host:**
-
-```
-DELETE {AGENT_VAULT_ADDR}/v1/vaults/{vault_name}/services/{host}
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
-```
-
-Returns: `{"vault": "...", "removed": "api.stripe.com", "services_count": 4}` (404 if host not found)
-
-Use these endpoints when you already have credentials stored and just need to configure the proxy rule. Use proposals when the human needs to provide new credentials.
 
 ## Proposals -- Requesting and Storing Credentials
 
@@ -146,11 +100,6 @@ passthrough -- forward client headers, inject nothing  {"auth": {"type": "passth
 Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic -- API key as username), Jira (basic -- email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
 
 **Passthrough** allowlists a host but does not store or inject a credential. Use it only when the operator has decided their client already holds the credential and wants netguard / audit / MITM coverage without putting the secret in the vault. For the default case (agent needs the credential from the vault), use one of the credentialed types above. Passthrough auth entries reject all credential fields (`token`, `username`, `password`, `key`, `header`, `prefix`, `headers`).
-
-Header handling on passthrough depends on the ingress:
-
-- **Transparent MITM (`HTTPS_PROXY`, the default under `vault run`):** hop-by-hop and `Proxy-Authorization` are stripped. `Authorization` and all other client headers flow through unchanged — use this ingress if you need to forward an upstream `Authorization: Bearer <target-token>`.
-- **Explicit `/proxy/{host}/{path}` fallback:** hop-by-hop, `X-Vault`, **and** `Authorization` are stripped before the request is forwarded. `Authorization` carries your session token on this ingress, so it cannot be repurposed to carry an upstream credential. Client headers the target accepts via `Cookie` or a custom header (e.g. `X-Api-Key`) still flow through.
 
 ### Creating a Proposal
 
@@ -226,15 +175,9 @@ Content-Type: application/json
 - Always check `available_credentials` first to avoid proposing duplicates
 - Include `obtain` and `obtain_instructions` to help the human find the credential
 
-## Instance-Level Agent Tokens
-
-If you were registered as a persistent agent (via an agent invite), your token is instance-level -- it is not scoped to a single vault. You may have access to multiple vaults. Include the `X-Vault` header on all vault-scoped requests (proxy, discover, proposals, credentials) to select which vault to operate on.
-
-If your token has no expiry, it works indefinitely. If it does expire, contact your operator for a new token.
-
 ## Error Handling
 
-- 401: Invalid or expired token -- check `AGENT_VAULT_SESSION_TOKEN` (persistent agents: contact operator for a new token)
+- 401: Invalid or expired token -- check `AGENT_VAULT_SESSION_TOKEN`
 - 403: Host not allowed -- create a proposal
 - 429: Too many pending proposals -- wait for review
 - 502: Missing credential or upstream unreachable, tell user a credential may need to be added

--- a/docs/guides/connect-coding-agent.mdx
+++ b/docs/guides/connect-coding-agent.mdx
@@ -22,6 +22,7 @@ The simplest approach for local development. Wraps your agent process with the e
 agent-vault vault run -- claude    # Claude Code
 agent-vault vault run -- agent     # Cursor
 agent-vault vault run -- codex     # Codex
+agent-vault vault run -- hermes    # Hermes Agent
 ```
 
 The agent can immediately make proxied requests and raise [proposals](/learn/proposals).

--- a/docs/quickstart/hermes-agent.mdx
+++ b/docs/quickstart/hermes-agent.mdx
@@ -5,26 +5,30 @@ description: "Learn how to connect Hermes Agent to Agent Vault so it can make au
 
 ## Prerequisites
 
-To get the most out of this guide, you'll need to:
+- A running Agent Vault instance ([see installation guide](/installation))
+- [Hermes Agent](https://hermesagent.dev/) installed
 
-- A deployed Agent Vault instance ([see installation guide](/installation))
-- Have [Hermes Agent](https://hermesagent.dev/) installed
+## Quick start
 
-## 1. Create an agent invite
-
-If you haven't logged in yet, you'll be guided through setup automatically.
+Launch Hermes Agent with `vault run`. It wraps Hermes with a vault-scoped session and installs the Agent Vault skill so Hermes knows how to proxy requests and raise proposals automatically. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
-agent-vault agent invite hermes
+agent-vault vault run -- hermes
 ```
 
-This generates a one-time onboarding prompt and copies it to your clipboard.
+That's it. Hermes Agent launches with Agent Vault access — no invite, no token pasting.
 
-## 2. Paste the prompt into Hermes Agent
+<Tip>
+`vault run` also installs an Agent Vault skill at `~/.hermes/skills/agent-vault/SKILL.md`. This teaches Hermes Agent how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
+</Tip>
 
-Open Hermes Agent's chat and paste the invite prompt. Hermes Agent redeems the invite automatically and receives an agent token.
+### Target a specific vault
 
-## 3. Start using it
+```bash
+agent-vault vault run --vault myproject -- hermes
+```
+
+## Try it out
 
 Ask Hermes Agent to do something that requires an external API:
 
@@ -34,14 +38,24 @@ Here's what happens — with zero pre-configuration:
 
 1. Hermes Agent routes a request to `api.stripe.com` through Agent Vault
 2. Agent Vault returns a **403** — Stripe isn't configured yet
-3. Hermes Agent reads the `proposal_hint` and creates a proposal proposing Stripe access
+3. Hermes Agent reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. Hermes Agent presents you with an approval link
 5. You click the link, paste your Stripe key, and click **Allow**
-6. Hermes Agent retries — Agent Vault reconstructs the request with your Stripe credentials and the request succeeds
+6. Hermes Agent retries — Agent Vault injects your Stripe credentials and the request succeeds
 
 <Note>
 You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
 </Note>
+
+## Alternative: invite-based setup
+
+If you can't use `vault run` (e.g. you're connecting a remote or cloud-hosted Hermes instance), use the invite flow instead:
+
+```bash
+agent-vault agent invite hermes
+```
+
+This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Hermes Agent — it redeems the invite automatically and receives an agent token plus usage instructions inline.
 
 ## Next steps
 

--- a/docs/quickstart/hermes-agent.mdx
+++ b/docs/quickstart/hermes-agent.mdx
@@ -19,7 +19,7 @@ agent-vault vault run -- hermes
 That's it. Hermes Agent launches with Agent Vault access — no invite, no token pasting.
 
 <Tip>
-`vault run` also installs an Agent Vault skill at `~/.hermes/skills/agent-vault/SKILL.md`. This teaches Hermes Agent how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
+`vault run` also installs two Agent Vault skills at `~/.hermes/skills/agent-vault-cli/SKILL.md` and `~/.hermes/skills/agent-vault-http/SKILL.md`. These teach Hermes Agent how to discover services, proxy requests, and raise proposals through Agent Vault. The skills persist across sessions.
 </Tip>
 
 ### Target a specific vault

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -233,7 +233,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault run [flags] -- <command>
     ```
 
-    Wrap a process with Agent Vault environment variables. The child process always receives `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT`. When the server's transparent MITM proxy is reachable (default), it also receives `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` plus CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) pointing at `~/.agent-vault/mitm-ca.pem`, so standard HTTPS clients transparently route through the broker.
+    Wrap a process with Agent Vault environment variables. The child process always receives `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT`. When the server's transparent MITM proxy is reachable (default), it also receives `HTTPS_PROXY` / `NO_PROXY` plus CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) pointing at `~/.agent-vault/mitm-ca.pem`, so standard HTTPS clients transparently route through the broker.
 
     | Flag | Default | Description |
     |------|---------|-------------|

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -233,7 +233,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault run [flags] -- <command>
     ```
 
-    Wrap a process with Agent Vault environment variables. The child process always receives `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT`. When the server's transparent MITM proxy is reachable (default), it also receives `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` plus CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`) pointing at `~/.agent-vault/mitm-ca.pem`, so standard HTTPS clients transparently route through the broker.
+    Wrap a process with Agent Vault environment variables. The child process always receives `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT`. When the server's transparent MITM proxy is reachable (default), it also receives `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` plus CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) pointing at `~/.agent-vault/mitm-ca.pem`, so standard HTTPS clients transparently route through the broker.
 
     | Flag | Default | Description |
     |------|---------|-------------|

--- a/internal/brokercore/brokercore.go
+++ b/internal/brokercore/brokercore.go
@@ -142,11 +142,23 @@ func ApplyInjection(src, dst http.Header, inject *InjectResult, extraStrip ...st
 	}
 }
 
+// helpLinks returns the standard "see available services / usage instructions"
+// suffix appended to broker-layer error messages when baseURL is known.
+func helpLinks(baseURL string) string {
+	return fmt.Sprintf(
+		"To see available services, GET %s/discover. For usage instructions including how to create a proposal, GET %s/v1/skills/http",
+		baseURL, baseURL,
+	)
+}
+
 // ForbiddenHintBody returns the JSON-shaped body for a 403 response when
 // the target host is not matched by any broker service in the vault. Both
 // ingresses emit identical bytes so agents can uniformly parse the hint.
-func ForbiddenHintBody(targetHost, vaultName string) map[string]interface{} {
-	return map[string]interface{}{
+// baseURL is the externally-reachable control-plane URL used to build
+// actionable help links so agents without the skill file pre-loaded can
+// self-discover available services and usage instructions.
+func ForbiddenHintBody(targetHost, vaultName, baseURL string) map[string]interface{} {
+	body := map[string]interface{}{
 		"error":   "forbidden",
 		"message": fmt.Sprintf("No broker service matching host %q in vault %q", targetHost, vaultName),
 		"proposal_hint": map[string]interface{}{
@@ -155,6 +167,10 @@ func ForbiddenHintBody(targetHost, vaultName string) map[string]interface{} {
 			"supported_auth_types": broker.SupportedAuthTypes,
 		},
 	}
+	if baseURL != "" {
+		body["help"] = "This request was intercepted by Agent Vault. " + helpLinks(baseURL)
+	}
+	return body
 }
 
 // ShouldStripResponseHeader reports whether an upstream response header
@@ -179,24 +195,28 @@ func WriteProxyError(w http.ResponseWriter, status int, code, message string) {
 // WriteForbiddenHint writes a 403 with the shared proposal_hint body so
 // both ingress paths emit identical bytes for the "host not brokerable"
 // case.
-func WriteForbiddenHint(w http.ResponseWriter, targetHost, vaultName string) {
+func WriteForbiddenHint(w http.ResponseWriter, targetHost, vaultName, baseURL string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set(ProxyErrorHeader, "true")
 	w.WriteHeader(http.StatusForbidden)
-	_ = json.NewEncoder(w).Encode(ForbiddenHintBody(targetHost, vaultName))
+	_ = json.NewEncoder(w).Encode(ForbiddenHintBody(targetHost, vaultName, baseURL))
 }
 
 // WriteInjectError maps a CredentialProvider.Inject error to the standard
-// HTTP response for both ingress paths. Callers that want to log before
+// HTTP response for both ingress paths. baseURL is the externally-reachable
+// control-plane URL for help links. Callers that want to log before
 // responding (e.g. the /proxy path logs credential-resolution failures)
 // should do so before calling this helper.
-func WriteInjectError(w http.ResponseWriter, err error, targetHost, vaultName string) {
+func WriteInjectError(w http.ResponseWriter, err error, targetHost, vaultName, baseURL string) {
 	switch {
 	case errors.Is(err, ErrServiceNotFound):
-		WriteForbiddenHint(w, targetHost, vaultName)
+		WriteForbiddenHint(w, targetHost, vaultName, baseURL)
 	case errors.Is(err, ErrCredentialMissing):
-		WriteProxyError(w, http.StatusBadGateway, "credential_not_found",
-			"A required credential could not be resolved; check vault configuration")
+		msg := "A required credential could not be resolved; check vault configuration"
+		if baseURL != "" {
+			msg += ". " + helpLinks(baseURL)
+		}
+		WriteProxyError(w, http.StatusBadGateway, "credential_not_found", msg)
 	default:
 		WriteProxyError(w, http.StatusInternalServerError, "internal",
 			"Failed to resolve broker services")

--- a/internal/brokercore/brokercore.go
+++ b/internal/brokercore/brokercore.go
@@ -212,11 +212,17 @@ func WriteInjectError(w http.ResponseWriter, err error, targetHost, vaultName, b
 	case errors.Is(err, ErrServiceNotFound):
 		WriteForbiddenHint(w, targetHost, vaultName, baseURL)
 	case errors.Is(err, ErrCredentialMissing):
-		msg := "A required credential could not be resolved; check vault configuration"
-		if baseURL != "" {
-			msg += ". " + helpLinks(baseURL)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(ProxyErrorHeader, "true")
+		w.WriteHeader(http.StatusBadGateway)
+		body := map[string]interface{}{
+			"error":   "credential_not_found",
+			"message": "A required credential could not be resolved; check vault configuration",
 		}
-		WriteProxyError(w, http.StatusBadGateway, "credential_not_found", msg)
+		if baseURL != "" {
+			body["help"] = helpLinks(baseURL)
+		}
+		_ = json.NewEncoder(w).Encode(body)
 	default:
 		WriteProxyError(w, http.StatusInternalServerError, "internal",
 			"Failed to resolve broker services")

--- a/internal/brokercore/brokercore_test.go
+++ b/internal/brokercore/brokercore_test.go
@@ -129,7 +129,7 @@ func TestCopyPassthroughRequestHeaders_ExtraStrip(t *testing.T) {
 }
 
 func TestForbiddenHintBody(t *testing.T) {
-	body := ForbiddenHintBody("api.example.com", "default")
+	body := ForbiddenHintBody("api.example.com", "default", "http://127.0.0.1:14321")
 	if body["error"] != "forbidden" {
 		t.Fatalf("error = %v", body["error"])
 	}
@@ -148,8 +148,27 @@ func TestForbiddenHintBody(t *testing.T) {
 		t.Fatalf("hint endpoint = %v", hint["endpoint"])
 	}
 
+	// help field must contain actionable URLs.
+	help, ok := body["help"].(string)
+	if !ok {
+		t.Fatal("expected help field in body")
+	}
+	if !strings.Contains(help, "http://127.0.0.1:14321/discover") {
+		t.Fatalf("help missing discover URL: %s", help)
+	}
+	if !strings.Contains(help, "http://127.0.0.1:14321/v1/skills/http") {
+		t.Fatalf("help missing skills URL: %s", help)
+	}
+
 	// Must be JSON-serializable (used by both ingresses as response body).
 	if _, err := json.Marshal(body); err != nil {
 		t.Fatalf("marshal: %v", err)
+	}
+}
+
+func TestForbiddenHintBody_EmptyBaseURL(t *testing.T) {
+	body := ForbiddenHintBody("api.example.com", "default", "")
+	if _, ok := body["help"]; ok {
+		t.Fatal("help field should be absent when baseURL is empty")
 	}
 }

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -57,7 +57,7 @@ func (p *Proxy) forwardHandler(target, host string, scope *brokercore.ProxyScope
 				status = http.StatusBadGateway
 				brokercore.LogCredentialMissing(p.logger, scope.VaultID, event.MatchedService, event.CredentialKeys)
 			}
-			brokercore.WriteInjectError(w, err, host, scope.VaultName)
+			brokercore.WriteInjectError(w, err, host, scope.VaultName, p.baseURL)
 			emit(status, errCode)
 			return
 		}

--- a/internal/mitm/proxy.go
+++ b/internal/mitm/proxy.go
@@ -33,14 +33,17 @@ type Proxy struct {
 	httpServer  *http.Server
 	upstream    *http.Transport
 	isListening atomic.Bool
+	baseURL     string // externally-reachable control-plane URL for help links
 	logger      *slog.Logger
 }
 
 // New builds a Proxy bound to addr using caProv for leaf certificates and
 // the brokercore sessions/creds for authentication and credential injection.
+// baseURL is the externally-reachable control-plane URL (e.g.
+// "http://127.0.0.1:14321") used to build help links in error responses.
 // The returned Proxy does not begin listening until ListenAndServe is
 // called. logger must be non-nil; tests can pass slog.New(slog.DiscardHandler).
-func New(addr string, caProv ca.Provider, sessions brokercore.SessionResolver, creds brokercore.CredentialProvider, logger *slog.Logger) *Proxy {
+func New(addr string, caProv ca.Provider, sessions brokercore.SessionResolver, creds brokercore.CredentialProvider, baseURL string, logger *slog.Logger) *Proxy {
 	upstream := &http.Transport{
 		DialContext:           netguard.SafeDialContext(netguard.ModeFromEnv()),
 		TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
@@ -56,6 +59,7 @@ func New(addr string, caProv ca.Provider, sessions brokercore.SessionResolver, c
 		sessions: sessions,
 		creds:    creds,
 		upstream: upstream,
+		baseURL:  baseURL,
 		logger:   logger,
 	}
 

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -97,7 +97,7 @@ func setupProxy(t *testing.T, sr brokercore.SessionResolver, cp brokercore.Crede
 		t.Fatal("failed to load CA root PEM into pool")
 	}
 
-	p = New("127.0.0.1:0", caProv, sr, cp, slog.New(slog.DiscardHandler))
+	p = New("127.0.0.1:0", caProv, sr, cp, "http://127.0.0.1:14321", slog.New(slog.DiscardHandler))
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/server/handle_mitm_test.go
+++ b/internal/server/handle_mitm_test.go
@@ -29,7 +29,7 @@ func TestHandleMITMCA(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ca.New: %v", err)
 		}
-		p := mitm.New("127.0.0.1:0", caProv, srv.SessionResolver(), srv.CredentialProvider(), srv.Logger())
+		p := mitm.New("127.0.0.1:0", caProv, srv.SessionResolver(), srv.CredentialProvider(), srv.BaseURL(), srv.Logger())
 		srv.AttachMITM(p)
 
 		// Start the proxy so IsListening() reports true. The handler gates
@@ -96,7 +96,7 @@ func TestHandleMITMCA(t *testing.T) {
 		}
 		// Bind to an explicit non-default port so we can assert the
 		// header reflects the configured Addr rather than any constant.
-		p := mitm.New("127.0.0.1:19322", caProv, srv.SessionResolver(), srv.CredentialProvider(), srv.Logger())
+		p := mitm.New("127.0.0.1:19322", caProv, srv.SessionResolver(), srv.CredentialProvider(), srv.BaseURL(), srv.Logger())
 		srv.AttachMITM(p)
 
 		l, err := net.Listen("tcp", "127.0.0.1:0")
@@ -160,7 +160,7 @@ func TestHandleMITMCA(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ca.New: %v", err)
 		}
-		p := mitm.New("127.0.0.1:0", caProv, srv.SessionResolver(), srv.CredentialProvider(), srv.Logger())
+		p := mitm.New("127.0.0.1:0", caProv, srv.SessionResolver(), srv.CredentialProvider(), srv.BaseURL(), srv.Logger())
 		srv.AttachMITM(p)
 		// Intentionally do not call Serve — simulates a bind failure.
 

--- a/internal/server/handle_proxy.go
+++ b/internal/server/handle_proxy.go
@@ -170,7 +170,7 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 			status = http.StatusBadGateway
 			brokercore.LogCredentialMissing(s.logger, ns.ID, event.MatchedService, event.CredentialKeys)
 		}
-		brokercore.WriteInjectError(w, err, targetHost, ns.Name)
+		brokercore.WriteInjectError(w, err, targetHost, ns.Name, s.baseURL)
 		emit(status, errCode)
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -87,6 +87,10 @@ func (s *Server) CredentialProvider() brokercore.CredentialProvider {
 // across ingress paths.
 func (s *Server) Logger() *slog.Logger { return s.logger }
 
+// BaseURL returns the externally-reachable base URL of the server
+// (e.g. "http://127.0.0.1:14321").
+func (s *Server) BaseURL() string { return s.baseURL }
+
 // Store is the persistence interface used by the server.
 type Store interface {
 	GetMasterKeyRecord(ctx context.Context) (*store.MasterKeyRecord, error)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2082,6 +2082,11 @@ func TestProxyNoMatchingRule(t *testing.T) {
 	if hint["endpoint"] != "POST /v1/proposals" {
 		t.Fatalf("expected proposal_hint endpoint, got %q", hint["endpoint"])
 	}
+	// Verify help field with actionable URLs is present.
+	help, ok := resp["help"].(string)
+	if !ok || help == "" {
+		t.Fatal("expected help field with actionable URLs in 403 response")
+	}
 }
 
 func TestProxyPassthroughForwardsClientHeaders(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Skill files simplified**: Remove explicit `/proxy/{host}/{path}` fallback, "Managing Services Directly", dual-ingress passthrough header handling, and "Instance-Level Agent Tokens" sections from both `skill_cli.md` and `skill_http.md`. The agent contract is now just "make normal requests, raise a proposal if blocked" — no explicit proxy pattern to latch onto.
- **Self-discovery via error responses**: 403 (host not allowed) and 502 (credential not found) proxy errors now include a `help` field with actionable URLs pointing at `GET {baseURL}/discover` and `GET {baseURL}/v1/skills/http`. Agents without the skill pre-loaded can follow these links to self-discover services and usage instructions on-demand.
- **Table-driven agent detection**: Consolidates `isClaudeCommand()`, `isCursorCommand()`, `isCodexCommand()`, `isHermesCommand()` into a single `knownAgents` table + `agentSkillDir()` lookup. Adding a new agent is now one table entry.
- **Shared help link helper**: Extracts `helpLinks(baseURL)` in brokercore so the 403 and 502 paths share the same URL format string.

## Test plan

- [x] `make test` passes — all packages green
- [ ] Verify 403 response body includes `help` field when hitting an unconfigured host through the proxy
- [ ] Verify 502 response body includes help links when a credential is missing
- [ ] Verify `vault run -- claude` still installs skills correctly
- [ ] Verify skill files read cleanly at `/v1/skills/cli` and `/v1/skills/http`

🤖 Generated with [Claude Code](https://claude.com/claude-code)