### PR TITLE
feat: add `agent-vault run` shorthand for `agent-vault vault run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ The server starts the HTTP API on port `14321` and a TLS-encrypted transparent H
 
 ### CLI — local agents (Claude Code, Cursor, Codex, OpenClaw, Hermes, OpenCode)
 
-Wrap any local agent process with `vault run`. Agent Vault creates a scoped session, sets `HTTPS_PROXY` and CA-trust env vars, and launches the agent — all HTTPS traffic is transparently proxied and authenticated:
+Wrap any local agent process with `agent-vault run` (long form: `agent-vault vault run`). Agent Vault creates a scoped session, sets `HTTPS_PROXY` and CA-trust env vars, and launches the agent — all HTTPS traffic is transparently proxied and authenticated:
 
 ```bash
-agent-vault vault run -- claude
+agent-vault run -- claude
 ```
 
 The agent calls APIs normally (e.g. `fetch("https://api.github.com/...")`). Agent Vault intercepts the request, injects the credential, and forwards it upstream. The agent never sees secrets.
@@ -88,7 +88,7 @@ The agent calls APIs normally (e.g. `fetch("https://api.github.com/...")`). Agen
 For **non-cooperative** sandboxing — where the child physically cannot reach anything except the Agent Vault proxy, regardless of what it tries — launch it in a Docker container with egress locked down by iptables:
 
 ```bash
-agent-vault vault run --sandbox=container -- claude
+agent-vault run --sandbox=container -- claude
 ```
 
 See [Container sandbox](https://docs.agent-vault.dev/guides/container-sandbox) for the threat model and flags.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -468,6 +468,12 @@ func requestScopedSession(addr, adminToken, vault, role string, ttlSeconds int) 
 }
 
 func init() {
+	// `vault run` inherits --vault from vaultCmd's persistent flag set; the
+	// top-level shorthand is parented to rootCmd, which has no such flag, so
+	// we register it locally here. Registering it inside newRunCmd would
+	// collide with the inherited one on runCmd at flag-merge time.
+	topRunCmd.Flags().String("vault", "", "target vault (overrides active context)")
+
 	vaultCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(topRunCmd)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -26,14 +26,14 @@ var skillCLI string
 //go:embed skill_http.md
 var skillHTTP string
 
-// sandboxMode is enum-typed so `--sandbox=foo` fails at flag-parse time
-// with the allowed set, rather than deep inside RunE.
-var sandboxMode SandboxMode
-
-var runCmd = &cobra.Command{
-	Use:   "run [flags] -- <command> [args...]",
-	Short: "Wrap an agent process with Agent Vault access",
-	Long: `Start an agent process (e.g. claude, agent, codex, hermes, opencode) with an Agent Vault session.
+// newRunCmd is called twice — for `vault run` and top-level `run` — so each
+// command gets its own pflag state. examplePrefix parameterizes the Example
+// section of Long.
+func newRunCmd(examplePrefix string) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "run [flags] -- <command> [args...]",
+		Short: "Wrap an agent process with Agent Vault access",
+		Long: `Start an agent process (e.g. claude, agent, codex, hermes, opencode) with an Agent Vault session.
 Everything after -- is treated as the command to execute.
 
 Environment variables always set on the child:
@@ -52,99 +52,122 @@ is written to ~/.agent-vault/mitm-ca.pem. Pass --no-mitm to disable
 injection and rely solely on the explicit /proxy/{host}/{path} endpoint.
 
 Example:
-  agent-vault vault run -- claude
-  agent-vault vault run --vault myproject -- claude
-  agent-vault vault run --no-mitm -- claude`,
-	Args:                  cobra.MinimumNArgs(1),
-	DisableFlagsInUseLine: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// 0. Resolve sandbox mode and validate flag compatibility before any
-		//    network I/O — the user sees conflicts immediately, not after
-		//    a slow session-mint round-trip.
-		mode := sandboxMode
-		if mode == "" {
-			if v := os.Getenv("AGENT_VAULT_SANDBOX"); v != "" {
-				if err := mode.Set(v); err != nil {
-					return fmt.Errorf("AGENT_VAULT_SANDBOX: %w", err)
-				}
+  ` + examplePrefix + ` -- claude
+  ` + examplePrefix + ` --vault myproject -- claude
+  ` + examplePrefix + ` --no-mitm -- claude`,
+		Args:                  cobra.MinimumNArgs(1),
+		DisableFlagsInUseLine: true,
+		RunE:                  runCmdRunE,
+	}
+
+	var sbx SandboxMode
+	c.Flags().Var(&sbx, "sandbox", "Sandbox mode: process (default) or container")
+
+	c.Flags().String("address", "", "Agent Vault server address (defaults to session address)")
+	c.Flags().String("role", "", "Vault role for the agent session (proxy, member, admin; default: proxy)")
+	c.Flags().Int("ttl", 0, "Session TTL in seconds (300–604800; default: server default 24h)")
+	c.Flags().Bool("no-mitm", false, "Skip HTTPS_PROXY/CA env injection for the child (explicit /proxy only)")
+
+	c.Flags().String("image", "", "Container image override (requires --sandbox=container)")
+	c.Flags().StringArray("mount", nil, "Extra bind mount src:dst[:ro] (repeatable; requires --sandbox=container)")
+	c.Flags().Bool("keep", false, "Don't pass --rm to docker (requires --sandbox=container)")
+	c.Flags().Bool("no-firewall", false, "Skip iptables egress rules inside the container (requires --sandbox=container; debug only)")
+	c.Flags().Bool("home-volume-shared", false, "Share /home/claude/.claude across invocations (requires --sandbox=container); default is a per-invocation volume, losing auth state but avoiding concurrency corruption")
+	c.Flags().Bool("share-agent-dir", false, "Bind-mount the host's agent state dir (~/.claude) into the container so the sandbox reuses your host login (requires --sandbox=container; mutually exclusive with --home-volume-shared)")
+
+	return c
+}
+
+var runCmd = newRunCmd("agent-vault vault run")
+var topRunCmd = newRunCmd("agent-vault run")
+
+func runCmdRunE(cmd *cobra.Command, args []string) error {
+	// 0. Resolve sandbox mode and validate flag compatibility before any
+	//    network I/O — the user sees conflicts immediately, not after
+	//    a slow session-mint round-trip.
+	mode := *cmd.Flags().Lookup("sandbox").Value.(*SandboxMode)
+	if mode == "" {
+		if v := os.Getenv("AGENT_VAULT_SANDBOX"); v != "" {
+			if err := mode.Set(v); err != nil {
+				return fmt.Errorf("AGENT_VAULT_SANDBOX: %w", err)
 			}
 		}
-		if mode == "" {
-			mode = SandboxProcess
-		}
-		if err := validateSandboxFlagConflicts(cmd, mode); err != nil {
-			return err
-		}
+	}
+	if mode == "" {
+		mode = SandboxProcess
+	}
+	if err := validateSandboxFlagConflicts(cmd, mode); err != nil {
+		return err
+	}
 
-		// 1. Load the admin session from agent-vault auth login.
-		sess, err := ensureSession()
-		if err != nil {
-			return err
+	// 1. Load the admin session from agent-vault auth login.
+	sess, err := ensureSession()
+	if err != nil {
+		return err
+	}
+
+	addr, _ := cmd.Flags().GetString("address")
+	if addr == "" {
+		addr = sess.Address
+	}
+
+	// 2. Resolve the target vault: --vault flag > context > interactive select > "default".
+	vault, err := resolveVaultForRun(cmd, addr, sess.Token)
+	if err != nil {
+		return err
+	}
+
+	// 3. Request a vault-scoped session token from the server.
+	role, _ := cmd.Flags().GetString("role")
+	ttl, _ := cmd.Flags().GetInt("ttl")
+	scopedToken, err := requestScopedSession(addr, sess.Token, vault, role, ttl)
+	if err != nil {
+		return err
+	}
+
+	if mode == SandboxContainer {
+		return runContainer(cmd, args, scopedToken, addr, vault)
+	}
+
+	// 4. Resolve the target binary.
+	binary, err := exec.LookPath(args[0])
+	if err != nil {
+		return fmt.Errorf("command not found: %s", args[0])
+	}
+
+	// 5. Build env: inherit current env + inject Agent Vault vars.
+	env := os.Environ()
+	env = append(env,
+		"AGENT_VAULT_SESSION_TOKEN="+scopedToken,
+		"AGENT_VAULT_ADDR="+addr,
+		"AGENT_VAULT_VAULT="+vault,
+	)
+
+	// 6. Route the child's HTTPS traffic through the transparent MITM
+	//    proxy. Explicit /proxy stays available as a fallback.
+	if noMITM, _ := cmd.Flags().GetBool("no-mitm"); !noMITM {
+		newEnv, mitmPort, ok, err := augmentEnvWithMITM(env, addr, scopedToken, vault, "")
+		switch {
+		case err != nil:
+			fmt.Fprintf(os.Stderr, "agent-vault: MITM setup failed (%v); continuing with explicit proxy only\n", err)
+		case !ok:
+			fmt.Fprintln(os.Stderr, "agent-vault: MITM proxy disabled on server; using explicit proxy only")
+		default:
+			env = newEnv
+			fmt.Fprintf(os.Stderr, "%s routing HTTPS through MITM proxy (127.0.0.1:%d)\n", successText("agent-vault:"), mitmPort)
 		}
+	}
 
-		addr, _ := cmd.Flags().GetString("address")
-		if addr == "" {
-			addr = sess.Address
-		}
+	// 7. If the target command is a supported agent, offer to install the
+	//    Agent Vault skill (only when not already present).
+	if name, dir, ok := agentSkillDir(args[0]); ok {
+		maybeInstallSkills(name, dir)
+	}
 
-		// 2. Resolve the target vault: --vault flag > context > interactive select > "default".
-		vault, err := resolveVaultForRun(cmd, addr, sess.Token)
-		if err != nil {
-			return err
-		}
-
-		// 3. Request a vault-scoped session token from the server.
-		role, _ := cmd.Flags().GetString("role")
-		ttl, _ := cmd.Flags().GetInt("ttl")
-		scopedToken, err := requestScopedSession(addr, sess.Token, vault, role, ttl)
-		if err != nil {
-			return err
-		}
-
-		if mode == SandboxContainer {
-			return runContainer(cmd, args, scopedToken, addr, vault)
-		}
-
-		// 4. Resolve the target binary.
-		binary, err := exec.LookPath(args[0])
-		if err != nil {
-			return fmt.Errorf("command not found: %s", args[0])
-		}
-
-		// 5. Build env: inherit current env + inject Agent Vault vars.
-		env := os.Environ()
-		env = append(env,
-			"AGENT_VAULT_SESSION_TOKEN="+scopedToken,
-			"AGENT_VAULT_ADDR="+addr,
-			"AGENT_VAULT_VAULT="+vault,
-		)
-
-		// 6. Route the child's HTTPS traffic through the transparent MITM
-		//    proxy. Explicit /proxy stays available as a fallback.
-		if noMITM, _ := cmd.Flags().GetBool("no-mitm"); !noMITM {
-			newEnv, mitmPort, ok, err := augmentEnvWithMITM(env, addr, scopedToken, vault, "")
-			switch {
-			case err != nil:
-				fmt.Fprintf(os.Stderr, "agent-vault: MITM setup failed (%v); continuing with explicit proxy only\n", err)
-			case !ok:
-				fmt.Fprintln(os.Stderr, "agent-vault: MITM proxy disabled on server; using explicit proxy only")
-			default:
-				env = newEnv
-				fmt.Fprintf(os.Stderr, "%s routing HTTPS through MITM proxy (127.0.0.1:%d)\n", successText("agent-vault:"), mitmPort)
-			}
-		}
-
-		// 7. If the target command is a supported agent, offer to install the
-		//    Agent Vault skill (only when not already present).
-		if name, dir, ok := agentSkillDir(args[0]); ok {
-			maybeInstallSkills(name, dir)
-		}
-
-		// 8. Confirm, then exec — replaces this process entirely so the child
-		//    (e.g. Claude Code) gets direct terminal control.
-		fmt.Fprintf(os.Stderr, "%s agent-vault connected. Starting %s...\n\n", successText("agent-vault:"), boldText(args[0]))
-		return syscall.Exec(binary, args, env)
-	},
+	// 8. Confirm, then exec — replaces this process entirely so the child
+	//    (e.g. Claude Code) gets direct terminal control.
+	fmt.Fprintf(os.Stderr, "%s agent-vault connected. Starting %s...\n\n", successText("agent-vault:"), boldText(args[0]))
+	return syscall.Exec(binary, args, env)
 }
 
 // knownAgents maps CLI binary base-names to the (agentName, skillsDir)
@@ -445,18 +468,6 @@ func requestScopedSession(addr, adminToken, vault, role string, ttlSeconds int) 
 }
 
 func init() {
-	runCmd.Flags().String("address", "", "Agent Vault server address (defaults to session address)")
-	runCmd.Flags().String("role", "", "Vault role for the agent session (proxy, member, admin; default: proxy)")
-	runCmd.Flags().Int("ttl", 0, "Session TTL in seconds (300–604800; default: server default 24h)")
-	runCmd.Flags().Bool("no-mitm", false, "Skip HTTPS_PROXY/CA env injection for the child (explicit /proxy only)")
-
-	runCmd.Flags().Var(&sandboxMode, "sandbox", "Sandbox mode: process (default) or container")
-	runCmd.Flags().String("image", "", "Container image override (requires --sandbox=container)")
-	runCmd.Flags().StringArray("mount", nil, "Extra bind mount src:dst[:ro] (repeatable; requires --sandbox=container)")
-	runCmd.Flags().Bool("keep", false, "Don't pass --rm to docker (requires --sandbox=container)")
-	runCmd.Flags().Bool("no-firewall", false, "Skip iptables egress rules inside the container (requires --sandbox=container; debug only)")
-	runCmd.Flags().Bool("home-volume-shared", false, "Share /home/claude/.claude across invocations (requires --sandbox=container); default is a per-invocation volume, losing auth state but avoiding concurrency corruption")
-	runCmd.Flags().Bool("share-agent-dir", false, "Bind-mount the host's agent state dir (~/.claude) into the container so the sandbox reuses your host login (requires --sandbox=container; mutually exclusive with --home-volume-shared)")
-
 	vaultCmd.AddCommand(runCmd)
+	rootCmd.AddCommand(topRunCmd)
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -11,6 +11,15 @@ import (
 	"testing"
 )
 
+// expectedRunFlags is the single source of truth for flags both `vault run`
+// and the top-level `run` shorthand must expose. Adding a flag to one without
+// the other is a bug.
+var expectedRunFlags = []string{
+	"address", "role", "ttl", "no-mitm",
+	"sandbox", "image", "mount", "keep", "no-firewall",
+	"home-volume-shared", "share-agent-dir",
+}
+
 func TestRunFlagsRegistered(t *testing.T) {
 	vCmd := findSubcommand(rootCmd, "vault")
 	if vCmd == nil {
@@ -21,9 +30,27 @@ func TestRunFlagsRegistered(t *testing.T) {
 		t.Fatal("vault run subcommand not found")
 	}
 
-	for _, name := range []string{"address", "role", "ttl", "no-mitm"} {
+	for _, name := range expectedRunFlags {
 		if rCmd.Flags().Lookup(name) == nil {
 			t.Errorf("expected vault run flag --%s to be registered", name)
+		}
+	}
+}
+
+// TestTopLevelRunRegistered guards the `agent-vault run` shorthand — it must
+// be a direct child of rootCmd and expose the same flag surface as `vault run`.
+func TestTopLevelRunRegistered(t *testing.T) {
+	tCmd := findSubcommand(rootCmd, "run")
+	if tCmd == nil {
+		t.Fatal("top-level run command not found")
+	}
+	if tCmd.Parent() != rootCmd {
+		t.Errorf("top-level run must be parented to rootCmd, got %v", tCmd.Parent())
+	}
+
+	for _, name := range expectedRunFlags {
+		if tCmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected top-level run flag --%s to be registered", name)
 		}
 	}
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -13,9 +13,10 @@ import (
 
 // expectedRunFlags is the single source of truth for flags both `vault run`
 // and the top-level `run` shorthand must expose. Adding a flag to one without
-// the other is a bug.
+// the other is a bug. `vault` is inherited from vaultCmd's persistent flags
+// on `vault run` and registered locally on the top-level `run`.
 var expectedRunFlags = []string{
-	"address", "role", "ttl", "no-mitm",
+	"address", "role", "ttl", "no-mitm", "vault",
 	"sandbox", "image", "mount", "keep", "no-firewall",
 	"home-volume-shared", "share-agent-dir",
 }
@@ -30,8 +31,9 @@ func TestRunFlagsRegistered(t *testing.T) {
 		t.Fatal("vault run subcommand not found")
 	}
 
+	// Flag walks local + inherited persistent flags, matching what users see.
 	for _, name := range expectedRunFlags {
-		if rCmd.Flags().Lookup(name) == nil {
+		if rCmd.Flag(name) == nil {
 			t.Errorf("expected vault run flag --%s to be registered", name)
 		}
 	}
@@ -49,7 +51,7 @@ func TestTopLevelRunRegistered(t *testing.T) {
 	}
 
 	for _, name := range expectedRunFlags {
-		if tCmd.Flags().Lookup(name) == nil {
+		if tCmd.Flag(name) == nil {
 			t.Errorf("expected top-level run flag --%s to be registered", name)
 		}
 	}

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -21,7 +21,7 @@ You have access to Agent Vault, a transparent HTTPS proxy that injects credentia
 **Before telling the user you cannot access an external service, you MUST check Agent Vault.** This applies whenever a task involves any third-party service or API -- project management (Linear, Jira, Asana), source control (GitHub, GitLab), communication (Slack, Discord), payments (Stripe), databases, or any other authenticated service.
 
 **Your workflow for ANY external service interaction:**
-1. Check that `AGENT_VAULT_SESSION_TOKEN` is set (it should be if you were launched via `agent-vault vault run`)
+1. Check that `AGENT_VAULT_SESSION_TOKEN` is set (it should be if you were launched via `agent-vault run` — `agent-vault vault run` is the long form)
 2. Run `agent-vault vault discover --json` to see which hosts have credentials configured
 3. If the host is listed, **just make the request to the real API URL** -- Agent Vault transparently injects the credential
 4. If the host is NOT listed, create a proposal via CLI (the user approves and provides credentials)
@@ -37,9 +37,9 @@ You have access to Agent Vault, a transparent HTTPS proxy that injects credentia
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault's control-plane endpoints (`discover`, proposals, etc.) |
-| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`) |
+| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `agent-vault run`) |
 
-`vault run` also pre-configures `HTTPS_PROXY`, `NO_PROXY`, `NODE_USE_ENV_PROXY`, and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) so HTTPS calls from your process route through the broker transparently. You don't manage these yourself.
+`agent-vault run` also pre-configures `HTTPS_PROXY`, `NO_PROXY`, `NODE_USE_ENV_PROXY`, and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) so HTTPS calls from your process route through the broker transparently. You don't manage these yourself.
 
 Under `--sandbox=container`, the same env shape is injected inside a Docker container, but the proxy URL host is `host.docker.internal` instead of `127.0.0.1` and egress to any other destination is blocked by iptables. From your perspective nothing changes — standard HTTP clients pick up the envvars as normal.
 
@@ -57,7 +57,7 @@ Response includes `vault`, `services` (host + description), and `available_crede
 
 ## Making Requests
 
-**Just call the real API URL.** When you were launched via `agent-vault vault run`, your HTTPS traffic already routes through Agent Vault transparently — `HTTPS_PROXY` and the broker's CA cert are pre-configured in your environment. Agent Vault intercepts the call, looks up the host in the vault's services, injects the credential, and forwards over HTTPS.
+**Just call the real API URL.** When you were launched via `agent-vault run` (or the long form `agent-vault vault run`), your HTTPS traffic already routes through Agent Vault transparently — `HTTPS_PROXY` and the broker's CA cert are pre-configured in your environment. Agent Vault intercepts the call, looks up the host in the vault's services, injects the credential, and forwards over HTTPS.
 
 ```bash
 curl https://api.stripe.com/v1/charges

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -229,19 +229,23 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault discover [flags]
     ```
 
-    Show available services and credentials for the current vault. Requires a vault-scoped session (via `agent-vault vault run` or `AGENT_VAULT_SESSION_TOKEN` + `AGENT_VAULT_ADDR` env vars).
+    Show available services and credentials for the current vault. Requires a vault-scoped session (via `agent-vault run` or `AGENT_VAULT_SESSION_TOKEN` + `AGENT_VAULT_ADDR` env vars).
 
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--json` | `false` | Output response as JSON |
   </Accordion>
 
-  <Accordion title="agent-vault vault run">
+  <Accordion title="agent-vault run (alias: agent-vault vault run)">
     ```bash
+    agent-vault run [flags] -- <command>
+    # Long form — identical behavior:
     agent-vault vault run [flags] -- <command>
     ```
 
-    Wrap a process with Agent Vault environment variables. The child process always receives `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT`. When the server's transparent MITM proxy is reachable (default), it also receives `HTTPS_PROXY` / `NO_PROXY` / `NODE_USE_ENV_PROXY` plus CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) pointing at `~/.agent-vault/mitm-ca.pem`, so standard HTTPS clients transparently route through the broker.
+    Wrap a process with Agent Vault environment variables. `agent-vault run` is the shorthand; `agent-vault vault run` is the long form. Both are identical in behavior and flags.
+
+    The child process always receives `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT`. When the server's transparent MITM proxy is reachable (default), it also receives `HTTPS_PROXY` / `NO_PROXY` / `NODE_USE_ENV_PROXY` plus CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) pointing at `~/.agent-vault/mitm-ca.pem`, so standard HTTPS clients transparently route through the broker.
 
     | Flag | Default | Description |
     |------|---------|-------------|
@@ -263,7 +267,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault token [flags]
     ```
 
-    Mint a vault-scoped session token and print it to stdout. Useful when you need a scoped token without wrapping a child process via `vault run`.
+    Mint a vault-scoped session token and print it to stdout. Useful when you need a scoped token without wrapping a child process via `agent-vault run`.
 
     | Flag | Default | Description |
     |------|---------|-------------|


### PR DESCRIPTION
## Summary

- Promote `run` to a top-level command so wrapping an agent reads `agent-vault run -- claude` instead of `agent-vault vault run -- claude`. Both forms are identical in behavior and flags.
- A factory `newRunCmd(examplePrefix)` in [cmd/run.go](cmd/run.go) builds the command twice — once under `vaultCmd`, once under `rootCmd` — with independent pflag state so the registrations don't share sandbox-flag values. The shared `runCmdRunE` reads everything from `cmd.Flags()`.
- Docs updated to lead with the new shorthand ([README.md](README.md), [cmd/skill_cli.md](cmd/skill_cli.md), [docs/reference/cli.mdx](docs/reference/cli.mdx)); the long form is kept in the accordion as an alias so existing scripts and the 15 quickstart/guide pages keep working verbatim.

## Test plan

- [x] `go test ./...` passes, including new `TestTopLevelRunRegistered` which asserts the top-level `run` is parented to `rootCmd` and exposes the same flag set as `vault run` (shared `expectedRunFlags` slice so the two tests can't drift).
- [x] `./agent-vault --help` lists `run` at the top level.
- [x] `./agent-vault run --help` and `./agent-vault vault run --help` render identical usage/flags.
- [ ] End-to-end: `agent-vault run -- sh -c 'env | grep AGENT_VAULT_'` injects `AGENT_VAULT_SESSION_TOKEN`, `AGENT_VAULT_ADDR`, `AGENT_VAULT_VAULT`, and `HTTPS_PROXY` into the child exactly as `agent-vault vault run` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)