### PR TITLE
fix(server): keep `server stop` working after a foreground retry against a live daemon

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2,9 +2,13 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/Infisical/agent-vault/internal/pidfile"
 	"github.com/Infisical/agent-vault/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -239,6 +243,46 @@ func TestServerSubcommandsRegistered(t *testing.T) {
 		if !registered[name] {
 			t.Errorf("expected server subcommand %q to be registered, but it was not", name)
 		}
+	}
+}
+
+// TestServerCmd_RefusesWhenPIDFileLive ensures the server command bails out
+// at the pre-flight stage when another live server already owns the PID file,
+// without prompting for a password and without touching the file.
+func TestServerCmd_RefusesWhenPIDFileLive(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, ".agent-vault"), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Seed the PID file with our own PID — guaranteed to be a live process.
+	owner := os.Getpid()
+	if err := pidfile.Write(owner); err != nil {
+		t.Fatalf("seed pidfile: %v", err)
+	}
+
+	// Set a master password env var that would normally drive setup; the
+	// pre-flight check must fire before we ever reach unlockOrSetup, so this
+	// value should be irrelevant.
+	t.Setenv("AGENT_VAULT_MASTER_PASSWORD", "irrelevant-because-we-bail-first")
+
+	_, err := executeCommand("server", "--port", "0", "--mitm-port", "0")
+	if err == nil {
+		t.Fatal("expected error when another live server holds the PID file, got nil")
+	}
+	wantSubstr := fmt.Sprintf("server is already running (PID %d)", owner)
+	if !strings.Contains(err.Error(), wantSubstr) {
+		t.Errorf("error %q does not name the live PID — want substring %q", err.Error(), wantSubstr)
+	}
+
+	// PID file must be untouched.
+	got, err := pidfile.Read()
+	if err != nil {
+		t.Fatalf("Read after refusal: %v", err)
+	}
+	if got != owner {
+		t.Errorf("pidfile contents = %d, want %d (file should not have been overwritten)", got, owner)
 	}
 }
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -97,7 +97,7 @@ var serverCmd = &cobra.Command{
 		// master password just to learn the port is taken.
 		if pid, err := pidfile.Read(); err == nil {
 			if pidfile.IsRunning(pid) {
-				return fmt.Errorf("server is already running (PID %d). Use 'agent-vault server stop' to stop it, or pass --port to run a second instance", pid)
+				return fmt.Errorf("server is already running (PID %d). Use 'agent-vault server stop' to stop it first", pid)
 			}
 			_ = pidfile.Remove()
 		}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -93,6 +93,15 @@ var serverCmd = &cobra.Command{
 			return runDetachedChild(host, addr, mitmPort, logger)
 		}
 
+		// Pre-flight before unlocking the vault: don't make the user type a
+		// master password just to learn the port is taken.
+		if pid, err := pidfile.Read(); err == nil {
+			if pidfile.IsRunning(pid) {
+				return fmt.Errorf("server is already running (PID %d). Use 'agent-vault server stop' to stop it, or pass --port to run a second instance", pid)
+			}
+			_ = pidfile.Remove()
+		}
+
 		dbPath, err := store.DefaultDBPath()
 		if err != nil {
 			return fmt.Errorf("resolving db path: %w", err)
@@ -476,15 +485,6 @@ func runDetachedChild(host, addr string, mitmPort int, logger *slog.Logger) erro
 // invocation (no env var) still takes effect after re-exec.
 func spawnDetached(cmd *cobra.Command, masterKey *auth.MasterKey, initialized bool, host string, port, mitmPort int, addr string, explicitLogLevel *string) error {
 	defer masterKey.Wipe()
-
-	// Check if a server is already running.
-	if pid, err := pidfile.Read(); err == nil {
-		if pidfile.IsRunning(pid) {
-			return fmt.Errorf("server is already running (PID %d). Use 'agent-vault server stop' to stop it first", pid)
-		}
-		// Stale PID file — clean up.
-		_ = pidfile.Remove()
-	}
 
 	exe, err := os.Executable()
 	if err != nil {

--- a/internal/pidfile/pidfile.go
+++ b/internal/pidfile/pidfile.go
@@ -21,6 +21,10 @@ func Path() (string, error) {
 	return filepath.Join(home, ".agent-vault", fileName), nil
 }
 
+// ErrAlreadyRunning is returned by WriteIfFree when the PID file is already
+// owned by a live process other than the caller.
+var ErrAlreadyRunning = errors.New("pidfile owned by another live process")
+
 // Write atomically writes the given PID to the PID file.
 func Write(pid int) error {
 	path, err := Path()
@@ -36,6 +40,20 @@ func Write(pid int) error {
 		return err
 	}
 	return os.Rename(tmp, path)
+}
+
+// WriteIfFree atomically writes pid only if no live process other than the
+// caller owns the file. Stale files (process gone) are overwritten. Returns
+// ErrAlreadyRunning when the existing PID points at a different live process —
+// callers should treat this as "another server beat me to it" and avoid
+// removing the file on shutdown.
+func WriteIfFree(pid int) error {
+	if existing, err := Read(); err == nil {
+		if existing != pid && IsRunning(existing) {
+			return ErrAlreadyRunning
+		}
+	}
+	return Write(pid)
 }
 
 // Read reads the PID from the PID file.

--- a/internal/pidfile/pidfile_test.go
+++ b/internal/pidfile/pidfile_test.go
@@ -1,6 +1,7 @@
 package pidfile
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -77,5 +78,85 @@ func TestIsRunning(t *testing.T) {
 	// A very high PID should not exist.
 	if IsRunning(4194304) {
 		t.Error("IsRunning(4194304) = true, want false")
+	}
+}
+
+func TestWriteIfFreeNoExistingFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	os.MkdirAll(filepath.Join(tmp, ".agent-vault"), 0700)
+
+	if err := WriteIfFree(os.Getpid()); err != nil {
+		t.Fatalf("WriteIfFree on empty slot: %v", err)
+	}
+	got, err := Read()
+	if err != nil {
+		t.Fatalf("Read after WriteIfFree: %v", err)
+	}
+	if got != os.Getpid() {
+		t.Errorf("Read = %d, want %d", got, os.Getpid())
+	}
+}
+
+func TestWriteIfFreeStalePID(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	os.MkdirAll(filepath.Join(tmp, ".agent-vault"), 0700)
+
+	// Seed with a PID that cannot be live.
+	if err := Write(4194304); err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+	if err := WriteIfFree(os.Getpid()); err != nil {
+		t.Fatalf("WriteIfFree over stale PID: %v", err)
+	}
+	got, err := Read()
+	if err != nil {
+		t.Fatalf("Read after WriteIfFree: %v", err)
+	}
+	if got != os.Getpid() {
+		t.Errorf("Read = %d, want %d (stale PID should have been overwritten)", got, os.Getpid())
+	}
+}
+
+func TestWriteIfFreeLiveOwner(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	os.MkdirAll(filepath.Join(tmp, ".agent-vault"), 0700)
+
+	// Seed with our own PID, which is definitely live.
+	owner := os.Getpid()
+	if err := Write(owner); err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+
+	// A different PID asking to claim the slot should be rejected.
+	err := WriteIfFree(owner + 1)
+	if !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("WriteIfFree against live owner: got %v, want ErrAlreadyRunning", err)
+	}
+
+	// File contents must be unchanged.
+	got, err := Read()
+	if err != nil {
+		t.Fatalf("Read after rejected WriteIfFree: %v", err)
+	}
+	if got != owner {
+		t.Errorf("Read = %d, want %d (file should be untouched)", got, owner)
+	}
+}
+
+func TestWriteIfFreeSamePIDNoOp(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	os.MkdirAll(filepath.Join(tmp, ".agent-vault"), 0700)
+
+	// Same PID re-claiming its own slot must succeed (idempotent).
+	owner := os.Getpid()
+	if err := Write(owner); err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+	if err := WriteIfFree(owner); err != nil {
+		t.Fatalf("WriteIfFree with same PID: %v", err)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -763,6 +763,14 @@ func (s *Server) Start() error {
 		}
 	}
 
+	// Bind synchronously so EADDRINUSE returns from Start() before any pidfile
+	// work happens. Keeps a foreground invocation against an already-running
+	// daemon from clobbering the daemon's PID file.
+	httpLn, err := net.Listen("tcp", s.httpServer.Addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", s.httpServer.Addr, err)
+	}
+
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
@@ -772,7 +780,7 @@ func (s *Server) Start() error {
 		if !s.initialized {
 			fmt.Printf("Run `agent-vault auth register` or visit %s to create the owner account\n", s.baseURL)
 		}
-		if err := s.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := s.httpServer.Serve(httpLn); err != nil && err != http.ErrServerClosed {
 			errCh <- err
 		}
 	}()
@@ -793,10 +801,15 @@ func (s *Server) Start() error {
 		}()
 	}
 
-	if err := pidfile.Write(os.Getpid()); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: could not write PID file: %v\n", err)
+	if err := pidfile.WriteIfFree(os.Getpid()); err != nil {
+		if errors.Is(err, pidfile.ErrAlreadyRunning) {
+			s.logger.Warn("pidfile owned by another process; not claiming or removing it")
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: could not write PID file: %v\n", err)
+		}
+	} else {
+		defer func() { _ = pidfile.Remove() }()
 	}
-	defer func() { _ = pidfile.Remove() }()
 
 	select {
 	case err := <-errCh:


### PR DESCRIPTION
## Summary

- Pre-flight PID check in `serverCmd.RunE` refuses early — before opening the DB or prompting for the master password — when another live server already owns the PID file. The duplicate check inside `spawnDetached` is removed since `RunE` now guards both branches.
- `Server.Start()` now binds HTTP synchronously, so `EADDRINUSE` returns before any pidfile work happens.
- New `pidfile.WriteIfFree` + `ErrAlreadyRunning` sentinel give defense in depth: if a foreign owner ever holds the file at write time, `Start` skips the deferred `Remove` instead of destroying state it doesn't own.

## Bug being fixed

`agent-vault server -d` (daemon) followed by `agent-vault server` (foreground) used to:

1. Goroutine'd `ListenAndServe` errors with `EADDRINUSE`.
2. Main goroutine reaches `pidfile.Write(os.Getpid())` first → **overwrites the daemon's PID** with the foreground's.
3. Select sees the bind error, returns.
4. `defer pidfile.Remove()` fires → **deletes the PID file entirely.**

Result: `agent-vault server stop` reported "no server appears to be running" while the daemon kept its sockets bound — only `kill <pid>` recovered it.

## Test plan

- [x] `go test ./...` and `go vet ./...` clean
- [x] `internal/pidfile`: 4 new `WriteIfFree` cases (empty slot, stale PID, live owner refused with file untouched, same-PID idempotent)
- [x] `cmd`: `TestServerCmd_RefusesWhenPIDFileLive` proves the pre-flight bails with the right message and leaves the PID file untouched, even with `AGENT_VAULT_MASTER_PASSWORD` set (confirms we never reach `unlockOrSetup`)
- [ ] Manual: `agent-vault server -d`, then `agent-vault server` — fails immediately naming the daemon's PID, no password prompt, PID file unchanged
- [ ] Manual: `agent-vault server stop` after the above — succeeds, daemon exits cleanly
- [ ] Manual: `agent-vault server -d` then `kill -9 <pid>` then `agent-vault server` — pre-flight clears the stale file and starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)