### PR TITLE
docs: refresh connection docs around HTTPS_PROXY, add sandbox note, link blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Agents should not possess credentials. Agent Vault eliminates credential exfiltr
 </p>
 
 <p align="center">
-<a href="https://docs.agent-vault.dev">Documentation</a> | <a href="https://docs.agent-vault.dev/installation">Installation</a> | <a href="https://docs.agent-vault.dev/reference/cli">CLI Reference</a> | <a href="https://infisical.com/slack">Slack</a>
+<a href="https://docs.agent-vault.dev">Documentation</a> | <a href="https://docs.agent-vault.dev/installation">Installation</a> | <a href="https://docs.agent-vault.dev/reference/cli">CLI Reference</a> | <a href="https://infisical.com/blog/agent-vault-the-open-source-credential-proxy-and-vault-for-agents">Blog</a> | <a href="https://infisical.com/slack">Slack</a>
 </p>
 
 <p align="center">
@@ -19,13 +19,13 @@ Agents should not possess credentials. Agent Vault eliminates credential exfiltr
 
 ## Why Agent Vault
 
-Secret managers return credentials directly to the caller. This breaks down with AI agents, which are non-deterministic systems vulnerable to prompt injection that can be tricked into exfiltrating secrets.
+Traditional secrets management relies on returning credentials directly to the caller. This breaks down with AI agents, which are non-deterministic systems vulnerable to prompt injection that can be fooled into leaking its secrets.
 
 Agent Vault takes a different approach: **Agent Vault never reveals vault-stored credentials to agents**. Instead, agents route HTTP requests through a local proxy that injects the right credentials at the network layer.
 
-- **Brokered access, not retrieval** - Your agent gets a scoped session and a local `HTTPS_PROXY`. It calls target APIs normally, and Agent Vault injects the right credential at the network layer. Credentials are never returned to the agent. [Learn more](https://docs.agent-vault.dev/learn/security)
-- **Works with any agent** - Custom Python/TypeScript agents, sandboxed processes, and coding agents like Claude Code, Cursor, and Codex. Anything that speaks HTTP. [Learn more](https://docs.agent-vault.dev/quickstart)
-- **Encrypted at rest** - Credentials are encrypted with AES-256-GCM using a random data encryption key (DEK). An optional master password wraps the DEK via Argon2id, so rotating the password does not re-encrypt credentials. A passwordless mode is available for PaaS deploys. [Learn more](https://docs.agent-vault.dev/learn/credentials)
+- **Brokered access, not retrieval** - Your agent gets a scoped session and a local `HTTPS_PROXY`. It calls target APIs normally, and Agent Vault injects the right credential at the network layer. Credentials are never returned to the agent.
+- **Works with any agent** - Custom Python/TypeScript agents, sandboxed processes, and coding agents like Claude Code, Cursor, and Codex. Anything that speaks HTTP.
+- **Encrypted at rest** - Credentials are encrypted with AES-256-GCM using a random data encryption key (DEK). An optional master password wraps the DEK via Argon2id, so rotating the password does not re-encrypt credentials. A passwordless mode is available for PaaS deploys.
 - **Request logs** - Every proxied request is persisted per vault with method, host, path, status, latency, and the credential key names involved. Bodies, headers, and query strings are not recorded. Retention is configurable per vault.
 
 ## Installation
@@ -92,8 +92,13 @@ npm install @infisical/agent-vault-sdk
 ```typescript
 import { AgentVault, buildProxyEnv } from "@infisical/agent-vault-sdk";
 
-const av = new AgentVault({ token: "YOUR_TOKEN", address: "http://localhost:14321" });
-const session = await av.vault("default").sessions.create({ vaultRole: "proxy" });
+const av = new AgentVault({
+  token: "YOUR_TOKEN",
+  address: "http://localhost:14321",
+});
+const session = await av
+  .vault("default")
+  .sessions.create({ vaultRole: "proxy" });
 
 // certPath is where you'll mount the CA certificate inside the sandbox.
 const certPath = "/etc/ssl/agent-vault-ca.pem";

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Agents should not possess credentials. Agent Vault eliminates credential exfiltr
 </p>
 
 <p align="center">
-<strong>New here? Read the <a href="https://infisical.com/blog/agent-vault-the-open-source-credential-proxy-and-vault-for-agents">launch blog post</a> for the full story — why agents shouldn't hold credentials, and how Agent Vault brokers access instead.</strong>
+<strong>New here? The <a href="https://infisical.com/blog/agent-vault-the-open-source-credential-proxy-and-vault-for-agents">launch blog post</a> has the full story behind Agent Vault.</strong>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ Agents should not possess credentials. Agent Vault eliminates credential exfiltr
 </p>
 
 <p align="center">
-<a href="https://docs.agent-vault.dev">Documentation</a> | <a href="https://docs.agent-vault.dev/installation">Installation</a> | <a href="https://docs.agent-vault.dev/reference/cli">CLI Reference</a> | <a href="https://infisical.com/blog/agent-vault-the-open-source-credential-proxy-and-vault-for-agents">Blog</a> | <a href="https://infisical.com/slack">Slack</a>
+<strong>New here? Read the <a href="https://infisical.com/blog/agent-vault-the-open-source-credential-proxy-and-vault-for-agents">launch blog post</a> for the full story — why agents shouldn't hold credentials, and how Agent Vault brokers access instead.</strong>
+</p>
+
+<p align="center">
+<a href="https://docs.agent-vault.dev">Documentation</a> | <a href="https://docs.agent-vault.dev/installation">Installation</a> | <a href="https://docs.agent-vault.dev/reference/cli">CLI Reference</a> | <a href="https://infisical.com/slack">Slack</a>
 </p>
 
 <p align="center">

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -9,14 +9,18 @@ There are two ways to connect an agent: **wrapping** a local process or **inviti
 
 ## Wrapping with `vault run`
 
-The simplest approach for local development. Wraps a local agent process with the environment variables it needs — no invite, no token management.
+The simplest approach for local development. Wraps a local agent process with the environment variables it needs — no invite, no token management. `vault run` also pre-configures `HTTPS_PROXY` and the CA trust chain on the child, so the agent calls upstream URLs directly and Agent Vault transparently injects credentials at the proxy boundary.
 
 ```bash
 agent-vault vault run -- claude    # Claude Code
 agent-vault vault run --vault my-vault -- claude
 ```
 
-The agent receives a temporary, vault-scoped session and can immediately make proxied requests and raise proposals.
+The agent receives a temporary, vault-scoped session and can immediately make authenticated requests and raise proposals.
+
+<Note>
+`vault run` is a convenience wrapper, not a sandbox. A child process can unset `HTTPS_PROXY` or bypass the injected CA and reach the network directly — local credentials and network access are still fully available to the agent. Stronger isolation for local development is on the roadmap.
+</Note>
 
 ## Inviting an agent
 
@@ -131,7 +135,7 @@ Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
 X-Vault: my-vault
 ```
 
-This applies to all vault-scoped requests: `/discover`, `/proxy/...`, `/v1/proposals`, and `/v1/credentials`.
+This applies to all vault-scoped requests: `/discover`, `/v1/proposals`, `/v1/credentials`, and the explicit `/proxy/` endpoint.
 
 <Note>
 Agents created via `agent-vault vault run` receive vault-scoped sessions and do not need the `X-Vault` header — the vault is embedded in the session.
@@ -155,5 +159,5 @@ When in doubt, start with `agent-vault vault run`. You can always create a named
 Regardless of how an agent connects, it follows the same [protocol](/agents/protocol):
 
 1. Call `/discover` to learn which services are available
-2. Route requests through the proxy at `/proxy/{host}/{path}`
+2. Call upstream URLs directly — `HTTPS_PROXY` routes the request through Agent Vault transparently
 3. Raise [proposals](/learn/proposals) when access to a new service is needed

--- a/docs/agents/protocol.mdx
+++ b/docs/agents/protocol.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Agent protocol"
-description: "How agents authenticate, discover services, proxy requests, and propose changes through Agent Vault."
+description: "How agents authenticate, discover services, route requests through HTTPS_PROXY, and propose changes through Agent Vault."
 ---
 
-Agent Vault agents follow a standard HTTP protocol to interact with the server. Agents handle this automatically (the instructions are embedded in every invite response). This page is a reference for understanding what happens under the hood.
+Agent Vault agents follow a standard HTTP protocol to interact with the server. Agents handle this automatically — the instructions are embedded in every invite response and in the [agent skill files](https://github.com/Infisical/agent-vault/blob/main/cmd/skill_http.md). This page is a reference for understanding what happens under the hood.
 
 <Warning>
 Agents must never extract, log, or display credential values. They reference credentials by key name only.
@@ -34,7 +34,7 @@ There are two session types:
 
 ### The X-Vault header
 
-Instance-level agent tokens must include `X-Vault: {vault_name}` on all vault-scoped requests (discover, proxy, proposals, credentials):
+Instance-level agent tokens must include `X-Vault: {vault_name}` on all vault-scoped requests (discover, proposals, credentials):
 
 ```
 GET {AGENT_VAULT_ADDR}/discover
@@ -44,15 +44,9 @@ X-Vault: my-vault
 
 Agents created via `agent-vault vault run` do not need this header — the vault is embedded in the session token.
 
-### Instance-level agent tokens
-
-Agents invited via `agent-vault agent invite` receive instance-level agent tokens that can access multiple vaults. The agent token can be configured with no expiry (works indefinitely) or a specific TTL. If the token expires, the operator can issue a new one via [rotation](/agents/overview#rotating-an-agent-token).
-
-See [Agents overview](/agents/overview) for the full lifecycle.
-
 ## Discover services
 
-Before proxying anything, the agent calls `/discover` to learn which hosts have [credentials](/learn/credentials) configured in the vault.
+Before making any proxied request, the agent calls `/discover` to learn which hosts have [credentials](/learn/credentials) configured in the vault.
 
 ```
 GET {AGENT_VAULT_ADDR}/discover
@@ -76,19 +70,43 @@ The `X-Vault` header is required for instance-level agent tokens. Vault-scoped s
 }
 ```
 
-- **`services`** lists the hosts the agent can proxy through Agent Vault (defined by the vault's [services](/learn/services)). Requests to any other host go direct.
+- **`services`** lists the hosts the agent can reach through Agent Vault (defined by the vault's [services](/learn/services)). Requests to any other host go direct.
 - **`available_credentials`** lists [credential](/learn/credentials) key names in the vault (values are never exposed). Agents use these to avoid creating duplicate slots in [proposals](/learn/proposals).
+- **`proxy_url`** is the fallback endpoint for clients that can't honor `HTTPS_PROXY`. See [Explicit proxy endpoint](#explicit-proxy-endpoint-fallback).
 
-## Proxy requests
+## Route requests through HTTPS_PROXY
 
-For hosts returned by `/discover`, the agent routes requests through the Agent Vault proxy:
+The canonical way for an agent to reach an upstream host is to call the real URL directly. `agent-vault vault run` pre-configures `HTTPS_PROXY` and the CA trust chain on the child process, so every standard HTTP client — `curl`, `fetch`, `requests`, `axios`, the Go stdlib, SDKs like `stripe-node`, CLIs like `gh` and `stripe` — transparently routes through the broker. Agent Vault intercepts the CONNECT, matches the target host against the vault's [services](/learn/services), strips any client-supplied auth, and injects the stored credential.
+
+```
+GET https://api.stripe.com/v1/charges?limit=10
+```
+
+The agent writes this line unchanged. No URL rewriting. No `Authorization` header. No credential in the code.
+
+### Environment set by `vault run`
+
+| Variable | Purpose |
+|---|---|
+| `HTTPS_PROXY` | Points at the MITM listener (`http://{token}:{vault}@host:14322`) |
+| `NO_PROXY` | `localhost,127.0.0.1` — so agent-to-vault traffic skips the proxy |
+| `NODE_USE_ENV_PROXY` | `1` — enables Node.js v22.21+ built-in `HTTPS_PROXY` support for `fetch()` and `https.get()` |
+| `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT` | Point standard HTTP libraries at the Agent Vault root CA so the proxied TLS handshake validates |
+
+<Tip>
+HTTP_PROXY is intentionally not set. The MITM listener only handles HTTPS (CONNECT) and would 405 on plain `http://` requests.
+</Tip>
+
+### Explicit proxy endpoint (fallback)
+
+For clients that can't honor `HTTPS_PROXY` — HTTP/2-terminating edges, constrained runtimes, sandboxes without CA-mounting — Agent Vault exposes an explicit endpoint:
 
 ```
 {AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
 Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
 ```
 
-Agent Vault strips the agent's auth header, attaches the real credentials from the vault's services, and forwards the request over HTTPS.
+Rewrite the upstream URL to this shape and Agent Vault applies the same credential-injection logic — strips the agent's `Authorization` header, attaches credentials from the vault's [services](/learn/services), forwards over HTTPS.
 
 <CodeGroup>
 
@@ -164,13 +182,14 @@ See [Proposals](/learn/proposals) for the full proposal lifecycle, including sto
 | Status | Meaning | What the agent does |
 |---|---|---|
 | 401 | Invalid or expired token | Re-check `AGENT_VAULT_SESSION_TOKEN`. Contact operator for a new token or [rotation](/agents/overview#rotating-an-agent-token). |
-| 403 | Host not allowed | Create a proposal to request access. The response includes a `proposal_hint`. |
-| 429 | Too many pending proposals | Wait for existing proposals to be reviewed. |
-| 502 | Missing credential or upstream error | Tell the user a credential may need to be added. |
+| 403 `forbidden` | Host not allowed | Create a proposal to request access. The response includes a `proposal_hint`. |
+| 403 `service_disabled` | Host is configured but disabled | Surface to the user — don't create a duplicate proposal. |
+| 429 | Rate limited | Respect the `Retry-After` header. The MITM and `/proxy` paths share one budget. |
+| 502 | Missing credential or upstream unreachable | Tell the user a credential may need to be added. |
 
 ## Security constraints
 
 - Never extract, log, or display credential values
 - Never hardcode tokens. Always read from `AGENT_VAULT_SESSION_TOKEN`.
-- Only proxy hosts returned by `/discover`. For unlisted hosts, create a proposal.
+- Only reach hosts returned by `/discover`. For unlisted hosts, create a proposal.
 - If a `credential_not_found` error occurs, inform the user which key is missing.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -17,8 +17,7 @@
         "group": "Getting Started",
         "pages": [
           "index",
-          "installation",
-          "first-proposal"
+          "installation"
         ]
       },
       {

--- a/docs/guides/connect-coding-agent.mdx
+++ b/docs/guides/connect-coding-agent.mdx
@@ -16,7 +16,7 @@ For agents that don't have a chat interface or need raw environment variables, s
 
 ## Option 1: Wrap with `agent-vault vault run`
 
-The simplest approach for local development. Wraps your agent process with the environment variables it needs — no invite, no token management.
+The simplest approach for local development. Wraps your agent process with the environment variables it needs — no invite, no token management. `vault run` also pre-configures `HTTPS_PROXY` and the CA trust chain on the child, so the agent calls upstream URLs directly and Agent Vault transparently injects credentials.
 
 ```bash
 agent-vault vault run -- claude    # Claude Code
@@ -25,13 +25,17 @@ agent-vault vault run -- codex     # Codex
 agent-vault vault run -- hermes    # Hermes Agent
 ```
 
-The agent can immediately make proxied requests and raise [proposals](/learn/proposals).
+The agent can immediately make authenticated requests and raise [proposals](/learn/proposals).
 
 Use `--vault` to target a specific vault:
 
 ```bash
 agent-vault vault run --vault my-vault -- claude
 ```
+
+<Note>
+`vault run` is a convenience wrapper, not a sandbox. A child process can unset `HTTPS_PROXY` or bypass the injected CA and reach the network directly — local credentials and network access are still fully available to the agent. Stronger isolation for local development is on the roadmap.
+</Note>
 
 ## Option 2: Paste an invite prompt
 
@@ -73,7 +77,7 @@ For agents you can't wrap with `vault run` (e.g. cloud-hosted agents, or when yo
 
 Once connected, the agent follows the Agent Vault protocol automatically:
 
-1. Routes API requests through the Agent Vault proxy
+1. Calls upstream APIs normally — `HTTPS_PROXY` and CA trust are pre-wired so Agent Vault transparently intercepts the call
 2. If a service isn't configured yet, the agent creates a [proposal](/learn/proposals) and shares an approval link
 3. You click the link, provide any required credentials, and approve
 4. The agent retries and the request succeeds

--- a/docs/guides/connect-custom-agent.mdx
+++ b/docs/guides/connect-custom-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Connect a custom agent"
-description: "Wire up a custom agent or script to Agent Vault using environment variables and the HTTP protocol."
+description: "Wire up a custom agent or script to Agent Vault through HTTPS_PROXY and the transparent CA."
 ---
 
 This guide walks through connecting a custom agent to Agent Vault. Use this when you're building your own sandboxed agent, a CI pipeline, or any process that needs to make authenticated API calls through Agent Vault.
@@ -11,7 +11,7 @@ If you're using Claude Code, Cursor, or another supported agent, see the [Quicks
 
 ## Prerequisites
 
-- A running Agent Vault server
+- A running Agent Vault server with the transparent proxy enabled (default)
 - A user account with vault access ([member or admin](/learn/permissions#vault-roles))
 
 ## Get connection credentials
@@ -24,7 +24,7 @@ If you're using Claude Code, Cursor, or another supported agent, see the [Quicks
     agent-vault vault run -- my-agent
     ```
 
-    This sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT` in the child process automatically. No invite needed.
+    `vault run` sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT` on the child, then pre-configures `HTTPS_PROXY` and the CA trust chain so standard HTTP clients transparently route through the broker. No invite needed.
   </Tab>
   <Tab title="Agent invite">
     For CI pipelines, cloud-hosted agents, or when you need the agent to redeem an invite via HTTP:
@@ -37,6 +37,9 @@ If you're using Claude Code, Cursor, or another supported agent, see the [Quicks
     - `av_addr` — the Agent Vault server URL
     - `av_agent_token` — bearer token for all requests
     - `vaults` — list of accessible vaults
+    - `proxy_url` — the [explicit proxy endpoint](#explicit-proxy-endpoint-fallback) fallback
+
+    Invited agents don't get `HTTPS_PROXY` auto-configured. You can either set it yourself (see [Set HTTPS_PROXY manually](#set-https-proxy-manually)) or use the explicit endpoint.
 
     Instance-level agent tokens require the `X-Vault` header on every vault-scoped request.
   </Tab>
@@ -49,92 +52,135 @@ Your agent needs these values to operate:
 | Variable | Required | Description |
 |---|---|---|
 | `AGENT_VAULT_ADDR` | Yes | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
-| `AGENT_VAULT_SESSION_TOKEN` | Yes | Bearer token for authenticating all requests to Agent Vault |
+| `AGENT_VAULT_SESSION_TOKEN` | Yes | Bearer token for authenticating control-plane requests (`/discover`, proposals) |
 
 For instance-level agent tokens (from agent invites), the agent must also send the `X-Vault` header on every vault-scoped request. For vault-scoped sessions (from `vault run`), the vault is embedded in the session.
 
-## Make proxied requests
+When the agent is launched via `vault run`, these additional variables are also set automatically on the child:
 
-The core of Agent Vault is the proxy. Your agent makes HTTP requests to Agent Vault, which injects the real credentials and forwards to the target service over HTTPS. Your agent never sees or handles the actual API keys.
+| Variable | Purpose |
+|---|---|
+| `HTTPS_PROXY` | Routes HTTPS traffic through the transparent proxy |
+| `NO_PROXY` | `localhost,127.0.0.1` — so agent-to-vault traffic skips the proxy |
+| `NODE_USE_ENV_PROXY` | Enables Node.js 22.21+ built-in proxy support |
+| `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT` | Trust the Agent Vault root CA from standard HTTP libraries |
 
-The proxy URL format is:
+## Make requests
 
-```
-{AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
-```
-
-Every request to the proxy must include your agent token in the `Authorization` header. Agent Vault strips it before forwarding and replaces it with the real credentials from the vault's services.
+When your agent is launched via `vault run`, HTTPS traffic already routes through Agent Vault transparently. Call the real API URL — standard HTTP clients honor `HTTPS_PROXY` automatically. Agent Vault intercepts the CONNECT, matches the host against the vault's [services](/learn/services), strips client auth, and injects the stored credential over HTTPS.
 
 <CodeGroup>
 
 ```python Python
 import os, requests
 
-ADDR = os.environ["AGENT_VAULT_ADDR"]
-TOKEN = os.environ["AGENT_VAULT_SESSION_TOKEN"]
-
-headers = {"Authorization": f"Bearer {TOKEN}"}
-
-# GET request through the proxy
+# Authorization intentionally omitted — Agent Vault injects the real credential.
 charges = requests.get(
-    f"{ADDR}/proxy/api.stripe.com/v1/charges",
+    "https://api.stripe.com/v1/charges",
     params={"limit": 10},
-    headers=headers,
 )
 print(charges.json())
 
-# POST request through the proxy
 new_charge = requests.post(
-    f"{ADDR}/proxy/api.stripe.com/v1/charges",
-    headers={**headers, "Content-Type": "application/x-www-form-urlencoded"},
-    data="amount=2000&currency=usd",
+    "https://api.stripe.com/v1/charges",
+    data={"amount": 2000, "currency": "usd"},
 )
 print(new_charge.json())
 ```
 
 ```typescript TypeScript
-const ADDR = process.env.AGENT_VAULT_ADDR;
-const TOKEN = process.env.AGENT_VAULT_SESSION_TOKEN;
-
-const headers = { Authorization: `Bearer ${TOKEN}` };
-
-// GET request through the proxy
-const charges = await fetch(
-  `${ADDR}/proxy/api.stripe.com/v1/charges?limit=10`,
-  { headers },
-);
+// fetch() in Node.js v22.21+ honors HTTPS_PROXY when NODE_USE_ENV_PROXY=1.
+const charges = await fetch("https://api.stripe.com/v1/charges?limit=10");
 console.log(await charges.json());
 
-// POST request through the proxy
-const newCharge = await fetch(
-  `${ADDR}/proxy/api.stripe.com/v1/charges`,
-  {
-    method: "POST",
-    headers: { ...headers, "Content-Type": "application/x-www-form-urlencoded" },
-    body: "amount=2000&currency=usd",
-  },
-);
+const newCharge = await fetch("https://api.stripe.com/v1/charges", {
+  method: "POST",
+  headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  body: "amount=2000&currency=usd",
+});
 console.log(await newCharge.json());
 ```
 
 ```bash curl
-# GET
-curl "${AGENT_VAULT_ADDR}/proxy/api.stripe.com/v1/charges?limit=10" \
-  -H "Authorization: Bearer ${AGENT_VAULT_SESSION_TOKEN}"
+curl "https://api.stripe.com/v1/charges?limit=10"
 
-# POST
-curl -X POST "${AGENT_VAULT_ADDR}/proxy/api.stripe.com/v1/charges" \
-  -H "Authorization: Bearer ${AGENT_VAULT_SESSION_TOKEN}" \
+curl -X POST "https://api.stripe.com/v1/charges" \
   -d "amount=2000&currency=usd"
 ```
 
 </CodeGroup>
 
-Any HTTP method works (GET, POST, PUT, DELETE, PATCH). Query parameters, request bodies, and headers (other than `Authorization`) are forwarded as-is.
+Any HTTP method works (GET, POST, PUT, DELETE, PATCH). Query parameters, request bodies, and headers flow through unchanged.
+
+<Tip>
+Leave the upstream `Authorization` header blank or set it to a placeholder — Agent Vault strips whatever the client sends and attaches the real credential at the proxy boundary.
+</Tip>
+
+### Set HTTPS_PROXY manually
+
+If your agent wasn't launched via `vault run` (e.g. an invited agent, a Docker container, a sandboxed runtime), configure the proxy yourself. The MITM listener is TLS-encrypted, so the proxy URL uses the `https://` scheme and needs the root CA trusted.
+
+```bash
+# 1. Fetch the CA certificate
+agent-vault ca fetch -o /etc/ssl/certs/agent-vault-ca.pem
+
+# 2. Build the proxy URL (basic auth: token:vault)
+export HTTPS_PROXY="https://${AGENT_VAULT_SESSION_TOKEN}:my-vault@127.0.0.1:14322"
+export NO_PROXY="localhost,127.0.0.1"
+export NODE_USE_ENV_PROXY=1
+
+# 3. Point standard HTTP libraries at the CA
+export SSL_CERT_FILE=/etc/ssl/certs/agent-vault-ca.pem
+export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/agent-vault-ca.pem
+export REQUESTS_CA_BUNDLE=/etc/ssl/certs/agent-vault-ca.pem
+export CURL_CA_BUNDLE=/etc/ssl/certs/agent-vault-ca.pem
+export GIT_SSL_CAINFO=/etc/ssl/certs/agent-vault-ca.pem
+export DENO_CERT=/etc/ssl/certs/agent-vault-ca.pem
+```
+
+For containerized agents, the [TypeScript SDK](https://github.com/Infisical/agent-vault/tree/main/sdks/sdk-typescript) provides `buildProxyEnv()`, which returns the complete environment block from a session's `containerConfig`.
+
+### Explicit proxy endpoint (fallback)
+
+For clients that can't honor `HTTPS_PROXY` — HTTP/2-only runtimes, sandboxes without CA-mounting, or minimal environments — Agent Vault exposes an explicit endpoint. Rewrite the upstream URL to:
+
+```
+{AGENT_VAULT_ADDR}/proxy/{target_host}/{path}[?query]
+```
+
+<CodeGroup>
+
+```bash curl
+curl "${AGENT_VAULT_ADDR}/proxy/api.stripe.com/v1/charges?limit=10" \
+  -H "Authorization: Bearer ${AGENT_VAULT_SESSION_TOKEN}"
+```
+
+```python Python
+import os, requests
+
+resp = requests.get(
+    f"{os.environ['AGENT_VAULT_ADDR']}/proxy/api.stripe.com/v1/charges",
+    params={"limit": 10},
+    headers={"Authorization": f"Bearer {os.environ['AGENT_VAULT_SESSION_TOKEN']}"},
+)
+print(resp.json())
+```
+
+```typescript TypeScript
+const resp = await fetch(
+  `${process.env.AGENT_VAULT_ADDR}/proxy/api.stripe.com/v1/charges?limit=10`,
+  { headers: { Authorization: `Bearer ${process.env.AGENT_VAULT_SESSION_TOKEN}` } },
+);
+console.log(await resp.json());
+```
+
+</CodeGroup>
+
+Instance-level agent tokens must also include `X-Vault: {vault_name}`.
 
 ## Discover available services
 
-Your agent can call `/discover` to check which hosts have credentials configured before making proxy requests.
+Your agent can call `/discover` to check which hosts have credentials configured before making requests.
 
 ```bash
 curl ${AGENT_VAULT_ADDR}/discover \
@@ -153,12 +199,12 @@ curl ${AGENT_VAULT_ADDR}/discover \
 }
 ```
 
-- **`services`** lists the hosts your agent can route through the proxy.
+- **`services`** lists the hosts configured in the vault. Requests to unlisted hosts go direct.
 - **`available_credentials`** lists credential key names in the vault (values are never exposed).
-- Requests to hosts **not** in this list should go direct, not through the proxy.
+- **`proxy_url`** is the explicit endpoint fallback.
 
 <Tip>
-Discovery is optional. If your agent already knows which hosts are configured, it can skip straight to proxying. If it hits a host that isn't configured, Agent Vault returns a 403 with a `proposal_hint`.
+Discovery is optional. If your agent already knows which hosts are configured, it can skip straight to making requests. If it hits a host that isn't configured, Agent Vault returns a 403 with a `proposal_hint`.
 </Tip>
 
 ## Handle errors
@@ -166,15 +212,15 @@ Discovery is optional. If your agent already knows which hosts are configured, i
 | Status | Meaning | What to do |
 |---|---|---|
 | 401 | Invalid or expired token | Re-authenticate. Contact the operator for a [token rotation](/agents/overview#rotating-an-agent-token). |
-| 403 | Host not allowed | The service isn't configured in the vault. Create a [proposal](/learn/proposals) to request access, or ask the vault admin to add it. The response body includes a `proposal_hint`. |
-| 429 | Too many pending proposals | Wait for existing proposals to be reviewed before creating new ones. |
-| 502 | Missing credential or upstream error | A credential may need to be added to the vault. Inform the user. |
+| 403 | Host not allowed | Create a [proposal](/learn/proposals) to request access, or ask the vault admin to add it. |
+| 429 | Too many requests | Respect the `Retry-After` header. |
+| 502 | Missing credential or upstream error | A credential may need to be added to the vault. |
 
 ## Next steps
 
 <CardGroup cols={2}>
   <Card title="Agent protocol" icon="code" href="/agents/protocol">
-    Full HTTP reference for sessions, discovery, proxy, and proposals.
+    Full HTTP reference for sessions, discovery, and proposals.
   </Card>
   <Card title="Proposals" icon="file-circle-check" href="/learn/proposals">
     Request access to new services via the proposal API.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -21,10 +21,10 @@ Enter Agent Vault - a new credential management solution built for agents that p
 
 ## How it works
 
-1. Your agent calls `/discover` to see which services are available in the [vault](/learn/vaults).
-2. If a service isn't listed, the agent raises a [**proposal**](/learn/proposals) requesting access.
-3. You review and approve in the browser, pasting in the API key.
-4. The agent retries through the proxy — Agent Vault attaches the real credentials and forwards to the target API.
+1. You point the agent at Agent Vault by setting `HTTPS_PROXY` and trusting the Agent Vault CA certificate.
+2. The agent makes API calls the way it normally would — direct `fetch`, a vendor SDK, a CLI like `gh` or `stripe`, or an MCP server. All outbound HTTPS transparently routes through the Agent Vault proxy.
+3. Agent Vault matches the target host against the services in the [vault](/learn/vaults), strips any client-supplied auth, injects the stored credential, and forwards the request upstream.
+4. If no service matches the host, the agent can raise a [**proposal**](/learn/proposals) requesting access. You review and approve in the browser, pasting in the API key, and the next request succeeds.
 
 The agent never sees or handles your secrets. Learn more about [vaults](/learn/vaults), [services](/learn/services), [proposals](/learn/proposals), and [agents](/agents/overview).
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -124,6 +124,8 @@ agent-vault server
 
 On first run, Agent Vault generates a random **data encryption key (DEK)** that encrypts all [credentials](/learn/credentials) at rest with AES-256-GCM. You can optionally set a **master password** to wrap the DEK (leave it empty for passwordless mode). The master password is never stored on disk. For non-interactive or automated environments, set the `AGENT_VAULT_MASTER_PASSWORD` environment variable or pass `--password-stdin`. Omit it entirely for passwordless mode. See [environment variables](/self-hosting/environment-variables) for all options.
 
+The server listens on port `14321` for the HTTP API and web UI, and on port `14322` for the transparent HTTPS proxy that agents' `HTTPS_PROXY` points at. Disable the transparent proxy with `--mitm-port 0`. See [transparent proxy setup](/self-hosting/local#transparent-proxy) for the CA-trust flow.
+
 To run in the background:
 
 ```bash

--- a/docs/learn/security.mdx
+++ b/docs/learn/security.mdx
@@ -116,6 +116,14 @@ This means:
 - The agent's token never reaches the target service.
 - Credential values only exist in the outbound request headers, never in the agent's address space.
 
+### Transparent proxy (HTTPS_PROXY) transport
+
+The MITM listener that backs `HTTPS_PROXY` is itself TLS-wrapped with a cert signed by the software-backed root CA. This means the CONNECT handshake carrying the agent's session token is encrypted end-to-end between the client and the broker — session tokens are never exposed in plaintext on the wire, even on an untrusted local network.
+
+- **Root CA private key** is encrypted at rest with the DEK (same key that wraps credentials). See [Encryption at rest](#encryption-at-rest).
+- **DNS rebinding protection** and **[netguard](#network-security)** apply to both the transparent proxy and the explicit `/proxy` endpoint — every outbound connection is resolved and validated against the IP blocklist before Agent Vault dials the upstream.
+- **Rate limiting** shares one `(actor, vault)` budget across both ingress paths; switching from one to the other does not bypass the limit.
+
 ## Access control
 
 Agent Vault enforces access at two independent layers. For full details, see [Permissions](/learn/permissions).

--- a/docs/quickstart/claude-code.mdx
+++ b/docs/quickstart/claude-code.mdx
@@ -10,13 +10,13 @@ description: "Learn how to connect Claude Code to Agent Vault so it can make aut
 
 ## Quick start
 
-Launch Claude Code with `vault run`. It wraps Claude Code with a vault-scoped session and installs the Agent Vault skill so Claude knows how to proxy requests and raise proposals automatically. If you haven't logged in yet, you'll be guided through setup automatically.
+Launch Claude Code with `vault run`. It wraps Claude Code with a vault-scoped session, pre-configures `HTTPS_PROXY` and CA trust so outbound HTTPS routes through Agent Vault transparently, and installs the Agent Vault skill so Claude knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault run -- claude
 ```
 
-That's it. Claude Code launches with Agent Vault access — no invite, no token pasting.
+That's it. Claude Code launches with Agent Vault access — no invite, no token pasting, no URL rewriting.
 
 <Tip>
 `vault run` also installs a [Claude Code skill](https://docs.anthropic.com/en/docs/claude-code/skills) at `~/.claude/skills/agent-vault/SKILL.md`. This teaches Claude Code how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
@@ -36,12 +36,12 @@ Ask Claude Code to do something that requires an external API:
 
 Here's what happens — with zero pre-configuration:
 
-1. Claude Code routes a request to `api.stripe.com` through Agent Vault
+1. Claude Code calls `https://api.stripe.com/...` directly. `HTTPS_PROXY` routes the call through Agent Vault
 2. Agent Vault returns a **403** — Stripe isn't configured yet
 3. Claude Code reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. Claude Code presents you with an approval link
 5. You click the link, paste your Stripe key, and click **Allow**
-6. Claude Code retries — Agent Vault injects your Stripe credentials and the request succeeds
+6. Claude Code retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
 
 <Note>
 You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
@@ -60,7 +60,7 @@ This generates a one-time onboarding prompt and copies it to your clipboard. Pas
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="How it works" icon="lightbulb" href="/how-it-works">
+  <Card title="Agent protocol" icon="code" href="/agents/protocol">
     Full request lifecycle end-to-end.
   </Card>
   <Card title="Services" icon="shield" href="/learn/services">

--- a/docs/quickstart/codex.mdx
+++ b/docs/quickstart/codex.mdx
@@ -10,13 +10,13 @@ description: "Learn how to connect Codex to Agent Vault so it can make authentic
 
 ## Quick start
 
-Launch Codex with `vault run`. It wraps Codex with a vault-scoped session and installs the Agent Vault skill so Codex knows how to proxy requests and raise proposals automatically. If you haven't logged in yet, you'll be guided through setup automatically.
+Launch Codex with `vault run`. It wraps Codex with a vault-scoped session, pre-configures `HTTPS_PROXY` and CA trust so outbound HTTPS routes through Agent Vault transparently, and installs the Agent Vault skill so Codex knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault run -- codex
 ```
 
-That's it. Codex launches with Agent Vault access — no invite, no token pasting.
+That's it. Codex launches with Agent Vault access — no invite, no token pasting, no URL rewriting.
 
 <Tip>
 `vault run` also installs an Agent Vault skill at `~/.agents/skills/agent-vault/SKILL.md`. This teaches Codex how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
@@ -36,12 +36,12 @@ Ask Codex to do something that requires an external API:
 
 Here's what happens — with zero pre-configuration:
 
-1. Codex routes a request to `api.stripe.com` through Agent Vault
+1. Codex calls `https://api.stripe.com/...` directly. `HTTPS_PROXY` routes the call through Agent Vault
 2. Agent Vault returns a **403** — Stripe isn't configured yet
 3. Codex reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. Codex presents you with an approval link
 5. You click the link, paste your Stripe key, and click **Allow**
-6. Codex retries — Agent Vault injects your Stripe credentials and the request succeeds
+6. Codex retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
 
 <Note>
 You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
@@ -60,7 +60,7 @@ This generates a one-time onboarding prompt and copies it to your clipboard. Pas
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="How it works" icon="lightbulb" href="/how-it-works">
+  <Card title="Agent protocol" icon="code" href="/agents/protocol">
     Full request lifecycle end-to-end.
   </Card>
   <Card title="Services" icon="shield" href="/learn/services">

--- a/docs/quickstart/cursor.mdx
+++ b/docs/quickstart/cursor.mdx
@@ -10,13 +10,13 @@ description: "Learn how to connect Cursor to Agent Vault so it can make authenti
 
 ## Quick start
 
-Launch Cursor with `vault run`. It wraps Cursor with a vault-scoped session and installs the Agent Vault skill so Cursor knows how to proxy requests and raise proposals automatically. If you haven't logged in yet, you'll be guided through setup automatically.
+Launch Cursor with `vault run`. It wraps Cursor with a vault-scoped session, pre-configures `HTTPS_PROXY` and CA trust so outbound HTTPS routes through Agent Vault transparently, and installs the Agent Vault skill so Cursor knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault run -- agent
 ```
 
-That's it. Cursor launches with Agent Vault access — no invite, no token pasting.
+That's it. Cursor launches with Agent Vault access — no invite, no token pasting, no URL rewriting.
 
 <Tip>
 `vault run` also installs an Agent Vault skill at `~/.cursor/skills/agent-vault/SKILL.md`. This teaches Cursor how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
@@ -36,12 +36,12 @@ Ask Cursor to do something that requires an external API:
 
 Here's what happens — with zero pre-configuration:
 
-1. Cursor routes a request to `api.stripe.com` through Agent Vault
+1. Cursor calls `https://api.stripe.com/...` directly. `HTTPS_PROXY` routes the call through Agent Vault
 2. Agent Vault returns a **403** — Stripe isn't configured yet
 3. Cursor reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. Cursor presents you with an approval link
 5. You click the link, paste your Stripe key, and click **Allow**
-6. Cursor retries — Agent Vault injects your Stripe credentials and the request succeeds
+6. Cursor retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
 
 <Note>
 You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
@@ -60,7 +60,7 @@ This generates a one-time onboarding prompt and copies it to your clipboard. Pas
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="How it works" icon="lightbulb" href="/how-it-works">
+  <Card title="Agent protocol" icon="code" href="/agents/protocol">
     Full request lifecycle end-to-end.
   </Card>
   <Card title="Services" icon="shield" href="/learn/services">

--- a/docs/quickstart/custom-agent.mdx
+++ b/docs/quickstart/custom-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Custom Agent"
-description: "Connect any HTTP-capable agent or script to Agent Vault using environment variables and the proxy API."
+description: "Connect any HTTP-capable agent or script to Agent Vault through HTTPS_PROXY."
 ---
 
 ## Prerequisites
@@ -10,13 +10,11 @@ description: "Connect any HTTP-capable agent or script to Agent Vault using envi
 
 ## Quick start
 
-The simplest way to connect a custom agent is with `vault run`, which sets up the environment variables automatically:
+Wrap your agent process with `vault run`. It sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT`, then pre-configures `HTTPS_PROXY` and the CA trust chain so standard HTTP clients transparently route through the broker:
 
 ```bash
 agent-vault vault run -- my-agent
 ```
-
-This sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT` in your agent's environment.
 
 ### Target a specific vault
 
@@ -24,49 +22,29 @@ This sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAUL
 agent-vault vault run --vault myproject -- my-agent
 ```
 
-### Alternative: agent invite
-
-For agents that can't be wrapped with `vault run` (e.g. cloud-hosted or CI pipelines), create an invite:
-
-```bash
-agent-vault agent invite my-agent --vault default:proxy
-```
-
-The agent redeems the invite via HTTP and receives an agent token. See [Connect a custom agent](/guides/connect-custom-agent) for the full walkthrough.
-
 ## Try it out
 
-Have your agent make a request through the proxy. The proxy URL format is:
-
-```
-{AGENT_VAULT_ADDR}/proxy/{target_host}/{path}
-```
-
-For example, to call Stripe:
+Your agent calls real API URLs directly. `HTTPS_PROXY` routes the request through Agent Vault, which matches the host against the vault's [services](/learn/services), strips client auth, and injects the stored credential.
 
 <CodeGroup>
 
 ```bash curl
-curl "${AGENT_VAULT_ADDR}/proxy/api.stripe.com/v1/charges?limit=10" \
-  -H "Authorization: Bearer ${AGENT_VAULT_SESSION_TOKEN}"
+curl "https://api.stripe.com/v1/charges?limit=10"
 ```
 
 ```python Python
-import os, requests
+import requests
 
+# Authorization intentionally omitted — Agent Vault injects the real credential.
 resp = requests.get(
-    f"{os.environ['AGENT_VAULT_ADDR']}/proxy/api.stripe.com/v1/charges",
+    "https://api.stripe.com/v1/charges",
     params={"limit": 10},
-    headers={"Authorization": f"Bearer {os.environ['AGENT_VAULT_SESSION_TOKEN']}"},
 )
 print(resp.json())
 ```
 
 ```typescript TypeScript
-const resp = await fetch(
-  `${process.env.AGENT_VAULT_ADDR}/proxy/api.stripe.com/v1/charges?limit=10`,
-  { headers: { Authorization: `Bearer ${process.env.AGENT_VAULT_SESSION_TOKEN}` } },
-);
+const resp = await fetch("https://api.stripe.com/v1/charges?limit=10");
 console.log(await resp.json());
 ```
 
@@ -75,8 +53,14 @@ console.log(await resp.json());
 If the service isn't configured yet, Agent Vault returns a **403** with a `proposal_hint`. Your agent can use this to create a [proposal](/learn/proposals) requesting access.
 
 <Note>
-Your agent never sees or handles credentials. Agent Vault strips the agent's token and injects the real API key before forwarding to the target service.
+Your agent never sees or handles credentials. Agent Vault strips whatever the client sends and injects the real API key at the proxy boundary.
 </Note>
+
+## Other connection flows
+
+- **Agent invites** — for cloud-hosted agents or CI pipelines that can't be wrapped with `vault run`. See [Connect a custom agent](/guides/connect-custom-agent#get-connection-credentials).
+- **Manual HTTPS_PROXY setup** — for containerized agents and sandboxes that need to configure the proxy themselves. See [Set HTTPS_PROXY manually](/guides/connect-custom-agent#set-https-proxy-manually).
+- **Explicit `/proxy` endpoint** — for clients that can't honor `HTTPS_PROXY` (HTTP/2-only runtimes, no CA-mounting). See [Explicit proxy endpoint](/guides/connect-custom-agent#explicit-proxy-endpoint-fallback).
 
 ## Discover available services
 
@@ -98,15 +82,15 @@ curl ${AGENT_VAULT_ADDR}/discover \
 }
 ```
 
-Requests to hosts not in this list should go direct, not through the proxy.
+Requests to hosts not in `services` go direct, not through the proxy.
 
 ## Next steps
 
 <CardGroup cols={2}>
   <Card title="Connect a custom agent" icon="plug" href="/guides/connect-custom-agent">
-    Full guide with error handling and proposals.
+    Full guide with manual HTTPS_PROXY setup, error handling, and proposals.
   </Card>
   <Card title="Agent protocol" icon="code" href="/agents/protocol">
-    HTTP reference for sessions, discovery, proxy, and proposals.
+    HTTP reference for sessions, discovery, and proposals.
   </Card>
 </CardGroup>

--- a/docs/quickstart/hermes-agent.mdx
+++ b/docs/quickstart/hermes-agent.mdx
@@ -10,13 +10,13 @@ description: "Learn how to connect Hermes Agent to Agent Vault so it can make au
 
 ## Quick start
 
-Launch Hermes Agent with `vault run`. It wraps Hermes with a vault-scoped session and installs the Agent Vault skill so Hermes knows how to proxy requests and raise proposals automatically. If you haven't logged in yet, you'll be guided through setup automatically.
+Launch Hermes Agent with `vault run`. It wraps Hermes with a vault-scoped session, pre-configures `HTTPS_PROXY` and CA trust so outbound HTTPS routes through Agent Vault transparently, and installs the Agent Vault skills so Hermes knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault run -- hermes
 ```
 
-That's it. Hermes Agent launches with Agent Vault access — no invite, no token pasting.
+That's it. Hermes Agent launches with Agent Vault access — no invite, no token pasting, no URL rewriting.
 
 <Tip>
 `vault run` also installs two Agent Vault skills at `~/.hermes/skills/agent-vault-cli/SKILL.md` and `~/.hermes/skills/agent-vault-http/SKILL.md`. These teach Hermes Agent how to discover services, proxy requests, and raise proposals through Agent Vault. The skills persist across sessions.
@@ -36,12 +36,12 @@ Ask Hermes Agent to do something that requires an external API:
 
 Here's what happens — with zero pre-configuration:
 
-1. Hermes Agent routes a request to `api.stripe.com` through Agent Vault
+1. Hermes Agent calls `https://api.stripe.com/...` directly. `HTTPS_PROXY` routes the call through Agent Vault
 2. Agent Vault returns a **403** — Stripe isn't configured yet
 3. Hermes Agent reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. Hermes Agent presents you with an approval link
 5. You click the link, paste your Stripe key, and click **Allow**
-6. Hermes Agent retries — Agent Vault injects your Stripe credentials and the request succeeds
+6. Hermes Agent retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
 
 <Note>
 You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
@@ -60,7 +60,7 @@ This generates a one-time onboarding prompt and copies it to your clipboard. Pas
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="How it works" icon="lightbulb" href="/how-it-works">
+  <Card title="Agent protocol" icon="code" href="/agents/protocol">
     Full request lifecycle end-to-end.
   </Card>
   <Card title="Services" icon="shield" href="/learn/services">

--- a/docs/quickstart/nanoclaw.mdx
+++ b/docs/quickstart/nanoclaw.mdx
@@ -32,12 +32,16 @@ Ask NanoClaw to do something that requires an external API:
 
 Here's what happens — with zero pre-configuration:
 
-1. NanoClaw routes a request to `api.stripe.com` through Agent Vault
+1. NanoClaw routes a request through Agent Vault's explicit `/proxy/api.stripe.com/...` endpoint
 2. Agent Vault returns a **403** — Stripe isn't configured yet
-3. NanoClaw reads the `proposal_hint` and creates a proposal proposing Stripe access
+3. NanoClaw reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. NanoClaw presents you with an approval link
 5. You click the link, paste your Stripe key, and click **Allow**
-6. NanoClaw retries — Agent Vault reconstructs the request with your Stripe credentials and the request succeeds
+6. NanoClaw retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
+
+<Note>
+Invited agents like NanoClaw use the explicit `/proxy/{host}/{path}` endpoint rather than `HTTPS_PROXY`. For local agents you wrap with `agent-vault vault run` (Claude Code, Cursor, Codex, Hermes), the `HTTPS_PROXY` flow is transparent and no URL rewriting is needed.
+</Note>
 
 <Note>
 You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
@@ -46,7 +50,7 @@ You didn't pre-configure anything. The agent discovered what it needed, asked fo
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="How it works" icon="lightbulb" href="/how-it-works">
+  <Card title="Agent protocol" icon="code" href="/agents/protocol">
     Full request lifecycle end-to-end.
   </Card>
   <Card title="Services" icon="shield" href="/learn/services">

--- a/docs/quickstart/openclaw.mdx
+++ b/docs/quickstart/openclaw.mdx
@@ -32,12 +32,16 @@ Ask OpenClaw to do something that requires an external API:
 
 Here's what happens — with zero pre-configuration:
 
-1. OpenClaw routes a request to `api.stripe.com` through Agent Vault
+1. OpenClaw routes a request through Agent Vault's explicit `/proxy/api.stripe.com/...` endpoint
 2. Agent Vault returns a **403** — Stripe isn't configured yet
-3. OpenClaw reads the `proposal_hint` and creates a proposal proposing Stripe access
+3. OpenClaw reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. OpenClaw presents you with an approval link
 5. You click the link, paste your Stripe key, and click **Allow**
-6. OpenClaw retries — Agent Vault reconstructs the request with your Stripe credentials and the request succeeds
+6. OpenClaw retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
+
+<Note>
+Invited agents like OpenClaw use the explicit `/proxy/{host}/{path}` endpoint rather than `HTTPS_PROXY`. For local agents you wrap with `agent-vault vault run` (Claude Code, Cursor, Codex, Hermes), the `HTTPS_PROXY` flow is transparent and no URL rewriting is needed.
+</Note>
 
 <Note>
 You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
@@ -46,7 +50,7 @@ You didn't pre-configure anything. The agent discovered what it needed, asked fo
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="How it works" icon="lightbulb" href="/how-it-works">
+  <Card title="Agent protocol" icon="code" href="/agents/protocol">
     Full request lifecycle end-to-end.
   </Card>
   <Card title="Services" icon="shield" href="/learn/services">

--- a/docs/self-hosting/docker.mdx
+++ b/docs/self-hosting/docker.mdx
@@ -21,10 +21,10 @@ The final image runs as non-root user `agentvault` (UID 65532) and includes a bu
 
 ## Configuration
 
-Pass the master password via environment variable to wrap the data encryption key (DEK):
+Expose both the HTTP API (`14321`) and the transparent HTTPS proxy (`14322`) so agents' `HTTPS_PROXY` can reach the broker. Pass the master password via environment variable to wrap the data encryption key (DEK):
 
 ```bash
-docker run -it -p 14321:14321 \
+docker run -it -p 14321:14321 -p 14322:14322 \
   -v agent-vault-data:/data \
   -e AGENT_VAULT_MASTER_PASSWORD=your-password \
   -e AGENT_VAULT_ADDR=https://agent-vault.example.com \
@@ -32,6 +32,15 @@ docker run -it -p 14321:14321 \
 ```
 
 Omit `AGENT_VAULT_MASTER_PASSWORD` for **passwordless mode** — the DEK is stored unwrapped, relying on volume access controls for security.
+
+Fetch the root CA from the running container so agents outside Docker trust the proxied TLS handshake:
+
+```bash
+# The /v1/mitm/ca.pem endpoint is public — no auth required
+curl -O http://localhost:14321/v1/mitm/ca.pem
+```
+
+See [transparent proxy setup](/self-hosting/local#transparent-proxy) for installing the CA into client trust stores.
 
 | Variable | Required | Description |
 |----------|----------|-------------|
@@ -54,6 +63,7 @@ services:
     image: infisical/agent-vault
     ports:
       - "14321:14321"
+      - "14322:14322"
     volumes:
       - agent-vault-data:/data
     environment:

--- a/docs/self-hosting/environment-variables.mdx
+++ b/docs/self-hosting/environment-variables.mdx
@@ -77,10 +77,28 @@ The callback URL configured in Google Cloud Console must be `{AGENT_VAULT_ADDR}/
 
 These variables are set automatically by `agent-vault vault run` on the agent's environment. You do not need to set them manually.
 
+### Control-plane
+
 | Variable | Description |
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Server base URL (e.g., `http://127.0.0.1:14321`) |
-| `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with the proxy, scoped to the vault |
+| `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault (control-plane: `/discover`, proposals, credentials). Scoped to the vault. |
 | `AGENT_VAULT_VAULT` | Name of the vault the session is scoped to |
 
-Agents use these to discover available services (`GET {AGENT_VAULT_ADDR}/discover`) and route authenticated requests through the proxy (`{AGENT_VAULT_ADDR}/proxy/{host}/{path}`).
+### Transparent proxy
+
+`vault run` also wires up `HTTPS_PROXY` and the CA trust chain so standard HTTP clients transparently route through Agent Vault. Disable with `--no-mitm`.
+
+| Variable | Description |
+|----------|-------------|
+| `HTTPS_PROXY` | Points at the MITM listener (`https://{token}:{vault}@host:14322`). HTTP_PROXY is intentionally not set — the MITM only handles HTTPS CONNECT. |
+| `NO_PROXY` | `localhost,127.0.0.1` — so agent-to-vault control-plane traffic skips the proxy |
+| `NODE_USE_ENV_PROXY` | `1` — enables Node.js v22.21+ built-in proxy support for `fetch()` and `https.get()` |
+| `SSL_CERT_FILE` | Points OpenSSL-linked clients (Python, Ruby, PHP) at the Agent Vault root CA |
+| `NODE_EXTRA_CA_CERTS` | Trusts the root CA in Node.js |
+| `REQUESTS_CA_BUNDLE` | Trusts the root CA in Python `requests` |
+| `CURL_CA_BUNDLE` | Trusts the root CA in `curl` |
+| `GIT_SSL_CAINFO` | Trusts the root CA in `git` |
+| `DENO_CERT` | Trusts the root CA in Deno |
+
+The CA PEM is written to `~/.agent-vault/mitm-ca.pem` by `vault run` on first launch. Agents use `HTTPS_PROXY` to make authenticated requests to upstream APIs transparently and call `GET {AGENT_VAULT_ADDR}/discover` over the control-plane to learn which services are available.

--- a/docs/self-hosting/fly-io.mdx
+++ b/docs/self-hosting/fly-io.mdx
@@ -72,7 +72,8 @@ description: "Deploy Agent Vault to Fly.io with persistent storage"
 
 ## Key details
 
-- **Config**: `fly.toml` sets port 14321, forces HTTPS, and enables auto-stop/auto-start machines
+- **Config**: `fly.toml` exposes port 14321 via Fly's HTTP service (force HTTPS, auto-stop/auto-start) and port 14322 via TCP passthrough for the transparent MITM proxy — the MITM listener's own TLS cert handles the handshake, so Fly doesn't terminate TLS on that port
+- **Agent `HTTPS_PROXY`**: `https://<token>:<vault>@your-app.fly.dev:14322` — the root CA must be trusted by the agent's HTTP client (fetch with [`agent-vault ca fetch --address https://your-app.fly.dev`](docs/reference/cli.mdx))
 - **Entrypoint**: `scripts/docker-entrypoint.sh` forwards arguments to the `agent-vault` binary, which natively reads `AGENT_VAULT_MASTER_PASSWORD` from the environment
 - **Storage**: Persistent volume `agent_vault_data` mounted at `/data` -- all state is in a single SQLite file
 - **Cold starts**: `min_machines_running` defaults to `0`, so the app scales to zero when idle. The first request after sleep incurs a few seconds of cold-start latency. Set it to `1` in `fly.toml` if you need always-on availability.

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -82,18 +82,18 @@ Subsequent users can self-register via `agent-vault auth register`, the web regi
 
 ## Transparent proxy
 
-<Warning>
-  HTTP/1.1 only today. Clients that negotiate HTTP/2 end-to-end will not proxy through this path — use the explicit `/proxy` endpoint instead.
-</Warning>
-
-Agent Vault exposes a second ingress as a transparent `HTTPS_PROXY`. This lets clients that respect the proxy environment variable (but can't be pointed at a custom base URL) route through Agent Vault. The listener is TLS-encrypted (cert signed by the MITM CA) so the CONNECT handshake carrying session tokens is protected. It listens on port `14322` by default; pass `--mitm-port 0` to disable, or a different port to change it:
+Agent Vault exposes a transparent `HTTPS_PROXY` listener on port `14322` — the canonical ingress agents use. Any standard HTTP client that honors `HTTPS_PROXY` (curl, fetch, requests, axios, the Go stdlib, SDKs, CLIs) transparently routes through the broker. The listener is TLS-encrypted (cert signed by the MITM CA) so the CONNECT handshake carrying session tokens is protected.
 
 ```bash
 agent-vault server               # transparent proxy on 14322 (default)
 agent-vault server --mitm-port 0 # disable
 ```
 
-A software-backed root CA is created on first launch under `~/.agent-vault/ca/` (private key encrypted with the DEK). Clients must trust this root before the proxied TLS handshake will succeed.
+<Warning>
+HTTP/1.1 only today. Clients that negotiate HTTP/2 end-to-end bypass this ingress and must use the explicit [`/proxy/{host}/{path}`](/agents/protocol#explicit-proxy-endpoint-fallback) endpoint.
+</Warning>
+
+A software-backed root CA is created on first launch under `~/.agent-vault/ca/` (private key encrypted with the DEK). Clients must trust this root before the proxied TLS handshake will succeed. `agent-vault vault run` handles this automatically for child processes — only fetch the CA manually when configuring agents outside of `vault run` (containers, CI, invited agents).
 
 Fetch the root certificate from any machine that can reach the server:
 


### PR DESCRIPTION
## Summary
- Reframe agent connection docs (overview, protocol, coding/custom-agent guides, quickstarts, self-hosting) so the transparent `HTTPS_PROXY` path is the primary flow — the explicit `/proxy/{host}/{path}` endpoint stays documented but is no longer the lead narrative.
- Add a `<Note>` under the `vault run` sections in [docs/agents/overview.mdx](docs/agents/overview.mdx) and [docs/guides/connect-coding-agent.mdx](docs/guides/connect-coding-agent.mdx) calling out that `vault run` is a convenience wrapper, not a sandbox: a child process can unset `HTTPS_PROXY` or bypass the injected CA, and stronger isolation is on the roadmap.
- Surface the Agent Vault launch blog post in the README header link row.
- Minor supporting touch-ups: transparent-proxy transport section in `learn/security.mdx`, port callout in `installation.mdx`, misc quickstart/self-hosting wording.

## Test plan
- [ ] `cd docs && mintlify dev` — verify every updated page renders with no broken components or links
- [ ] Spot-check the two sandbox `<Note>` blocks render correctly
- [ ] Click the new Blog link in the README preview on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)