### PR TITLE
feat(cli): re-prompt for credentials on expired session and retry once

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -253,12 +253,17 @@ func reauthInteractive(sess *session.ClientSession) (*session.ClientSession, err
 // place so callers holding the pointer pick up the new token, and runs op
 // exactly once more. Non-interactive callers see the original error
 // untouched so CI/scripts can detect and handle it themselves.
-func withReauthRetry(sess *session.ClientSession, op func(*session.ClientSession) error) error {
+//
+// addr is the server the failing request was sent to; reauth is skipped
+// when it differs from sess.Address, because the saved login is tied to
+// sess.Address and a fresh token for that server would still be useless
+// against a different one (e.g. `--address=B` with a session for A).
+func withReauthRetry(sess *session.ClientSession, addr string, op func(*session.ClientSession) error) error {
 	err := op(sess)
 	if err == nil || !errors.Is(err, errSessionExpired) {
 		return err
 	}
-	if !isInteractiveFn() {
+	if !isInteractiveFn() || addr != sess.Address {
 		return err
 	}
 	newSess, rerr := reauthFn(sess)
@@ -480,7 +485,7 @@ func fetchAndDecode[T any](method, path string) (*T, error) {
 		return nil, err
 	}
 	var respBody []byte
-	err = withReauthRetry(sess, func(s *session.ClientSession) error {
+	err = withReauthRetry(sess, sess.Address, func(s *session.ClientSession) error {
 		var ierr error
 		respBody, ierr = doAdminRequestWithBody(method, s.Address+path, s.Token, nil)
 		return ierr

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,6 +19,33 @@ import (
 	"github.com/Infisical/agent-vault/internal/store"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+)
+
+// errSessionExpired marks an error as recoverable by re-authenticating.
+// It is returned by HTTP helpers whenever the server replies with 401 to
+// an admin-token-bearing request; withReauthRetry uses errors.Is to detect
+// it. Match on status (not the error string) so all three 401 messages
+// the server emits — "Session expired", "Invalid or expired session",
+// "Authorization required" — are handled the same way.
+var errSessionExpired = &sessionExpiredError{msg: "session expired"}
+
+// sessionExpiredError carries a server- or caller-supplied message while
+// still matching errSessionExpired via errors.Is. Wrapping the sentinel
+// through fmt.Errorf("%s: %w", body, errSessionExpired) would stutter
+// ("Session expired: session expired"); this type renders only `msg`.
+type sessionExpiredError struct{ msg string }
+
+func (e *sessionExpiredError) Error() string { return e.msg }
+func (e *sessionExpiredError) Is(target error) bool {
+	_, ok := target.(*sessionExpiredError)
+	return ok
+}
+
+// isInteractiveFn and reauthFn are indirections so tests can stub the TTY
+// check and the interactive re-auth without wiring a real terminal.
+var (
+	isInteractiveFn = isInteractive
+	reauthFn        = reauthInteractive
 )
 
 const (
@@ -181,11 +209,64 @@ func doLogin(address, email, password string) (*session.ClientSession, error) {
 	sess := &session.ClientSession{
 		Token:   result.Token,
 		Address: address,
+		Email:   email,
 	}
 	if err := session.Save(sess); err != nil {
 		return nil, fmt.Errorf("saving session: %w", err)
 	}
 	return sess, nil
+}
+
+// reauthInteractive prompts the user to log in again on the same address as
+// sess and returns the freshly-saved session. Skips the email prompt when
+// sess.Email is already known (i.e. session was minted by a doLogin call
+// after the Email field was added).
+func reauthInteractive(sess *session.ClientSession) (*session.ClientSession, error) {
+	fmt.Fprintln(os.Stderr, "\nYour session has expired. Please log in again.")
+
+	email := sess.Email
+	if email == "" {
+		got, err := interactiveReadEmail()
+		if err != nil {
+			return nil, err
+		}
+		email = got
+	} else {
+		fmt.Fprintf(os.Stderr, "Re-authenticating as %s\n", email)
+	}
+
+	password, err := interactiveReadPassword()
+	if err != nil {
+		return nil, err
+	}
+
+	newSess, err := doLogin(sess.Address, email, password)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintln(os.Stderr, successText("✓")+" Login successful.")
+	return newSess, nil
+}
+
+// withReauthRetry runs op once. If op fails with errSessionExpired and
+// stdin is a TTY, prompts the user to re-authenticate, updates *sess in
+// place so callers holding the pointer pick up the new token, and runs op
+// exactly once more. Non-interactive callers see the original error
+// untouched so CI/scripts can detect and handle it themselves.
+func withReauthRetry(sess *session.ClientSession, op func(*session.ClientSession) error) error {
+	err := op(sess)
+	if err == nil || !errors.Is(err, errSessionExpired) {
+		return err
+	}
+	if !isInteractiveFn() {
+		return err
+	}
+	newSess, rerr := reauthFn(sess)
+	if rerr != nil {
+		return fmt.Errorf("re-authentication failed: %w", rerr)
+	}
+	*sess = *newSess
+	return op(sess)
 }
 
 // interactiveReadEmail prompts for an email address on stderr and reads from stdin.
@@ -398,7 +479,12 @@ func fetchAndDecode[T any](method, path string) (*T, error) {
 	if err != nil {
 		return nil, err
 	}
-	respBody, err := doAdminRequestWithBody(method, sess.Address+path, sess.Token, nil)
+	var respBody []byte
+	err = withReauthRetry(sess, func(s *session.ClientSession) error {
+		var ierr error
+		respBody, ierr = doAdminRequestWithBody(method, s.Address+path, s.Token, nil)
+		return ierr
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -438,10 +524,14 @@ func doAdminRequestWithBody(method, url, token string, body []byte) ([]byte, err
 			Error string `json:"error"`
 		}
 		_ = json.Unmarshal(respBody, &errResp)
-		if errResp.Error != "" {
-			return nil, fmt.Errorf("%s", errResp.Error)
+		msg := errResp.Error
+		if msg == "" {
+			msg = fmt.Sprintf("server returned status %d", resp.StatusCode)
 		}
-		return nil, fmt.Errorf("server returned status %d", resp.StatusCode)
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, &sessionExpiredError{msg: msg}
+		}
+		return nil, fmt.Errorf("%s", msg)
 	}
 
 	return respBody, nil

--- a/cmd/reauth_test.go
+++ b/cmd/reauth_test.go
@@ -155,6 +155,10 @@ func TestFetchUserVaults_401PreservesServerMessage(t *testing.T) {
 // would be re-prompted by the picker, and a single-vault user would pay an
 // extra `/v1/vaults` round-trip.
 func TestMintScopedSession_VaultResolutionMemoized(t *testing.T) {
+	// Isolate $HOME so a developer-set ~/.agent-vault/context doesn't
+	// short-circuit resolveVaultForRun before fetchUserVaults runs.
+	t.Setenv("HOME", t.TempDir())
+
 	var vaultsHits, sessionsHits int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -226,7 +230,7 @@ func TestWithReauthRetry_NonInteractiveReturnsOriginalError(t *testing.T) {
 	calls := 0
 	original := errSessionExpired
 	sess := &session.ClientSession{Token: "stale", Address: "http://x"}
-	err := withReauthRetry(sess, func(s *session.ClientSession) error {
+	err := withReauthRetry(sess, sess.Address, func(s *session.ClientSession) error {
 		calls++
 		return original
 	})
@@ -249,7 +253,7 @@ func TestWithReauthRetry_NoErrorRunsOpOnce(t *testing.T) {
 
 	calls := 0
 	sess := &session.ClientSession{Token: "good", Address: "http://x"}
-	err := withReauthRetry(sess, func(s *session.ClientSession) error {
+	err := withReauthRetry(sess, sess.Address, func(s *session.ClientSession) error {
 		calls++
 		return nil
 	})
@@ -271,7 +275,7 @@ func TestWithReauthRetry_RetriesAfterReauth(t *testing.T) {
 	sess := &session.ClientSession{Token: "stale", Address: "http://x"}
 	calls := 0
 	var seenTokens []string
-	err := withReauthRetry(sess, func(s *session.ClientSession) error {
+	err := withReauthRetry(sess, sess.Address, func(s *session.ClientSession) error {
 		calls++
 		seenTokens = append(seenTokens, s.Token)
 		if calls == 1 {
@@ -305,7 +309,7 @@ func TestWithReauthRetry_DoesNotLoop(t *testing.T) {
 
 	sess := &session.ClientSession{Token: "stale", Address: "http://x"}
 	calls := 0
-	err := withReauthRetry(sess, func(s *session.ClientSession) error {
+	err := withReauthRetry(sess, sess.Address, func(s *session.ClientSession) error {
 		calls++
 		return errSessionExpired
 	})
@@ -320,6 +324,29 @@ func TestWithReauthRetry_DoesNotLoop(t *testing.T) {
 	}
 }
 
+func TestWithReauthRetry_CrossServerSkipsReauth(t *testing.T) {
+	withTestStubs(t, true, func(s *session.ClientSession) (*session.ClientSession, error) {
+		t.Fatal("reauth should not run when addr differs from sess.Address")
+		return nil, nil
+	})
+
+	calls := 0
+	sess := &session.ClientSession{Token: "tokA", Address: "http://server-a"}
+	err := withReauthRetry(sess, "http://server-b", func(s *session.ClientSession) error {
+		calls++
+		return errSessionExpired
+	})
+	if calls != 1 {
+		t.Fatalf("op should not retry on cross-server 401, ran %d times", calls)
+	}
+	if !errors.Is(err, errSessionExpired) {
+		t.Fatalf("expected errSessionExpired bubbled, got %v", err)
+	}
+	if sess.Token != "tokA" {
+		t.Fatalf("session token should be untouched, got %q", sess.Token)
+	}
+}
+
 func TestWithReauthRetry_ReauthFailureWraps(t *testing.T) {
 	stubErr := errors.New("invalid email or password")
 	withTestStubs(t, true, func(s *session.ClientSession) (*session.ClientSession, error) {
@@ -328,7 +355,7 @@ func TestWithReauthRetry_ReauthFailureWraps(t *testing.T) {
 
 	sess := &session.ClientSession{Token: "stale", Address: "http://x"}
 	calls := 0
-	err := withReauthRetry(sess, func(s *session.ClientSession) error {
+	err := withReauthRetry(sess, sess.Address, func(s *session.ClientSession) error {
 		calls++
 		return errSessionExpired
 	})

--- a/cmd/reauth_test.go
+++ b/cmd/reauth_test.go
@@ -1,0 +1,258 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Infisical/agent-vault/internal/session"
+)
+
+func TestDoAdminRequestWithBody_401WrapsErrSessionExpired(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"session expired", `{"error":"Session expired"}`},
+		{"invalid or expired session", `{"error":"Invalid or expired session"}`},
+		{"authorization required", `{"error":"Authorization required"}`},
+		{"empty body still wraps", ``},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			_, err := doAdminRequestWithBody(http.MethodGet, srv.URL+"/whatever", "stale-token", nil)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, errSessionExpired) {
+				t.Fatalf("err %q does not wrap errSessionExpired", err)
+			}
+		})
+	}
+}
+
+func TestDoAdminRequestWithBody_401MessageDoesNotStutter(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"Session expired"}`))
+	}))
+	defer srv.Close()
+
+	_, err := doAdminRequestWithBody(http.MethodGet, srv.URL+"/x", "tok", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); got != "Session expired" {
+		t.Fatalf("expected exact server message %q, got %q", "Session expired", got)
+	}
+}
+
+func TestRequestScopedSession_401MessagePreservesPrefix(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"Session expired"}`))
+	}))
+	defer srv.Close()
+
+	_, err := requestScopedSession(srv.URL, "tok", "default", "", 0)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	want := "failed to create scoped session: Session expired"
+	if got := err.Error(); got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestDoAdminRequestWithBody_Non401DoesNotWrap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer srv.Close()
+
+	_, err := doAdminRequestWithBody(http.MethodGet, srv.URL+"/whatever", "tok", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, errSessionExpired) {
+		t.Fatalf("403 should not wrap errSessionExpired, got %q", err)
+	}
+}
+
+func TestRequestScopedSession_401WrapsErrSessionExpired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"Session expired"}`))
+	}))
+	defer srv.Close()
+
+	_, err := requestScopedSession(srv.URL, "stale-token", "default", "", 0)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, errSessionExpired) {
+		t.Fatalf("err %q does not wrap errSessionExpired", err)
+	}
+}
+
+func TestFetchUserVaults_401WrapsErrSessionExpired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"Session expired"}`))
+	}))
+	defer srv.Close()
+
+	_, err := fetchUserVaults(srv.URL, "stale-token")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, errSessionExpired) {
+		t.Fatalf("err %q does not wrap errSessionExpired", err)
+	}
+}
+
+// withTestStubs swaps the package-level isInteractiveFn / reauthFn for the
+// duration of the test and restores them on cleanup.
+func withTestStubs(t *testing.T, interactive bool, reauth func(*session.ClientSession) (*session.ClientSession, error)) {
+	t.Helper()
+	origInteractive := isInteractiveFn
+	origReauth := reauthFn
+	isInteractiveFn = func() bool { return interactive }
+	reauthFn = reauth
+	t.Cleanup(func() {
+		isInteractiveFn = origInteractive
+		reauthFn = origReauth
+	})
+}
+
+func TestWithReauthRetry_NonInteractiveReturnsOriginalError(t *testing.T) {
+	withTestStubs(t, false, func(s *session.ClientSession) (*session.ClientSession, error) {
+		t.Fatal("reauth should not run when stdin is not a TTY")
+		return nil, nil
+	})
+
+	calls := 0
+	original := errSessionExpired
+	sess := &session.ClientSession{Token: "stale", Address: "http://x"}
+	err := withReauthRetry(sess, func(s *session.ClientSession) error {
+		calls++
+		return original
+	})
+	if calls != 1 {
+		t.Fatalf("op should run exactly once, ran %d times", calls)
+	}
+	if !errors.Is(err, errSessionExpired) {
+		t.Fatalf("expected wrapped errSessionExpired, got %v", err)
+	}
+	if sess.Token != "stale" {
+		t.Fatalf("session token should be untouched, got %q", sess.Token)
+	}
+}
+
+func TestWithReauthRetry_NoErrorRunsOpOnce(t *testing.T) {
+	withTestStubs(t, true, func(s *session.ClientSession) (*session.ClientSession, error) {
+		t.Fatal("reauth should not run when op succeeds")
+		return nil, nil
+	})
+
+	calls := 0
+	sess := &session.ClientSession{Token: "good", Address: "http://x"}
+	err := withReauthRetry(sess, func(s *session.ClientSession) error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("op should run exactly once, ran %d times", calls)
+	}
+}
+
+func TestWithReauthRetry_RetriesAfterReauth(t *testing.T) {
+	reauthCalls := 0
+	withTestStubs(t, true, func(s *session.ClientSession) (*session.ClientSession, error) {
+		reauthCalls++
+		return &session.ClientSession{Token: "fresh", Address: s.Address, Email: "user@example.com"}, nil
+	})
+
+	sess := &session.ClientSession{Token: "stale", Address: "http://x"}
+	calls := 0
+	var seenTokens []string
+	err := withReauthRetry(sess, func(s *session.ClientSession) error {
+		calls++
+		seenTokens = append(seenTokens, s.Token)
+		if calls == 1 {
+			return errSessionExpired
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil after retry, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("op should run twice, ran %d times", calls)
+	}
+	if reauthCalls != 1 {
+		t.Fatalf("reauth should run exactly once, ran %d times", reauthCalls)
+	}
+	if seenTokens[0] != "stale" || seenTokens[1] != "fresh" {
+		t.Fatalf("op should see fresh token on retry, saw %v", seenTokens)
+	}
+	if sess.Token != "fresh" || sess.Email != "user@example.com" {
+		t.Fatalf("caller's session should be updated in place, got %+v", sess)
+	}
+}
+
+func TestWithReauthRetry_DoesNotLoop(t *testing.T) {
+	reauthCalls := 0
+	withTestStubs(t, true, func(s *session.ClientSession) (*session.ClientSession, error) {
+		reauthCalls++
+		return &session.ClientSession{Token: "fresh", Address: s.Address}, nil
+	})
+
+	sess := &session.ClientSession{Token: "stale", Address: "http://x"}
+	calls := 0
+	err := withReauthRetry(sess, func(s *session.ClientSession) error {
+		calls++
+		return errSessionExpired
+	})
+	if calls != 2 {
+		t.Fatalf("op should run exactly twice (one retry), ran %d times", calls)
+	}
+	if reauthCalls != 1 {
+		t.Fatalf("reauth should run exactly once, ran %d times", reauthCalls)
+	}
+	if !errors.Is(err, errSessionExpired) {
+		t.Fatalf("second 401 should bubble up unchanged, got %v", err)
+	}
+}
+
+func TestWithReauthRetry_ReauthFailureWraps(t *testing.T) {
+	stubErr := errors.New("invalid email or password")
+	withTestStubs(t, true, func(s *session.ClientSession) (*session.ClientSession, error) {
+		return nil, stubErr
+	})
+
+	sess := &session.ClientSession{Token: "stale", Address: "http://x"}
+	calls := 0
+	err := withReauthRetry(sess, func(s *session.ClientSession) error {
+		calls++
+		return errSessionExpired
+	})
+	if calls != 1 {
+		t.Fatalf("op should not retry when reauth fails, ran %d times", calls)
+	}
+	if !errors.Is(err, stubErr) {
+		t.Fatalf("expected wrapped reauth error, got %v", err)
+	}
+}

--- a/cmd/reauth_test.go
+++ b/cmd/reauth_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Infisical/agent-vault/internal/session"
+	"github.com/spf13/cobra"
 )
 
 func TestDoAdminRequestWithBody_401WrapsErrSessionExpired(t *testing.T) {
@@ -117,6 +118,88 @@ func TestFetchUserVaults_401WrapsErrSessionExpired(t *testing.T) {
 	}
 	if !errors.Is(err, errSessionExpired) {
 		t.Fatalf("err %q does not wrap errSessionExpired", err)
+	}
+}
+
+func TestFetchUserVaults_401PreservesServerMessage(t *testing.T) {
+	cases := []struct {
+		body string
+		want string
+	}{
+		{`{"error":"Authorization required"}`, "listing vaults: Authorization required"},
+		{`{"error":"Invalid or expired session"}`, "listing vaults: Invalid or expired session"},
+		{``, "listing vaults: status 401"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			_, err := fetchUserVaults(srv.URL, "tok")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if got := err.Error(); got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestMintScopedSession_VaultResolutionMemoized asserts that when the admin
+// session expires between the vault lookup and the scoped-session mint, the
+// retry does not re-run vault resolution — otherwise a multi-vault user
+// would be re-prompted by the picker, and a single-vault user would pay an
+// extra `/v1/vaults` round-trip.
+func TestMintScopedSession_VaultResolutionMemoized(t *testing.T) {
+	var vaultsHits, sessionsHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/vaults":
+			vaultsHits++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"vaults":[{"name":"myvault"}]}`))
+		case "/v1/sessions":
+			sessionsHits++
+			if sessionsHits == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"Session expired"}`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"token":"scoped-token"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	withTestStubs(t, true, func(s *session.ClientSession) (*session.ClientSession, error) {
+		return &session.ClientSession{Token: "fresh", Address: s.Address}, nil
+	})
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("vault", "", "")
+
+	sess := &session.ClientSession{Token: "stale", Address: srv.URL}
+	vault, token, err := mintScopedSession(cmd, sess, srv.URL, "", 0)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if vault != "myvault" {
+		t.Fatalf("expected vault=myvault, got %q", vault)
+	}
+	if token != "scoped-token" {
+		t.Fatalf("expected token=scoped-token, got %q", token)
+	}
+	if vaultsHits != 1 {
+		t.Fatalf("expected /v1/vaults hit exactly once across retry, got %d", vaultsHits)
+	}
+	if sessionsHits != 2 {
+		t.Fatalf("expected /v1/sessions hit twice (initial + retry), got %d", sessionsHits)
 	}
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -112,27 +112,11 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 		addr = sess.Address
 	}
 
-	// 2-3. Resolve the vault and request a vault-scoped session token.
-	//      Wrapped together so an interactive user whose admin session
-	//      has expired sees one re-auth prompt and the whole sequence
-	//      retries cleanly with the new token (otherwise the silent
-	//      DefaultVault fallback in resolveVaultForRun would mask the
-	//      expiry and demote a multi-vault user to "default").
+	// 2-3. Resolve the vault and mint a vault-scoped session token,
+	//      retrying on session expiry. Shared with `vault token`.
 	role, _ := cmd.Flags().GetString("role")
 	ttl, _ := cmd.Flags().GetInt("ttl")
-	var vault, scopedToken string
-	err = withReauthRetry(sess, func(s *session.ClientSession) error {
-		v, err := resolveVaultForRun(cmd, addr, s.Token)
-		if err != nil {
-			return err
-		}
-		token, err := requestScopedSession(addr, s.Token, v, role, ttl)
-		if err != nil {
-			return err
-		}
-		vault, scopedToken = v, token
-		return nil
-	})
+	vault, scopedToken, err := mintScopedSession(cmd, sess, addr, role, ttl)
 	if err != nil {
 		return err
 	}
@@ -328,10 +312,18 @@ func fetchUserVaults(addr, token string) ([]string, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == http.StatusUnauthorized {
-			return nil, &sessionExpiredError{msg: "listing vaults: session expired"}
+		var errResp struct {
+			Error string `json:"error"`
 		}
-		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+		_ = json.NewDecoder(resp.Body).Decode(&errResp)
+		msg := errResp.Error
+		if msg == "" {
+			msg = fmt.Sprintf("status %d", resp.StatusCode)
+		}
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, &sessionExpiredError{msg: "listing vaults: " + msg}
+		}
+		return nil, fmt.Errorf("listing vaults: %s", msg)
 	}
 
 	var result struct {
@@ -440,6 +432,32 @@ func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]stri
 		MITMTLS: mitmTLS,
 	})...)
 	return env, port, true, nil
+}
+
+// mintScopedSession resolves the target vault and mints a vault-scoped
+// session token, with inline re-auth on a 401 from the admin session.
+// The interactive vault picker (huh.NewSelect for multi-vault users with
+// no override) runs at most once across retries — re-prompting after
+// re-auth would be a UX regression, and the user's earlier choice is
+// still valid because vault membership is rechecked server-side when
+// requestScopedSession fires.
+func mintScopedSession(cmd *cobra.Command, sess *session.ClientSession, addr, role string, ttl int) (vault, scopedToken string, err error) {
+	err = withReauthRetry(sess, func(s *session.ClientSession) error {
+		if vault == "" {
+			v, verr := resolveVaultForRun(cmd, addr, s.Token)
+			if verr != nil {
+				return verr
+			}
+			vault = v
+		}
+		token, terr := requestScopedSession(addr, s.Token, vault, role, ttl)
+		if terr != nil {
+			return terr
+		}
+		scopedToken = token
+		return nil
+	})
+	return
 }
 
 // requestScopedSession calls the server to create a vault-scoped session

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -442,7 +442,7 @@ func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]stri
 // still valid because vault membership is rechecked server-side when
 // requestScopedSession fires.
 func mintScopedSession(cmd *cobra.Command, sess *session.ClientSession, addr, role string, ttl int) (vault, scopedToken string, err error) {
-	err = withReauthRetry(sess, func(s *session.ClientSession) error {
+	err = withReauthRetry(sess, addr, func(s *session.ClientSession) error {
 		if vault == "" {
 			v, verr := resolveVaultForRun(cmd, addr, s.Token)
 			if verr != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -111,16 +112,27 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 		addr = sess.Address
 	}
 
-	// 2. Resolve the target vault: --vault flag > context > interactive select > "default".
-	vault, err := resolveVaultForRun(cmd, addr, sess.Token)
-	if err != nil {
-		return err
-	}
-
-	// 3. Request a vault-scoped session token from the server.
+	// 2-3. Resolve the vault and request a vault-scoped session token.
+	//      Wrapped together so an interactive user whose admin session
+	//      has expired sees one re-auth prompt and the whole sequence
+	//      retries cleanly with the new token (otherwise the silent
+	//      DefaultVault fallback in resolveVaultForRun would mask the
+	//      expiry and demote a multi-vault user to "default").
 	role, _ := cmd.Flags().GetString("role")
 	ttl, _ := cmd.Flags().GetInt("ttl")
-	scopedToken, err := requestScopedSession(addr, sess.Token, vault, role, ttl)
+	var vault, scopedToken string
+	err = withReauthRetry(sess, func(s *session.ClientSession) error {
+		v, err := resolveVaultForRun(cmd, addr, s.Token)
+		if err != nil {
+			return err
+		}
+		token, err := requestScopedSession(addr, s.Token, v, role, ttl)
+		if err != nil {
+			return err
+		}
+		vault, scopedToken = v, token
+		return nil
+	})
 	if err != nil {
 		return err
 	}
@@ -266,7 +278,15 @@ func resolveVaultForRun(cmd *cobra.Command, addr, token string) (string, error) 
 	// Fetch vaults from the server to decide.
 	vaults, err := fetchUserVaults(addr, token)
 	if err != nil {
-		// If we can't list vaults, fall back to "default".
+		// Bubble session-expiry so the outer retry can re-auth and
+		// resolve the user's actual vault membership; otherwise a
+		// multi-vault user would be silently demoted to "default".
+		if errors.Is(err, errSessionExpired) {
+			return "", err
+		}
+		// For any other failure (offline, server down) keep the
+		// historical silent fallback to "default" so single-vault
+		// users on flaky networks still get something working.
 		return store.DefaultVault, nil
 	}
 
@@ -308,6 +328,9 @@ func fetchUserVaults(addr, token string) ([]string, error) {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, &sessionExpiredError{msg: "listing vaults: session expired"}
+		}
 		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
 	}
 
@@ -452,10 +475,14 @@ func requestScopedSession(addr, adminToken, vault, role string, ttlSeconds int) 
 			Error string `json:"error"`
 		}
 		_ = json.NewDecoder(resp.Body).Decode(&errResp)
-		if errResp.Error != "" {
-			return "", fmt.Errorf("failed to create scoped session: %s", errResp.Error)
+		msg := errResp.Error
+		if msg == "" {
+			msg = fmt.Sprintf("status %d", resp.StatusCode)
 		}
-		return "", fmt.Errorf("failed to create scoped session (status %d)", resp.StatusCode)
+		if resp.StatusCode == http.StatusUnauthorized {
+			return "", &sessionExpiredError{msg: "failed to create scoped session: " + msg}
+		}
+		return "", fmt.Errorf("failed to create scoped session: %s", msg)
 	}
 
 	var result struct {

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -31,14 +31,9 @@ Example:
 			addr = sess.Address
 		}
 
-		vault, err := resolveVaultForRun(cmd, addr, sess.Token)
-		if err != nil {
-			return err
-		}
-
 		role, _ := cmd.Flags().GetString("role")
 		ttl, _ := cmd.Flags().GetInt("ttl")
-		token, err := requestScopedSession(addr, sess.Token, vault, role, ttl)
+		_, token, err := mintScopedSession(cmd, sess, addr, role, ttl)
 		if err != nil {
 			return err
 		}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -11,6 +11,10 @@ import (
 type ClientSession struct {
 	Token   string `json:"token"`
 	Address string `json:"address"`
+	// Email of the account that minted Token. Cached so re-auth on
+	// expiry can skip the email prompt; empty for sessions saved by
+	// older clients.
+	Email string `json:"email,omitempty"`
 }
 
 func sessionPath() (string, error) {


### PR DESCRIPTION
## Summary

- A user running `agent-vault run -- claude` whose stored broker session had expired hit a dead end: `Error: failed to create scoped session: Session expired`. They had to read the error, recall that `agent-vault auth login` was the fix, run it, then re-run the original command. `run` is the marquee entrypoint for spawning Claude/Cursor agents, so the friction here disproportionately damaged the agent-bootstrap UX.
- This change detects 401s on the admin-token path and, on an interactive TTY, prompts for a password inline, persists the fresh session, and retries the original request exactly once. Non-interactive callers (CI, scripts, agents reading from pipes) keep getting the raw error so they can detect and handle it themselves.
- Wired into the two surfaces that surface this dead-end today: the `run` command (vault resolution + scoped-session mint) and `fetchAndDecode` (every list/get admin command). Mutating commands calling `doAdminRequest` directly are out of scope for this change.

## How it works

- New `errSessionExpired` sentinel + typed `sessionExpiredError` so 401s match via `errors.Is(err, errSessionExpired)` while preserving the server's user-facing message (no `"Session expired: session expired"` stutter).
- 401-status detection (not string-matching) covers all three messages the auth middleware emits today: `"Session expired"`, `"Invalid or expired session"`, `"Authorization required"`.
- `withReauthRetry(sess, op)` runs `op`, and on `errSessionExpired` in an interactive TTY it calls `reauthInteractive`, mutates `*sess` in place so the caller's pointer picks up the new token, and re-runs `op` exactly once.
- `Email` cached in `~/.agent-vault/session.json` (new `Email` field on `ClientSession`, JSON-omitempty so older session files keep working) — re-auth becomes a single password prompt.
- `resolveVaultForRun` now propagates `errSessionExpired` instead of silently demoting a multi-vault user to `default` when listing vaults 401s.

## Test plan

- [x] `make test` — all suites green, including 11 new unit tests in `cmd/reauth_test.go` (status mapping for 401 vs non-401, no stutter, prefix preservation, non-interactive bypass, retry-once invariant, in-place session mutation, reauth-failure wrapping)
- [x] `make build` — binary builds, frontend bundles
- [x] `go vet ./...` clean
- [ ] Manual TTY: log in with short TTL, wait, run `agent-vault run -- echo hi` → see password prompt → continue
- [ ] Manual non-TTY: `agent-vault run -- echo hi < /dev/null` with expired session → see raw error, exit non-zero
- [ ] Manual fresh-install: delete `~/.agent-vault/session.json`, run `agent-vault run -- echo hi` → existing first-run flow (hosting select / register / login) intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)