### PR TITLE
feat: use get.agent-vault.dev short URL and add anonymous install beacon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,9 @@
 # where TIER ∈ AUTH | PROXY | AUTHED | GLOBAL
 # and KNOB ∈ RATE | BURST | WINDOW | MAX | CONCURRENCY. Example:
 # AGENT_VAULT_RATELIMIT_PROXY_BURST=50
+
+# Installer (install.sh only — not read by the server or CLI binary).
+# Set to any non-empty value to disable the anonymous install/upgrade beacon.
+# Must be passed to `sh`, not `curl`:
+#   curl -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
+# AGENT_VAULT_NO_TELEMETRY=1

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -13,10 +13,14 @@ Agent Vault ships as a single binary that acts as both a server and CLI client. 
     Works for both fresh installs and upgrades (backs up your database before upgrading).
 
     ```bash
-    curl -fsSL https://raw.githubusercontent.com/Infisical/agent-vault/main/install.sh | sh
+    curl -fsSL https://get.agent-vault.dev | sh
     ```
 
     Supports macOS (Intel + Apple Silicon) and Linux (x86\_64 + ARM64).
+
+    <Note>
+      On a successful install the script sends an anonymous ping (OS, architecture, version — nothing else) so we can count installs for the launch. Opt out with `AGENT_VAULT_NO_TELEMETRY=1`.
+    </Note>
 
   </Tab>
   <Tab title="Docker">
@@ -73,7 +77,7 @@ cosign verify-blob \
     Re-run the same install command — the script detects your existing installation, stops the running server, backs up your database, and installs the latest version:
 
     ```bash
-    curl -fsSL https://raw.githubusercontent.com/Infisical/agent-vault/main/install.sh | sh
+    curl -fsSL https://get.agent-vault.dev | sh
     ```
 
     Restart the server afterward:

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -19,7 +19,11 @@ Agent Vault ships as a single binary that acts as both a server and CLI client. 
     Supports macOS (Intel + Apple Silicon) and Linux (x86\_64 + ARM64).
 
     <Note>
-      On a successful install the script sends an anonymous ping (OS, architecture, version — nothing else) so we can count installs for the launch. Opt out with `AGENT_VAULT_NO_TELEMETRY=1`.
+      On a successful install the script sends an anonymous ping (OS, architecture, version — nothing else) so we can count installs for the launch. Opt out by placing `AGENT_VAULT_NO_TELEMETRY=1` in front of `sh`, not `curl`:
+
+      ```bash
+      curl -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
+      ```
     </Note>
 
   </Tab>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -968,3 +968,11 @@ Manage the master password that wraps the data encryption key (DEK). All command
     Print the version and build information.
   </Accordion>
 </AccordionGroup>
+
+## Installer
+
+The [`install.sh`](https://github.com/Infisical/agent-vault/blob/main/install.sh) script (`curl -fsSL https://get.agent-vault.dev | sh`) is not part of the `agent-vault` binary but reads one environment variable:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGENT_VAULT_NO_TELEMETRY` | (unset) | When set to any non-empty value, skips the anonymous install/upgrade beacon (OS, architecture, version — nothing else). Must be placed in front of `sh`, not `curl`: `curl -fsSL https://get.agent-vault.dev \| AGENT_VAULT_NO_TELEMETRY=1 sh`. |

--- a/docs/self-hosting/environment-variables.mdx
+++ b/docs/self-hosting/environment-variables.mdx
@@ -28,6 +28,14 @@ Master password resolution order:
   Never put `AGENT_VAULT_MASTER_PASSWORD` in Dockerfiles, committed `.env` files, or shell history. Use secret management features of your deployment platform (e.g., `fly secrets set`, Docker secrets, or your CI/CD provider's secret store).
 </Warning>
 
+## Installer
+
+Read by [`install.sh`](https://github.com/Infisical/agent-vault/blob/main/install.sh) only — not by the server or the CLI binary.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGENT_VAULT_NO_TELEMETRY` | (unset) | When set to any non-empty value, skips the anonymous install/upgrade beacon that reports OS, architecture, and version. Must be placed in front of `sh`, not `curl`: `curl -fsSL https://get.agent-vault.dev \| AGENT_VAULT_NO_TELEMETRY=1 sh`. |
+
 ## Email SMTP configuration
 
 Configure SMTP to enable Agent Vault to send emails for verification codes, vault invites, and notifications.

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -13,6 +13,14 @@ curl -fsSL https://get.agent-vault.dev | sh
 
 Supports macOS (Intel + Apple Silicon) and Linux (x86\_64 + ARM64).
 
+<Note>
+  On a successful install the script sends an anonymous ping (OS, architecture, version — nothing else) so we can count installs for the launch. Opt out by placing `AGENT_VAULT_NO_TELEMETRY=1` in front of `sh`, not `curl`:
+
+  ```bash
+  curl -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
+  ```
+</Note>
+
 Verify the installation:
 
 ```bash
@@ -116,6 +124,14 @@ Re-run the same install command — the script detects your existing installatio
 ```bash
 curl -fsSL https://get.agent-vault.dev | sh
 ```
+
+<Note>
+  On a successful upgrade the script sends the same anonymous ping (OS, architecture, version). Opt out by placing `AGENT_VAULT_NO_TELEMETRY=1` in front of `sh`, not `curl`:
+
+  ```bash
+  curl -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
+  ```
+</Note>
 
 Restart the server afterward:
 

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -8,7 +8,7 @@ description: "Install and run Agent Vault on Linux or macOS using the install sc
 Auto-detects your OS and architecture, downloads the latest release, and installs. Works for both fresh installs and upgrades.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Infisical/agent-vault/main/install.sh | sh
+curl -fsSL https://get.agent-vault.dev | sh
 ```
 
 Supports macOS (Intel + Apple Silicon) and Linux (x86\_64 + ARM64).
@@ -114,7 +114,7 @@ See the [CLI reference](/reference/cli#ca) for all `agent-vault ca fetch` flags.
 Re-run the same install command — the script detects your existing installation, stops the running server, backs up your database, and installs the latest version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Infisical/agent-vault/main/install.sh | sh
+curl -fsSL https://get.agent-vault.dev | sh
 ```
 
 Restart the server afterward:

--- a/install.sh
+++ b/install.sh
@@ -2,10 +2,14 @@
 set -e
 
 # Agent Vault installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/Infisical/agent-vault/main/install.sh | sh
+# Usage: curl -fsSL https://get.agent-vault.dev | sh
 #
 # Supports: macOS (Intel + Apple Silicon), Linux (amd64 + arm64)
 # Works for both fresh install and upgrade.
+#
+# Privacy: on successful install, sends an anonymous ping with OS, arch,
+# and version only — no identifiers, no IP retention. Opt out with:
+#   AGENT_VAULT_NO_TELEMETRY=1 curl -fsSL https://get.agent-vault.dev | sh
 
 REPO="Infisical/agent-vault"
 INSTALL_DIR="/usr/local/bin"
@@ -175,6 +179,16 @@ main() {
         info "The server was stopped for the upgrade."
         info "Run 'agent-vault server' to start it again."
         info "Database migrations (if any) will run automatically on startup."
+    fi
+
+    # Anonymous completion beacon. No PII, no identifiers.
+    # Opt out: AGENT_VAULT_NO_TELEMETRY=1
+    if [ -z "$AGENT_VAULT_NO_TELEMETRY" ]; then
+        EVENT="install"
+        if [ -n "$EXISTING_VERSION" ] && [ "$EXISTING_VERSION" != "unknown" ]; then
+            EVENT="upgrade"
+        fi
+        curl -fsS -m 3 "https://get.agent-vault.dev/ok?os=${OS}&arch=${ARCH}&v=${LATEST}&event=${EVENT}" >/dev/null 2>&1 || true
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ set -e
 #
 # Privacy: on successful install, sends an anonymous ping with OS, arch,
 # and version only — no identifiers, no IP retention. Opt out with:
-#   AGENT_VAULT_NO_TELEMETRY=1 curl -fsSL https://get.agent-vault.dev | sh
+#   curl -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
 
 REPO="Infisical/agent-vault"
 INSTALL_DIR="/usr/local/bin"
@@ -160,7 +160,7 @@ main() {
     INSTALLED_VERSION="$(agent-vault version 2>/dev/null || echo "")"
     if [ -z "$INSTALLED_VERSION" ]; then
         warn "Could not verify installed binary."
-        if [ -n "$EXISTING_VERSION" ]; then
+        if [ -n "$BACKUP_FILE" ]; then
             warn "A database backup was saved at: ${BACKUP_FILE}"
         fi
         error "Installation may have failed. Check that ${INSTALL_DIR} is in your PATH."
@@ -171,7 +171,9 @@ main() {
 
     if [ -n "$EXISTING_VERSION" ] && [ "$EXISTING_VERSION" != "unknown" ]; then
         info "Upgraded from ${EXISTING_VERSION}"
-        info "Database backup: ${BACKUP_FILE}"
+        if [ -n "$BACKUP_FILE" ]; then
+            info "Database backup: ${BACKUP_FILE}"
+        fi
     fi
 
     if [ "$SERVER_WAS_RUNNING" = true ]; then

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -63,7 +63,7 @@ function InviteOnlyNotice() {
   );
 }
 
-const INSTALL_COMMAND = "curl -fsSL https://raw.githubusercontent.com/Infisical/agent-vault/main/install.sh | sh";
+const INSTALL_COMMAND = "curl -fsSL https://get.agent-vault.dev | sh";
 
 function CommandBlock({ command }: { command: string }) {
   const [copied, setCopied] = useState(false);


### PR DESCRIPTION
## Summary
- Swap the install one-liner from `raw.githubusercontent.com/Infisical/agent-vault/main/install.sh` to `https://get.agent-vault.dev` in [docs/installation.mdx](docs/installation.mdx), [docs/self-hosting/local.mdx](docs/self-hosting/local.mdx), and [web/src/pages/Register.tsx](web/src/pages/Register.tsx).
- Installer sends an anonymous `install` / `upgrade` beacon (OS, arch, version) to `get.agent-vault.dev/ok` on success; opt out with `AGENT_VAULT_NO_TELEMETRY=1`. Failure is swallowed so it never breaks an install.
- Docs call out the beacon and opt-out via a `<Note>` on the install page.

## Test plan
- [ ] Run `curl -fsSL https://get.agent-vault.dev | sh` on macOS (fresh install) — binary lands in `/usr/local/bin`, beacon fires with `event=install`.
- [ ] Re-run on same machine — beacon fires with `event=upgrade`.
- [ ] Run with `AGENT_VAULT_NO_TELEMETRY=1` — no beacon request.
- [ ] Install still succeeds if the beacon endpoint is unreachable (simulate with bad DNS / firewall).
- [ ] Register page renders the new command and copy-to-clipboard still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)