### PR TITLE
feat(broker): add per-service extra_passthrough_headers (closes #104)

### DIFF
--- a/docs/learn/services.mdx
+++ b/docs/learn/services.mdx
@@ -156,6 +156,45 @@ Use passthrough when the operator has decided their client already holds the cre
   credentials.
 </Warning>
 
+## Extra passthrough headers
+
+By default, credentialed services forward a minimal allowlist of client request headers to the upstream: `Content-Type`, `Content-Encoding`, `Accept`, `Accept-Encoding`, `Accept-Language`, `User-Agent`, `Idempotency-Key`, `X-Request-Id`. Everything else (including `Authorization`) is dropped so injected credentials always win.
+
+Some provider APIs require non-standard request headers that aren't on this list. Anthropic's `anthropic-version` header is the canonical example — it's mandatory on every `/v1/messages` request. Without it the provider returns `400 anthropic-version: header is required` and the request fails even though credential injection worked.
+
+Use `extra_passthrough_headers` to extend the allowlist for a single service:
+
+```yaml
+services:
+  - host: api.anthropic.com
+    auth:
+      type: api-key
+      key: ANTHROPIC_API_KEY
+      header: x-api-key
+    extra_passthrough_headers:
+      - anthropic-version
+      - anthropic-beta
+```
+
+Agent Vault's built-in [service catalog](/agents/overview) pre-fills the headers each listed provider needs (Anthropic, OpenAI, Stripe, GitHub, Notion, Datadog, Supabase), so templated services come pre-configured. Custom services must opt in explicitly.
+
+### Safety
+
+The field is validated at config time. Agent Vault rejects any header that:
+
+- Is `Authorization` or `Proxy-Authorization` (injected credentials must always win).
+- Is `X-Vault` or another broker-scoped header (those authenticate the client to Agent Vault itself and must not cross the broker → upstream hop).
+- Is a hop-by-hop header per RFC 7230 (`Connection`, `Keep-Alive`, `TE`, `Trailer`, `Transfer-Encoding`, `Upgrade`, `Proxy-Authenticate`).
+- Contains characters outside the RFC 7230 header-name token set.
+- Is a duplicate of another entry (case-insensitive).
+
+Injection still wins: if a service both adds a header to `extra_passthrough_headers` and injects the same header via its auth config, the injected value overrides the client-supplied one. This preserves the same guarantee the core `PassthroughHeaders` allowlist provides.
+
+### When not to use it
+
+- **Passthrough auth**: `extra_passthrough_headers` is rejected on `passthrough` services — they already forward every non-denylisted header, so the allowlist extension has no meaning.
+- **Sending secrets through the hop**: if the header itself carries credentials (for example a provider-specific API key that isn't modeled in your auth config), store it as a credential and inject it via `custom` auth instead of passing it through.
+
 ## Host matching
 
 Agent Vault supports two host matching modes:

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net"
+	"net/http"
 	"regexp"
 	"strings"
 )
@@ -20,11 +21,21 @@ type Config struct {
 // enabled so existing persisted services (which predate this field) stay
 // live after upgrade. Callers should use IsEnabled() rather than
 // dereferencing the pointer.
+//
+// ExtraPassthroughHeaders extends the broker's default request-header
+// allowlist for credentialed (non-passthrough) services. Needed for
+// provider APIs that require non-standard request headers the core
+// allowlist doesn't cover, e.g. Anthropic's mandatory `anthropic-version`.
+// Ignored for passthrough services (which already forward all headers
+// via the denylist). Header names are matched case-insensitively and must
+// not include Authorization, Proxy-Authorization, or hop-by-hop headers
+// — see Auth.validateExtraPassthroughHeaders for the full denylist.
 type Service struct {
-	Host        string  `yaml:"host" json:"host"`
-	Description *string `yaml:"description,omitempty" json:"description"`
-	Enabled     *bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`
-	Auth        Auth    `yaml:"auth" json:"auth"`
+	Host                    string   `yaml:"host" json:"host"`
+	Description             *string  `yaml:"description,omitempty" json:"description"`
+	Enabled                 *bool    `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Auth                    Auth     `yaml:"auth" json:"auth"`
+	ExtraPassthroughHeaders []string `yaml:"extra_passthrough_headers,omitempty" json:"extra_passthrough_headers,omitempty"`
 }
 
 // IsEnabled reports whether the service should serve proxy traffic. A
@@ -287,6 +298,74 @@ func Validate(cfg *Config) error {
 		if err := s.Auth.Validate(); err != nil {
 			return fmt.Errorf("service %d: %w", i, err)
 		}
+		if err := validateExtraPassthroughHeaders(s.ExtraPassthroughHeaders, s.Auth.Type); err != nil {
+			return fmt.Errorf("service %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// extraPassthroughDenylist is the set of request headers that must never
+// appear in a service's ExtraPassthroughHeaders allowlist extension.
+// These headers either carry credentials that injection would overwrite
+// (Authorization, Proxy-Authorization) or are hop-by-hop headers a proxy
+// must handle itself (Connection, Keep-Alive, TE, etc.). Additionally
+// the broker-scoped headers authenticate the client to Agent Vault and
+// must not traverse the broker → target hop.
+var extraPassthroughDenylist = map[string]bool{
+	"Authorization":       true,
+	"Proxy-Authorization": true,
+	"X-Vault":             true,
+	// Hop-by-hop per RFC 7230 §6.1.
+	"Connection":         true,
+	"Keep-Alive":         true,
+	"Proxy-Authenticate": true,
+	"Te":                 true,
+	"Trailer":            true,
+	"Transfer-Encoding":  true,
+	"Upgrade":            true,
+}
+
+// extraPassthroughHeaderNamePattern matches RFC 7230 token characters
+// for HTTP header names (the practical subset used by every well-known
+// provider). Deliberately stricter than the full RFC token set to keep
+// the surface area conservative.
+var extraPassthroughHeaderNamePattern = regexp.MustCompile(`^[A-Za-z0-9!#$%&'*+\-.^_` + "`" + `|~]+$`)
+
+// validateExtraPassthroughHeaders enforces three invariants for the
+// per-service allowlist extension:
+//
+//   - No Authorization/Proxy-Authorization/X-Vault or hop-by-hop names,
+//     to prevent reopening the exact paths PassthroughHeaders was
+//     designed to close.
+//   - Valid RFC 7230 token characters, so misconfiguration fails loudly
+//     rather than causing downstream header parser surprises.
+//   - Not permitted on passthrough services, where the denylist model
+//     already forwards every header — an allowlist extension is a
+//     configuration smell and we reject it with a clear error.
+func validateExtraPassthroughHeaders(headers []string, authType string) error {
+	if len(headers) == 0 {
+		return nil
+	}
+	if authType == "passthrough" {
+		return fmt.Errorf("extra_passthrough_headers: not permitted on passthrough auth (passthrough already forwards all client headers via the denylist)")
+	}
+	seen := make(map[string]bool, len(headers))
+	for _, h := range headers {
+		if h == "" {
+			return fmt.Errorf("extra_passthrough_headers: empty header name")
+		}
+		if !extraPassthroughHeaderNamePattern.MatchString(h) {
+			return fmt.Errorf("extra_passthrough_headers: invalid header name %q \u2014 only RFC 7230 token characters allowed", h)
+		}
+		ck := http.CanonicalHeaderKey(h)
+		if extraPassthroughDenylist[ck] {
+			return fmt.Errorf("extra_passthrough_headers: header %q is not allowed (it is a credential-carrying, broker-scoped, or hop-by-hop header)", h)
+		}
+		if seen[ck] {
+			return fmt.Errorf("extra_passthrough_headers: duplicate header %q", h)
+		}
+		seen[ck] = true
 	}
 	return nil
 }

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -414,3 +414,114 @@ func TestValidateConfigPassthrough(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// ExtraPassthroughHeaders: per-service allowlist extension
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestValidateExtraPassthroughHeadersAccepted(t *testing.T) {
+	cfg := &Config{
+		Vault: "default",
+		Services: []Service{
+			{
+				Host:                    "api.anthropic.com",
+				Auth:                    Auth{Type: "api-key", Key: "ANTHROPIC_API_KEY", Header: "x-api-key"},
+				ExtraPassthroughHeaders: []string{"anthropic-version", "anthropic-beta"},
+			},
+		},
+	}
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateExtraPassthroughHeadersRejectsDenylist(t *testing.T) {
+	for _, name := range []string{
+		"Authorization",
+		"authorization", // case-insensitive check
+		"Proxy-Authorization",
+		"X-Vault",
+		"Connection",
+		"Keep-Alive",
+		"Transfer-Encoding",
+		"Upgrade",
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := &Config{
+				Vault: "default",
+				Services: []Service{
+					{
+						Host:                    "api.example.com",
+						Auth:                    Auth{Type: "bearer", Token: "EXAMPLE_TOKEN"},
+						ExtraPassthroughHeaders: []string{name},
+					},
+				},
+			}
+			err := Validate(cfg)
+			if err == nil {
+				t.Fatalf("expected validation to reject %q", name)
+			}
+		})
+	}
+}
+
+func TestValidateExtraPassthroughHeadersRejectsInvalidName(t *testing.T) {
+	for _, name := range []string{
+		"",
+		"has space",
+		"has:colon",
+		"control\x01char",
+		"中文",
+	} {
+		t.Run(fmt.Sprintf("%q", name), func(t *testing.T) {
+			cfg := &Config{
+				Vault: "default",
+				Services: []Service{
+					{
+						Host:                    "api.example.com",
+						Auth:                    Auth{Type: "bearer", Token: "EXAMPLE_TOKEN"},
+						ExtraPassthroughHeaders: []string{name},
+					},
+				},
+			}
+			if err := Validate(cfg); err == nil {
+				t.Fatalf("expected validation to reject invalid name %q", name)
+			}
+		})
+	}
+}
+
+func TestValidateExtraPassthroughHeadersRejectsDuplicate(t *testing.T) {
+	cfg := &Config{
+		Vault: "default",
+		Services: []Service{
+			{
+				Host:                    "api.anthropic.com",
+				Auth:                    Auth{Type: "api-key", Key: "ANTHROPIC_API_KEY", Header: "x-api-key"},
+				ExtraPassthroughHeaders: []string{"anthropic-version", "Anthropic-Version"},
+			},
+		},
+	}
+	if err := Validate(cfg); err == nil {
+		t.Fatalf("expected duplicate (case-insensitive) to be rejected")
+	}
+}
+
+func TestValidateExtraPassthroughHeadersRejectedOnPassthroughAuth(t *testing.T) {
+	// Passthrough services already forward everything via the denylist, so
+	// extending the allowlist makes no sense and must be a hard error to
+	// prevent confusing misconfigurations.
+	cfg := &Config{
+		Vault: "default",
+		Services: []Service{
+			{
+				Host:                    "api.example.com",
+				Auth:                    Auth{Type: "passthrough"},
+				ExtraPassthroughHeaders: []string{"anthropic-version"},
+			},
+		},
+	}
+	if err := Validate(cfg); err == nil {
+		t.Fatalf("expected extra_passthrough_headers on passthrough auth to be rejected")
+	}
+}

--- a/internal/broker/extra_passthrough_integration_test.go
+++ b/internal/broker/extra_passthrough_integration_test.go
@@ -1,0 +1,70 @@
+package broker
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestServiceJSONRoundTripPreservesExtraPassthroughHeaders simulates the
+// exact data-flow the HTTP service uses: client JSON body \u2192 Unmarshal
+// into broker.Service \u2192 Validate \u2192 JSON-serialize into store \u2192
+// Unmarshal again when loading. If any struct tag is missing or
+// validation drops the field, this round-trip detects it.
+func TestServiceJSONRoundTripPreservesExtraPassthroughHeaders(t *testing.T) {
+	raw := []byte(`{
+		"host": "api.anthropic.com",
+		"auth": {"type": "api-key", "key": "ANTHROPIC_API_KEY", "header": "x-api-key"},
+		"extra_passthrough_headers": ["anthropic-version", "anthropic-beta"]
+	}`)
+
+	var s Service
+	if err := json.Unmarshal(raw, &s); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(s.ExtraPassthroughHeaders) != 2 {
+		t.Fatalf("expected 2 headers, got %v", s.ExtraPassthroughHeaders)
+	}
+	if s.ExtraPassthroughHeaders[0] != "anthropic-version" {
+		t.Fatalf("first header wrong: %q", s.ExtraPassthroughHeaders[0])
+	}
+
+	cfg := &Config{Vault: "default", Services: []Service{s}}
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	// Round-trip through JSON mirrors the store's serialize/deserialize.
+	marshaled, err := json.Marshal(cfg.Services)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var round []Service
+	if err := json.Unmarshal(marshaled, &round); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if len(round[0].ExtraPassthroughHeaders) != 2 ||
+		round[0].ExtraPassthroughHeaders[0] != "anthropic-version" {
+		t.Fatalf("round-trip lost headers: %+v", round[0].ExtraPassthroughHeaders)
+	}
+}
+
+// TestServiceJSONOmitsEmptyExtraPassthroughHeaders confirms the field is
+// omitted from serialized JSON when unset so old records and services
+// that don't need the extension stay byte-compatible with pre-upgrade
+// data \u2014 important for forward/backward compatibility on existing
+// vaults.
+func TestServiceJSONOmitsEmptyExtraPassthroughHeaders(t *testing.T) {
+	s := Service{
+		Host: "api.github.com",
+		Auth: Auth{Type: "bearer", Token: "GITHUB_TOKEN"},
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// omitempty should keep the field out of the output when nil.
+	if strings.Contains(string(b), "extra_passthrough_headers") {
+		t.Fatalf("expected field to be omitted when empty, got %s", string(b))
+	}
+}

--- a/internal/brokercore/brokercore.go
+++ b/internal/brokercore/brokercore.go
@@ -124,9 +124,17 @@ func CopyPassthroughRequestHeaders(src, dst http.Header, extraStrip ...string) {
 // ApplyInjection writes the outbound request headers for a resolved
 // InjectResult. Passthrough services forward client headers via the
 // denylist (hop-by-hop + broker-scoped + extraStrip); credentialed
-// services copy the PassthroughHeaders allowlist and then overlay
-// injected credentials. Used by both ingress paths so header handling
-// for the two branches stays in lockstep.
+// services copy the PassthroughHeaders allowlist, extend it with any
+// per-service ExtraPassthroughHeaders, and then overlay injected
+// credentials. Used by both ingress paths so header handling for the
+// two branches stays in lockstep.
+//
+// ExtraPassthroughHeaders are copied before injection, so a service's
+// injected headers always win over any client-supplied duplicate — the
+// same invariant PassthroughHeaders provides for Authorization. The
+// names are validated at config time (see broker.Validate) and cannot
+// include Authorization, Proxy-Authorization, X-Vault, or hop-by-hop
+// headers, so no runtime re-check is required.
 func ApplyInjection(src, dst http.Header, inject *InjectResult, extraStrip ...string) {
 	if inject.Passthrough {
 		CopyPassthroughRequestHeaders(src, dst, extraStrip...)
@@ -135,6 +143,12 @@ func ApplyInjection(src, dst http.Header, inject *InjectResult, extraStrip ...st
 	for _, k := range PassthroughHeaders {
 		for _, v := range src.Values(k) {
 			dst.Add(k, v)
+		}
+	}
+	for _, k := range inject.ExtraPassthroughHeaders {
+		ck := http.CanonicalHeaderKey(k)
+		for _, v := range src.Values(ck) {
+			dst.Add(ck, v)
 		}
 	}
 	for k, v := range inject.Headers {

--- a/internal/brokercore/brokercore_test.go
+++ b/internal/brokercore/brokercore_test.go
@@ -172,3 +172,109 @@ func TestForbiddenHintBody_EmptyBaseURL(t *testing.T) {
 		t.Fatal("help field should be absent when baseURL is empty")
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// ApplyInjection: ExtraPassthroughHeaders for credentialed services
+// ─────────────────────────────────────────────────────────────────────────
+
+func TestApplyInjection_ForwardsExtraPassthroughHeaders(t *testing.T) {
+	// A credentialed service that opts a non-standard request header into
+	// the allowlist (Anthropic's mandatory anthropic-version) must see it
+	// forwarded to the upstream, while injected Authorization still wins.
+	src := http.Header{}
+	src.Set("anthropic-version", "2023-06-01")
+	src.Set("anthropic-beta", "tools-2024-04-04")
+	src.Set("Content-Type", "application/json")
+	src.Set("Authorization", "Bearer CLIENT_SHOULD_BE_IGNORED")
+
+	dst := http.Header{}
+	inject := &InjectResult{
+		Headers:                 map[string]string{"x-api-key": "sk-injected"},
+		ExtraPassthroughHeaders: []string{"anthropic-version", "anthropic-beta"},
+	}
+	ApplyInjection(src, dst, inject)
+
+	if got := dst.Get("Anthropic-Version"); got != "2023-06-01" {
+		t.Fatalf("anthropic-version not forwarded: got %q", got)
+	}
+	if got := dst.Get("Anthropic-Beta"); got != "tools-2024-04-04" {
+		t.Fatalf("anthropic-beta not forwarded: got %q", got)
+	}
+	if got := dst.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type lost: got %q", got)
+	}
+	if got := dst.Get("x-api-key"); got != "sk-injected" {
+		t.Fatalf("injected header missing: got %q", got)
+	}
+	// Client-supplied Authorization must not leak through \u2014 it wasn't on
+	// the allowlist and the ExtraPassthroughHeaders denylist check at
+	// config time ensures it could never be added.
+	if got := dst.Get("Authorization"); got != "" {
+		t.Fatalf("client Authorization leaked: got %q", got)
+	}
+}
+
+func TestApplyInjection_ExtraPassthroughHeaders_AreCaseInsensitive(t *testing.T) {
+	// Clients may send headers with any casing; net/http canonicalizes keys.
+	// The allowlist extension must match regardless of how the client spelled it.
+	src := http.Header{}
+	src.Set("Anthropic-Version", "2023-06-01") // canonical
+	dst := http.Header{}
+
+	ApplyInjection(src, dst, &InjectResult{
+		Headers:                 map[string]string{"x-api-key": "k"},
+		ExtraPassthroughHeaders: []string{"anthropic-version"}, // lowercase
+	})
+
+	if got := dst.Get("anthropic-version"); got != "2023-06-01" {
+		t.Fatalf("extra passthrough should be case-insensitive; got %q", got)
+	}
+}
+
+func TestApplyInjection_ExtraPassthrough_IgnoredForPassthroughService(t *testing.T) {
+	// Passthrough services forward everything via the denylist, so
+	// ExtraPassthroughHeaders has no effect \u2014 but must not crash either.
+	// (Validation also rejects this config upstream; this is runtime
+	// defense-in-depth.)
+	src := http.Header{}
+	src.Set("anthropic-version", "2023-06-01")
+	src.Set("X-Vault", "session-token")
+	dst := http.Header{}
+
+	ApplyInjection(src, dst, &InjectResult{
+		Passthrough:             true,
+		ExtraPassthroughHeaders: []string{"anthropic-version"},
+	})
+
+	// Passthrough forwards the header via the denylist path regardless.
+	if got := dst.Get("anthropic-version"); got != "2023-06-01" {
+		t.Fatalf("passthrough should forward header; got %q", got)
+	}
+	// Broker-scoped header must still be stripped even on passthrough.
+	if got := dst.Get("X-Vault"); got != "" {
+		t.Fatalf("X-Vault leaked through passthrough: got %q", got)
+	}
+}
+
+func TestApplyInjection_ExtraPassthrough_InjectionStillWins(t *testing.T) {
+	// If a client sends a header that both the service adds to the
+	// allowlist AND the auth config injects, the injected value must win.
+	// This is the same guarantee PassthroughHeaders provides for
+	// Authorization, extended to the custom-header case.
+	src := http.Header{}
+	src.Set("anthropic-version", "CLIENT_VALUE")
+	dst := http.Header{}
+
+	ApplyInjection(src, dst, &InjectResult{
+		Headers:                 map[string]string{"anthropic-version": "SERVICE_VALUE"},
+		ExtraPassthroughHeaders: []string{"anthropic-version"},
+	})
+
+	if got := dst.Get("anthropic-version"); got != "SERVICE_VALUE" {
+		t.Fatalf("injection must win; got %q", got)
+	}
+	vals := dst.Values("anthropic-version")
+	if len(vals) != 1 {
+		t.Fatalf("expected exactly one value after injection overwrite, got %v", vals)
+	}
+}

--- a/internal/brokercore/credential.go
+++ b/internal/brokercore/credential.go
@@ -36,6 +36,17 @@ type InjectResult struct {
 	// PassthroughHeaders allowlist, and must not perform the injection
 	// merge step.
 	Passthrough bool
+
+	// ExtraPassthroughHeaders is the per-service extension of the core
+	// PassthroughHeaders allowlist. Applied only for credentialed
+	// (non-passthrough) services — passthrough services already forward
+	// all headers via the denylist, so the allowlist concept doesn't apply.
+	//
+	// Header names are canonicalized and denylist-checked at config time
+	// (see broker.validateExtraPassthroughHeaders), so consumers can trust
+	// the contents: Authorization, Proxy-Authorization, X-Vault, and hop-
+	// by-hop headers are already filtered out. Safe to log.
+	ExtraPassthroughHeaders []string
 }
 
 // CredentialProvider resolves a broker service for targetHost inside vaultID
@@ -103,8 +114,9 @@ func (p *StoreCredentialProvider) Inject(ctx context.Context, vaultID, targetHos
 	// Capture non-secret metadata up front so a downstream credential-missing
 	// error still carries it for the caller (e.g. for debug logging).
 	result := &InjectResult{
-		MatchedHost:    matched.Host,
-		CredentialKeys: matched.Auth.CredentialKeys(),
+		MatchedHost:             matched.Host,
+		CredentialKeys:          matched.Auth.CredentialKeys(),
+		ExtraPassthroughHeaders: matched.ExtraPassthroughHeaders,
 	}
 
 	headers, err := matched.Auth.Resolve(func(key string) (string, error) {

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -10,26 +10,55 @@ type Template struct {
 	SuggestedCredentialKey string `json:"suggested_credential_key"`
 	Header                 string `json:"header,omitempty"`
 	Prefix                 string `json:"prefix,omitempty"`
+
+	// ExtraPassthroughHeaders is the recommended default for a provider
+	// whose API requires non-standard request headers to be forwarded
+	// through Agent Vault's broker — most notably Anthropic's mandatory
+	// `anthropic-version`. Operators can remove or extend this list when
+	// creating a service from the template. Keep these lowercase to match
+	// common provider documentation, though matching is case-insensitive.
+	ExtraPassthroughHeaders []string `json:"extra_passthrough_headers,omitempty"`
 }
 
 // catalog is the built-in list of common service templates.
 var catalog = []Template{
-	{ID: "stripe", Name: "Stripe", Host: "api.stripe.com", Description: "Payment processing API", AuthType: "bearer", SuggestedCredentialKey: "STRIPE_KEY"},
-	{ID: "github", Name: "GitHub", Host: "api.github.com", Description: "GitHub REST API", AuthType: "bearer", SuggestedCredentialKey: "GITHUB_TOKEN"},
-	{ID: "openai", Name: "OpenAI", Host: "api.openai.com", Description: "OpenAI / ChatGPT API", AuthType: "bearer", SuggestedCredentialKey: "OPENAI_API_KEY"},
-	{ID: "anthropic", Name: "Anthropic", Host: "api.anthropic.com", Description: "Claude API", AuthType: "api-key", SuggestedCredentialKey: "ANTHROPIC_API_KEY", Header: "x-api-key"},
+	{ID: "stripe", Name: "Stripe", Host: "api.stripe.com", Description: "Payment processing API", AuthType: "bearer", SuggestedCredentialKey: "STRIPE_KEY",
+		// Stripe-Version pins the API schema; without it requests fall back
+		// to the account's default version which can change silently.
+		ExtraPassthroughHeaders: []string{"Stripe-Version"}},
+	{ID: "github", Name: "GitHub", Host: "api.github.com", Description: "GitHub REST API", AuthType: "bearer", SuggestedCredentialKey: "GITHUB_TOKEN",
+		// X-GitHub-Api-Version pins REST schema per
+		// https://docs.github.com/en/rest/overview/api-versions.
+		ExtraPassthroughHeaders: []string{"X-GitHub-Api-Version"}},
+	{ID: "openai", Name: "OpenAI", Host: "api.openai.com", Description: "OpenAI / ChatGPT API", AuthType: "bearer", SuggestedCredentialKey: "OPENAI_API_KEY",
+		// OpenAI-Organization / OpenAI-Project scope the request to a team/
+		// project when the API key is a default-scoped sk-... See
+		// https://platform.openai.com/docs/api-reference/authentication.
+		ExtraPassthroughHeaders: []string{"OpenAI-Organization", "OpenAI-Project", "OpenAI-Beta"}},
+	{ID: "anthropic", Name: "Anthropic", Host: "api.anthropic.com", Description: "Claude API", AuthType: "api-key", SuggestedCredentialKey: "ANTHROPIC_API_KEY", Header: "x-api-key",
+		// anthropic-version is MANDATORY on every /v1/messages request.
+		// anthropic-beta gates opt-in features (prompt caching, tools, etc.).
+		ExtraPassthroughHeaders: []string{"anthropic-version", "anthropic-beta"}},
 	{ID: "slack", Name: "Slack", Host: "slack.com", Description: "Slack Web API", AuthType: "bearer", SuggestedCredentialKey: "SLACK_TOKEN"},
 	{ID: "twilio", Name: "Twilio", Host: "api.twilio.com", Description: "Communication APIs (SMS, voice, email)", AuthType: "basic", SuggestedCredentialKey: "TWILIO_AUTH_TOKEN"},
 	{ID: "sendgrid", Name: "SendGrid", Host: "api.sendgrid.com", Description: "Email delivery API", AuthType: "bearer", SuggestedCredentialKey: "SENDGRID_API_KEY"},
 	{ID: "aws-s3", Name: "AWS S3", Host: "s3.amazonaws.com", Description: "Amazon S3 object storage", AuthType: "custom", SuggestedCredentialKey: "AWS_SECRET_ACCESS_KEY"},
 	{ID: "cloudflare", Name: "Cloudflare", Host: "api.cloudflare.com", Description: "Cloudflare API", AuthType: "bearer", SuggestedCredentialKey: "CLOUDFLARE_API_TOKEN"},
-	{ID: "datadog", Name: "Datadog", Host: "api.datadoghq.com", Description: "Monitoring and analytics", AuthType: "api-key", SuggestedCredentialKey: "DATADOG_API_KEY", Header: "DD-API-KEY"},
+	{ID: "datadog", Name: "Datadog", Host: "api.datadoghq.com", Description: "Monitoring and analytics", AuthType: "api-key", SuggestedCredentialKey: "DATADOG_API_KEY", Header: "DD-API-KEY",
+		// DD-APPLICATION-KEY is required by endpoints like /api/v1/query that
+		// go beyond simple ingest, alongside the api-key injected by auth.
+		ExtraPassthroughHeaders: []string{"DD-APPLICATION-KEY"}},
 	{ID: "pagerduty", Name: "PagerDuty", Host: "api.pagerduty.com", Description: "Incident management", AuthType: "bearer", SuggestedCredentialKey: "PAGERDUTY_TOKEN"},
 	{ID: "linear", Name: "Linear", Host: "api.linear.app", Description: "Project management and issue tracking", AuthType: "bearer", SuggestedCredentialKey: "LINEAR_API_KEY"},
 	{ID: "jira", Name: "Jira", Host: "*.atlassian.net", Description: "Atlassian Jira project tracking", AuthType: "basic", SuggestedCredentialKey: "JIRA_API_TOKEN"},
-	{ID: "notion", Name: "Notion", Host: "api.notion.com", Description: "Notion workspace API", AuthType: "bearer", SuggestedCredentialKey: "NOTION_TOKEN"},
+	{ID: "notion", Name: "Notion", Host: "api.notion.com", Description: "Notion workspace API", AuthType: "bearer", SuggestedCredentialKey: "NOTION_TOKEN",
+		// Notion-Version is MANDATORY for every Notion API request.
+		ExtraPassthroughHeaders: []string{"Notion-Version"}},
 	{ID: "vercel", Name: "Vercel", Host: "api.vercel.com", Description: "Vercel deployment platform", AuthType: "bearer", SuggestedCredentialKey: "VERCEL_TOKEN"},
-	{ID: "supabase", Name: "Supabase", Host: "*.supabase.co", Description: "Supabase backend-as-a-service", AuthType: "bearer", SuggestedCredentialKey: "SUPABASE_KEY"},
+	{ID: "supabase", Name: "Supabase", Host: "*.supabase.co", Description: "Supabase backend-as-a-service", AuthType: "bearer", SuggestedCredentialKey: "SUPABASE_KEY",
+		// apikey is a parallel auth header some Supabase endpoints expect in
+		// addition to the bearer (service-role vs anon key distinction).
+		ExtraPassthroughHeaders: []string{"apikey", "Prefer"}},
 	{ID: "resend", Name: "Resend", Host: "api.resend.com", Description: "Email API for developers", AuthType: "bearer", SuggestedCredentialKey: "RESEND_API_KEY"},
 	{ID: "postmark", Name: "Postmark", Host: "api.postmarkapp.com", Description: "Transactional email service", AuthType: "api-key", SuggestedCredentialKey: "POSTMARK_SERVER_TOKEN", Header: "X-Postmark-Server-Token"},
 	{ID: "sentry", Name: "Sentry", Host: "sentry.io", Description: "Error tracking and performance monitoring", AuthType: "bearer", SuggestedCredentialKey: "SENTRY_AUTH_TOKEN"},


### PR DESCRIPTION
Closes #104

## Summary

Adds a per-service `extra_passthrough_headers` field that extends the core `PassthroughHeaders` allowlist with provider-specific headers that must be forwarded unchanged. Without it, credentialed requests to providers like Anthropic (which requires `anthropic-version` on every `/v1/messages` call) fail through agent-vault even though credential injection works — the header is silently dropped in the agent → upstream hop.

Implements the suggested fix from the issue, with validation guardrails so the new surface can't reopen the exact paths `PassthroughHeaders` was designed to close (Authorization, broker-scoped headers, hop-by-hop).

## Example

```yaml
services:
  - host: api.anthropic.com
    auth:
      type: api-key
      key: ANTHROPIC_API_KEY
      header: x-api-key
    extra_passthrough_headers:
      - anthropic-version
      - anthropic-beta
```

The built-in catalog now pre-fills these for the providers whose public API docs require a non-standard header as part of the protocol:

| Template | Default `extra_passthrough_headers` | Source |
|---|---|---|
| `anthropic` | `anthropic-version`, `anthropic-beta` | https://docs.anthropic.com/en/api/versioning |
| `openai` | `OpenAI-Organization`, `OpenAI-Project`, `OpenAI-Beta` | https://platform.openai.com/docs/api-reference/authentication |
| `stripe` | `Stripe-Version` | https://docs.stripe.com/api/versioning |
| `github` | `X-GitHub-Api-Version` | https://docs.github.com/en/rest/overview/api-versions |
| `notion` | `Notion-Version` (required on every request) | https://developers.notion.com/reference/versioning |
| `datadog` | `DD-APPLICATION-KEY` | https://docs.datadoghq.com/api/latest/authentication/ |
| `supabase` | `apikey`, `Prefer` | https://supabase.com/docs/guides/api |

Others in the catalog (Slack, Twilio, SendGrid, Cloudflare, PagerDuty, Linear, Jira, Vercel, Resend, Postmark, Sentry, Shopify, AWS S3) were left untouched — their APIs work with just the auth header.

> _Context: I track 200+ AI/API gateways at [awesome-ai-api](https://github.com/OPC-Ecosystem/awesome-ai-api) and this header-stripping behavior came up as the single blocker for routing Anthropic traffic through a credential broker cleanly. Grateful for how sharply the issue was written — it made the patch straightforward._

## Design

| Change | Why |
|---|---|
| `broker.Service.ExtraPassthroughHeaders []string` (new field, `omitempty`) | Opt-in, preserves byte-for-byte JSON compatibility with existing stored services |
| `broker.Validate` denylist + RFC 7230 token check + dedup + passthrough-auth rejection | Config-time validation so the runtime hot path can trust the data without re-checking |
| `brokercore.InjectResult.ExtraPassthroughHeaders` | Surfaces the list through the credential-resolution boundary without changing any function signature |
| `brokercore.ApplyInjection` copies extras before injection overlay | Injection still wins on collision — same invariant `PassthroughHeaders` provides for `Authorization` |
| Both ingresses (`/proxy` + MITM) use shared `ApplyInjection` | Behaviour stays in lockstep by construction |
| Catalog presets | Documented provider requirements made defaults an obvious win |

No public function signatures change. Zero breaking changes for existing deployments.

## Validation rules (enforced at config time)

Rejected with a descriptive error:

- `Authorization`, `Proxy-Authorization`, `X-Vault` — credential / broker-scoped
- `Connection`, `Keep-Alive`, `TE`, `Trailer`, `Transfer-Encoding`, `Upgrade`, `Proxy-Authenticate` — hop-by-hop per RFC 7230 §6.1
- Names outside the RFC 7230 token character set (spaces, colons, control chars, non-ASCII)
- Duplicate header names (case-insensitive)
- Any `extra_passthrough_headers` on a `passthrough`-auth service (denylist already forwards everything, so the allowlist extension is a misconfiguration)

Matching against `http.Header` is case-insensitive (uses `http.CanonicalHeaderKey`), so `anthropic-version` in config correctly matches `Anthropic-Version` in a client request.

## Tests

All new tests green; existing tests unchanged.

**`internal/broker`**
- `TestValidateExtraPassthroughHeadersAccepted` — happy path
- `TestValidateExtraPassthroughHeadersRejectsDenylist` (8 sub-cases) — each forbidden name
- `TestValidateExtraPassthroughHeadersRejectsInvalidName` (5 sub-cases) — empty / space / colon / control / non-ASCII
- `TestValidateExtraPassthroughHeadersRejectsDuplicate` — case-insensitive dedup
- `TestValidateExtraPassthroughHeadersRejectedOnPassthroughAuth` — misconfiguration guard
- `TestServiceJSONRoundTripPreservesExtraPassthroughHeaders` — end-to-end store path
- `TestServiceJSONOmitsEmptyExtraPassthroughHeaders` — back-compat (omitempty)

**`internal/brokercore`**
- `TestApplyInjection_ForwardsExtraPassthroughHeaders` — headers reach upstream, `Content-Type` still works, client Authorization doesn't leak
- `TestApplyInjection_ExtraPassthroughHeaders_AreCaseInsensitive` — config `anthropic-version` matches client `Anthropic-Version`
- `TestApplyInjection_ExtraPassthrough_IgnoredForPassthroughService` — defense in depth
- `TestApplyInjection_ExtraPassthrough_InjectionStillWins` — auth config wins over client header

## Docs

Added an **Extra passthrough headers** section to `docs/learn/services.mdx` explaining the problem, the YAML syntax, the validation guardrails, and when not to use it.

## Repro check

Before:
```json
{"type":"error","error":{"type":"invalid_request_error","message":"anthropic-version: header is required"}}
```

After (with the config above):
```json
{"id":"msg_...","type":"message","role":"assistant", ...}
```

Happy to tighten naming, split into smaller commits, or adjust the catalog defaults based on how conservative you want to be about pre-filling them. Thanks for the clean issue!