### PR TITLE
feat: KEK/DEK key-wrapping architecture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,39 @@
+# Agent Vault – local development environment variables
+# Copy to .env and fill in values. Loaded automatically by `make dev`.
+# Alternatively, use the Infisical CLI to inject secrets:
+#   infisical run -- make dev
+# See https://infisical.com/docs/cli/overview
+
+# Server listen port (respected by PaaS platforms like Fly.io, Cloud Run, Heroku)
+# PORT=14321
+
+# Master password — derives a KEK that wraps the data encryption key (DEK).
+# If omitted, the DEK is stored unwrapped (passwordless mode).
+# AGENT_VAULT_MASTER_PASSWORD=
+
+# External base URL (for links in emails, invites, discovery)
+# AGENT_VAULT_ADDR=http://localhost:14321
+
+# SMTP (optional – if unset, email notifications are silently disabled)
+# AGENT_VAULT_SMTP_HOST=
+# AGENT_VAULT_SMTP_PORT=587
+# AGENT_VAULT_SMTP_USERNAME=
+# AGENT_VAULT_SMTP_PASSWORD=
+# AGENT_VAULT_SMTP_FROM=
+# AGENT_VAULT_SMTP_FROM_NAME=Agent Vault
+# AGENT_VAULT_SMTP_TLS_MODE=opportunistic
+# AGENT_VAULT_SMTP_TLS_SKIP_VERIFY=false
+
+# OAuth – Google (optional)
+# AGENT_VAULT_OAUTH_GOOGLE_CLIENT_ID=
+# AGENT_VAULT_OAUTH_GOOGLE_CLIENT_SECRET=
+
+# Network security (optional)
+# AGENT_VAULT_NETWORK_MODE=public          # public (default) blocks private/reserved IPs; private allows all
+# AGENT_VAULT_TRUSTED_PROXIES=             # comma-separated CIDRs for trusted reverse proxies (e.g. 10.0.0.0/8)
+
+# Development (optional)
+# AGENT_VAULT_DEV_MODE=false               # when true, allows internal/localhost hosts in proposals
+
+# Observability (optional)
+# AGENT_VAULT_LOG_LEVEL=info               # info (default) | debug — debug emits one line per proxied request (no secret values)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ make docker       # Multi-stage Docker image; data persisted at /data/.agent-vau
 - **Two independent permission axes**:
   - Instance role: `owner` vs `member` (applies to both users and agents).
   - Vault role: `proxy` < `member` < `admin`. Proxy can use the proxy and raise proposals; member can manage credentials/services; admin can invite humans.
-- **Master password vs login password**: the master password encrypts credentials at rest (AES-256-GCM / Argon2id) and is only used at server startup. Login uses email+password or Google OAuth. The first user to register becomes the instance owner and is auto-granted vault admin on `default`.
+- **KEK/DEK key wrapping**: A random DEK (Data Encryption Key) encrypts credentials and the CA key at rest (AES-256-GCM). If a master password is set, Argon2id derives a KEK (Key Encryption Key) that wraps the DEK; changing the password re-wraps the DEK without re-encrypting credentials. If no password is set (passwordless mode), the DEK is stored in plaintext — suitable for PaaS deploys where volume security is the trust boundary. Login uses email+password or Google OAuth. The first user to register becomes the instance owner and is auto-granted vault admin on `default`.
 - **Agent skills are the agent-facing contract.** [cmd/skill_cli.md](cmd/skill_cli.md) and [cmd/skill_http.md](cmd/skill_http.md) are embedded into the binary, installed by `vault run`, and served publicly at `/v1/skills/{cli,http}`. They are the authoritative reference for what agents can do.
 
 ## Where to look for details

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Agent Vault takes a different approach: **Agent Vault never reveals vault-stored
 - **Brokered access, not retrieval** - Your agent gets a token and a proxy URL. It sends requests to `proxy/{host}/{path}` and Agent Vault authenticates them. Credentials stored in the vault are never returned to the agent. [Learn more](https://docs.agent-vault.dev/learn/security)
 - **Works with any agent** - Custom Python/TypeScript agents, sandboxed processes, coding agents (Claude Code, Cursor, Codex), anything that can make HTTP requests. [Learn more](https://docs.agent-vault.dev/quickstart)
 - **Self-service access** - Agents discover available services at runtime and [propose access](https://docs.agent-vault.dev/learn/proposals) for anything missing. You review and approve in your browser with one click.
-- **Encrypted at rest** - Credentials are encrypted with AES-256-GCM using an Argon2id-derived key. The master password never touches disk. [Learn more](https://docs.agent-vault.dev/learn/credentials)
+- **Encrypted at rest** - Credentials are encrypted with AES-256-GCM using a random data encryption key (DEK). An optional master password wraps the DEK via Argon2id — change the password without re-encrypting credentials. Passwordless mode available for PaaS deploys. [Learn more](https://docs.agent-vault.dev/learn/credentials)
 - **Multi-user, multi-vault** - Role-based access control with instance and vault-level [permissions](https://docs.agent-vault.dev/learn/permissions). Invite teammates, scope agents to specific [vaults](https://docs.agent-vault.dev/learn/vaults), and audit everything.
 
 <p align="center">

--- a/cmd/master_password.go
+++ b/cmd/master_password.go
@@ -1,0 +1,266 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/Infisical/agent-vault/internal/auth"
+	"github.com/Infisical/agent-vault/internal/crypto"
+	"github.com/Infisical/agent-vault/internal/pidfile"
+	"github.com/Infisical/agent-vault/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var masterPasswordCmd = &cobra.Command{
+	Use:   "master-password",
+	Short: "Manage the master password that protects the encryption key",
+}
+
+var masterPasswordSetCmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set a master password on a passwordless instance",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := ensureServerStopped(); err != nil {
+			return err
+		}
+
+		db, cleanup, err := openDB()
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		ctx := context.Background()
+		record, err := db.GetMasterKeyRecord(ctx)
+		if err != nil {
+			return fmt.Errorf("reading master key record: %w", err)
+		}
+		if record == nil {
+			return fmt.Errorf("no master key record found — run 'agent-vault server' first")
+		}
+		if record.DEKPlaintext == nil {
+			return fmt.Errorf("instance already has a master password — use 'agent-vault master-password change' instead")
+		}
+
+		// Load the DEK and verify the sentinel.
+		verRec := buildVerificationRecord(record)
+		mk, err := auth.UnlockPasswordless(verRec)
+		if err != nil {
+			return fmt.Errorf("failed to load encryption key: %w", err)
+		}
+		defer mk.Wipe()
+
+		// Prompt for the new password.
+		newPw, err := auth.PromptNewPassword(
+			"New master password: ",
+			"Confirm master password: ",
+		)
+		if err != nil {
+			return fmt.Errorf("password input: %w", err)
+		}
+		if len(newPw) == 0 {
+			return fmt.Errorf("password cannot be empty")
+		}
+
+		// Wrap the DEK under the new KEK.
+		salt, dekCT, dekNonce, params, err := auth.WrapDEK(mk.Key(), newPw)
+		crypto.WipeBytes(newPw)
+		if err != nil {
+			return fmt.Errorf("wrapping encryption key: %w", err)
+		}
+
+		// Update the record: set wrapped DEK, clear plaintext DEK.
+		record.DEKCiphertext = dekCT
+		record.DEKNonce = dekNonce
+		record.DEKPlaintext = nil
+		record.Salt = salt
+		record.KDFTime = &params.Time
+		record.KDFMemory = &params.Memory
+		record.KDFThreads = &params.Threads
+
+		if err := db.UpdateMasterKeyRecord(ctx, record); err != nil {
+			return fmt.Errorf("persisting updated record: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "%s Master password set. The server will require this password on startup.\n", successText("✓"))
+		return nil
+	},
+}
+
+var masterPasswordChangeCmd = &cobra.Command{
+	Use:   "change",
+	Short: "Change the master password",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := ensureServerStopped(); err != nil {
+			return err
+		}
+
+		db, cleanup, err := openDB()
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		ctx := context.Background()
+		record, err := db.GetMasterKeyRecord(ctx)
+		if err != nil {
+			return fmt.Errorf("reading master key record: %w", err)
+		}
+		if record == nil {
+			return fmt.Errorf("no master key record found — run 'agent-vault server' first")
+		}
+		if record.DEKCiphertext == nil {
+			return fmt.Errorf("instance has no master password — use 'agent-vault master-password set' instead")
+		}
+
+		// Prompt for the current password and unlock.
+		currentPw, err := auth.PromptPassword("Current master password: ")
+		if err != nil {
+			return fmt.Errorf("password input: %w", err)
+		}
+
+		verRec := buildVerificationRecord(record)
+		mk, err := auth.Unlock(currentPw, verRec)
+		crypto.WipeBytes(currentPw)
+		if err != nil {
+			return fmt.Errorf("wrong password")
+		}
+		defer mk.Wipe()
+
+		// Prompt for the new password.
+		newPw, err := auth.PromptNewPassword(
+			"New master password: ",
+			"Confirm new master password: ",
+		)
+		if err != nil {
+			return fmt.Errorf("password input: %w", err)
+		}
+		if len(newPw) == 0 {
+			return fmt.Errorf("password cannot be empty")
+		}
+
+		// Re-wrap the DEK under the new KEK.
+		salt, dekCT, dekNonce, params, err := auth.WrapDEK(mk.Key(), newPw)
+		crypto.WipeBytes(newPw)
+		if err != nil {
+			return fmt.Errorf("wrapping encryption key: %w", err)
+		}
+
+		// Update the record with the new wrapped DEK.
+		record.DEKCiphertext = dekCT
+		record.DEKNonce = dekNonce
+		record.Salt = salt
+		record.KDFTime = &params.Time
+		record.KDFMemory = &params.Memory
+		record.KDFThreads = &params.Threads
+
+		if err := db.UpdateMasterKeyRecord(ctx, record); err != nil {
+			return fmt.Errorf("persisting updated record: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "%s Master password changed. No credentials were re-encrypted.\n", successText("✓"))
+		return nil
+	},
+}
+
+var masterPasswordRemoveCmd = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove the master password (switch to passwordless mode)",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := ensureServerStopped(); err != nil {
+			return err
+		}
+
+		db, cleanup, err := openDB()
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		ctx := context.Background()
+		record, err := db.GetMasterKeyRecord(ctx)
+		if err != nil {
+			return fmt.Errorf("reading master key record: %w", err)
+		}
+		if record == nil {
+			return fmt.Errorf("no master key record found — run 'agent-vault server' first")
+		}
+		if record.DEKCiphertext == nil {
+			return fmt.Errorf("instance already has no master password")
+		}
+
+		// Prompt for the current password and unlock.
+		currentPw, err := auth.PromptPassword("Current master password: ")
+		if err != nil {
+			return fmt.Errorf("password input: %w", err)
+		}
+
+		verRec := buildVerificationRecord(record)
+		mk, err := auth.Unlock(currentPw, verRec)
+		crypto.WipeBytes(currentPw)
+		if err != nil {
+			return fmt.Errorf("wrong password")
+		}
+		defer mk.Wipe()
+
+		// Store the DEK in plaintext, clear the wrapped DEK.
+		dekCopy := make([]byte, len(mk.Key()))
+		copy(dekCopy, mk.Key())
+
+		record.DEKPlaintext = dekCopy
+		record.DEKCiphertext = nil
+		record.DEKNonce = nil
+		record.Salt = nil
+		record.KDFTime = nil
+		record.KDFMemory = nil
+		record.KDFThreads = nil
+
+		if err := db.UpdateMasterKeyRecord(ctx, record); err != nil {
+			return fmt.Errorf("persisting updated record: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "%s Master password removed. The encryption key is now stored in plaintext.\n", successText("✓"))
+		fmt.Fprintln(cmd.OutOrStderr(), "Security now depends on filesystem access controls.")
+		return nil
+	},
+}
+
+// ensureServerStopped checks that no server process is running.
+// Master password operations require exclusive access to the database.
+func ensureServerStopped() error {
+	pid, err := pidfile.Read()
+	if err != nil {
+		return nil // no PID file means no server running
+	}
+	if pidfile.IsRunning(pid) {
+		return fmt.Errorf("server is running (PID %d) — stop it first with 'agent-vault server stop'", pid)
+	}
+	return nil
+}
+
+// openDB opens the SQLite store at the default path.
+func openDB() (*store.SQLiteStore, func(), error) {
+	dbPath, err := store.DefaultDBPath()
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolving db path: %w", err)
+	}
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return nil, nil, fmt.Errorf("database not found at %s — run 'agent-vault server' first", dbPath)
+	}
+	db, err := store.Open(dbPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening store: %w", err)
+	}
+	return db, func() { _ = db.Close() }, nil
+}
+
+func init() {
+	masterPasswordCmd.AddCommand(masterPasswordSetCmd)
+	masterPasswordCmd.AddCommand(masterPasswordChangeCmd)
+	masterPasswordCmd.AddCommand(masterPasswordRemoveCmd)
+	rootCmd.AddCommand(masterPasswordCmd)
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -223,8 +223,9 @@ func promptOwnerSetup(cmd *cobra.Command, db *store.SQLiteStore, masterPassword 
 	return nil
 }
 
-// unlockOrSetup prompts for the master password and returns the derived key.
+// unlockOrSetup resolves the master password and returns the DEK.
 // Priority: AGENT_VAULT_MASTER_PASSWORD envvar > --password-stdin > interactive prompt.
+// When no password is provided (envvar empty, no --password-stdin), sets up in passwordless mode.
 func unlockOrSetup(cmd *cobra.Command, db *store.SQLiteStore, passwordStdin bool) (*auth.MasterKey, error) {
 	// 1. AGENT_VAULT_MASTER_PASSWORD envvar (highest priority, for containerized/cloud deployments)
 	if envPw := os.Getenv("AGENT_VAULT_MASTER_PASSWORD"); envPw != "" {
@@ -249,10 +250,10 @@ func unlockOrSetup(cmd *cobra.Command, db *store.SQLiteStore, passwordStdin bool
 	}
 
 	if record == nil {
-		// First-time setup — prompt with confirmation
-		fmt.Fprintln(cmd.OutOrStderr(), boldText("No master password set. Setting up for the first time."))
+		// First-time setup — prompt with confirmation, allow empty for passwordless
+		fmt.Fprintln(cmd.OutOrStderr(), boldText("Setting up for the first time."))
 		pw, err := auth.PromptNewPassword(
-			"Enter master password: ",
+			"Enter master password (leave empty for passwordless): ",
 			"Confirm master password: ",
 		)
 		if err != nil {
@@ -261,7 +262,17 @@ func unlockOrSetup(cmd *cobra.Command, db *store.SQLiteStore, passwordStdin bool
 		return setupMasterKey(db, pw)
 	}
 
-	// Interactive unlock — up to 3 attempts
+	// Existing record — check if passwordless
+	if record.DEKPlaintext != nil {
+		verRec := buildVerificationRecord(record)
+		mk, err := auth.UnlockPasswordless(verRec)
+		if err != nil {
+			return nil, fmt.Errorf("unlocking (passwordless): %w", err)
+		}
+		return mk, nil
+	}
+
+	// Password-protected — interactive unlock, up to 3 attempts
 	verRec := buildVerificationRecord(record)
 	fmt.Fprintln(cmd.OutOrStderr(), boldText("Agent Vault is locked. Enter master password to unlock."))
 
@@ -287,7 +298,7 @@ func unlockOrSetup(cmd *cobra.Command, db *store.SQLiteStore, passwordStdin bool
 	return nil, fmt.Errorf("too many failed attempts")
 }
 
-// unlockOrSetupWithPassword derives the master key from a known password (no prompting, no retry).
+// unlockOrSetupWithPassword resolves the DEK using a known password (no prompting, no retry).
 // Used by the AGENT_VAULT_MASTER_PASSWORD envvar and --password-stdin code paths.
 func unlockOrSetupWithPassword(db *store.SQLiteStore, password []byte) (*auth.MasterKey, error) {
 	ctx := context.Background()
@@ -300,7 +311,18 @@ func unlockOrSetupWithPassword(db *store.SQLiteStore, password []byte) (*auth.Ma
 		return setupMasterKey(db, password)
 	}
 
-	// Unlock — single attempt, no retry
+	// Passwordless instance — password is ignored, unlock without it
+	if record.DEKPlaintext != nil {
+		crypto.WipeBytes(password)
+		verRec := buildVerificationRecord(record)
+		mk, err := auth.UnlockPasswordless(verRec)
+		if err != nil {
+			return nil, fmt.Errorf("unlocking (passwordless): %w", err)
+		}
+		return mk, nil
+	}
+
+	// Password-protected — single attempt, no retry
 	verRec := buildVerificationRecord(record)
 	mk, err := auth.Unlock(password, verRec)
 	crypto.WipeBytes(password)
@@ -310,22 +332,24 @@ func unlockOrSetupWithPassword(db *store.SQLiteStore, password []byte) (*auth.Ma
 	return mk, nil
 }
 
-// setupMasterKey runs first-time master key setup with the given password.
+// setupMasterKey runs first-time DEK generation and KEK wrapping.
+// If password is empty, sets up in passwordless mode.
 func setupMasterKey(db *store.SQLiteStore, password []byte) (*auth.MasterKey, error) {
-	mk, rec, err := auth.Setup(password)
-	crypto.WipeBytes(password)
+	var mk *auth.MasterKey
+	var rec *auth.VerificationRecord
+	var err error
+
+	if len(password) == 0 {
+		mk, rec, err = auth.SetupPasswordless()
+	} else {
+		mk, rec, err = auth.SetupWithPassword(password)
+		crypto.WipeBytes(password)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("setting up master key: %w", err)
 	}
 
-	storeRec := &store.MasterKeyRecord{
-		Salt:       rec.Salt,
-		Sentinel:   rec.Sentinel,
-		Nonce:      rec.Nonce,
-		KDFTime:    rec.Params.Time,
-		KDFMemory:  rec.Params.Memory,
-		KDFThreads: rec.Params.Threads,
-	}
+	storeRec := verificationToStoreRecord(rec)
 	if err := db.SetMasterKeyRecord(context.Background(), storeRec); err != nil {
 		mk.Wipe()
 		return nil, fmt.Errorf("persisting master key record: %w", err)
@@ -333,20 +357,45 @@ func setupMasterKey(db *store.SQLiteStore, password []byte) (*auth.MasterKey, er
 	return mk, nil
 }
 
+// verificationToStoreRecord converts an auth VerificationRecord to a store MasterKeyRecord.
+func verificationToStoreRecord(rec *auth.VerificationRecord) *store.MasterKeyRecord {
+	r := &store.MasterKeyRecord{
+		Sentinel:      rec.Sentinel,
+		SentinelNonce: rec.SentinelNonce,
+		DEKCiphertext: rec.DEKCiphertext,
+		DEKNonce:      rec.DEKNonce,
+		DEKPlaintext:  rec.DEKPlaintext,
+		Salt:          rec.Salt,
+	}
+	if rec.Params.Time > 0 {
+		r.KDFTime = &rec.Params.Time
+		r.KDFMemory = &rec.Params.Memory
+		r.KDFThreads = &rec.Params.Threads
+	}
+	return r
+}
+
 // buildVerificationRecord converts a store record to an auth verification record.
 func buildVerificationRecord(record *store.MasterKeyRecord) *auth.VerificationRecord {
-	return &auth.VerificationRecord{
-		Salt:     record.Salt,
-		Sentinel: record.Sentinel,
-		Nonce:    record.Nonce,
-		Params: crypto.KDFParams{
-			Time:    record.KDFTime,
-			Memory:  record.KDFMemory,
-			Threads: record.KDFThreads,
-			KeyLen:  32,
-			SaltLen: 16,
-		},
+	vr := &auth.VerificationRecord{
+		Sentinel:      record.Sentinel,
+		SentinelNonce: record.SentinelNonce,
+		DEKCiphertext: record.DEKCiphertext,
+		DEKNonce:      record.DEKNonce,
+		DEKPlaintext:  record.DEKPlaintext,
+		Salt:          record.Salt,
 	}
+	if record.KDFTime != nil {
+		defaults := crypto.DefaultKDFParams()
+		vr.Params = crypto.KDFParams{
+			Time:    *record.KDFTime,
+			Memory:  *record.KDFMemory,
+			Threads: *record.KDFThreads,
+			KeyLen:  defaults.KeyLen,
+			SaltLen: defaults.SaltLen,
+		}
+	}
+	return vr
 }
 
 // readPasswordFromStdin reads a single line from stdin for non-interactive password input.
@@ -455,19 +504,13 @@ func spawnDetached(cmd *cobra.Command, masterKey *auth.MasterKey, initialized bo
 	copy(payload, masterKey.Key())
 	payload[32] = initByte
 	if _, err := pw.Write(payload); err != nil {
-		// Wipe payload before returning.
-		for i := range payload {
-			payload[i] = 0
-		}
+		crypto.WipeBytes(payload)
 		_ = pw.Close()
 		_ = pr.Close()
 		_ = logFile.Close()
 		return fmt.Errorf("sending master key to child: %w", err)
 	}
-	// Wipe the payload copy of the master key.
-	for i := range payload {
-		payload[i] = 0
-	}
+	crypto.WipeBytes(payload)
 	_ = pw.Close()
 	_ = pr.Close()
 	_ = logFile.Close()

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -114,7 +114,7 @@ Database migrations run automatically on server startup — no manual steps requ
 agent-vault server
 ```
 
-Agent Vault prompts for a **master password** on first run. This password encrypts all [credentials](/learn/credentials) at rest using AES-256-GCM with an Argon2id-derived key. It is never stored on disk. For non-interactive or automated environments, you can set the `AGENT_VAULT_MASTER_PASSWORD` environment variable or pass `--password-stdin` instead. See [environment variables](/self-hosting/environment-variables) for all options.
+On first run, Agent Vault generates a random **data encryption key (DEK)** that encrypts all [credentials](/learn/credentials) at rest with AES-256-GCM. You can optionally set a **master password** to wrap the DEK (leave it empty for passwordless mode). The master password is never stored on disk. For non-interactive or automated environments, set the `AGENT_VAULT_MASTER_PASSWORD` environment variable or pass `--password-stdin`. Omit it entirely for passwordless mode. See [environment variables](/self-hosting/environment-variables) for all options.
 
 To run in the background:
 

--- a/docs/learn/security.mdx
+++ b/docs/learn/security.mdx
@@ -21,25 +21,33 @@ This page covers the cryptographic primitives, token model, network protections,
 
 All [credentials](/learn/credentials) stored in a [vault](/learn/vaults) are encrypted using **AES-256-GCM**, an authenticated encryption scheme that provides both confidentiality and tamper detection.
 
-The encryption key is derived from the **master password** you set at server startup using **Argon2id**, a memory-hard key derivation function resistant to GPU and ASIC attacks.
+Agent Vault uses a **KEK/DEK key-wrapping architecture**:
+
+1. A random 256-bit **DEK** (Data Encryption Key) is generated on first boot. This key encrypts all credentials and the CA private key.
+2. If a **master password** is set, Argon2id derives a **KEK** (Key Encryption Key) that wraps the DEK. The KEK is never stored — it is derived in memory, used to unwrap the DEK, then wiped.
+3. If no master password is set (**passwordless mode**), the DEK is stored in plaintext in the database. Security depends on filesystem access controls — suitable for PaaS platforms where the platform manages volume isolation.
 
 | Parameter | Value |
 | --------- | ----- |
-| Algorithm | AES-256-GCM |
-| KDF | Argon2id |
+| Data encryption | AES-256-GCM |
+| Key wrapping | AES-256-GCM |
+| KDF (for KEK) | Argon2id |
 | Time cost | 3 iterations |
 | Memory cost | 64 MiB |
 | Parallelism | 4 threads |
-| Key length | 256 bits |
+| DEK length | 256 bits (random, `crypto/rand`) |
+| KEK length | 256 bits (Argon2id output) |
 | Salt length | 128 bits (random per setup) |
 
 Each encryption operation uses a fresh random nonce generated from `crypto/rand`. Credential values are decrypted in memory only at proxy time to resolve auth headers, then discarded.
 
+**Password changes are lightweight**: changing the master password re-wraps the DEK under a new KEK — a single database update with zero credential re-encryption. You can also add a password to a passwordless instance or remove a password entirely using `agent-vault master-password set|change|remove`.
+
 <Note>
   The master password is **never stored on disk**. If set via the
   `AGENT_VAULT_MASTER_PASSWORD` environment variable, Agent Vault unsets it from the process
-  immediately after reading. A sentinel value (encrypted at setup) is used to
-  verify the password on subsequent startups without storing it.
+  immediately after reading. The KEK derived from the password is wiped from
+  memory after unwrapping the DEK.
 </Note>
 
 ## Password hashing
@@ -163,6 +171,7 @@ A summary of how each category of sensitive data is stored:
 | Credentials | AES-256-GCM ciphertext + nonce | Yes, by vault members and admins via CLI (`credential get`, `credential list --reveal`). Proxy-role agents cannot read values. |
 | User passwords | Argon2id hash + salt + params | No |
 | Session tokens | SHA-256 hash | No (raw returned once at creation) |
-| Master password | Not stored | N/A (derived key held in memory only) |
+| DEK (data encryption key) | Wrapped by KEK (password mode) or plaintext (passwordless mode) in `master_key` table | Yes, in memory while server runs |
+| Master password | Not stored | N/A (KEK derived in memory, wiped after DEK unwrap) |
 
 Key material is zeroed after use via `WipeBytes()` on a best-effort basis. Sensitive byte slices are never converted to strings (Go strings are immutable and cannot be wiped from memory).

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -11,9 +11,9 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault server [flags]
     ```
 
-    Start the Agent Vault server. Default port is 14321. On a fresh install, prompts for a master password interactively unless provided via environment variable or stdin.
+    Start the Agent Vault server. Default port is 14321. On a fresh install, generates a random data encryption key (DEK) and optionally wraps it with a master password.
 
-    Password resolution order: `AGENT_VAULT_MASTER_PASSWORD` env var, then `--password-stdin`, then interactive prompt. The env var is unset from the process immediately after reading.
+    Password resolution order: `AGENT_VAULT_MASTER_PASSWORD` env var, then `--password-stdin`, then interactive prompt. If no password is provided, runs in passwordless mode (DEK stored unwrapped). The env var is unset from the process immediately after reading.
 
     | Flag | Default | Description |
     |------|---------|-------------|
@@ -29,7 +29,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     | Variable | Description |
     |----------|-------------|
     | `PORT` | Server listen port (default `14321`). The `--port` flag takes precedence. |
-    | `AGENT_VAULT_MASTER_PASSWORD` | Master password for encrypting credentials at rest |
+    | `AGENT_VAULT_MASTER_PASSWORD` | Derives a KEK that wraps the data encryption key. Omit for passwordless mode. |
     | `AGENT_VAULT_LOG_LEVEL` | Fallback for `--log-level` when the flag is not set. Accepts `info` or `debug`. |
     | `AGENT_VAULT_ADDR` | Externally-reachable base URL (e.g. `https://agent-vault.example.com`). Used for links in emails, invites, and discovery. Falls back to `https://<FLY_APP_NAME>.fly.dev` on Fly.io, then `http://{host}:{port}`. |
     | `FLY_APP_NAME` | Auto-detected on Fly.io. When `AGENT_VAULT_ADDR` is unset, derives the base URL as `https://<FLY_APP_NAME>.fly.dev`. |
@@ -856,6 +856,36 @@ description: "Complete reference for all Agent Vault CLI commands."
     |------|---------|-------------|
     | `--invite-only` | | Enable or disable invite-only registration (`true` or `false`) |
     | `--allowed-domains` | | Comma-separated list of allowed email domains (empty to clear) |
+  </Accordion>
+</AccordionGroup>
+
+## Master password
+
+Manage the master password that wraps the data encryption key (DEK). All commands require the server to be stopped.
+
+<AccordionGroup>
+  <Accordion title="agent-vault master-password set">
+    ```bash
+    agent-vault master-password set
+    ```
+
+    Set a master password on a passwordless instance. Wraps the existing DEK under a new KEK derived from the password. No credentials are re-encrypted.
+  </Accordion>
+
+  <Accordion title="agent-vault master-password change">
+    ```bash
+    agent-vault master-password change
+    ```
+
+    Change the master password. Re-wraps the DEK under a new KEK. No credentials are re-encrypted.
+  </Accordion>
+
+  <Accordion title="agent-vault master-password remove">
+    ```bash
+    agent-vault master-password remove
+    ```
+
+    Remove the master password, switching to passwordless mode. The DEK is stored in plaintext — security depends on filesystem access controls.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/self-hosting/docker.mdx
+++ b/docs/self-hosting/docker.mdx
@@ -21,7 +21,7 @@ The final image runs as non-root user `agentvault` (UID 65532) and includes a bu
 
 ## Configuration
 
-Pass the master password via environment variable to skip the interactive prompt:
+Pass the master password via environment variable to wrap the data encryption key (DEK):
 
 ```bash
 docker run -it -p 14321:14321 \
@@ -31,9 +31,11 @@ docker run -it -p 14321:14321 \
   infisical/agent-vault
 ```
 
+Omit `AGENT_VAULT_MASTER_PASSWORD` for **passwordless mode** — the DEK is stored unwrapped, relying on volume access controls for security.
+
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `AGENT_VAULT_MASTER_PASSWORD` | **Yes** | Master key for encrypting credentials at rest. |
+| `AGENT_VAULT_MASTER_PASSWORD` | No | Derives a KEK that wraps the data encryption key. If omitted, runs in passwordless mode. |
 | `AGENT_VAULT_ADDR` | Recommended | Externally-reachable base URL. Defaults to `http://localhost:14321`. Used for generating links in emails, invites, and discovery responses. |
 
 <Warning>
@@ -81,6 +83,6 @@ docker compose up -d
 
 All state lives in a single SQLite database at `/data/.agent-vault/agent-vault.db`. The Docker image declares `VOLUME /data`, so data survives container restarts as long as you mount a named volume or host path.
 
-<Warning>
-  Use a consistent master password across container restarts. Changing it makes existing encrypted credentials unreadable.
-</Warning>
+<Tip>
+  Changing the master password re-wraps the data encryption key without re-encrypting credentials. Use `agent-vault master-password change` while the server is stopped.
+</Tip>

--- a/docs/self-hosting/environment-variables.mdx
+++ b/docs/self-hosting/environment-variables.mdx
@@ -8,7 +8,7 @@ description: "All environment variables used to configure Agent Vault"
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORT` | `14321` | Server listen port. Respected by most PaaS platforms (Fly.io, Cloud Run, Heroku). The `--port` flag takes precedence when set. |
-| `AGENT_VAULT_MASTER_PASSWORD` | (unset) | Master key for encrypting credentials at rest (AES-256-GCM / Argon2id). Read at startup, then immediately unset from the process. |
+| `AGENT_VAULT_MASTER_PASSWORD` | (unset) | Derives a KEK (Key Encryption Key) via Argon2id that wraps the data encryption key (DEK). If omitted, the DEK is stored unwrapped (passwordless mode). Read at startup, then immediately unset from the process. |
 | `AGENT_VAULT_ADDR` | (auto) | Externally-reachable base URL. Used for generating links in emails, invites, and discovery responses. Falls back to `https://<FLY_APP_NAME>.fly.dev` on Fly.io, then `http://{host}:{port}`. |
 | `FLY_APP_NAME` | (set by Fly.io) | When `AGENT_VAULT_ADDR` is unset and this variable is present, the base URL is automatically derived as `https://<FLY_APP_NAME>.fly.dev`. Set automatically by the Fly.io platform — you should not need to set this manually. |
 | `AGENT_VAULT_NETWORK_MODE` | `public` | Proxy network restriction mode. `public` blocks connections to private/reserved IP ranges (RFC-1918, link-local, cloud metadata). `private` allows all outbound connections including private ranges — use this for local/private deployments where the proxy needs to reach internal services. |

--- a/docs/self-hosting/fly-io.mdx
+++ b/docs/self-hosting/fly-io.mdx
@@ -26,13 +26,14 @@ description: "Deploy Agent Vault to Fly.io with persistent storage"
 
   <Step title="Set secrets">
     ```bash
+    # Optional — omit for passwordless mode (DEK stored unwrapped on volume)
     fly secrets set AGENT_VAULT_MASTER_PASSWORD=your-password
     fly secrets set AGENT_VAULT_ADDR=https://your-app.fly.dev
     ```
 
     | Variable | Required | Description |
     |----------|----------|-------------|
-    | `AGENT_VAULT_MASTER_PASSWORD` | **Yes** | Master key for encrypting credentials at rest. |
+    | `AGENT_VAULT_MASTER_PASSWORD` | No | Derives a KEK that wraps the data encryption key. Omit for passwordless mode. |
     | `AGENT_VAULT_ADDR` | Recommended | Externally-reachable base URL. Used for generating links in emails, invites, and discovery responses. |
 
     <Tip>
@@ -76,6 +77,6 @@ description: "Deploy Agent Vault to Fly.io with persistent storage"
 - **Storage**: Persistent volume `agent_vault_data` mounted at `/data` -- all state is in a single SQLite file
 - **Cold starts**: `min_machines_running` defaults to `0`, so the app scales to zero when idle. The first request after sleep incurs a few seconds of cold-start latency. Set it to `1` in `fly.toml` if you need always-on availability.
 
-<Warning>
-  Use a consistent master password across deploys. Changing it makes existing encrypted credentials unreadable. If you need to rotate, export your data first.
-</Warning>
+<Tip>
+  Changing the master password re-wraps the data encryption key without re-encrypting credentials. Use `agent-vault master-password change` while the server is stopped.
+</Tip>

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -36,9 +36,9 @@ sudo mv agent-vault /usr/local/bin/
 agent-vault server
 ```
 
-Agent Vault prompts for a **master password** on first run. This password encrypts all [credentials](/learn/credentials) at rest using AES-256-GCM with an Argon2id-derived key. It is never stored on disk.
+On first run, Agent Vault generates a random **data encryption key (DEK)** that encrypts all [credentials](/learn/credentials) at rest with AES-256-GCM. You can optionally set a **master password** to wrap the DEK (leave it empty for passwordless mode). The master password is never stored on disk.
 
-For non-interactive or automated environments, set the `AGENT_VAULT_MASTER_PASSWORD` environment variable or pass `--password-stdin` instead. See [environment variables](/self-hosting/environment-variables) for all options.
+For non-interactive or automated environments, set the `AGENT_VAULT_MASTER_PASSWORD` environment variable or pass `--password-stdin` instead. Omit it entirely for passwordless mode. See [environment variables](/self-hosting/environment-variables) for all options.
 
 To run in the background:
 
@@ -85,7 +85,7 @@ agent-vault server               # transparent proxy on 14322 (default)
 agent-vault server --mitm-port 0 # disable
 ```
 
-A software-backed root CA is created on first launch under `~/.agent-vault/ca/` (private key encrypted with the master key). Clients must trust this root before the proxied TLS handshake will succeed.
+A software-backed root CA is created on first launch under `~/.agent-vault/ca/` (private key encrypted with the DEK). Clients must trust this root before the proxied TLS handshake will succeed.
 
 Fetch the root certificate from any machine that can reach the server:
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -9,18 +9,19 @@ import (
 	"github.com/Infisical/agent-vault/internal/crypto"
 )
 
-// sentinel is the known plaintext encrypted during setup and verified during unlock.
+// sentinel is the known plaintext encrypted with the DEK during setup and
+// verified during unlock.
 const sentinel = "agent-vault-master-key-check"
 
 // ErrWrongPassword is returned when the master password does not match.
 var ErrWrongPassword = errors.New("wrong master password")
 
-// MasterKey holds a derived encryption key in memory.
+// MasterKey holds the DEK (Data Encryption Key) in memory.
 type MasterKey struct {
 	key []byte
 }
 
-// Key returns the raw 32-byte encryption key.
+// Key returns the raw 32-byte DEK.
 func (mk *MasterKey) Key() []byte {
 	return mk.key
 }
@@ -30,60 +31,141 @@ func (mk *MasterKey) Wipe() {
 	crypto.WipeBytes(mk.key)
 }
 
-// VerificationRecord holds the artifacts needed to verify a master password
+// VerificationRecord holds the artifacts needed to unlock the DEK
 // on subsequent startups.
 type VerificationRecord struct {
-	Salt   []byte
-	Sentinel []byte // encrypted sentinel ciphertext
-	Nonce  []byte
-	Params crypto.KDFParams
+	Sentinel      []byte // sentinel ciphertext (encrypted with DEK)
+	SentinelNonce []byte // sentinel GCM nonce
+	DEKCiphertext []byte // KEK-wrapped DEK (nil in passwordless mode)
+	DEKNonce      []byte // DEK wrapping nonce (nil in passwordless mode)
+	DEKPlaintext  []byte // unwrapped DEK (nil when password-protected)
+	Salt          []byte // KDF salt for KEK derivation (nil in passwordless mode)
+	Params        crypto.KDFParams
 }
 
-// Setup creates a new master key from the given password. It generates a random
-// salt, derives an encryption key via Argon2id, and encrypts a sentinel value.
-// Returns the master key (for immediate use) and a verification record (to persist).
-func Setup(password []byte) (*MasterKey, *VerificationRecord, error) {
-	params := crypto.DefaultKDFParams()
-
-	salt, err := crypto.GenerateSalt(int(params.SaltLen))
+// SetupWithPassword creates a new random DEK, encrypts the sentinel with it,
+// then wraps the DEK under a KEK derived from the password via Argon2id.
+func SetupWithPassword(password []byte) (*MasterKey, *VerificationRecord, error) {
+	dek, sentinelCT, sentinelNonce, err := generateDEK()
 	if err != nil {
-		return nil, nil, fmt.Errorf("generating salt: %w", err)
+		return nil, nil, err
 	}
 
-	key := crypto.DeriveKey(password, salt, params)
-
-	ciphertext, nonce, err := crypto.Encrypt([]byte(sentinel), key)
+	salt, dekCT, dekNonce, params, err := WrapDEK(dek, password)
 	if err != nil {
-		crypto.WipeBytes(key)
-		return nil, nil, fmt.Errorf("encrypting sentinel: %w", err)
+		crypto.WipeBytes(dek)
+		return nil, nil, fmt.Errorf("wrapping DEK: %w", err)
 	}
 
-	return &MasterKey{key: key}, &VerificationRecord{
-		Salt:     salt,
-		Sentinel: ciphertext,
-		Nonce:    nonce,
-		Params:   params,
+	return &MasterKey{key: dek}, &VerificationRecord{
+		Sentinel:      sentinelCT,
+		SentinelNonce: sentinelNonce,
+		DEKCiphertext: dekCT,
+		DEKNonce:      dekNonce,
+		Salt:          salt,
+		Params:        params,
 	}, nil
 }
 
-// Unlock derives the encryption key from the password and stored verification
-// record, then verifies correctness by decrypting the sentinel. Returns
-// ErrWrongPassword if the password is incorrect.
-func Unlock(password []byte, record *VerificationRecord) (*MasterKey, error) {
-	key := crypto.DeriveKey(password, record.Salt, record.Params)
-
-	plaintext, err := crypto.Decrypt(record.Sentinel, record.Nonce, key)
+// SetupPasswordless creates a new random DEK and encrypts the sentinel with it.
+// The DEK is stored in plaintext — security depends on filesystem access controls.
+func SetupPasswordless() (*MasterKey, *VerificationRecord, error) {
+	dek, sentinelCT, sentinelNonce, err := generateDEK()
 	if err != nil {
-		crypto.WipeBytes(key)
+		return nil, nil, err
+	}
+
+	// Copy the DEK for storage — the MasterKey holds the original.
+	dekCopy := make([]byte, len(dek))
+	copy(dekCopy, dek)
+
+	return &MasterKey{key: dek}, &VerificationRecord{
+		Sentinel:      sentinelCT,
+		SentinelNonce: sentinelNonce,
+		DEKPlaintext:  dekCopy,
+	}, nil
+}
+
+// generateDEK creates a random 32-byte DEK and encrypts the sentinel with it.
+func generateDEK() (dek, sentinelCT, sentinelNonce []byte, err error) {
+	dek, err = crypto.GenerateSalt(32)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("generating DEK: %w", err)
+	}
+
+	sentinelCT, sentinelNonce, err = crypto.Encrypt([]byte(sentinel), dek)
+	if err != nil {
+		crypto.WipeBytes(dek)
+		return nil, nil, nil, fmt.Errorf("encrypting sentinel: %w", err)
+	}
+
+	return dek, sentinelCT, sentinelNonce, nil
+}
+
+// Unlock derives the KEK from the password, unwraps the DEK, and verifies
+// the sentinel. Returns ErrWrongPassword if the password is incorrect.
+func Unlock(password []byte, record *VerificationRecord) (*MasterKey, error) {
+	kek := crypto.DeriveKey(password, record.Salt, record.Params)
+
+	dek, err := crypto.Decrypt(record.DEKCiphertext, record.DEKNonce, kek)
+	crypto.WipeBytes(kek)
+	if err != nil {
 		return nil, ErrWrongPassword
 	}
 
-	if string(plaintext) != sentinel {
-		crypto.WipeBytes(key)
-		return nil, ErrWrongPassword
+	if err := verifySentinel(dek, record.Sentinel, record.SentinelNonce); err != nil {
+		crypto.WipeBytes(dek)
+		return nil, err
 	}
 
-	return &MasterKey{key: key}, nil
+	return &MasterKey{key: dek}, nil
+}
+
+// UnlockPasswordless loads the DEK from plaintext storage and verifies the sentinel.
+func UnlockPasswordless(record *VerificationRecord) (*MasterKey, error) {
+	// Make a copy so the caller's record isn't shared with the MasterKey.
+	dek := make([]byte, len(record.DEKPlaintext))
+	copy(dek, record.DEKPlaintext)
+
+	if err := verifySentinel(dek, record.Sentinel, record.SentinelNonce); err != nil {
+		crypto.WipeBytes(dek)
+		return nil, err
+	}
+
+	return &MasterKey{key: dek}, nil
+}
+
+// WrapDEK wraps a DEK under a new KEK derived from the password.
+// Returns the salt, wrapped DEK ciphertext, nonce, and KDF params.
+func WrapDEK(dek, password []byte) (salt, dekCT, dekNonce []byte, params crypto.KDFParams, err error) {
+	params = crypto.DefaultKDFParams()
+
+	salt, err = crypto.GenerateSalt(int(params.SaltLen))
+	if err != nil {
+		return nil, nil, nil, params, fmt.Errorf("generating KEK salt: %w", err)
+	}
+
+	kek := crypto.DeriveKey(password, salt, params)
+	dekCT, dekNonce, err = crypto.Encrypt(dek, kek)
+	crypto.WipeBytes(kek)
+	if err != nil {
+		return nil, nil, nil, params, fmt.Errorf("wrapping DEK: %w", err)
+	}
+
+	return salt, dekCT, dekNonce, params, nil
+}
+
+// verifySentinel decrypts the stored sentinel with the DEK and checks it
+// matches the expected value.
+func verifySentinel(dek, sentinelCT, sentinelNonce []byte) error {
+	plaintext, err := crypto.Decrypt(sentinelCT, sentinelNonce, dek)
+	if err != nil {
+		return ErrWrongPassword
+	}
+	if subtle.ConstantTimeCompare(plaintext, []byte(sentinel)) != 1 {
+		return ErrWrongPassword
+	}
+	return nil
 }
 
 // HashUserPassword hashes a user password with a random salt using Argon2id.

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -2,31 +2,71 @@ package auth
 
 import (
 	"testing"
+
+	"github.com/Infisical/agent-vault/internal/crypto"
 )
 
-func TestSetupAndUnlockRoundTrip(t *testing.T) {
+func TestSetupWithPasswordAndUnlockRoundTrip(t *testing.T) {
 	password := []byte("correct-horse-battery-staple")
 
-	mk, rec, err := Setup(password)
+	mk, rec, err := SetupWithPassword(password)
 	if err != nil {
-		t.Fatalf("Setup: %v", err)
+		t.Fatalf("SetupWithPassword: %v", err)
 	}
 	defer mk.Wipe()
 
 	if len(mk.Key()) != 32 {
-		t.Fatalf("expected 32-byte key, got %d", len(mk.Key()))
+		t.Fatalf("expected 32-byte DEK, got %d", len(mk.Key()))
 	}
 
-	// Unlock with the same password should succeed.
+	// Wrapped DEK fields should be populated, plaintext DEK should be nil.
+	if rec.DEKCiphertext == nil || rec.DEKNonce == nil {
+		t.Fatal("expected DEKCiphertext and DEKNonce to be set")
+	}
+	if rec.DEKPlaintext != nil {
+		t.Fatal("expected DEKPlaintext to be nil for password-protected setup")
+	}
+
+	// Unlock with the same password should succeed and return the same DEK.
 	mk2, err := Unlock(password, rec)
 	if err != nil {
 		t.Fatalf("Unlock: %v", err)
 	}
 	defer mk2.Wipe()
 
-	// Both keys should be identical.
 	if string(mk.Key()) != string(mk2.Key()) {
-		t.Fatal("keys from Setup and Unlock differ")
+		t.Fatal("DEKs from SetupWithPassword and Unlock differ")
+	}
+}
+
+func TestSetupPasswordlessAndUnlockRoundTrip(t *testing.T) {
+	mk, rec, err := SetupPasswordless()
+	if err != nil {
+		t.Fatalf("SetupPasswordless: %v", err)
+	}
+	defer mk.Wipe()
+
+	if len(mk.Key()) != 32 {
+		t.Fatalf("expected 32-byte DEK, got %d", len(mk.Key()))
+	}
+
+	// Plaintext DEK should be populated, wrapped DEK fields should be nil.
+	if rec.DEKPlaintext == nil {
+		t.Fatal("expected DEKPlaintext to be set")
+	}
+	if rec.DEKCiphertext != nil || rec.DEKNonce != nil {
+		t.Fatal("expected DEKCiphertext/DEKNonce to be nil for passwordless setup")
+	}
+
+	// UnlockPasswordless should return the same DEK.
+	mk2, err := UnlockPasswordless(rec)
+	if err != nil {
+		t.Fatalf("UnlockPasswordless: %v", err)
+	}
+	defer mk2.Wipe()
+
+	if string(mk.Key()) != string(mk2.Key()) {
+		t.Fatal("DEKs from SetupPasswordless and UnlockPasswordless differ")
 	}
 }
 
@@ -34,9 +74,9 @@ func TestUnlockWrongPassword(t *testing.T) {
 	password := []byte("correct-password")
 	wrong := []byte("wrong-password")
 
-	_, rec, err := Setup(password)
+	_, rec, err := SetupWithPassword(password)
 	if err != nil {
-		t.Fatalf("Setup: %v", err)
+		t.Fatalf("SetupWithPassword: %v", err)
 	}
 
 	_, err = Unlock(wrong, rec)
@@ -46,9 +86,9 @@ func TestUnlockWrongPassword(t *testing.T) {
 }
 
 func TestWipeZerosKey(t *testing.T) {
-	mk, _, err := Setup([]byte("test"))
+	mk, _, err := SetupPasswordless()
 	if err != nil {
-		t.Fatalf("Setup: %v", err)
+		t.Fatalf("SetupPasswordless: %v", err)
 	}
 
 	key := mk.Key()
@@ -61,17 +101,99 @@ func TestWipeZerosKey(t *testing.T) {
 	}
 }
 
-func TestSetupProducesDifferentSalts(t *testing.T) {
-	_, rec1, err := Setup([]byte("pw"))
+func TestSetupProducesDifferentDEKs(t *testing.T) {
+	mk1, _, err := SetupPasswordless()
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, rec2, err := Setup([]byte("pw"))
+	mk2, _, err := SetupPasswordless()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if string(rec1.Salt) == string(rec2.Salt) {
-		t.Fatal("two Setup calls produced the same salt")
+	if string(mk1.Key()) == string(mk2.Key()) {
+		t.Fatal("two SetupPasswordless calls produced the same DEK")
+	}
+}
+
+func TestWrapDEKRoundTrip(t *testing.T) {
+	mk, _, err := SetupPasswordless()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mk.Wipe()
+
+	password := []byte("test-password")
+	salt, dekCT, dekNonce, params, err := WrapDEK(mk.Key(), password)
+	if err != nil {
+		t.Fatalf("WrapDEK: %v", err)
+	}
+
+	// Build a verification record to unlock.
+	sentinelCT, sentinelNonce, err := crypto.Encrypt([]byte(sentinel), mk.Key())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := &VerificationRecord{
+		Sentinel:      sentinelCT,
+		SentinelNonce: sentinelNonce,
+		DEKCiphertext: dekCT,
+		DEKNonce:      dekNonce,
+		Salt:          salt,
+		Params:        params,
+	}
+
+	mk2, err := Unlock(password, rec)
+	if err != nil {
+		t.Fatalf("Unlock after WrapDEK: %v", err)
+	}
+	defer mk2.Wipe()
+
+	if string(mk.Key()) != string(mk2.Key()) {
+		t.Fatal("DEK mismatch after WrapDEK round-trip")
+	}
+}
+
+func TestPasswordChangePreservesDEK(t *testing.T) {
+	oldPw := []byte("old-password")
+	newPw := []byte("new-password")
+
+	mk, rec, err := SetupWithPassword(oldPw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mk.Wipe()
+
+	originalDEK := make([]byte, len(mk.Key()))
+	copy(originalDEK, mk.Key())
+
+	// Re-wrap the DEK under a new password.
+	salt, dekCT, dekNonce, params, err := WrapDEK(mk.Key(), newPw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Update the verification record.
+	rec.DEKCiphertext = dekCT
+	rec.DEKNonce = dekNonce
+	rec.Salt = salt
+	rec.Params = params
+
+	// Old password should no longer work.
+	_, err = Unlock(oldPw, rec)
+	if err != ErrWrongPassword {
+		t.Fatalf("expected ErrWrongPassword with old password, got %v", err)
+	}
+
+	// New password should work and return the same DEK.
+	mk2, err := Unlock(newPw, rec)
+	if err != nil {
+		t.Fatalf("Unlock with new password: %v", err)
+	}
+	defer mk2.Wipe()
+
+	if string(mk2.Key()) != string(originalDEK) {
+		t.Fatal("DEK changed after password change — it should be preserved")
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1167,29 +1167,47 @@ func testKDFParams() crypto.KDFParams {
 	return crypto.KDFParams{Time: 1, Memory: 64, Threads: 1, KeyLen: 32, SaltLen: 16}
 }
 
-// setupMockStoreWithPassword creates a mock store with a master key record
-// derived from the given password using fast test KDF params.
+// setupMockStoreWithPassword creates a mock store with a KEK/DEK master key
+// record derived from the given password using fast test KDF params.
 func setupMockStoreWithPassword(t *testing.T, password string) *mockStore {
 	t.Helper()
 	ms := newMockStore()
 	params := testKDFParams()
+
+	// Generate a random DEK.
+	dek, err := crypto.GenerateSalt(32)
+	if err != nil {
+		t.Fatalf("GenerateSalt (DEK): %v", err)
+	}
+
+	// Encrypt sentinel with DEK.
+	sentinel := []byte("agent-vault-master-key-check")
+	sentinelCT, sentinelNonce, err := crypto.Encrypt(sentinel, dek)
+	if err != nil {
+		t.Fatalf("Encrypt sentinel: %v", err)
+	}
+
+	// Derive KEK from password and wrap the DEK.
 	salt, err := crypto.GenerateSalt(int(params.SaltLen))
 	if err != nil {
-		t.Fatalf("GenerateSalt: %v", err)
+		t.Fatalf("GenerateSalt (KEK salt): %v", err)
 	}
-	key := crypto.DeriveKey([]byte(password), salt, params)
-	sentinel := []byte("agent-vault-master-key-check")
-	ciphertext, nonce, err := crypto.Encrypt(sentinel, key)
+	kek := crypto.DeriveKey([]byte(password), salt, params)
+	dekCT, dekNonce, err := crypto.Encrypt(dek, kek)
 	if err != nil {
-		t.Fatalf("Encrypt: %v", err)
+		t.Fatalf("Encrypt DEK: %v", err)
 	}
+	crypto.WipeBytes(kek)
+
 	ms.masterKeyRecord = &store.MasterKeyRecord{
-		Salt:       salt,
-		Sentinel:   ciphertext,
-		Nonce:      nonce,
-		KDFTime:    params.Time,
-		KDFMemory:  params.Memory,
-		KDFThreads: params.Threads,
+		Sentinel:      sentinelCT,
+		SentinelNonce: sentinelNonce,
+		DEKCiphertext: dekCT,
+		DEKNonce:      dekNonce,
+		Salt:          salt,
+		KDFTime:       &params.Time,
+		KDFMemory:     &params.Memory,
+		KDFThreads:    &params.Threads,
 	}
 	return ms
 }

--- a/internal/store/migrations/002_master_key.sql
+++ b/internal/store/migrations/002_master_key.sql
@@ -1,10 +1,13 @@
 CREATE TABLE master_key (
-    id          INTEGER PRIMARY KEY CHECK (id = 1),
-    salt        BLOB NOT NULL,
-    sentinel    BLOB NOT NULL,
-    nonce       BLOB NOT NULL,
-    kdf_time    INTEGER NOT NULL,
-    kdf_memory  INTEGER NOT NULL,
-    kdf_threads INTEGER NOT NULL,
-    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    id              INTEGER PRIMARY KEY CHECK (id = 1),
+    sentinel        BLOB NOT NULL,
+    sentinel_nonce  BLOB NOT NULL,
+    dek_ciphertext  BLOB,          -- wrapped DEK (non-NULL when password-protected)
+    dek_nonce       BLOB,          -- GCM nonce for DEK wrapping
+    dek_plaintext   BLOB,          -- unwrapped DEK (non-NULL in passwordless mode)
+    salt            BLOB,          -- KDF salt (non-NULL when password-protected)
+    kdf_time        INTEGER,
+    kdf_memory      INTEGER,
+    kdf_threads     INTEGER,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/internal/store/migrations/002_master_key.sql
+++ b/internal/store/migrations/002_master_key.sql
@@ -1,13 +1,10 @@
 CREATE TABLE master_key (
-    id              INTEGER PRIMARY KEY CHECK (id = 1),
-    sentinel        BLOB NOT NULL,
-    sentinel_nonce  BLOB NOT NULL,
-    dek_ciphertext  BLOB,          -- wrapped DEK (non-NULL when password-protected)
-    dek_nonce       BLOB,          -- GCM nonce for DEK wrapping
-    dek_plaintext   BLOB,          -- unwrapped DEK (non-NULL in passwordless mode)
-    salt            BLOB,          -- KDF salt (non-NULL when password-protected)
-    kdf_time        INTEGER,
-    kdf_memory      INTEGER,
-    kdf_threads     INTEGER,
-    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+    id          INTEGER PRIMARY KEY CHECK (id = 1),
+    salt        BLOB NOT NULL,
+    sentinel    BLOB NOT NULL,
+    nonce       BLOB NOT NULL,
+    kdf_time    INTEGER NOT NULL,
+    kdf_memory  INTEGER NOT NULL,
+    kdf_threads INTEGER NOT NULL,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/internal/store/migrations/038_master_key_kek_dek.sql
+++ b/internal/store/migrations/038_master_key_kek_dek.sql
@@ -1,0 +1,22 @@
+-- Rebuild master_key for KEK/DEK key-wrapping architecture.
+-- Adds DEK storage columns, renames nonce → sentinel_nonce, makes KDF columns nullable.
+CREATE TABLE master_key_new (
+    id              INTEGER PRIMARY KEY CHECK (id = 1),
+    sentinel        BLOB NOT NULL,
+    sentinel_nonce  BLOB NOT NULL,
+    dek_ciphertext  BLOB,
+    dek_nonce       BLOB,
+    dek_plaintext   BLOB,
+    salt            BLOB,
+    kdf_time        INTEGER,
+    kdf_memory      INTEGER,
+    kdf_threads     INTEGER,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO master_key_new (id, sentinel, sentinel_nonce, salt, kdf_time, kdf_memory, kdf_threads, created_at)
+SELECT id, sentinel, nonce, salt, kdf_time, kdf_memory, kdf_threads, created_at
+FROM master_key;
+
+DROP TABLE master_key;
+ALTER TABLE master_key_new RENAME TO master_key;

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -778,12 +778,19 @@ func (s *SQLiteStore) DeleteSession(ctx context.Context, rawToken string) error 
 
 func (s *SQLiteStore) GetMasterKeyRecord(ctx context.Context) (*MasterKeyRecord, error) {
 	row := s.db.QueryRowContext(ctx,
-		"SELECT salt, sentinel, nonce, kdf_time, kdf_memory, kdf_threads, created_at FROM master_key WHERE id = 1",
+		`SELECT sentinel, sentinel_nonce, dek_ciphertext, dek_nonce, dek_plaintext,
+		        salt, kdf_time, kdf_memory, kdf_threads, created_at
+		 FROM master_key WHERE id = 1`,
 	)
 
 	var rec MasterKeyRecord
 	var createdAt string
-	err := row.Scan(&rec.Salt, &rec.Sentinel, &rec.Nonce, &rec.KDFTime, &rec.KDFMemory, &rec.KDFThreads, &createdAt)
+	err := row.Scan(
+		&rec.Sentinel, &rec.SentinelNonce,
+		&rec.DEKCiphertext, &rec.DEKNonce, &rec.DEKPlaintext,
+		&rec.Salt, &rec.KDFTime, &rec.KDFMemory, &rec.KDFThreads,
+		&createdAt,
+	)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -796,11 +803,31 @@ func (s *SQLiteStore) GetMasterKeyRecord(ctx context.Context) (*MasterKeyRecord,
 
 func (s *SQLiteStore) SetMasterKeyRecord(ctx context.Context, record *MasterKeyRecord) error {
 	_, err := s.db.ExecContext(ctx,
-		"INSERT INTO master_key (id, salt, sentinel, nonce, kdf_time, kdf_memory, kdf_threads) VALUES (1, ?, ?, ?, ?, ?, ?)",
-		record.Salt, record.Sentinel, record.Nonce, record.KDFTime, record.KDFMemory, record.KDFThreads,
+		`INSERT INTO master_key (id, sentinel, sentinel_nonce, dek_ciphertext, dek_nonce, dek_plaintext, salt, kdf_time, kdf_memory, kdf_threads)
+		 VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		record.Sentinel, record.SentinelNonce,
+		record.DEKCiphertext, record.DEKNonce, record.DEKPlaintext,
+		record.Salt, record.KDFTime, record.KDFMemory, record.KDFThreads,
 	)
 	if err != nil {
 		return fmt.Errorf("setting master key record: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) UpdateMasterKeyRecord(ctx context.Context, record *MasterKeyRecord) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE master_key SET
+		    sentinel = ?, sentinel_nonce = ?,
+		    dek_ciphertext = ?, dek_nonce = ?, dek_plaintext = ?,
+		    salt = ?, kdf_time = ?, kdf_memory = ?, kdf_threads = ?
+		 WHERE id = 1`,
+		record.Sentinel, record.SentinelNonce,
+		record.DEKCiphertext, record.DEKNonce, record.DEKPlaintext,
+		record.Salt, record.KDFTime, record.KDFMemory, record.KDFThreads,
+	)
+	if err != nil {
+		return fmt.Errorf("updating master key record: %w", err)
 	}
 	return nil
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -816,7 +816,7 @@ func (s *SQLiteStore) SetMasterKeyRecord(ctx context.Context, record *MasterKeyR
 }
 
 func (s *SQLiteStore) UpdateMasterKeyRecord(ctx context.Context, record *MasterKeyRecord) error {
-	_, err := s.db.ExecContext(ctx,
+	res, err := s.db.ExecContext(ctx,
 		`UPDATE master_key SET
 		    sentinel = ?, sentinel_nonce = ?,
 		    dek_ciphertext = ?, dek_nonce = ?, dek_plaintext = ?,
@@ -828,6 +828,9 @@ func (s *SQLiteStore) UpdateMasterKeyRecord(ctx context.Context, record *MasterK
 	)
 	if err != nil {
 		return fmt.Errorf("updating master key record: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return sql.ErrNoRows
 	}
 	return nil
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -28,8 +28,8 @@ func TestOpenAndMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("querying schema_migrations: %v", err)
 	}
-	if version != 37 {
-		t.Fatalf("expected migration version 37, got %d", version)
+	if version != 38 {
+		t.Fatalf("expected migration version 38, got %d", version)
 	}
 }
 

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -404,17 +404,22 @@ func TestGetMasterKeyRecordEmpty(t *testing.T) {
 	}
 }
 
-func TestMasterKeyRecordRoundTrip(t *testing.T) {
+func TestMasterKeyRecordRoundTripWithPassword(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
+	kdfTime := uint32(3)
+	kdfMemory := uint32(65536)
+	kdfThreads := uint8(4)
 	in := &MasterKeyRecord{
-		Salt:       []byte("test-salt-16byte"),
-		Sentinel:   []byte("encrypted-sentinel"),
-		Nonce:      []byte("test-nonce-12"),
-		KDFTime:    3,
-		KDFMemory:  65536,
-		KDFThreads: 4,
+		Sentinel:      []byte("encrypted-sentinel"),
+		SentinelNonce: []byte("sentinel-nonce"),
+		DEKCiphertext: []byte("wrapped-dek-ciphertext"),
+		DEKNonce:      []byte("dek-nonce-12b"),
+		Salt:          []byte("test-salt-16byte"),
+		KDFTime:       &kdfTime,
+		KDFMemory:     &kdfMemory,
+		KDFThreads:    &kdfThreads,
 	}
 	if err := s.SetMasterKeyRecord(ctx, in); err != nil {
 		t.Fatalf("SetMasterKeyRecord: %v", err)
@@ -424,13 +429,83 @@ func TestMasterKeyRecordRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetMasterKeyRecord: %v", err)
 	}
-	if string(got.Salt) != string(in.Salt) ||
-		string(got.Sentinel) != string(in.Sentinel) ||
-		string(got.Nonce) != string(in.Nonce) ||
-		got.KDFTime != in.KDFTime ||
-		got.KDFMemory != in.KDFMemory ||
-		got.KDFThreads != in.KDFThreads {
+	if string(got.Sentinel) != string(in.Sentinel) ||
+		string(got.SentinelNonce) != string(in.SentinelNonce) ||
+		string(got.DEKCiphertext) != string(in.DEKCiphertext) ||
+		string(got.DEKNonce) != string(in.DEKNonce) ||
+		string(got.Salt) != string(in.Salt) ||
+		*got.KDFTime != *in.KDFTime ||
+		*got.KDFMemory != *in.KDFMemory ||
+		*got.KDFThreads != *in.KDFThreads {
 		t.Fatalf("round-trip mismatch: got %+v", got)
+	}
+	if got.DEKPlaintext != nil {
+		t.Fatal("expected DEKPlaintext to be nil for password-protected record")
+	}
+}
+
+func TestMasterKeyRecordRoundTripPasswordless(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	in := &MasterKeyRecord{
+		Sentinel:      []byte("encrypted-sentinel"),
+		SentinelNonce: []byte("sentinel-nonce"),
+		DEKPlaintext:  []byte("plaintext-dek-32-bytes-here!!!!"),
+	}
+	if err := s.SetMasterKeyRecord(ctx, in); err != nil {
+		t.Fatalf("SetMasterKeyRecord: %v", err)
+	}
+
+	got, err := s.GetMasterKeyRecord(ctx)
+	if err != nil {
+		t.Fatalf("GetMasterKeyRecord: %v", err)
+	}
+	if string(got.Sentinel) != string(in.Sentinel) ||
+		string(got.SentinelNonce) != string(in.SentinelNonce) ||
+		string(got.DEKPlaintext) != string(in.DEKPlaintext) {
+		t.Fatalf("round-trip mismatch: got %+v", got)
+	}
+	if got.DEKCiphertext != nil || got.Salt != nil || got.KDFTime != nil {
+		t.Fatal("expected KEK fields to be nil for passwordless record")
+	}
+}
+
+func TestMasterKeyRecordUpdate(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	// Start passwordless.
+	in := &MasterKeyRecord{
+		Sentinel:      []byte("sentinel"),
+		SentinelNonce: []byte("nonce"),
+		DEKPlaintext:  []byte("plaintext-dek"),
+	}
+	if err := s.SetMasterKeyRecord(ctx, in); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update to password-protected (simulating "set password").
+	kdfTime := uint32(1)
+	kdfMemory := uint32(1024)
+	kdfThreads := uint8(1)
+	in.DEKCiphertext = []byte("wrapped-dek")
+	in.DEKNonce = []byte("dek-nonce")
+	in.DEKPlaintext = nil
+	in.Salt = []byte("salt")
+	in.KDFTime = &kdfTime
+	in.KDFMemory = &kdfMemory
+	in.KDFThreads = &kdfThreads
+	if err := s.UpdateMasterKeyRecord(ctx, in); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.GetMasterKeyRecord(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got.DEKCiphertext) != "wrapped-dek" || got.DEKPlaintext != nil {
+		t.Fatalf("update mismatch: got %+v", got)
 	}
 }
 
@@ -439,8 +514,8 @@ func TestMasterKeyRecordSingleton(t *testing.T) {
 	ctx := context.Background()
 
 	rec := &MasterKeyRecord{
-		Salt: []byte("s"), Sentinel: []byte("e"), Nonce: []byte("n"),
-		KDFTime: 1, KDFMemory: 1024, KDFThreads: 1,
+		Sentinel: []byte("e"), SentinelNonce: []byte("n"),
+		DEKPlaintext: []byte("dek"),
 	}
 	if err := s.SetMasterKeyRecord(ctx, rec); err != nil {
 		t.Fatal(err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -45,16 +45,21 @@ type Credential struct {
 	UpdatedAt  time.Time
 }
 
-// MasterKeyRecord holds the KDF salt and encrypted sentinel used to verify
-// the master password on subsequent server startups.
+// MasterKeyRecord holds the KEK/DEK key-wrapping artifacts.
+// The sentinel is always encrypted with the DEK for verification.
+// In password-protected mode: DEKCiphertext/DEKNonce hold the KEK-wrapped DEK.
+// In passwordless mode: DEKPlaintext holds the unwrapped DEK.
 type MasterKeyRecord struct {
-	Salt       []byte
-	Sentinel   []byte
-	Nonce      []byte
-	KDFTime    uint32
-	KDFMemory  uint32
-	KDFThreads uint8
-	CreatedAt  time.Time
+	Sentinel      []byte // sentinel ciphertext (encrypted with DEK)
+	SentinelNonce []byte // sentinel GCM nonce
+	DEKCiphertext []byte // wrapped DEK (nil in passwordless mode)
+	DEKNonce      []byte // DEK wrapping nonce (nil in passwordless mode)
+	DEKPlaintext  []byte // unwrapped DEK (nil when password-protected)
+	Salt          []byte // KDF salt (nil in passwordless mode)
+	KDFTime       *uint32
+	KDFMemory     *uint32
+	KDFThreads    *uint8
+	CreatedAt     time.Time
 }
 
 // Session represents an authenticated session.
@@ -285,6 +290,7 @@ type Store interface {
 	// Master key
 	GetMasterKeyRecord(ctx context.Context) (*MasterKeyRecord, error)
 	SetMasterKeyRecord(ctx context.Context, record *MasterKeyRecord) error
+	UpdateMasterKeyRecord(ctx context.Context, record *MasterKeyRecord) error
 
 	// Proposals
 	CreateProposal(ctx context.Context, vaultID, sessionID, servicesJSON, credentialsJSON, message, userMessage string, credentials map[string]EncryptedCredential) (*Proposal, error)


### PR DESCRIPTION
## Summary

- Introduce a random DEK (Data Encryption Key) as an intermediary between the master password and credential encryption. The master password derives a KEK (Key Encryption Key) via Argon2id that wraps the DEK — changing the password re-wraps the DEK without re-encrypting any credentials.
- Support **passwordless mode** where the DEK is stored unwrapped, enabling zero-config PaaS deploys (Fly.io, Cloud Run) where volume security is the trust boundary.
- Add `agent-vault master-password set|change|remove` CLI commands for managing the master password while the server is stopped.

### Architecture

```
master password → Argon2id → KEK → unwraps DEK → DEK encrypts/decrypts all data
```

Downstream consumers (`server.go`, `handle_credentials.go`, `brokercore/credential.go`, `ca/soft.go`) are unchanged — they receive a 32-byte `[]byte` key and are agnostic to how it was derived.

### Files changed

| Area | Files |
|------|-------|
| Core crypto | `internal/auth/auth.go` — `SetupWithPassword`, `SetupPasswordless`, `Unlock`, `UnlockPasswordless`, `WrapDEK`, `generateDEK`, `verifySentinel` |
| Schema | `internal/store/migrations/002_master_key.sql` — `dek_ciphertext`, `dek_nonce`, `dek_plaintext` columns; nullable KDF params |
| Store | `internal/store/store.go`, `sqlite.go` — `MasterKeyRecord` struct, `UpdateMasterKeyRecord` |
| Startup | `cmd/server.go` — passwordless/password-protected branching |
| CLI | `cmd/master_password.go` (new) — `set`, `change`, `remove` subcommands |
| Docs | 8 doc files updated for KEK/DEK terminology |

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -count=1 ./...` — all 15 packages pass
- [x] Unit tests for password setup + unlock round-trip
- [x] Unit tests for passwordless setup + unlock round-trip
- [x] Unit tests for wrong password → `ErrWrongPassword`
- [x] Unit tests for `WrapDEK` round-trip
- [x] Unit tests for password change preserving DEK
- [x] Store tests for insert/update/get with nullable columns
- [x] Server test mock updated for KEK/DEK architecture
- [ ] Manual smoke test: fresh install with password, restart, verify credentials decrypt
- [ ] Manual smoke test: fresh install passwordless, restart, verify credentials decrypt
- [ ] Manual smoke test: `master-password set/change/remove` round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)