### PR TITLE
feat(server,cli): long-lived sessions with idle expiry and revocation

### DIFF
--- a/cmd/auth_sessions.go
+++ b/cmd/auth_sessions.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Infisical/agent-vault/internal/session"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+)
+
+var authSessionsCmd = &cobra.Command{
+	Use:   "sessions",
+	Short: "Manage your active CLI/web logins (parity with `gh auth status`)",
+}
+
+var authSessionsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List active sessions for the logged-in user",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := fetchAndDecode[authSessionsListResponse]("GET", "/v1/auth/sessions")
+		if err != nil {
+			return err
+		}
+		if len(out.Sessions) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No active sessions.")
+			return nil
+		}
+		t := newTable(cmd.OutOrStdout())
+		t.AppendHeader(table.Row{"ID", "DEVICE", "LAST IP", "LAST USED", "EXPIRES", "CURRENT"})
+		for _, s := range out.Sessions {
+			marker := ""
+			if s.Current {
+				marker = "✓"
+			}
+			t.AppendRow(table.Row{s.ID, s.DeviceLabel, s.LastIP, shortTime(s.LastUsedAt), shortTime(s.ExpiresAt), marker})
+		}
+		t.Render()
+		return nil
+	},
+}
+
+type authSessionsListResponse struct {
+	Sessions []struct {
+		ID          string `json:"id"`
+		DeviceLabel string `json:"device_label,omitempty"`
+		LastIP      string `json:"last_ip,omitempty"`
+		CreatedAt   string `json:"created_at"`
+		LastUsedAt  string `json:"last_used_at,omitempty"`
+		ExpiresAt   string `json:"expires_at,omitempty"`
+		Current     bool   `json:"current"`
+	} `json:"sessions"`
+}
+
+var authSessionsRevokeCmd = &cobra.Command{
+	Use:   "revoke <id>",
+	Short: "Revoke a session by id (from `auth sessions list`)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		sess, err := ensureSession()
+		if err != nil {
+			return err
+		}
+		err = withReauthRetry(sess, sess.Address, func(s *session.ClientSession) error {
+			return doAdminRequest("DELETE", s.Address+"/v1/auth/sessions/"+id, s.Token, nil)
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stderr, successText("✓")+" Session revoked.")
+		return nil
+	},
+}
+
+// shortTime renders an RFC3339 timestamp as "2006-01-02 15:04" for table
+// readability, matching cmd/user_invite.go and cmd/vaults.go. Falls back
+// to the raw string if it doesn't parse.
+func shortTime(rfc3339 string) string {
+	if rfc3339 == "" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339, rfc3339)
+	if err != nil {
+		return rfc3339
+	}
+	return t.Local().Format("2006-01-02 15:04")
+}
+
+func init() {
+	authSessionsCmd.AddCommand(authSessionsListCmd)
+	authSessionsCmd.AddCommand(authSessionsRevokeCmd)
+	authCmd.AddCommand(authSessionsCmd)
+}

--- a/cmd/auth_sessions.go
+++ b/cmd/auth_sessions.go
@@ -10,11 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type revokeSessionResponse struct {
-	Status  string `json:"status"`
-	Current bool   `json:"current"`
-}
-
 var authSessionsCmd = &cobra.Command{
 	Use:   "sessions",
 	Short: "Manage your active CLI/web logins (parity with `gh auth status`)",
@@ -64,7 +59,10 @@ var authSessionsRevokeCmd = &cobra.Command{
 	Short: "Revoke a session by id (from `auth sessions list`)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		resp, err := fetchAndDecode[revokeSessionResponse]("DELETE", "/v1/auth/sessions/"+args[0])
+		resp, err := fetchAndDecode[struct {
+			Status  string `json:"status"`
+			Current bool   `json:"current"`
+		}]("DELETE", "/v1/auth/sessions/"+args[0])
 		if err != nil {
 			return err
 		}

--- a/cmd/auth_sessions.go
+++ b/cmd/auth_sessions.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -64,11 +65,28 @@ var authSessionsRevokeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		var resp struct {
+			Status  string `json:"status"`
+			Current bool   `json:"current"`
+		}
 		err = withReauthRetry(sess, sess.Address, func(s *session.ClientSession) error {
-			return doAdminRequest("DELETE", s.Address+"/v1/auth/sessions/"+id, s.Token, nil)
+			body, ierr := doAdminRequestWithBody("DELETE", s.Address+"/v1/auth/sessions/"+id, s.Token, nil)
+			if ierr != nil {
+				return ierr
+			}
+			return json.Unmarshal(body, &resp)
 		})
 		if err != nil {
 			return err
+		}
+		// Self-revoke: drop the on-disk token immediately so the next
+		// CLI call doesn't 401 against a session we just killed.
+		if resp.Current {
+			if err := session.Clear(); err != nil {
+				return fmt.Errorf("session revoked but local clear failed: %w", err)
+			}
+			fmt.Fprintln(os.Stderr, successText("✓")+" Session revoked. Run `agent-vault auth login` to log in again.")
+			return nil
 		}
 		fmt.Fprintln(os.Stderr, successText("✓")+" Session revoked.")
 		return nil

--- a/cmd/auth_sessions.go
+++ b/cmd/auth_sessions.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -10,6 +9,11 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 )
+
+type revokeSessionResponse struct {
+	Status  string `json:"status"`
+	Current bool   `json:"current"`
+}
 
 var authSessionsCmd = &cobra.Command{
 	Use:   "sessions",
@@ -60,22 +64,7 @@ var authSessionsRevokeCmd = &cobra.Command{
 	Short: "Revoke a session by id (from `auth sessions list`)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id := args[0]
-		sess, err := ensureSession()
-		if err != nil {
-			return err
-		}
-		var resp struct {
-			Status  string `json:"status"`
-			Current bool   `json:"current"`
-		}
-		err = withReauthRetry(sess, sess.Address, func(s *session.ClientSession) error {
-			body, ierr := doAdminRequestWithBody("DELETE", s.Address+"/v1/auth/sessions/"+id, s.Token, nil)
-			if ierr != nil {
-				return ierr
-			}
-			return json.Unmarshal(body, &resp)
-		})
+		resp, err := fetchAndDecode[revokeSessionResponse]("DELETE", "/v1/auth/sessions/"+args[0])
 		if err != nil {
 			return err
 		}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -129,20 +129,28 @@ func checkServerStatus(address string) (*serverStatus, error) {
 	return &status, nil
 }
 
-// registerResult holds the parsed register API response.
+// registerResult holds the parsed register API response. Token and
+// ExpiresAt are populated only when the server auto-logs the caller in
+// (currently: the first-user register path). Other paths return them as
+// "" and the caller is expected to drive the verification flow.
 type registerResult struct {
 	Email                string `json:"email"`
 	Role                 string `json:"role"`
 	RequiresVerification bool   `json:"requires_verification"`
 	EmailSent            bool   `json:"email_sent"`
 	Message              string `json:"message"`
+	Token                string `json:"token,omitempty"`
+	ExpiresAt            string `json:"expires_at,omitempty"`
 }
 
-// doRegister posts credentials to /v1/auth/register and returns the result.
-func doRegister(address, email, password string) (*registerResult, error) {
+// doRegister posts credentials to /v1/auth/register. When the response
+// includes a token (first-user auto-login), the session is persisted to
+// disk so the caller can use it directly without a follow-up doLogin.
+func doRegister(address, email, password, deviceLabel string) (*registerResult, error) {
 	body, err := json.Marshal(map[string]string{
-		"email":    email,
-		"password": password,
+		"email":        email,
+		"password":     password,
+		"device_label": deviceLabel,
 	})
 	if err != nil {
 		return nil, err
@@ -165,6 +173,17 @@ func doRegister(address, email, password string) (*registerResult, error) {
 			return nil, fmt.Errorf("%s", result.Error)
 		}
 		return nil, fmt.Errorf("registration failed with status %d", resp.StatusCode)
+	}
+
+	if result.Token != "" {
+		sess := &session.ClientSession{
+			Token:   result.Token,
+			Address: address,
+			Email:   email,
+		}
+		if err := session.Save(sess); err != nil {
+			return nil, fmt.Errorf("saving session: %w", err)
+		}
 	}
 
 	return &result.registerResult, nil
@@ -215,9 +234,10 @@ func doLogin(address, email, password, deviceLabel string) (*session.ClientSessi
 	}
 
 	sess := &session.ClientSession{
-		Token:   result.Token,
-		Address: address,
-		Email:   email,
+		Token:       result.Token,
+		Address:     address,
+		Email:       email,
+		DeviceLabel: deviceLabel,
 	}
 	if err := session.Save(sess); err != nil {
 		return nil, fmt.Errorf("saving session: %w", err)
@@ -248,7 +268,14 @@ func reauthInteractive(sess *session.ClientSession) (*session.ClientSession, err
 		return nil, err
 	}
 
-	newSess, err := doLogin(sess.Address, email, password, defaultDeviceLabel())
+	// Preserve the operator's original --device-label choice across
+	// silent re-auth; fall back to hostname only when the saved session
+	// pre-dates the DeviceLabel field.
+	label := sess.DeviceLabel
+	if label == "" {
+		label = defaultDeviceLabel()
+	}
+	newSess, err := doLogin(sess.Address, email, password, label)
 	if err != nil {
 		return nil, err
 	}
@@ -346,16 +373,17 @@ func ensureSession() (*session.ClientSession, error) {
 			return nil, err
 		}
 
-		if _, err := doRegister(address, email, password); err != nil {
+		// First-user register auto-logs in server-side and returns the
+		// token in the JSON body, so doRegister persists the session
+		// directly. We just reload it instead of running a second login.
+		if _, err := doRegister(address, email, password, defaultDeviceLabel()); err != nil {
 			return nil, fmt.Errorf("registration failed: %w", err)
 		}
-		fmt.Fprintln(os.Stderr, successText("✓")+" Owner account created. Logging in...")
-
-		sess, err := doLogin(address, email, password, defaultDeviceLabel())
-		if err != nil {
-			return nil, fmt.Errorf("auto-login failed: %w", err)
+		sess, err := session.Load()
+		if err != nil || sess == nil {
+			return nil, fmt.Errorf("auto-login after register failed: session not saved")
 		}
-		fmt.Fprintln(os.Stderr, successText("✓")+" Login successful.\n")
+		fmt.Fprintln(os.Stderr, successText("✓")+" Owner account created. Login successful.\n")
 		return sess, nil
 	}
 
@@ -385,7 +413,7 @@ func ensureSession() (*session.ClientSession, error) {
 			return nil, err
 		}
 
-		result, err := doRegister(address, email, password)
+		result, err := doRegister(address, email, password, defaultDeviceLabel())
 		if err != nil {
 			return nil, fmt.Errorf("registration failed: %w", err)
 		}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -170,9 +170,17 @@ func doRegister(address, email, password string) (*registerResult, error) {
 	return &result.registerResult, nil
 }
 
-// doLogin posts credentials to /v1/auth/login, saves the session on success, and returns it.
-func doLogin(address, email, password string) (*session.ClientSession, error) {
-	body, err := json.Marshal(map[string]string{"email": email, "password": password})
+// doLogin posts credentials to /v1/auth/login, saves the session on
+// success, and returns it. deviceLabel is sent as `device_label` so the
+// server records this login in the user's active-sessions list. Callers
+// resolve the label themselves (the cobra command honors --device-label;
+// internal callers default to defaultDeviceLabel()).
+func doLogin(address, email, password, deviceLabel string) (*session.ClientSession, error) {
+	body, err := json.Marshal(map[string]string{
+		"email":        email,
+		"password":     password,
+		"device_label": deviceLabel,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +248,7 @@ func reauthInteractive(sess *session.ClientSession) (*session.ClientSession, err
 		return nil, err
 	}
 
-	newSess, err := doLogin(sess.Address, email, password)
+	newSess, err := doLogin(sess.Address, email, password, defaultDeviceLabel())
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +351,7 @@ func ensureSession() (*session.ClientSession, error) {
 		}
 		fmt.Fprintln(os.Stderr, successText("✓")+" Owner account created. Logging in...")
 
-		sess, err := doLogin(address, email, password)
+		sess, err := doLogin(address, email, password, defaultDeviceLabel())
 		if err != nil {
 			return nil, fmt.Errorf("auto-login failed: %w", err)
 		}
@@ -392,7 +400,7 @@ func ensureSession() (*session.ClientSession, error) {
 		}
 
 		fmt.Fprintln(os.Stderr, successText("✓")+" "+result.Message)
-		sess, err := doLogin(address, email, password)
+		sess, err := doLogin(address, email, password, defaultDeviceLabel())
 		if err != nil {
 			return nil, fmt.Errorf("auto-login failed: %w", err)
 		}
@@ -410,7 +418,7 @@ func ensureSession() (*session.ClientSession, error) {
 		return nil, err
 	}
 
-	sess, err = doLogin(address, email, password)
+	sess, err = doLogin(address, email, password, defaultDeviceLabel())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -144,21 +144,23 @@ type registerResult struct {
 }
 
 // doRegister posts credentials to /v1/auth/register. When the response
-// includes a token (first-user auto-login), the session is persisted to
-// disk so the caller can use it directly without a follow-up doLogin.
-func doRegister(address, email, password, deviceLabel string) (*registerResult, error) {
+// includes a token (first-user auto-login), the session is also saved
+// to disk and returned so the caller can use it directly without a
+// follow-up /v1/auth/login. Returns (result, sess, err); sess is nil
+// when verification is required.
+func doRegister(address, email, password, deviceLabel string) (*registerResult, *session.ClientSession, error) {
 	body, err := json.Marshal(map[string]string{
 		"email":        email,
 		"password":     password,
 		"device_label": deviceLabel,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	resp, err := http.Post(address+"/v1/auth/register", "application/json", bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("could not reach server at %s: %w", address, err)
+		return nil, nil, fmt.Errorf("could not reach server at %s: %w", address, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -170,23 +172,25 @@ func doRegister(address, email, password, deviceLabel string) (*registerResult, 
 
 	if resp.StatusCode >= 400 {
 		if result.Error != "" {
-			return nil, fmt.Errorf("%s", result.Error)
+			return nil, nil, fmt.Errorf("%s", result.Error)
 		}
-		return nil, fmt.Errorf("registration failed with status %d", resp.StatusCode)
+		return nil, nil, fmt.Errorf("registration failed with status %d", resp.StatusCode)
 	}
 
-	if result.Token != "" {
-		sess := &session.ClientSession{
-			Token:   result.Token,
-			Address: address,
-			Email:   email,
-		}
-		if err := session.Save(sess); err != nil {
-			return nil, fmt.Errorf("saving session: %w", err)
-		}
+	if result.Token == "" {
+		return &result.registerResult, nil, nil
 	}
 
-	return &result.registerResult, nil
+	sess := &session.ClientSession{
+		Token:       result.Token,
+		Address:     address,
+		Email:       email,
+		DeviceLabel: deviceLabel,
+	}
+	if err := session.Save(sess); err != nil {
+		return nil, nil, fmt.Errorf("saving session: %w", err)
+	}
+	return &result.registerResult, sess, nil
 }
 
 // doLogin posts credentials to /v1/auth/login, saves the session on
@@ -373,15 +377,12 @@ func ensureSession() (*session.ClientSession, error) {
 			return nil, err
 		}
 
-		// First-user register auto-logs in server-side and returns the
-		// token in the JSON body, so doRegister persists the session
-		// directly. We just reload it instead of running a second login.
-		if _, err := doRegister(address, email, password, defaultDeviceLabel()); err != nil {
+		_, sess, err := doRegister(address, email, password, defaultDeviceLabel())
+		if err != nil {
 			return nil, fmt.Errorf("registration failed: %w", err)
 		}
-		sess, err := session.Load()
-		if err != nil || sess == nil {
-			return nil, fmt.Errorf("auto-login after register failed: session not saved")
+		if sess == nil {
+			return nil, fmt.Errorf("auto-login after register failed: server did not return a session")
 		}
 		fmt.Fprintln(os.Stderr, successText("✓")+" Owner account created. Login successful.\n")
 		return sess, nil
@@ -413,7 +414,7 @@ func ensureSession() (*session.ClientSession, error) {
 			return nil, err
 		}
 
-		result, err := doRegister(address, email, password, defaultDeviceLabel())
+		result, _, err := doRegister(address, email, password, defaultDeviceLabel())
 		if err != nil {
 			return nil, fmt.Errorf("registration failed: %w", err)
 		}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -10,6 +10,17 @@ import (
 	"golang.org/x/term"
 )
 
+// defaultDeviceLabel returns os.Hostname() so a login from a typical
+// workstation is recognizable in `auth sessions list`. Falls back to "cli"
+// if the OS refuses to give us a hostname.
+func defaultDeviceLabel() string {
+	h, err := os.Hostname()
+	if err != nil || strings.TrimSpace(h) == "" {
+		return "cli"
+	}
+	return h
+}
+
 // readLoginEmail reads the email either from --email flag or by prompting interactively.
 func readLoginEmail(cmd *cobra.Command) (string, error) {
 	email, _ := cmd.Flags().GetString("email")
@@ -91,7 +102,12 @@ var loginCmd = &cobra.Command{
 			return err
 		}
 
-		if _, err := doLogin(address, email, password); err != nil {
+		deviceLabel, _ := cmd.Flags().GetString("device-label")
+		if deviceLabel == "" {
+			deviceLabel = defaultDeviceLabel()
+		}
+
+		if _, err := doLogin(address, email, password, deviceLabel); err != nil {
 			return err
 		}
 
@@ -104,4 +120,5 @@ func init() {
 	loginCmd.Flags().String("address", DefaultAddress, "server address")
 	loginCmd.Flags().String("email", "", "account email address")
 	loginCmd.Flags().Bool("password-stdin", false, "read password from stdin (for non-interactive use)")
+	loginCmd.Flags().String("device-label", "", "label shown in 'auth sessions list' (defaults to hostname)")
 }

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Infisical/agent-vault/internal/auth"
+	"github.com/Infisical/agent-vault/internal/session"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -108,9 +109,11 @@ var registerCmd = &cobra.Command{
 		}
 		code := strings.TrimSpace(codeLine)
 
+		deviceLabel := defaultDeviceLabel()
 		verifyBody, _ := json.Marshal(map[string]string{
-			"email": email,
-			"code":  code,
+			"email":        email,
+			"code":         code,
+			"device_label": deviceLabel,
 		})
 
 		verifyResp, err := http.Post(address+"/v1/auth/verify", "application/json", bytes.NewReader(verifyBody))
@@ -120,8 +123,10 @@ var registerCmd = &cobra.Command{
 		defer func() { _ = verifyResp.Body.Close() }()
 
 		var verifyResult struct {
-			Message string `json:"message"`
-			Error   string `json:"error"`
+			Message   string `json:"message"`
+			Token     string `json:"token"`
+			ExpiresAt string `json:"expires_at"`
+			Error     string `json:"error"`
 		}
 		_ = json.NewDecoder(verifyResp.Body).Decode(&verifyResult)
 
@@ -130,6 +135,23 @@ var registerCmd = &cobra.Command{
 				return fmt.Errorf("verification failed: %s", verifyResult.Error)
 			}
 			return fmt.Errorf("verification failed with status %d", verifyResp.StatusCode)
+		}
+
+		// Persist the verify-time auto-login so the next CLI call doesn't
+		// have to run /v1/auth/login (which would mint a second session
+		// row that lingers for the full 30-day idle TTL).
+		if verifyResult.Token != "" {
+			sess := &session.ClientSession{
+				Token:       verifyResult.Token,
+				Address:     address,
+				Email:       email,
+				DeviceLabel: deviceLabel,
+			}
+			if err := session.Save(sess); err != nil {
+				return fmt.Errorf("verification succeeded but saving session failed: %w", err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s Account verified. You're logged in.\n", successText("✓"))
+			return nil
 		}
 
 		fmt.Fprintf(cmd.OutOrStdout(), "%s Account verified. You can now log in with 'agent-vault auth login'.\n", successText("✓"))

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -76,7 +76,7 @@ var registerCmd = &cobra.Command{
 			return fmt.Errorf("password must be at least 8 characters")
 		}
 
-		result, err := doRegister(address, email, password)
+		result, err := doRegister(address, email, password, defaultDeviceLabel())
 		if err != nil {
 			return err
 		}

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -76,7 +76,7 @@ var registerCmd = &cobra.Command{
 			return fmt.Errorf("password must be at least 8 characters")
 		}
 
-		result, err := doRegister(address, email, password, defaultDeviceLabel())
+		result, _, err := doRegister(address, email, password, defaultDeviceLabel())
 		if err != nil {
 			return err
 		}

--- a/docs/learn/security.mdx
+++ b/docs/learn/security.mdx
@@ -58,13 +58,16 @@ KDF parameters are stored per user, so Agent Vault can upgrade hashing parameter
 
 Changing a password (`agent-vault account change-password` or `POST /v1/auth/change-password`) invalidates all existing sessions and issues a fresh token.
 
+User sessions are **long-lived but idle-expired**. A login is good for up to a year of activity; if a session goes 30 days without making a request, it is automatically rejected as expired. Active operators effectively never have to log in again, while a stolen `~/.agent-vault/session.json` that goes unused loses access in 30 days. Operators can view and revoke individual sessions with `agent-vault auth sessions list / revoke`, or invalidate every session at once via `account change-password`.
+
 ## Token model
 
 All tokens are generated from `crypto/rand` (256 bits of entropy) and hashed before storage. The raw token is returned to the caller exactly once; Agent Vault only stores the hash.
 
 | Token | Prefix | Storage hash | TTL | Notes |
 | ----- | ------ | ------------ | --- | ----- |
-| Session | `av_sess_` | SHA-256 | Configurable (or no expiry) | Vault-scoped or user-global |
+| User session | `av_sess_` | SHA-256 | 1 year absolute, 30-day idle | Bumped on each authenticated request |
+| Scoped session | `av_sess_` | SHA-256 | Configurable (5 min – 7 days, default 24h) | Vault-bound, minted by `vault run` |
 | Agent token | `av_agt_` | SHA-256 | Configurable (or no expiry) | Instance-level agent identity |
 | Invite | `av_inv_` | SHA-256 | 15 minutes | Single-use, burned on redemption |
 | Approval | `av_appr_` | SHA-256 | 24 hours | Grants read-only access to a [proposal](/learn/proposals) |

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -117,11 +117,30 @@ description: "Complete reference for all Agent Vault CLI commands."
 
     Authenticate with email and password. Prompts interactively by default. Rejects inactive (unverified) accounts.
 
+    Sessions are long-lived: 1 year absolute, 30 days idle. Active operators effectively never have to log in again. A session that goes 30 days without making a request is automatically expired.
+
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--address` | | Server URL |
     | `--email` | | Email address |
     | `--password-stdin` | `false` | Read password from stdin |
+    | `--device-label` | hostname | Label shown in `auth sessions list` |
+  </Accordion>
+
+  <Accordion title="agent-vault auth sessions list">
+    ```bash
+    agent-vault auth sessions list
+    ```
+
+    List active sessions for your account, with the device label, last IP, last activity, and expiry. The session being used for this request is marked with a checkmark in the `Current` column.
+  </Accordion>
+
+  <Accordion title="agent-vault auth sessions revoke">
+    ```bash
+    agent-vault auth sessions revoke <id>
+    ```
+
+    Revoke a specific session by id (from `auth sessions list`). Use this to invalidate a stolen `~/.agent-vault/session.json` or to log out a forgotten device. Revoking your current session forces you to log in again on this device.
   </Accordion>
 </AccordionGroup>
 

--- a/internal/brokercore/session.go
+++ b/internal/brokercore/session.go
@@ -81,7 +81,7 @@ func (r *StoreSessionResolver) ResolveForProxy(ctx context.Context, token, vault
 	if now == nil {
 		now = time.Now
 	}
-	if sess.ExpiresAt != nil && now().After(*sess.ExpiresAt) {
+	if sess.IsExpired(now()) {
 		return nil, ErrInvalidSession
 	}
 

--- a/internal/server/handle_agents.go
+++ b/internal/server/handle_agents.go
@@ -1024,12 +1024,14 @@ func (s *Server) handleAgentInviteCreate(w http.ResponseWriter, r *http.Request)
 
 	// Cap finite session TTL.
 	if req.SessionTTLSeconds != nil && *req.SessionTTLSeconds > 0 {
+		minSecs := int(scopedSessionMinTTL.Seconds())
+		maxSecs := int(scopedSessionMaxTTL.Seconds())
 		ttl := *req.SessionTTLSeconds
-		if ttl < scopedSessionMinTTL {
-			ttl = scopedSessionMinTTL
+		if ttl < minSecs {
+			ttl = minSecs
 			req.SessionTTLSeconds = &ttl
-		} else if ttl > scopedSessionMaxTTL {
-			ttl = scopedSessionMaxTTL
+		} else if ttl > maxSecs {
+			ttl = maxSecs
 			req.SessionTTLSeconds = &ttl
 		}
 	}

--- a/internal/server/handle_auth.go
+++ b/internal/server/handle_auth.go
@@ -158,12 +158,12 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		s.initialized = true
 
 		// Auto-login: create session and set cookie.
-		session, err := s.store.CreateSession(ctx, user.ID, time.Now().Add(sessionTTL))
+		session, err := s.store.CreateUserSession(ctx, newUserSessionParams(r, user.ID))
 		if err != nil {
 			jsonError(w, http.StatusInternalServerError, "Failed to create session")
 			return
 		}
-		http.SetCookie(w, sessionCookie(r, s.baseURL, session.ID, int(sessionTTL.Seconds())))
+		http.SetCookie(w, sessionCookie(r, s.baseURL, session.ID, int(userSessionAbsoluteTTL.Seconds())))
 
 		jsonCreated(w, map[string]interface{}{
 			"email":                 user.Email,
@@ -271,12 +271,12 @@ func (s *Server) handleVerify(w http.ResponseWriter, r *http.Request) {
 	s.rateLimit.FailureReset(ratelimit.TierVerifyFailure, verifyKey)
 
 	// Auto-login: create session and set cookie.
-	session, err := s.store.CreateSession(ctx, user.ID, time.Now().Add(sessionTTL))
+	session, err := s.store.CreateUserSession(ctx, newUserSessionParams(r, user.ID))
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create session")
 		return
 	}
-	http.SetCookie(w, sessionCookie(r, s.baseURL, session.ID, int(sessionTTL.Seconds())))
+	http.SetCookie(w, sessionCookie(r, s.baseURL, session.ID, int(userSessionAbsoluteTTL.Seconds())))
 
 	jsonOK(w, map[string]interface{}{
 		"email":         user.Email,
@@ -464,7 +464,7 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 	s.rateLimit.FailureReset(ratelimit.TierVerifyFailure, resetKey)
 
 	// Create new session and auto-login.
-	session, err := s.store.CreateSession(ctx, user.ID, time.Now().Add(sessionTTL))
+	session, err := s.store.CreateUserSession(ctx, newUserSessionParams(r, user.ID))
 	if err != nil {
 		// Password was reset but session creation failed — user can re-login.
 		jsonOK(w, map[string]interface{}{
@@ -474,7 +474,7 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.SetCookie(w, sessionCookie(r, s.baseURL, session.ID, int(sessionTTL.Seconds())))
+	http.SetCookie(w, sessionCookie(r, s.baseURL, session.ID, int(userSessionAbsoluteTTL.Seconds())))
 
 	jsonOK(w, map[string]interface{}{
 		"message":       "Password reset successfully.",
@@ -581,6 +581,22 @@ func init() {
 	dummyPasswordHash, dummyPasswordSalt, dummyKDFParams, _ = auth.HashUserPassword([]byte("sb-dummy-timing-equalization"))
 }
 
+// newUserSessionParams builds a CreateUserSessionParams populated with the
+// caller's IP and User-Agent. Centralized so every login path (password,
+// OAuth, verification, password reset) records the same shape and applies
+// the same TTLs. DeviceLabel is left empty here because only the password
+// login path receives one in the request body — other paths set it
+// post-construction if needed.
+func newUserSessionParams(r *http.Request, userID string) store.CreateUserSessionParams {
+	return store.CreateUserSessionParams{
+		UserID:        userID,
+		ExpiresAt:     time.Now().Add(userSessionAbsoluteTTL),
+		IdleTTL:       userSessionIdleTTL,
+		LastIP:        clientIP(r),
+		LastUserAgent: r.UserAgent(),
+	}
+}
+
 func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	var req loginRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Email == "" || req.Password == "" {
@@ -630,13 +646,15 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	session, err := s.store.CreateSession(ctx, user.ID, time.Now().Add(sessionTTL))
+	params := newUserSessionParams(r, user.ID)
+	params.DeviceLabel = truncateDeviceLabel(req.DeviceLabel)
+	session, err := s.store.CreateUserSession(ctx, params)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create session")
 		return
 	}
 
-	http.SetCookie(w, sessionCookie(r, s.baseURL, session.ID, int(sessionTTL.Seconds())))
+	http.SetCookie(w, sessionCookie(r, s.baseURL, session.ID, int(userSessionAbsoluteTTL.Seconds())))
 
 	jsonOK(w, loginResponse{
 		Token:     session.ID,
@@ -702,14 +720,14 @@ func (s *Server) handleChangePassword(w http.ResponseWriter, r *http.Request) {
 	// Invalidate all existing sessions, then create a fresh one for this request.
 	_ = s.store.DeleteUserSessions(ctx, user.ID)
 
-	newSess, err := s.store.CreateSession(ctx, user.ID, time.Now().Add(sessionTTL))
+	newSess, err := s.store.CreateUserSession(ctx, newUserSessionParams(r, user.ID))
 	if err != nil {
 		// Password was changed but session creation failed — user can re-login.
 		jsonError(w, http.StatusInternalServerError, "Password changed but failed to create new session")
 		return
 	}
 
-	http.SetCookie(w, sessionCookie(r, s.baseURL, newSess.ID, int(sessionTTL.Seconds())))
+	http.SetCookie(w, sessionCookie(r, s.baseURL, newSess.ID, int(userSessionAbsoluteTTL.Seconds())))
 
 	jsonOK(w, loginResponse{
 		Token:     newSess.ID,

--- a/internal/server/handle_auth.go
+++ b/internal/server/handle_auth.go
@@ -225,8 +225,9 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleVerify(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Email string `json:"email"`
-		Code  string `json:"code"`
+		Email       string `json:"email"`
+		Code        string `json:"code"`
+		DeviceLabel string `json:"device_label,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, http.StatusBadRequest, "Invalid request body")
@@ -277,19 +278,37 @@ func (s *Server) handleVerify(w http.ResponseWriter, r *http.Request) {
 	// Reset rate limit on successful verification.
 	s.rateLimit.FailureReset(ratelimit.TierVerifyFailure, verifyKey)
 
-	// Auto-login: create session and set cookie.
-	session, err := s.store.CreateUserSession(ctx, newUserSessionParams(r, user.ID))
+	// Auto-login: token + expires_at are returned alongside the cookie
+	// so non-cookie clients (the CLI) can persist the session without a
+	// follow-up /v1/auth/login. Mirrors handleRegister's first-user path.
+	params := newUserSessionParams(r, user.ID)
+	params.DeviceLabel = truncateDeviceLabel(req.DeviceLabel)
+	session, err := s.store.CreateUserSession(ctx, params)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create session")
 		return
 	}
 	http.SetCookie(w, sessionCookie(r, s.baseURL, session.ID, int(userSessionAbsoluteTTL.Seconds())))
 
-	jsonOK(w, map[string]interface{}{
-		"email":         user.Email,
-		"authenticated": true,
-		"message":       "Account verified.",
+	jsonOK(w, verifyResponse{
+		Email:         user.Email,
+		Authenticated: true,
+		Message:       "Account verified.",
+		Token:         session.ID,
+		ExpiresAt:     formatExpiresAt(session.ExpiresAt),
 	})
+}
+
+// verifyResponse is the JSON shape returned by POST /v1/auth/verify on
+// success. Mirrors registerResponse so the CLI's verify path can persist
+// the auto-login session without a follow-up /v1/auth/login (which would
+// orphan the verify-time row for the full 30-day idle window).
+type verifyResponse struct {
+	Email         string `json:"email"`
+	Authenticated bool   `json:"authenticated"`
+	Message       string `json:"message"`
+	Token         string `json:"token,omitempty"`
+	ExpiresAt     string `json:"expires_at,omitempty"`
 }
 
 func (s *Server) handleResendVerification(w http.ResponseWriter, r *http.Request) {
@@ -405,6 +424,7 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 		Email       string `json:"email"`
 		Code        string `json:"code"`
 		NewPassword string `json:"new_password"`
+		DeviceLabel string `json:"device_label,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, http.StatusBadRequest, "Invalid request body")
@@ -471,7 +491,9 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 	s.rateLimit.FailureReset(ratelimit.TierVerifyFailure, resetKey)
 
 	// Create new session and auto-login.
-	session, err := s.store.CreateUserSession(ctx, newUserSessionParams(r, user.ID))
+	resetParams := newUserSessionParams(r, user.ID)
+	resetParams.DeviceLabel = truncateDeviceLabel(req.DeviceLabel)
+	session, err := s.store.CreateUserSession(ctx, resetParams)
 	if err != nil {
 		// Password was reset but session creation failed — user can re-login.
 		jsonOK(w, map[string]interface{}{
@@ -724,10 +746,20 @@ func (s *Server) handleChangePassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Carry the caller's device_label onto the post-change session so
+	// `auth sessions list` keeps showing the same DEVICE label across
+	// password changes. Captured before DeleteUserSessions wipes the row.
+	var carryDeviceLabel string
+	if caller := sessionFromContext(ctx); caller != nil {
+		carryDeviceLabel = caller.DeviceLabel
+	}
+
 	// Invalidate all existing sessions, then create a fresh one for this request.
 	_ = s.store.DeleteUserSessions(ctx, user.ID)
 
-	newSess, err := s.store.CreateUserSession(ctx, newUserSessionParams(r, user.ID))
+	params := newUserSessionParams(r, user.ID)
+	params.DeviceLabel = carryDeviceLabel
+	newSess, err := s.store.CreateUserSession(ctx, params)
 	if err != nil {
 		// Password was changed but session creation failed — user can re-login.
 		jsonError(w, http.StatusInternalServerError, "Password changed but failed to create new session")

--- a/internal/server/handle_auth.go
+++ b/internal/server/handle_auth.go
@@ -787,6 +787,7 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	}
 	if token != "" {
 		_ = s.store.DeleteSession(r.Context(), token)
+		s.touchCache.Delete(token)
 	}
 	http.SetCookie(w, sessionCookie(r, s.baseURL, "", -1))
 	jsonOK(w, map[string]string{"status": "ok"})

--- a/internal/server/handle_auth.go
+++ b/internal/server/handle_auth.go
@@ -64,8 +64,9 @@ func (s *Server) generateAndSendVerificationCode(ctx context.Context, email stri
 
 func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Email    string `json:"email"`
-		Password string `json:"password"`
+		Email       string `json:"email"`
+		Password    string `json:"password"`
+		DeviceLabel string `json:"device_label,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, http.StatusBadRequest, "Invalid request body")
@@ -157,8 +158,13 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		// First user: owner created successfully.
 		s.initialized = true
 
-		// Auto-login: create session and set cookie.
-		session, err := s.store.CreateUserSession(ctx, newUserSessionParams(r, user.ID))
+		// Auto-login: create session and set cookie. Token + expires_at
+		// are also returned in the JSON body so non-cookie clients (the
+		// CLI) can persist the session without a follow-up /v1/auth/login
+		// — mirroring the browser's cookie-based auto-login.
+		params := newUserSessionParams(r, user.ID)
+		params.DeviceLabel = truncateDeviceLabel(req.DeviceLabel)
+		session, err := s.store.CreateUserSession(ctx, params)
 		if err != nil {
 			jsonError(w, http.StatusInternalServerError, "Failed to create session")
 			return
@@ -171,6 +177,8 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 			"requires_verification": false,
 			"authenticated":         true,
 			"message":               "Owner account created.",
+			"token":                 session.ID,
+			"expires_at":            formatExpiresAt(session.ExpiresAt),
 		})
 		return
 	}

--- a/internal/server/handle_auth.go
+++ b/internal/server/handle_auth.go
@@ -158,10 +158,9 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		// First user: owner created successfully.
 		s.initialized = true
 
-		// Auto-login: create session and set cookie. Token + expires_at
-		// are also returned in the JSON body so non-cookie clients (the
-		// CLI) can persist the session without a follow-up /v1/auth/login
-		// — mirroring the browser's cookie-based auto-login.
+		// Auto-login: token + expires_at are returned alongside the
+		// cookie so non-cookie clients (the CLI) can persist the
+		// session without a follow-up /v1/auth/login.
 		params := newUserSessionParams(r, user.ID)
 		params.DeviceLabel = truncateDeviceLabel(req.DeviceLabel)
 		session, err := s.store.CreateUserSession(ctx, params)
@@ -171,14 +170,14 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		}
 		http.SetCookie(w, sessionCookie(r, s.baseURL, session.ID, int(userSessionAbsoluteTTL.Seconds())))
 
-		jsonCreated(w, map[string]interface{}{
-			"email":                 user.Email,
-			"role":                  "owner",
-			"requires_verification": false,
-			"authenticated":         true,
-			"message":               "Owner account created.",
-			"token":                 session.ID,
-			"expires_at":            formatExpiresAt(session.ExpiresAt),
+		jsonCreated(w, registerResponse{
+			Email:                user.Email,
+			Role:                 "owner",
+			RequiresVerification: false,
+			Authenticated:        true,
+			Message:              "Owner account created.",
+			Token:                session.ID,
+			ExpiresAt:            formatExpiresAt(session.ExpiresAt),
 		})
 		return
 	}

--- a/internal/server/handle_oauth.go
+++ b/internal/server/handle_oauth.go
@@ -342,7 +342,12 @@ func (s *Server) handleOAuthDisconnect(w http.ResponseWriter, r *http.Request) {
 
 // createOAuthSession creates a session for an OAuth user and redirects.
 func (s *Server) createOAuthSession(w http.ResponseWriter, r *http.Request, user *store.User, redirectURL string) {
-	session, err := s.store.CreateUserSession(r.Context(), newUserSessionParams(r, user.ID))
+	params := newUserSessionParams(r, user.ID)
+	// Browser sign-ins don't carry a device_label in the request, but
+	// the User-Agent is enough to distinguish "Chrome on macOS" from
+	// "Firefox on Linux" in `auth sessions list`.
+	params.DeviceLabel = truncateDeviceLabel(r.UserAgent())
+	session, err := s.store.CreateUserSession(r.Context(), params)
 	if err != nil {
 		s.oauthErrorRedirect(w, r, "session_failed")
 		return

--- a/internal/server/handle_oauth.go
+++ b/internal/server/handle_oauth.go
@@ -342,13 +342,13 @@ func (s *Server) handleOAuthDisconnect(w http.ResponseWriter, r *http.Request) {
 
 // createOAuthSession creates a session for an OAuth user and redirects.
 func (s *Server) createOAuthSession(w http.ResponseWriter, r *http.Request, user *store.User, redirectURL string) {
-	session, err := s.store.CreateSession(r.Context(), user.ID, time.Now().Add(sessionTTL))
+	session, err := s.store.CreateUserSession(r.Context(), newUserSessionParams(r, user.ID))
 	if err != nil {
 		s.oauthErrorRedirect(w, r, "session_failed")
 		return
 	}
 
-	http.SetCookie(w, sessionCookie(r, s.baseURL, session.ID, int(sessionTTL.Seconds())))
+	http.SetCookie(w, sessionCookie(r, s.baseURL, session.ID, int(userSessionAbsoluteTTL.Seconds())))
 
 	target := "/"
 	if redirectURL != "" && isValidOAuthRedirect(redirectURL) {

--- a/internal/server/handle_proposals.go
+++ b/internal/server/handle_proposals.go
@@ -73,7 +73,7 @@ func (s *Server) handleProposalApproveDetails(w http.ResponseWriter, r *http.Req
 	userEmail := ""
 	if c, err := r.Cookie("av_session"); err == nil && c.Value != "" {
 		sess, err := s.store.GetSession(ctx, c.Value)
-		if err == nil && sess != nil && !sessionExpired(sess) && sess.UserID != "" {
+		if err == nil && sess != nil && !sess.IsExpired(time.Now()) && sess.UserID != "" {
 			actor, err := s.actorFromSession(ctx, sess)
 			if err == nil && actor != nil && actor.User != nil {
 				authenticated = true

--- a/internal/server/handle_sessions.go
+++ b/internal/server/handle_sessions.go
@@ -38,9 +38,12 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 
 	// Validate TTL bounds if provided.
 	if req.TTLSeconds != nil {
-		ttl := *req.TTLSeconds
+		ttl := time.Duration(*req.TTLSeconds) * time.Second
 		if ttl < scopedSessionMinTTL || ttl > scopedSessionMaxTTL {
-			jsonError(w, http.StatusBadRequest, fmt.Sprintf("ttl_seconds must be between %d and %d", scopedSessionMinTTL, scopedSessionMaxTTL))
+			jsonError(w, http.StatusBadRequest, fmt.Sprintf(
+				"ttl_seconds must be between %d and %d",
+				int(scopedSessionMinTTL.Seconds()), int(scopedSessionMaxTTL.Seconds()),
+			))
 			return
 		}
 	}
@@ -76,7 +79,7 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 		t := time.Now().Add(time.Duration(*req.TTLSeconds) * time.Second)
 		expiresAt = &t
 	} else {
-		t := time.Now().Add(sessionTTL)
+		t := time.Now().Add(scopedSessionDefaultTTL)
 		expiresAt = &t
 	}
 

--- a/internal/server/handle_user_sessions.go
+++ b/internal/server/handle_user_sessions.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+)
+
+// userSessionView is the JSON projection returned by GET /v1/auth/sessions.
+// Hides the underlying token hash; clients reference rows by PublicID.
+type userSessionView struct {
+	ID            string `json:"id"`
+	DeviceLabel   string `json:"device_label,omitempty"`
+	LastIP        string `json:"last_ip,omitempty"`
+	LastUserAgent string `json:"last_user_agent,omitempty"`
+	CreatedAt     string `json:"created_at"`
+	LastUsedAt    string `json:"last_used_at,omitempty"`
+	ExpiresAt     string `json:"expires_at,omitempty"`
+	Current       bool   `json:"current"`
+}
+
+// handleListUserSessions returns active sessions for the calling user. The
+// session that issued this request is flagged with current=true so a UI
+// can warn before revoking it.
+func (s *Server) handleListUserSessions(w http.ResponseWriter, r *http.Request) {
+	caller := sessionFromContext(r.Context())
+	if caller == nil || caller.UserID == "" {
+		jsonError(w, http.StatusForbidden, "User session required")
+		return
+	}
+
+	rows, err := s.store.ListUserSessions(r.Context(), caller.UserID)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to list sessions")
+		return
+	}
+
+	out := make([]userSessionView, 0, len(rows))
+	for _, sess := range rows {
+		created := sess.CreatedAt
+		out = append(out, userSessionView{
+			ID:            sess.PublicID,
+			DeviceLabel:   sess.DeviceLabel,
+			LastIP:        sess.LastIP,
+			LastUserAgent: sess.LastUserAgent,
+			CreatedAt:     formatExpiresAt(&created),
+			LastUsedAt:    formatExpiresAt(sess.LastUsedAt),
+			ExpiresAt:     formatExpiresAt(sess.ExpiresAt),
+			Current:       sess.PublicID == caller.PublicID,
+		})
+	}
+	jsonOK(w, map[string]interface{}{"sessions": out})
+}
+
+// handleRevokeUserSession deletes one session (by public id) belonging to
+// the calling user. Same-account scoping is enforced in the store; this
+// handler only exposes 404 vs 200 to the caller.
+func (s *Server) handleRevokeUserSession(w http.ResponseWriter, r *http.Request) {
+	caller := sessionFromContext(r.Context())
+	if caller == nil || caller.UserID == "" {
+		jsonError(w, http.StatusForbidden, "User session required")
+		return
+	}
+	publicID := r.PathValue("id")
+	if publicID == "" {
+		jsonError(w, http.StatusBadRequest, "Session id is required")
+		return
+	}
+
+	err := s.store.RevokeUserSession(r.Context(), caller.UserID, publicID)
+	if errors.Is(err, sql.ErrNoRows) {
+		jsonError(w, http.StatusNotFound, "Session not found")
+		return
+	}
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to revoke session")
+		return
+	}
+	jsonOK(w, map[string]string{"status": "revoked"})
+}
+

--- a/internal/server/handle_user_sessions.go
+++ b/internal/server/handle_user_sessions.go
@@ -76,13 +76,14 @@ func (s *Server) handleRevokeUserSession(w http.ResponseWriter, r *http.Request)
 		jsonError(w, http.StatusInternalServerError, "Failed to revoke session")
 		return
 	}
-	// Self-revoke: clear the av_session cookie so a browser caller drops
-	// the now-dead cookie immediately instead of carrying it until the
-	// next 401. Mirrors handleLogout / handleDeleteAccount. CLI Bearer
-	// callers don't carry the cookie and ignore Set-Cookie headers.
-	if caller.PublicID == publicID {
+	// Self-revoke handling: clear the av_session cookie so a browser
+	// drops the dead cookie immediately, and signal `current: true` in
+	// the JSON body so non-cookie clients (the CLI) can clear their own
+	// on-disk session.json without a follow-up sniffing call.
+	selfRevoke := caller.PublicID == publicID
+	if selfRevoke {
 		http.SetCookie(w, sessionCookie(r, s.baseURL, "", -1))
 	}
-	jsonOK(w, map[string]string{"status": "revoked"})
+	jsonOK(w, map[string]interface{}{"status": "revoked", "current": selfRevoke})
 }
 

--- a/internal/server/handle_user_sessions.go
+++ b/internal/server/handle_user_sessions.go
@@ -76,6 +76,13 @@ func (s *Server) handleRevokeUserSession(w http.ResponseWriter, r *http.Request)
 		jsonError(w, http.StatusInternalServerError, "Failed to revoke session")
 		return
 	}
+	// Self-revoke: clear the av_session cookie so a browser caller drops
+	// the now-dead cookie immediately instead of carrying it until the
+	// next 401. Mirrors handleLogout / handleDeleteAccount. CLI Bearer
+	// callers don't carry the cookie and ignore Set-Cookie headers.
+	if caller.PublicID == publicID {
+		http.SetCookie(w, sessionCookie(r, s.baseURL, "", -1))
+	}
 	jsonOK(w, map[string]string{"status": "revoked"})
 }
 

--- a/internal/server/handle_user_sessions.go
+++ b/internal/server/handle_user_sessions.go
@@ -84,6 +84,15 @@ func (s *Server) handleRevokeUserSession(w http.ResponseWriter, r *http.Request)
 	if selfRevoke {
 		http.SetCookie(w, sessionCookie(r, s.baseURL, "", -1))
 	}
-	jsonOK(w, map[string]interface{}{"status": "revoked", "current": selfRevoke})
+	jsonOK(w, revokeSessionResponse{Status: "revoked", Current: selfRevoke})
+}
+
+// revokeSessionResponse is the JSON shape returned by
+// DELETE /v1/auth/sessions/{id}. Current indicates whether the caller
+// just revoked their own session; CLI clients use it to decide whether
+// to drop their on-disk session.json.
+type revokeSessionResponse struct {
+	Status  string `json:"status"`
+	Current bool   `json:"current"`
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -788,8 +788,8 @@ func (s *Server) Start() error {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
-	pruneCtx, stopPruner := context.WithCancel(context.Background())
-	defer stopPruner()
+	pruneCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go s.runTouchCachePruner(pruneCtx)
 
 	errCh := make(chan error, 1)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -72,11 +72,9 @@ type Server struct {
 	// single WAL writer slot. Caching the last-touch wall-clock per
 	// token keeps the steady state at one SQL write per session per
 	// touchInterval; the SQL throttle remains as a defense-in-depth
-	// backstop. Bounded by a periodic prune that drops entries older
-	// than store.TouchInterval — anything older has zero correctness
-	// value (the SQL throttle would let the next write through anyway).
-	touchCache    sync.Map // raw token (string) -> time.Time
-	touchPruneCh  chan struct{}
+	// backstop. Bounded by a periodic prune (see runTouchCachePruner)
+	// that drops entries past the throttle window.
+	touchCache sync.Map // raw token (string) -> time.Time
 }
 
 // RateLimit returns the server's rate-limit registry. Exported so the
@@ -587,7 +585,6 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 		logger:         logger,
 		rateLimit:      rl,
 		logSink:        requestlog.Nop{},
-		touchPruneCh:   make(chan struct{}),
 	}
 
 	ipAuth := s.tier(ratelimit.TierAuth, s.ipKeyer())
@@ -791,7 +788,9 @@ func (s *Server) Start() error {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
-	go s.runTouchCachePruner()
+	pruneCtx, stopPruner := context.WithCancel(context.Background())
+	defer stopPruner()
+	go s.runTouchCachePruner(pruneCtx)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -840,7 +839,6 @@ func (s *Server) Start() error {
 	defer cancel()
 
 	fmt.Println("shutting down server...")
-	close(s.touchPruneCh)
 	if s.mitm != nil {
 		if err := s.mitm.Shutdown(ctx); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: mitm proxy shutdown: %v\n", err)
@@ -866,13 +864,10 @@ type loginRequest struct {
 	DeviceLabel string `json:"device_label,omitempty"` // optional, e.g. CLI hostname
 }
 
-// maxDeviceLabelRunes caps device_label values written to the session
-// row. Counts runes (not bytes) so a multi-byte character at the boundary
-// can't be sliced mid-encoding into invalid UTF-8. 64 runes covers any
-// hostname (RFC 1035 = 253 ASCII bytes is well above this) plus a CI
-// suffix; the worst-case storage cost is 64 × 4 = 256 bytes per row,
-// which is still well below the table-bloat threshold the original
-// constant was tuned for.
+// maxDeviceLabelRunes caps device_label values. Counts runes (not bytes)
+// so a multi-byte character at the boundary can't be sliced mid-encoding
+// into invalid UTF-8. 64 runes covers any RFC 1035 hostname plus a CI
+// suffix at a worst-case 256-byte storage cost.
 const maxDeviceLabelRunes = 64
 
 // truncateDeviceLabel sanitizes the user-supplied label: strips control
@@ -899,6 +894,21 @@ func truncateDeviceLabel(label string) string {
 type loginResponse struct {
 	Token     string `json:"token"`
 	ExpiresAt string `json:"expires_at"`
+}
+
+// registerResponse is the JSON shape returned by POST /v1/auth/register.
+// Token and ExpiresAt are populated only on the auto-login path
+// (currently: the first-user owner registration); other paths leave them
+// empty and set RequiresVerification.
+type registerResponse struct {
+	Email                string `json:"email"`
+	Role                 string `json:"role,omitempty"`
+	RequiresVerification bool   `json:"requires_verification"`
+	EmailSent            bool   `json:"email_sent"`
+	Authenticated        bool   `json:"authenticated"`
+	Message              string `json:"message"`
+	Token                string `json:"token,omitempty"`
+	ExpiresAt            string `json:"expires_at,omitempty"`
 }
 
 // userSessionAbsoluteTTL caps how long a user-login session can survive
@@ -1009,7 +1019,7 @@ func (s *Server) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		s.maybeTouchSession(r, sess, token)
+		s.maybeTouchSession(r.Context(), sess, token, clientIP(r), r.UserAgent())
 
 		ctx := context.WithValue(r.Context(), sessionContextKey, sess)
 		next(w, r.WithContext(ctx))
@@ -1031,7 +1041,7 @@ func (s *Server) optionalAuth(next http.HandlerFunc) http.HandlerFunc {
 
 		if token != "" {
 			if sess, err := s.store.GetSession(r.Context(), token); err == nil && sess != nil && !sess.IsExpired(time.Now()) {
-				s.maybeTouchSession(r, sess, token)
+				s.maybeTouchSession(r.Context(), sess, token, clientIP(r), r.UserAgent())
 				ctx := context.WithValue(r.Context(), sessionContextKey, sess)
 				next(w, r.WithContext(ctx))
 				return
@@ -1043,11 +1053,12 @@ func (s *Server) optionalAuth(next http.HandlerFunc) http.HandlerFunc {
 }
 
 // maybeTouchSession bumps last_used_at on user sessions and refreshes
-// last_ip / last_user_agent from the request, gated by an in-memory cache
-// so the SQL layer is hit at most once per session per TouchInterval.
-// The store-side WHERE-clause throttle is preserved as defense in depth
-// (e.g. a process restart resets the cache).
-func (s *Server) maybeTouchSession(r *http.Request, sess *store.Session, rawToken string) {
+// last_ip / last_user_agent, gated by an in-memory cache so the SQL
+// layer is hit at most once per session per TouchInterval. The store-
+// side WHERE-clause throttle is preserved as defense in depth (e.g. a
+// process restart resets the cache). Empty ip/ua leave existing column
+// values unchanged via COALESCE in the store.
+func (s *Server) maybeTouchSession(ctx context.Context, sess *store.Session, rawToken, ip, userAgent string) {
 	if sess == nil || sess.UserID == "" {
 		return
 	}
@@ -1058,16 +1069,16 @@ func (s *Server) maybeTouchSession(r *http.Request, sess *store.Session, rawToke
 		}
 	}
 	s.touchCache.Store(rawToken, now)
-	_ = s.store.TouchSession(r.Context(), rawToken, clientIP(r), r.UserAgent())
+	_ = s.store.TouchSession(ctx, rawToken, ip, userAgent)
 }
 
-// pruneTouchCache drops entries older than store.TouchInterval. Anything
-// older is past the SQL throttle window — the next request would issue
-// an UPDATE regardless — so retaining the entry has no correctness value
-// and just leaks memory across logout, revoke, and password-change
-// invalidation paths that don't hold the raw token.
+// pruneTouchCache drops entries past the throttle window. We use 2×
+// TouchInterval so a still-active session — touched within the last
+// minute — isn't evicted only to be re-stored on its next request;
+// anything older than that has zero correctness value because the SQL
+// throttle would let the next write through anyway.
 func (s *Server) pruneTouchCache() {
-	cutoff := time.Now().Add(-store.TouchInterval)
+	cutoff := time.Now().Add(-2 * store.TouchInterval)
 	s.touchCache.Range(func(key, val any) bool {
 		if t, ok := val.(time.Time); ok && t.Before(cutoff) {
 			s.touchCache.Delete(key)
@@ -1076,14 +1087,16 @@ func (s *Server) pruneTouchCache() {
 	})
 }
 
-// runTouchCachePruner drives pruneTouchCache on a ticker until Start's
-// shutdown closes touchPruneCh. Spawned by Start.
-func (s *Server) runTouchCachePruner() {
+// runTouchCachePruner drives pruneTouchCache on a ticker until ctx is
+// cancelled. Spawned by Start; stopped via the deferred WithCancel
+// cancel so a Start error path or a second Start cycle never leaks the
+// goroutine or panics on a re-closed channel.
+func (s *Server) runTouchCachePruner(ctx context.Context) {
 	ticker := time.NewTicker(store.TouchInterval)
 	defer ticker.Stop()
 	for {
 		select {
-		case <-s.touchPruneCh:
+		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			s.pruneTouchCache()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -140,7 +140,7 @@ type Store interface {
 	GetSession(ctx context.Context, id string) (*store.Session, error)
 	DeleteSession(ctx context.Context, id string) error
 	DeleteUserSessions(ctx context.Context, userID string) error
-	TouchSession(ctx context.Context, rawToken string) error
+	TouchSession(ctx context.Context, rawToken, ip, userAgent string) error
 	ListUserSessions(ctx context.Context, userID string) ([]store.Session, error)
 	RevokeUserSession(ctx context.Context, userID, publicID string) error
 
@@ -1009,7 +1009,7 @@ func (s *Server) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		s.maybeTouchSession(r.Context(), sess, token)
+		s.maybeTouchSession(r, sess, token)
 
 		ctx := context.WithValue(r.Context(), sessionContextKey, sess)
 		next(w, r.WithContext(ctx))
@@ -1031,7 +1031,7 @@ func (s *Server) optionalAuth(next http.HandlerFunc) http.HandlerFunc {
 
 		if token != "" {
 			if sess, err := s.store.GetSession(r.Context(), token); err == nil && sess != nil && !sess.IsExpired(time.Now()) {
-				s.maybeTouchSession(r.Context(), sess, token)
+				s.maybeTouchSession(r, sess, token)
 				ctx := context.WithValue(r.Context(), sessionContextKey, sess)
 				next(w, r.WithContext(ctx))
 				return
@@ -1042,11 +1042,12 @@ func (s *Server) optionalAuth(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-// maybeTouchSession bumps last_used_at on user sessions, gated by an
-// in-memory cache so the SQL layer is hit at most once per session per
-// touchInterval. The store-side WHERE-clause throttle is preserved as
-// defense in depth (e.g. a process restart resets the cache).
-func (s *Server) maybeTouchSession(ctx context.Context, sess *store.Session, rawToken string) {
+// maybeTouchSession bumps last_used_at on user sessions and refreshes
+// last_ip / last_user_agent from the request, gated by an in-memory cache
+// so the SQL layer is hit at most once per session per TouchInterval.
+// The store-side WHERE-clause throttle is preserved as defense in depth
+// (e.g. a process restart resets the cache).
+func (s *Server) maybeTouchSession(r *http.Request, sess *store.Session, rawToken string) {
 	if sess == nil || sess.UserID == "" {
 		return
 	}
@@ -1057,7 +1058,7 @@ func (s *Server) maybeTouchSession(ctx context.Context, sess *store.Session, raw
 		}
 	}
 	s.touchCache.Store(rawToken, now)
-	_ = s.store.TouchSession(ctx, rawToken)
+	_ = s.store.TouchSession(r.Context(), rawToken, clientIP(r), r.UserAgent())
 }
 
 // pruneTouchCache drops entries older than store.TouchInterval. Anything

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -66,6 +67,13 @@ type Server struct {
 	logger         *slog.Logger         // structured logger for per-request observability
 	rateLimit      *ratelimit.Registry  // tiered rate limiter; shared with the MITM ingress
 	logSink        requestlog.Sink      // per-request persistence sink; never nil (Nop default)
+	// touchCache short-circuits per-request session-touch writes. With
+	// db.SetMaxOpenConns(1), every UPDATE — even a no-op — opens the
+	// single WAL writer slot. Caching the last-touch wall-clock per
+	// token keeps the steady state at one SQL write per session per
+	// touchInterval; the SQL throttle remains as a defense-in-depth
+	// backstop. Size is bounded by the number of active sessions.
+	touchCache sync.Map // raw token (string) -> time.Time
 }
 
 // RateLimit returns the server's rate-limit registry. Exported so the
@@ -124,11 +132,14 @@ type Store interface {
 	DeleteUser(ctx context.Context, userID string) error
 	CountUsers(ctx context.Context) (int, error)
 	RegisterFirstUser(ctx context.Context, email string, passwordHash, passwordSalt []byte, defaultVaultID string, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) (*store.User, error)
-	CreateSession(ctx context.Context, userID string, expiresAt time.Time) (*store.Session, error)
+	CreateUserSession(ctx context.Context, p store.CreateUserSessionParams) (*store.Session, error)
 	CreateScopedSession(ctx context.Context, vaultID, vaultRole string, expiresAt *time.Time) (*store.Session, error)
 	GetSession(ctx context.Context, id string) (*store.Session, error)
 	DeleteSession(ctx context.Context, id string) error
 	DeleteUserSessions(ctx context.Context, userID string) error
+	TouchSession(ctx context.Context, rawToken string) error
+	ListUserSessions(ctx context.Context, userID string) ([]store.Session, error)
+	RevokeUserSession(ctx context.Context, userID, publicID string) error
 
 	// Vaults
 	CreateVault(ctx context.Context, name string) (*store.Vault, error)
@@ -595,6 +606,8 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("POST /v1/auth/login", s.requireInitialized(ipAuth(limitBody(s.handleLogin))))
 	mux.HandleFunc("POST /v1/auth/change-password", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleChangePassword)))))
 	mux.HandleFunc("DELETE /v1/auth/account", s.requireInitialized(s.requireAuth(actorAuthed(s.handleDeleteAccount))))
+	mux.HandleFunc("GET /v1/auth/sessions", s.requireInitialized(s.requireAuth(actorAuthed(s.handleListUserSessions))))
+	mux.HandleFunc("DELETE /v1/auth/sessions/{id}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleRevokeUserSession))))
 	mux.HandleFunc("POST /v1/sessions", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleScopedSession)))))
 	mux.HandleFunc("GET /v1/credentials", s.requireInitialized(s.requireAuth(actorAuthed(s.handleCredentialsList))))
 	mux.HandleFunc("POST /v1/credentials", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleCredentialsSet)))))
@@ -841,8 +854,37 @@ const passwordResetTTL = 15 * time.Minute
 const maxPendingPasswordResets = 3
 
 type loginRequest struct {
-	Email    string `json:"email"`
-	Password string `json:"password"`
+	Email       string `json:"email"`
+	Password    string `json:"password"`
+	DeviceLabel string `json:"device_label,omitempty"` // optional, e.g. CLI hostname
+}
+
+// maxDeviceLabelLen caps device_label values written to the session row.
+// Long enough for hostnames (RFC 1035 = 253) plus a CI suffix; short
+// enough that a flood of long labels can't bloat the sessions table.
+const maxDeviceLabelLen = 64
+
+// truncateDeviceLabel sanitizes the user-supplied label: strips control
+// characters, collapses whitespace, and caps the length. Empty input
+// returns "" (caller decides on a default).
+func truncateDeviceLabel(label string) string {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return ""
+	}
+	// Drop control chars; we keep printable ASCII + UTF-8 letters/numbers.
+	cleaned := make([]rune, 0, len(label))
+	for _, r := range label {
+		if r < 0x20 || r == 0x7f {
+			continue
+		}
+		cleaned = append(cleaned, r)
+	}
+	out := string(cleaned)
+	if len(out) > maxDeviceLabelLen {
+		out = out[:maxDeviceLabelLen]
+	}
+	return out
 }
 
 type loginResponse struct {
@@ -850,7 +892,16 @@ type loginResponse struct {
 	ExpiresAt string `json:"expires_at"`
 }
 
-const sessionTTL = 24 * time.Hour
+// userSessionAbsoluteTTL caps how long a user-login session can survive
+// regardless of activity. userSessionIdleTTL is the inactivity window:
+// any user session whose last_used_at is older than this is rejected at
+// auth time (see Session.IsExpired). Tuned for "log in once, stay logged
+// in" — a year max, drops dead after a month of disuse so a stolen
+// session.json doesn't grant indefinite undetected access.
+const (
+	userSessionAbsoluteTTL = 365 * 24 * time.Hour
+	userSessionIdleTTL     = 30 * 24 * time.Hour
+)
 
 // trustedProxyCIDRs holds parsed CIDR ranges from AGENT_VAULT_TRUSTED_PROXIES.
 // When non-empty, X-Forwarded-For is only trusted if RemoteAddr matches one of these.
@@ -944,10 +995,12 @@ func (s *Server) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 			jsonError(w, http.StatusUnauthorized, "Invalid or expired session")
 			return
 		}
-		if sessionExpired(sess) {
+		if sess.IsExpired(time.Now()) {
 			jsonError(w, http.StatusUnauthorized, "Session expired")
 			return
 		}
+
+		s.maybeTouchSession(r.Context(), sess, token)
 
 		ctx := context.WithValue(r.Context(), sessionContextKey, sess)
 		next(w, r.WithContext(ctx))
@@ -968,7 +1021,8 @@ func (s *Server) optionalAuth(next http.HandlerFunc) http.HandlerFunc {
 		}
 
 		if token != "" {
-			if sess, err := s.store.GetSession(r.Context(), token); err == nil && sess != nil && !sessionExpired(sess) {
+			if sess, err := s.store.GetSession(r.Context(), token); err == nil && sess != nil && !sess.IsExpired(time.Now()) {
+				s.maybeTouchSession(r.Context(), sess, token)
 				ctx := context.WithValue(r.Context(), sessionContextKey, sess)
 				next(w, r.WithContext(ctx))
 				return
@@ -979,9 +1033,28 @@ func (s *Server) optionalAuth(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// maybeTouchSession bumps last_used_at on user sessions, gated by an
+// in-memory cache so the SQL layer is hit at most once per session per
+// touchInterval. The store-side WHERE-clause throttle is preserved as
+// defense in depth (e.g. a process restart resets the cache).
+func (s *Server) maybeTouchSession(ctx context.Context, sess *store.Session, rawToken string) {
+	if sess == nil || sess.UserID == "" {
+		return
+	}
+	now := time.Now()
+	if last, ok := s.touchCache.Load(rawToken); ok {
+		if t, _ := last.(time.Time); now.Sub(t) < store.TouchInterval {
+			return
+		}
+	}
+	s.touchCache.Store(rawToken, now)
+	_ = s.store.TouchSession(ctx, rawToken)
+}
+
 const (
-	scopedSessionMinTTL = 5 * 60        // 5 minutes
-	scopedSessionMaxTTL = 7 * 24 * 3600 // 7 days
+	scopedSessionMinTTL     = 5 * time.Minute
+	scopedSessionMaxTTL     = 7 * 24 * time.Hour
+	scopedSessionDefaultTTL = 24 * time.Hour // when ttl_seconds is unset
 )
 
 // sessionCookie builds an av_session cookie with all hardening flags set.
@@ -1001,18 +1074,14 @@ func sessionCookie(r *http.Request, baseURL, value string, maxAge int) *http.Coo
 // timePtr returns a pointer to the given time value.
 func timePtr(t time.Time) *time.Time { return &t }
 
-// formatExpiresAt returns a formatted RFC3339 string for an optional expiry time,
-// or an empty string if the session never expires.
+// formatExpiresAt returns a formatted RFC3339 (UTC) string for an optional
+// time, or an empty string if the time is nil. Used for any *time.Time we
+// surface to API clients — expiry, last-used, etc.
 func formatExpiresAt(t *time.Time) string {
 	if t == nil {
 		return ""
 	}
-	return t.Format(time.RFC3339)
-}
-
-// sessionExpired returns true if the session has a finite expiry and that time has passed.
-func sessionExpired(s *store.Session) bool {
-	return s.ExpiresAt != nil && time.Now().After(*s.ExpiresAt)
+	return t.UTC().Format(time.RFC3339)
 }
 
 const settingAllowedDomains = "allowed_email_domains"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -72,8 +72,11 @@ type Server struct {
 	// single WAL writer slot. Caching the last-touch wall-clock per
 	// token keeps the steady state at one SQL write per session per
 	// touchInterval; the SQL throttle remains as a defense-in-depth
-	// backstop. Size is bounded by the number of active sessions.
-	touchCache sync.Map // raw token (string) -> time.Time
+	// backstop. Bounded by a periodic prune that drops entries older
+	// than store.TouchInterval — anything older has zero correctness
+	// value (the SQL throttle would let the next write through anyway).
+	touchCache    sync.Map // raw token (string) -> time.Time
+	touchPruneCh  chan struct{}
 }
 
 // RateLimit returns the server's rate-limit registry. Exported so the
@@ -584,6 +587,7 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 		logger:         logger,
 		rateLimit:      rl,
 		logSink:        requestlog.Nop{},
+		touchPruneCh:   make(chan struct{}),
 	}
 
 	ipAuth := s.tier(ratelimit.TierAuth, s.ipKeyer())
@@ -787,6 +791,8 @@ func (s *Server) Start() error {
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 
+	go s.runTouchCachePruner()
+
 	errCh := make(chan error, 1)
 	go func() {
 		fmt.Printf("Agent Vault server listening on %s\n", s.baseURL)
@@ -834,6 +840,7 @@ func (s *Server) Start() error {
 	defer cancel()
 
 	fmt.Println("shutting down server...")
+	close(s.touchPruneCh)
 	if s.mitm != nil {
 		if err := s.mitm.Shutdown(ctx); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: mitm proxy shutdown: %v\n", err)
@@ -859,20 +866,23 @@ type loginRequest struct {
 	DeviceLabel string `json:"device_label,omitempty"` // optional, e.g. CLI hostname
 }
 
-// maxDeviceLabelLen caps device_label values written to the session row.
-// Long enough for hostnames (RFC 1035 = 253) plus a CI suffix; short
-// enough that a flood of long labels can't bloat the sessions table.
-const maxDeviceLabelLen = 64
+// maxDeviceLabelRunes caps device_label values written to the session
+// row. Counts runes (not bytes) so a multi-byte character at the boundary
+// can't be sliced mid-encoding into invalid UTF-8. 64 runes covers any
+// hostname (RFC 1035 = 253 ASCII bytes is well above this) plus a CI
+// suffix; the worst-case storage cost is 64 × 4 = 256 bytes per row,
+// which is still well below the table-bloat threshold the original
+// constant was tuned for.
+const maxDeviceLabelRunes = 64
 
 // truncateDeviceLabel sanitizes the user-supplied label: strips control
-// characters, collapses whitespace, and caps the length. Empty input
-// returns "" (caller decides on a default).
+// characters and caps the length in runes. Empty input returns ""
+// (caller decides on a default).
 func truncateDeviceLabel(label string) string {
 	label = strings.TrimSpace(label)
 	if label == "" {
 		return ""
 	}
-	// Drop control chars; we keep printable ASCII + UTF-8 letters/numbers.
 	cleaned := make([]rune, 0, len(label))
 	for _, r := range label {
 		if r < 0x20 || r == 0x7f {
@@ -880,11 +890,10 @@ func truncateDeviceLabel(label string) string {
 		}
 		cleaned = append(cleaned, r)
 	}
-	out := string(cleaned)
-	if len(out) > maxDeviceLabelLen {
-		out = out[:maxDeviceLabelLen]
+	if len(cleaned) > maxDeviceLabelRunes {
+		cleaned = cleaned[:maxDeviceLabelRunes]
 	}
-	return out
+	return string(cleaned)
 }
 
 type loginResponse struct {
@@ -1049,6 +1058,36 @@ func (s *Server) maybeTouchSession(ctx context.Context, sess *store.Session, raw
 	}
 	s.touchCache.Store(rawToken, now)
 	_ = s.store.TouchSession(ctx, rawToken)
+}
+
+// pruneTouchCache drops entries older than store.TouchInterval. Anything
+// older is past the SQL throttle window — the next request would issue
+// an UPDATE regardless — so retaining the entry has no correctness value
+// and just leaks memory across logout, revoke, and password-change
+// invalidation paths that don't hold the raw token.
+func (s *Server) pruneTouchCache() {
+	cutoff := time.Now().Add(-store.TouchInterval)
+	s.touchCache.Range(func(key, val any) bool {
+		if t, ok := val.(time.Time); ok && t.Before(cutoff) {
+			s.touchCache.Delete(key)
+		}
+		return true
+	})
+}
+
+// runTouchCachePruner drives pruneTouchCache on a ticker until Start's
+// shutdown closes touchPruneCh. Spawned by Start.
+func (s *Server) runTouchCachePruner() {
+	ticker := time.NewTicker(store.TouchInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.touchPruneCh:
+			return
+		case <-ticker.C:
+			s.pruneTouchCache()
+		}
+	}
 }
 
 const (

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1439,16 +1439,20 @@ func TestListAndRevokeAuthSessionsRoute(t *testing.T) {
 		t.Fatalf("expected 2 sessions, got %d", len(listResp.Sessions))
 	}
 	currentCount := 0
-	var otherID string
+	var currentID, otherID string
 	for _, s := range listResp.Sessions {
 		if s.Current {
 			currentCount++
+			currentID = s.ID
 		} else {
 			otherID = s.ID
 		}
 	}
 	if currentCount != 1 {
 		t.Fatalf("expected exactly one Current=true session, got %d", currentCount)
+	}
+	if want := ms.sessions[login1.Token].PublicID; currentID != want {
+		t.Fatalf("Current=true row ID %q does not match login1's public_id %q", currentID, want)
 	}
 
 	// Revoke the other session via DELETE.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Infisical/agent-vault/internal/auth"
 	"github.com/Infisical/agent-vault/internal/crypto"
@@ -1469,6 +1470,105 @@ func TestListAndRevokeAuthSessionsRoute(t *testing.T) {
 	srv.httpServer.Handler.ServeHTTP(delAgainRec, delAgain)
 	if delAgainRec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 on duplicate revoke, got %d", delAgainRec.Code)
+	}
+}
+
+func TestSelfRevokeClearsCookie(t *testing.T) {
+	ms := setupMockStoreWithUser(t, "admin@test.com", "test-password-123")
+	srv := newTestServer(withStore(ms))
+
+	loginReq := httptest.NewRequest(http.MethodPost, "/v1/auth/login",
+		strings.NewReader(`{"email":"admin@test.com","password":"test-password-123","device_label":"laptop"}`))
+	loginRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(loginRec, loginReq)
+	if loginRec.Code != http.StatusOK {
+		t.Fatalf("login: %d %s", loginRec.Code, loginRec.Body.String())
+	}
+	var login loginResponse
+	_ = json.NewDecoder(loginRec.Body).Decode(&login)
+	myPub := ms.sessions[login.Token].PublicID
+
+	delReq := httptest.NewRequest(http.MethodDelete, "/v1/auth/sessions/"+myPub, nil)
+	delReq.Header.Set("Authorization", "Bearer "+login.Token)
+	delRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(delRec, delReq)
+	if delRec.Code != http.StatusOK {
+		t.Fatalf("self-revoke: %d %s", delRec.Code, delRec.Body.String())
+	}
+	var cleared *http.Cookie
+	for _, c := range delRec.Result().Cookies() {
+		if c.Name == "av_session" {
+			cleared = c
+		}
+	}
+	if cleared == nil {
+		t.Fatal("expected Set-Cookie clearing av_session on self-revoke")
+	}
+	if cleared.MaxAge >= 0 || cleared.Value != "" {
+		t.Fatalf("expected expired empty av_session cookie, got value=%q max_age=%d", cleared.Value, cleared.MaxAge)
+	}
+}
+
+func TestRevokeOtherSessionLeavesCookieAlone(t *testing.T) {
+	ms := setupMockStoreWithUser(t, "admin@test.com", "test-password-123")
+	srv := newTestServer(withStore(ms))
+
+	body := `{"email":"admin@test.com","password":"test-password-123","device_label":"laptop"}`
+	rec1 := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec1, httptest.NewRequest(http.MethodPost, "/v1/auth/login", strings.NewReader(body)))
+	rec2 := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec2, httptest.NewRequest(http.MethodPost, "/v1/auth/login", strings.NewReader(body)))
+	var login1, login2 loginResponse
+	_ = json.NewDecoder(rec1.Body).Decode(&login1)
+	_ = json.NewDecoder(rec2.Body).Decode(&login2)
+
+	otherPub := ms.sessions[login2.Token].PublicID
+	delReq := httptest.NewRequest(http.MethodDelete, "/v1/auth/sessions/"+otherPub, nil)
+	delReq.Header.Set("Authorization", "Bearer "+login1.Token)
+	delRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(delRec, delReq)
+	if delRec.Code != http.StatusOK {
+		t.Fatalf("revoke other: %d %s", delRec.Code, delRec.Body.String())
+	}
+	for _, c := range delRec.Result().Cookies() {
+		if c.Name == "av_session" {
+			t.Fatalf("revoking another session must not touch our own cookie, got %+v", c)
+		}
+	}
+}
+
+func TestTruncateDeviceLabelKeepsValidUTF8(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"33 accents (boundary at 64 bytes)", strings.Repeat("é", 33)},
+		{"17 emoji (boundary at 64 bytes)", strings.Repeat("🚀", 17)},
+		{"22 cjk runes (boundary at 64 bytes)", strings.Repeat("世", 22)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := truncateDeviceLabel(tc.in)
+			if !utf8.ValidString(out) {
+				t.Fatalf("truncated label is not valid UTF-8: %q", out)
+			}
+			if utf8.RuneCountInString(out) > maxDeviceLabelRunes {
+				t.Fatalf("rune count %d exceeds cap %d", utf8.RuneCountInString(out), maxDeviceLabelRunes)
+			}
+		})
+	}
+}
+
+func TestPruneTouchCacheDropsStaleEntries(t *testing.T) {
+	srv := newTestServer()
+	srv.touchCache.Store("fresh-token", time.Now())
+	srv.touchCache.Store("stale-token", time.Now().Add(-2*store.TouchInterval))
+	srv.pruneTouchCache()
+	if _, ok := srv.touchCache.Load("fresh-token"); !ok {
+		t.Fatal("fresh entry should be retained")
+	}
+	if _, ok := srv.touchCache.Load("stale-token"); ok {
+		t.Fatal("stale entry should be evicted")
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1656,14 +1656,16 @@ func TestTruncateDeviceLabelKeepsValidUTF8(t *testing.T) {
 
 func TestPruneTouchCacheDropsStaleEntries(t *testing.T) {
 	srv := newTestServer()
-	srv.touchCache.Store("fresh-token", time.Now())
-	srv.touchCache.Store("stale-token", time.Now().Add(-2*store.TouchInterval))
+	// Cutoff is 2*TouchInterval; pick a within-window and an outside-window
+	// timestamp so the bound is exercised without coupling to wall clock.
+	srv.touchCache.Store("within-window", time.Now().Add(-store.TouchInterval))
+	srv.touchCache.Store("past-cutoff", time.Now().Add(-3*store.TouchInterval))
 	srv.pruneTouchCache()
-	if _, ok := srv.touchCache.Load("fresh-token"); !ok {
-		t.Fatal("fresh entry should be retained")
+	if _, ok := srv.touchCache.Load("within-window"); !ok {
+		t.Fatal("entry inside the throttle grace window should be retained")
 	}
-	if _, ok := srv.touchCache.Load("stale-token"); ok {
-		t.Fatal("stale entry should be evicted")
+	if _, ok := srv.touchCache.Load("past-cutoff"); ok {
+		t.Fatal("entry past the cutoff should be evicted")
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -136,10 +136,16 @@ func (m *mockStore) CreateSession(ctx context.Context, userID string, expiresAt 
 	return m.CreateUserSession(ctx, store.CreateUserSessionParams{UserID: userID, ExpiresAt: expiresAt})
 }
 
-func (m *mockStore) TouchSession(_ context.Context, rawToken string) error {
+func (m *mockStore) TouchSession(_ context.Context, rawToken, ip, userAgent string) error {
 	if sess, ok := m.sessions[rawToken]; ok && sess != nil {
 		now := time.Now()
 		sess.LastUsedAt = &now
+		if ip != "" {
+			sess.LastIP = ip
+		}
+		if userAgent != "" {
+			sess.LastUserAgent = userAgent
+		}
 	}
 	return nil
 }
@@ -1507,6 +1513,18 @@ func TestSelfRevokeClearsCookie(t *testing.T) {
 	if cleared.MaxAge >= 0 || cleared.Value != "" {
 		t.Fatalf("expected expired empty av_session cookie, got value=%q max_age=%d", cleared.Value, cleared.MaxAge)
 	}
+	// Self-revoke must also surface `current: true` so non-cookie
+	// clients (the CLI) know to drop their on-disk session.
+	var resp struct {
+		Status  string `json:"status"`
+		Current bool   `json:"current"`
+	}
+	if err := json.Unmarshal(delRec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode revoke response: %v", err)
+	}
+	if !resp.Current {
+		t.Fatalf("self-revoke should report current=true, got %+v", resp)
+	}
 }
 
 func TestRevokeOtherSessionLeavesCookieAlone(t *testing.T) {
@@ -1534,6 +1552,83 @@ func TestRevokeOtherSessionLeavesCookieAlone(t *testing.T) {
 		if c.Name == "av_session" {
 			t.Fatalf("revoking another session must not touch our own cookie, got %+v", c)
 		}
+	}
+	var resp struct {
+		Current bool `json:"current"`
+	}
+	if err := json.Unmarshal(delRec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode revoke response: %v", err)
+	}
+	if resp.Current {
+		t.Fatalf("revoking another session should report current=false, got %+v", resp)
+	}
+}
+
+func TestRegisterFirstUserReturnsToken(t *testing.T) {
+	ms := newMockStore()
+	srv := newTestServer(withStore(ms))
+
+	body := `{"email":"owner@test.com","password":"test-password-123","device_label":"my-laptop"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/register", strings.NewReader(body))
+	req.Header.Set("User-Agent", "agent-vault-cli/test")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("register: %d %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Authenticated bool   `json:"authenticated"`
+		Token         string `json:"token"`
+		ExpiresAt     string `json:"expires_at"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Authenticated || resp.Token == "" || resp.ExpiresAt == "" {
+		t.Fatalf("first-user register should return authenticated session, got %+v", resp)
+	}
+	if sess := ms.sessions[resp.Token]; sess == nil || sess.DeviceLabel != "my-laptop" {
+		t.Fatalf("expected stored session with device_label='my-laptop', got %+v", sess)
+	}
+	// Exactly one session row was created — no orphan from a duplicate auto-login.
+	if len(ms.sessions) != 1 {
+		t.Fatalf("expected 1 session after first-user register, got %d", len(ms.sessions))
+	}
+}
+
+func TestTouchSessionRefreshesIPAndUserAgent(t *testing.T) {
+	ms := setupMockStoreWithUser(t, "admin@test.com", "test-password-123")
+	srv := newTestServer(withStore(ms))
+
+	loginReq := httptest.NewRequest(http.MethodPost, "/v1/auth/login",
+		strings.NewReader(`{"email":"admin@test.com","password":"test-password-123"}`))
+	loginReq.Header.Set("User-Agent", "first-agent/1.0")
+	loginReq.RemoteAddr = "10.0.0.1:1234"
+	loginRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(loginRec, loginReq)
+	var login loginResponse
+	_ = json.NewDecoder(loginRec.Body).Decode(&login)
+
+	// Force the cache miss so requireAuth's maybeTouchSession actually
+	// reaches the store on the next request.
+	srv.touchCache.Delete(login.Token)
+
+	meReq := httptest.NewRequest(http.MethodGet, "/v1/auth/me", nil)
+	meReq.Header.Set("Authorization", "Bearer "+login.Token)
+	meReq.Header.Set("User-Agent", "second-agent/2.0")
+	meReq.RemoteAddr = "192.168.1.1:5678"
+	meRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(meRec, meReq)
+	if meRec.Code != http.StatusOK {
+		t.Fatalf("/me: %d %s", meRec.Code, meRec.Body.String())
+	}
+
+	updated := ms.sessions[login.Token]
+	if updated.LastUserAgent != "second-agent/2.0" {
+		t.Fatalf("expected user-agent to refresh on touch, got %q", updated.LastUserAgent)
+	}
+	if updated.LastIP != "192.168.1.1" {
+		t.Fatalf("expected last_ip to refresh on touch, got %q", updated.LastIP)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1600,6 +1600,91 @@ func TestRegisterFirstUserReturnsToken(t *testing.T) {
 	}
 }
 
+func TestVerifyReturnsTokenAndPersistsDeviceLabel(t *testing.T) {
+	ms := newMockStore()
+	// Inactive user with a pending verification code — the same shape
+	// handleRegister produces on the second-user-onwards path.
+	hash, salt, kdfP, err := auth.HashUserPassword([]byte("test-password-123"))
+	if err != nil {
+		t.Fatalf("HashUserPassword: %v", err)
+	}
+	ms.users["new@test.com"] = &store.User{
+		ID: "u-new", Email: "new@test.com",
+		PasswordHash: hash, PasswordSalt: salt,
+		KDFTime: kdfP.Time, KDFMemory: kdfP.Memory, KDFThreads: kdfP.Threads,
+		Role: "member", IsActive: false,
+	}
+	if _, err := ms.CreateEmailVerification(context.Background(), "new@test.com", "123456", time.Now().Add(15*time.Minute)); err != nil {
+		t.Fatalf("CreateEmailVerification: %v", err)
+	}
+
+	srv := newTestServer(withStore(ms))
+	body := `{"email":"new@test.com","code":"123456","device_label":"verify-device"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/verify", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("verify: %d %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Authenticated bool   `json:"authenticated"`
+		Token         string `json:"token"`
+		ExpiresAt     string `json:"expires_at"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Authenticated || resp.Token == "" || resp.ExpiresAt == "" {
+		t.Fatalf("verify should return authenticated session, got %+v", resp)
+	}
+	sess := ms.sessions[resp.Token]
+	if sess == nil {
+		t.Fatal("verify should persist the session row")
+	}
+	if sess.DeviceLabel != "verify-device" {
+		t.Fatalf("expected device_label 'verify-device', got %q", sess.DeviceLabel)
+	}
+	// Exactly one session row — verify must not produce an orphan that
+	// a follow-up /v1/auth/login would duplicate.
+	if len(ms.sessions) != 1 {
+		t.Fatalf("expected 1 session after verify, got %d", len(ms.sessions))
+	}
+}
+
+func TestChangePasswordPreservesDeviceLabel(t *testing.T) {
+	ms := setupMockStoreWithUser(t, "admin@test.com", "old-password-123")
+	srv := newTestServer(withStore(ms))
+
+	// Login with a custom device label so we can prove it survives the
+	// post-change-password DeleteUserSessions + CreateUserSession round-trip.
+	body := `{"email":"admin@test.com","password":"old-password-123","device_label":"original-laptop"}`
+	loginRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(loginRec,
+		httptest.NewRequest(http.MethodPost, "/v1/auth/login", strings.NewReader(body)))
+	var login loginResponse
+	_ = json.NewDecoder(loginRec.Body).Decode(&login)
+
+	cpBody := `{"current_password":"old-password-123","new_password":"new-password-456"}`
+	cpReq := httptest.NewRequest(http.MethodPost, "/v1/auth/change-password", strings.NewReader(cpBody))
+	cpReq.Header.Set("Authorization", "Bearer "+login.Token)
+	cpRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(cpRec, cpReq)
+	if cpRec.Code != http.StatusOK {
+		t.Fatalf("change-password: %d %s", cpRec.Code, cpRec.Body.String())
+	}
+	var cp loginResponse
+	_ = json.NewDecoder(cpRec.Body).Decode(&cp)
+
+	newSess := ms.sessions[cp.Token]
+	if newSess == nil {
+		t.Fatal("expected post-change session to be persisted")
+	}
+	if newSess.DeviceLabel != "original-laptop" {
+		t.Fatalf("change-password should carry device_label across the new session, got %q", newSess.DeviceLabel)
+	}
+}
+
 func TestTouchSessionRefreshesIPAndUserAgent(t *testing.T) {
 	ms := setupMockStoreWithUser(t, "admin@test.com", "test-password-123")
 	srv := newTestServer(withStore(ms))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -109,16 +109,63 @@ func (m *mockStore) CountUsers(_ context.Context) (int, error) {
 	return len(m.users), nil
 }
 
-func (m *mockStore) CreateSession(_ context.Context, userID string, expiresAt time.Time) (*store.Session, error) {
+func (m *mockStore) CreateUserSession(_ context.Context, p store.CreateUserSessionParams) (*store.Session, error) {
 	m.sessionCounter++
+	exp := p.ExpiresAt
+	now := time.Now()
 	s := &store.Session{
-		ID:        fmt.Sprintf("test-session-id-%d", m.sessionCounter),
-		UserID:    userID,
-		ExpiresAt: &expiresAt,
-		CreatedAt: time.Now(),
+		ID:            fmt.Sprintf("test-session-id-%d", m.sessionCounter),
+		UserID:        p.UserID,
+		ExpiresAt:     &exp,
+		CreatedAt:     now,
+		PublicID:      fmt.Sprintf("pub-%d", m.sessionCounter),
+		LastUsedAt:    &now,
+		IdleTTL:       p.IdleTTL,
+		DeviceLabel:   p.DeviceLabel,
+		LastIP:        p.LastIP,
+		LastUserAgent: p.LastUserAgent,
 	}
 	m.sessions[s.ID] = s
 	return s, nil
+}
+
+// CreateSession is a convenience for older test sites that pre-date
+// CreateUserSession. New tests should call CreateUserSession directly.
+func (m *mockStore) CreateSession(ctx context.Context, userID string, expiresAt time.Time) (*store.Session, error) {
+	return m.CreateUserSession(ctx, store.CreateUserSessionParams{UserID: userID, ExpiresAt: expiresAt})
+}
+
+func (m *mockStore) TouchSession(_ context.Context, rawToken string) error {
+	if sess, ok := m.sessions[rawToken]; ok && sess != nil {
+		now := time.Now()
+		sess.LastUsedAt = &now
+	}
+	return nil
+}
+
+func (m *mockStore) ListUserSessions(_ context.Context, userID string) ([]store.Session, error) {
+	var out []store.Session
+	now := time.Now()
+	for _, sess := range m.sessions {
+		if sess.UserID != userID {
+			continue
+		}
+		if sess.IsExpired(now) {
+			continue
+		}
+		out = append(out, *sess)
+	}
+	return out, nil
+}
+
+func (m *mockStore) RevokeUserSession(_ context.Context, userID, publicID string) error {
+	for id, sess := range m.sessions {
+		if sess.UserID == userID && sess.PublicID == publicID {
+			delete(m.sessions, id)
+			return nil
+		}
+	}
+	return sql.ErrNoRows
 }
 
 func (m *mockStore) CreateScopedSession(_ context.Context, vaultID, vaultRole string, expiresAt *time.Time) (*store.Session, error) {
@@ -1312,6 +1359,116 @@ func TestLoginSuccess(t *testing.T) {
 	}
 	if resp.ExpiresAt == "" {
 		t.Fatal("expected non-empty expires_at")
+	}
+}
+
+func TestLoginRecordsDeviceMetadata(t *testing.T) {
+	ms := setupMockStoreWithUser(t, "admin@test.com", "test-password-123")
+	srv := newTestServer(withStore(ms))
+
+	body := `{"email":"admin@test.com","password":"test-password-123","device_label":"tony-mbp"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/auth/login", strings.NewReader(body))
+	req.Header.Set("User-Agent", "agent-vault-cli/test")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp loginResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	sess := ms.sessions[resp.Token]
+	if sess == nil {
+		t.Fatal("expected session to be persisted")
+	}
+	if sess.DeviceLabel != "tony-mbp" {
+		t.Fatalf("expected device_label 'tony-mbp', got %q", sess.DeviceLabel)
+	}
+	if sess.LastUserAgent != "agent-vault-cli/test" {
+		t.Fatalf("expected user-agent recorded, got %q", sess.LastUserAgent)
+	}
+	if sess.IdleTTL != userSessionIdleTTL {
+		t.Fatalf("expected idle ttl %v, got %v", userSessionIdleTTL, sess.IdleTTL)
+	}
+}
+
+func TestListAndRevokeAuthSessionsRoute(t *testing.T) {
+	ms := setupMockStoreWithUser(t, "admin@test.com", "test-password-123")
+	srv := newTestServer(withStore(ms))
+
+	// Two logins → two sessions for the same user.
+	loginBody := `{"email":"admin@test.com","password":"test-password-123","device_label":"laptop"}`
+	rec1 := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec1,
+		httptest.NewRequest(http.MethodPost, "/v1/auth/login", strings.NewReader(loginBody)))
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("login 1: %d %s", rec1.Code, rec1.Body.String())
+	}
+	var login1 loginResponse
+	_ = json.NewDecoder(rec1.Body).Decode(&login1)
+
+	loginBody2 := `{"email":"admin@test.com","password":"test-password-123","device_label":"server"}`
+	rec2 := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec2,
+		httptest.NewRequest(http.MethodPost, "/v1/auth/login", strings.NewReader(loginBody2)))
+	var login2 loginResponse
+	_ = json.NewDecoder(rec2.Body).Decode(&login2)
+
+	// GET /v1/auth/sessions using session #1.
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/auth/sessions", nil)
+	listReq.Header.Set("Authorization", "Bearer "+login1.Token)
+	listRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list sessions: %d %s", listRec.Code, listRec.Body.String())
+	}
+	var listResp struct {
+		Sessions []userSessionView `json:"sessions"`
+	}
+	if err := json.NewDecoder(listRec.Body).Decode(&listResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(listResp.Sessions) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(listResp.Sessions))
+	}
+	currentCount := 0
+	var otherID string
+	for _, s := range listResp.Sessions {
+		if s.Current {
+			currentCount++
+		} else {
+			otherID = s.ID
+		}
+	}
+	if currentCount != 1 {
+		t.Fatalf("expected exactly one Current=true session, got %d", currentCount)
+	}
+
+	// Revoke the other session via DELETE.
+	delReq := httptest.NewRequest(http.MethodDelete, "/v1/auth/sessions/"+otherID, nil)
+	delReq.Header.Set("Authorization", "Bearer "+login1.Token)
+	delRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(delRec, delReq)
+	if delRec.Code != http.StatusOK {
+		t.Fatalf("revoke session: %d %s", delRec.Code, delRec.Body.String())
+	}
+
+	// Session #2's token should no longer authenticate.
+	meReq := httptest.NewRequest(http.MethodGet, "/v1/auth/me", nil)
+	meReq.Header.Set("Authorization", "Bearer "+login2.Token)
+	meRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(meRec, meReq)
+	if meRec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 after revoke, got %d", meRec.Code)
+	}
+
+	// Revoking again returns 404.
+	delAgain := httptest.NewRequest(http.MethodDelete, "/v1/auth/sessions/"+otherID, nil)
+	delAgain.Header.Set("Authorization", "Bearer "+login1.Token)
+	delAgainRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(delAgainRec, delAgain)
+	if delAgainRec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 on duplicate revoke, got %d", delAgainRec.Code)
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -15,6 +15,11 @@ type ClientSession struct {
 	// expiry can skip the email prompt; empty for sessions saved by
 	// older clients.
 	Email string `json:"email,omitempty"`
+	// DeviceLabel is the label this CLI sent when minting the session.
+	// Cached so silent re-auth (withReauthRetry) preserves the operator's
+	// `--device-label` choice instead of falling back to os.Hostname().
+	// Empty for sessions saved by older clients.
+	DeviceLabel string `json:"device_label,omitempty"`
 }
 
 func sessionPath() (string, error) {

--- a/internal/store/migrations/040_session_sliding_expiry.sql
+++ b/internal/store/migrations/040_session_sliding_expiry.sql
@@ -3,7 +3,10 @@
 -- "active sessions" UI. Agent tokens and scoped sessions leave the new
 -- columns NULL and behave exactly as before.
 --
--- Pre-existing user sessions are wiped on upgrade — instances re-login once.
+-- Backward compatibility: pre-existing user sessions keep working through
+-- their original (24h) expires_at — IsExpired skips the idle check when
+-- idle_ttl_seconds is NULL, and the absolute expiry is unchanged. Users
+-- pick up the long-lived behavior on their next login.
 
 ALTER TABLE sessions ADD COLUMN last_used_at     TEXT;
 ALTER TABLE sessions ADD COLUMN idle_ttl_seconds INTEGER;
@@ -15,4 +18,11 @@ ALTER TABLE sessions ADD COLUMN public_id        TEXT;
 CREATE INDEX        idx_sessions_user_id   ON sessions(user_id);
 CREATE UNIQUE INDEX idx_sessions_public_id ON sessions(public_id);
 
-DELETE FROM sessions WHERE user_id IS NOT NULL;
+-- Backfill public_id for pre-existing user sessions so they appear in
+-- /v1/auth/sessions and can be revoked. randomblob(10) → 80 bits, matches
+-- newPublicID() in sqlite.go. Scoped and agent rows keep public_id NULL
+-- (SQLite UNIQUE indexes allow multiple NULLs).
+UPDATE sessions
+   SET public_id = lower(hex(randomblob(10)))
+ WHERE user_id IS NOT NULL
+   AND public_id IS NULL;

--- a/internal/store/migrations/040_session_sliding_expiry.sql
+++ b/internal/store/migrations/040_session_sliding_expiry.sql
@@ -1,0 +1,18 @@
+-- Long-lived user sessions: GitHub-CLI-style "log in once, stay logged in".
+-- Adds an idle-TTL window plus per-session metadata for a self-service
+-- "active sessions" UI. Agent tokens and scoped sessions leave the new
+-- columns NULL and behave exactly as before.
+--
+-- Pre-existing user sessions are wiped on upgrade — instances re-login once.
+
+ALTER TABLE sessions ADD COLUMN last_used_at     TEXT;
+ALTER TABLE sessions ADD COLUMN idle_ttl_seconds INTEGER;
+ALTER TABLE sessions ADD COLUMN device_label     TEXT;
+ALTER TABLE sessions ADD COLUMN last_ip          TEXT;
+ALTER TABLE sessions ADD COLUMN last_user_agent  TEXT;
+ALTER TABLE sessions ADD COLUMN public_id        TEXT;
+
+CREATE INDEX        idx_sessions_user_id   ON sessions(user_id);
+CREATE UNIQUE INDEX idx_sessions_public_id ON sessions(public_id);
+
+DELETE FROM sessions WHERE user_id IS NOT NULL;

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -53,6 +53,25 @@ func nullableInt(n int) interface{} {
 	return n
 }
 
+// nullableString returns nil for empty strings, enabling SQL NULL inserts.
+func nullableString(s string) interface{} {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// newPublicID returns a short, opaque, URL-safe handle (80 random bits as
+// 20 hex chars). Used as the {id} path parameter in /v1/auth/sessions/{id}
+// so the underlying token hash never appears in logs or URLs.
+func newPublicID() string {
+	var b [10]byte
+	if _, err := io.ReadFull(rand.Reader, b[:]); err != nil {
+		panic("crypto/rand: " + err.Error())
+	}
+	return hex.EncodeToString(b[:])
+}
+
 // SQLiteStore implements Store backed by a SQLite database.
 type SQLiteStore struct {
 	db *sql.DB
@@ -691,27 +710,55 @@ func (s *SQLiteStore) DeleteUserSessions(ctx context.Context, userID string) err
 
 // --- Sessions ---
 
-func (s *SQLiteStore) CreateSession(ctx context.Context, userID string, expiresAt time.Time) (*Session, error) {
+// CreateUserSession persists a user login session with sliding-expiry
+// metadata. Both ExpiresAt (absolute cap) and IdleTTL (inactivity window)
+// are enforced on read via Session.IsExpired.
+func (s *SQLiteStore) CreateUserSession(ctx context.Context, p CreateUserSessionParams) (*Session, error) {
+	if p.UserID == "" {
+		return nil, fmt.Errorf("CreateUserSession: UserID is required")
+	}
 	rawToken := newSessionToken()
 	tokenHash := hashSessionToken(rawToken)
+	publicID := newPublicID()
 	now := time.Now().UTC()
 
-	var uid sql.NullString
-	if userID != "" {
-		uid = sql.NullString{String: userID, Valid: true}
+	var idleSecs sql.NullInt64
+	if p.IdleTTL > 0 {
+		idleSecs = sql.NullInt64{Int64: int64(p.IdleTTL.Seconds()), Valid: true}
 	}
 
 	_, err := s.db.ExecContext(ctx,
-		"INSERT INTO sessions (id, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)",
-		tokenHash, uid, expiresAt.UTC().Format(time.DateTime), now.Format(time.DateTime),
+		`INSERT INTO sessions
+		   (id, user_id, expires_at, created_at, last_used_at, idle_ttl_seconds,
+		    device_label, last_ip, last_user_agent, public_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		tokenHash, p.UserID,
+		p.ExpiresAt.UTC().Format(time.DateTime),
+		now.Format(time.DateTime),
+		now.Format(time.DateTime),
+		idleSecs,
+		nullableString(p.DeviceLabel),
+		nullableString(p.LastIP),
+		nullableString(p.LastUserAgent),
+		publicID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating session: %w", err)
 	}
 
-	exp := expiresAt.UTC()
-	// Return the raw token as ID so the caller can send it to the client.
-	return &Session{ID: rawToken, UserID: userID, ExpiresAt: &exp, CreatedAt: now}, nil
+	exp := p.ExpiresAt.UTC()
+	return &Session{
+		ID:            rawToken,
+		UserID:        p.UserID,
+		ExpiresAt:     &exp,
+		CreatedAt:     now,
+		PublicID:      publicID,
+		LastUsedAt:    &now,
+		IdleTTL:       p.IdleTTL,
+		DeviceLabel:   p.DeviceLabel,
+		LastIP:        p.LastIP,
+		LastUserAgent: p.LastUserAgent,
+	}, nil
 }
 
 func (s *SQLiteStore) CreateScopedSession(ctx context.Context, vaultID, vaultRole string, expiresAt *time.Time) (*Session, error) {
@@ -738,14 +785,19 @@ func (s *SQLiteStore) CreateScopedSession(ctx context.Context, vaultID, vaultRol
 func (s *SQLiteStore) GetSession(ctx context.Context, rawToken string) (*Session, error) {
 	tokenHash := hashSessionToken(rawToken)
 	row := s.db.QueryRowContext(ctx,
-		"SELECT id, user_id, vault_id, agent_id, vault_role, expires_at, created_at FROM sessions WHERE id = ?", tokenHash,
+		`SELECT id, user_id, vault_id, agent_id, vault_role, expires_at, created_at,
+		        last_used_at, idle_ttl_seconds, device_label, last_ip, last_user_agent, public_id
+		 FROM sessions WHERE id = ?`, tokenHash,
 	)
 
 	var sess Session
 	var storedID string
 	var userID, vaultID, agentID, vaultRole, expiresAt sql.NullString
+	var lastUsedAt, deviceLabel, lastIP, lastUserAgent, publicID sql.NullString
+	var idleSecs sql.NullInt64
 	var createdAt string
-	if err := row.Scan(&storedID, &userID, &vaultID, &agentID, &vaultRole, &expiresAt, &createdAt); err != nil {
+	if err := row.Scan(&storedID, &userID, &vaultID, &agentID, &vaultRole, &expiresAt, &createdAt,
+		&lastUsedAt, &idleSecs, &deviceLabel, &lastIP, &lastUserAgent, &publicID); err != nil {
 		return nil, err
 	}
 	// Return the raw token as ID (not the hash) so callers can reference it.
@@ -759,7 +811,125 @@ func (s *SQLiteStore) GetSession(ctx context.Context, rawToken string) (*Session
 		sess.ExpiresAt = &t
 	}
 	sess.CreatedAt, _ = time.Parse(time.DateTime, createdAt)
+	if lastUsedAt.Valid {
+		t, _ := time.Parse(time.DateTime, lastUsedAt.String)
+		sess.LastUsedAt = &t
+	}
+	if idleSecs.Valid {
+		sess.IdleTTL = time.Duration(idleSecs.Int64) * time.Second
+	}
+	sess.DeviceLabel = deviceLabel.String
+	sess.LastIP = lastIP.String
+	sess.LastUserAgent = lastUserAgent.String
+	sess.PublicID = publicID.String
 	return &sess, nil
+}
+
+// TouchInterval is the minimum gap between last_used_at writes for a
+// single session. Per-request UPDATEs would serialize SQLite writes during
+// a proxy storm; collapsing to one write per minute keeps the idle window
+// accurate to within a minute while leaving headroom for concurrent reads.
+// Exported so callers (e.g. the server's in-memory touch cache) can stay
+// consistent with the store-side throttle.
+const TouchInterval = 60 * time.Second
+
+// TouchSession bumps last_used_at on a user session, throttled by
+// touchInterval so per-request calls collapse to one write per minute.
+// No-op for agent tokens and scoped sessions (their rows have user_id IS NULL).
+func (s *SQLiteStore) TouchSession(ctx context.Context, rawToken string) error {
+	tokenHash := hashSessionToken(rawToken)
+	now := time.Now().UTC().Format(time.DateTime)
+	cutoff := time.Now().UTC().Add(-TouchInterval).Format(time.DateTime)
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE sessions SET last_used_at = ?
+		 WHERE id = ?
+		   AND user_id IS NOT NULL
+		   AND (last_used_at IS NULL OR last_used_at < ?)`,
+		now, tokenHash, cutoff,
+	)
+	if err != nil {
+		return fmt.Errorf("touching session: %w", err)
+	}
+	return nil
+}
+
+// ListUserSessions returns active (non-expired) user sessions for userID,
+// most recently used first. Idle expiry is enforced at the row level so
+// stale rows don't leak into the UI.
+func (s *SQLiteStore) ListUserSessions(ctx context.Context, userID string) ([]Session, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, expires_at, created_at, last_used_at, idle_ttl_seconds,
+		        device_label, last_ip, last_user_agent, public_id
+		 FROM sessions
+		 WHERE user_id = ?
+		   AND (expires_at IS NULL OR expires_at > datetime('now'))
+		 ORDER BY COALESCE(last_used_at, created_at) DESC`,
+		userID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing user sessions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Session
+	now := time.Now().UTC()
+	for rows.Next() {
+		var sess Session
+		var hashedID, createdAt string
+		var expiresAt, lastUsedAt, deviceLabel, lastIP, lastUserAgent, publicID sql.NullString
+		var idleSecs sql.NullInt64
+		if err := rows.Scan(&hashedID, &expiresAt, &createdAt, &lastUsedAt, &idleSecs,
+			&deviceLabel, &lastIP, &lastUserAgent, &publicID); err != nil {
+			return nil, fmt.Errorf("scanning session: %w", err)
+		}
+		sess.UserID = userID
+		// ID is intentionally left empty — the raw token only lives on the
+		// client. Callers identify sessions by PublicID.
+		sess.PublicID = publicID.String
+		sess.DeviceLabel = deviceLabel.String
+		sess.LastIP = lastIP.String
+		sess.LastUserAgent = lastUserAgent.String
+		if expiresAt.Valid {
+			t, _ := time.Parse(time.DateTime, expiresAt.String)
+			sess.ExpiresAt = &t
+		}
+		sess.CreatedAt, _ = time.Parse(time.DateTime, createdAt)
+		if lastUsedAt.Valid {
+			t, _ := time.Parse(time.DateTime, lastUsedAt.String)
+			sess.LastUsedAt = &t
+		}
+		if idleSecs.Valid {
+			sess.IdleTTL = time.Duration(idleSecs.Int64) * time.Second
+		}
+		// Skip rows past their idle window — same rule as IsExpired.
+		if sess.IsExpired(now) {
+			continue
+		}
+		out = append(out, sess)
+	}
+	return out, rows.Err()
+}
+
+// RevokeUserSession deletes a single session by (userID, publicID).
+// Returns sql.ErrNoRows if no matching session exists — important so a
+// caller can distinguish "already gone" from a successful revoke without
+// a separate lookup.
+func (s *SQLiteStore) RevokeUserSession(ctx context.Context, userID, publicID string) error {
+	if userID == "" || publicID == "" {
+		return sql.ErrNoRows
+	}
+	res, err := s.db.ExecContext(ctx,
+		"DELETE FROM sessions WHERE user_id = ? AND public_id = ?",
+		userID, publicID,
+	)
+	if err != nil {
+		return fmt.Errorf("revoking session: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }
 
 func (s *SQLiteStore) DeleteSession(ctx context.Context, rawToken string) error {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -833,19 +833,26 @@ func (s *SQLiteStore) GetSession(ctx context.Context, rawToken string) (*Session
 // consistent with the store-side throttle.
 const TouchInterval = 60 * time.Second
 
-// TouchSession bumps last_used_at on a user session, throttled by
-// touchInterval so per-request calls collapse to one write per minute.
-// No-op for agent tokens and scoped sessions (their rows have user_id IS NULL).
-func (s *SQLiteStore) TouchSession(ctx context.Context, rawToken string) error {
+// TouchSession bumps last_used_at on a user session and refreshes
+// last_ip + last_user_agent so the auth-sessions view reflects the
+// caller's most recent request rather than only the login. Throttled by
+// TouchInterval so per-request calls collapse to one write per minute.
+// No-op for agent tokens and scoped sessions (rows with user_id IS NULL).
+// Empty ip/userAgent leave the existing column value untouched via
+// COALESCE — handy when a caller can't determine them.
+func (s *SQLiteStore) TouchSession(ctx context.Context, rawToken, ip, userAgent string) error {
 	tokenHash := hashSessionToken(rawToken)
 	now := time.Now().UTC().Format(time.DateTime)
 	cutoff := time.Now().UTC().Add(-TouchInterval).Format(time.DateTime)
 	_, err := s.db.ExecContext(ctx,
-		`UPDATE sessions SET last_used_at = ?
-		 WHERE id = ?
-		   AND user_id IS NOT NULL
-		   AND (last_used_at IS NULL OR last_used_at < ?)`,
-		now, tokenHash, cutoff,
+		`UPDATE sessions
+		    SET last_used_at    = ?,
+		        last_ip         = COALESCE(NULLIF(?, ''), last_ip),
+		        last_user_agent = COALESCE(NULLIF(?, ''), last_user_agent)
+		  WHERE id = ?
+		    AND user_id IS NOT NULL
+		    AND (last_used_at IS NULL OR last_used_at < ?)`,
+		now, ip, userAgent, tokenHash, cutoff,
 	)
 	if err != nil {
 		return fmt.Errorf("touching session: %w", err)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -544,6 +544,76 @@ func TestListAndRevokeUserSessions(t *testing.T) {
 	}
 }
 
+// TestPreMigrationSessionStillUsable simulates a session row created before
+// migration 040 — populated id/user_id/expires_at, NULL on the columns
+// added by 040 except for public_id (backfilled by the migration's UPDATE).
+// It must continue to authenticate, enumerate, and revoke without
+// requiring the user to re-login.
+func TestPreMigrationSessionStillUsable(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	u, _ := s.CreateUser(ctx, "legacy@test.com", []byte("h"), []byte("s"), "owner", 3, 65536, 4)
+
+	// Forge a row that looks like one minted by the pre-040 server: just
+	// id/user_id/expires_at/created_at, no idle_ttl, no last_used_at, but
+	// with the backfilled public_id the migration would have written.
+	rawToken := "av_sess_legacy_test_token_value_with_padding_to_64_chars_xxxxxxx"
+	tokenHash := hashSessionToken(rawToken)
+	expiresAt := time.Now().Add(time.Hour).UTC().Format(time.DateTime)
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO sessions (id, user_id, expires_at, created_at, public_id)
+		 VALUES (?, ?, ?, datetime('now'), ?)`,
+		tokenHash, u.ID, expiresAt, "legacypub01",
+	)
+	if err != nil {
+		t.Fatalf("forging legacy session row: %v", err)
+	}
+
+	got, err := s.GetSession(ctx, rawToken)
+	if err != nil {
+		t.Fatalf("GetSession on legacy row: %v", err)
+	}
+	if got.IdleTTL != 0 {
+		t.Fatalf("legacy row IdleTTL should be 0 (idle disabled), got %v", got.IdleTTL)
+	}
+	if got.LastUsedAt != nil {
+		t.Fatalf("legacy row LastUsedAt should be nil, got %v", got.LastUsedAt)
+	}
+	if got.IsExpired(time.Now()) {
+		t.Fatal("legacy row inside its absolute TTL must not be expired")
+	}
+
+	rows, err := s.ListUserSessions(ctx, u.ID)
+	if err != nil {
+		t.Fatalf("ListUserSessions: %v", err)
+	}
+	if len(rows) != 1 || rows[0].PublicID != "legacypub01" {
+		t.Fatalf("expected legacy row in list with public_id 'legacypub01', got %+v", rows)
+	}
+
+	// Touch a legacy session: should populate last_used_at without
+	// retroactively enabling the idle check.
+	if err := s.TouchSession(ctx, rawToken); err != nil {
+		t.Fatalf("TouchSession: %v", err)
+	}
+	got, _ = s.GetSession(ctx, rawToken)
+	if got.LastUsedAt == nil {
+		t.Fatal("touch should populate last_used_at on legacy row")
+	}
+	if got.IdleTTL != 0 {
+		t.Fatal("touch must not retroactively enable idle expiry on legacy row")
+	}
+
+	// Revoke by the backfilled public_id works.
+	if err := s.RevokeUserSession(ctx, u.ID, "legacypub01"); err != nil {
+		t.Fatalf("RevokeUserSession on legacy row: %v", err)
+	}
+	if _, err := s.GetSession(ctx, rawToken); err != sql.ErrNoRows {
+		t.Fatalf("revoked legacy session should be gone, got %v", err)
+	}
+}
+
 // --- Master Key ---
 
 func TestGetMasterKeyRecordEmpty(t *testing.T) {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -476,7 +476,7 @@ func TestTouchSessionThrottlesAndAdvances(t *testing.T) {
 		t.Fatalf("forcing last_used_at: %v", err)
 	}
 
-	if err := s.TouchSession(ctx, sess.ID); err != nil {
+	if err := s.TouchSession(ctx, sess.ID, "10.0.0.1", "agent-vault-cli/test"); err != nil {
 		t.Fatalf("TouchSession: %v", err)
 	}
 
@@ -490,15 +490,38 @@ func TestTouchSessionThrottlesAndAdvances(t *testing.T) {
 	if time.Since(*got.LastUsedAt) > time.Minute {
 		t.Fatalf("LastUsedAt should be ~now after Touch, got %v ago", time.Since(*got.LastUsedAt))
 	}
+	if got.LastIP != "10.0.0.1" || got.LastUserAgent != "agent-vault-cli/test" {
+		t.Fatalf("touch should refresh last_ip/last_user_agent, got ip=%q ua=%q", got.LastIP, got.LastUserAgent)
+	}
 
-	// Throttle: a second touch within touchInterval is a no-op.
+	// Throttle: a second touch within TouchInterval is a no-op, and
+	// non-empty ip/ua args still don't bleed through the throttle.
 	frozen := *got.LastUsedAt
-	if err := s.TouchSession(ctx, sess.ID); err != nil {
+	if err := s.TouchSession(ctx, sess.ID, "10.0.0.99", "other-agent"); err != nil {
 		t.Fatalf("TouchSession (second): %v", err)
 	}
 	got2, _ := s.GetSession(ctx, sess.ID)
 	if !got2.LastUsedAt.Equal(frozen) {
 		t.Fatalf("expected throttled write to leave last_used_at = %v, got %v", frozen, got2.LastUsedAt)
+	}
+	if got2.LastIP != "10.0.0.1" {
+		t.Fatalf("throttled touch must not overwrite last_ip, got %q", got2.LastIP)
+	}
+
+	// Empty ip/ua leaves existing values untouched even when the
+	// throttle window expires.
+	if _, err := s.db.ExecContext(ctx,
+		"UPDATE sessions SET last_used_at = ? WHERE id = ?",
+		time.Now().Add(-2*time.Hour).UTC().Format(time.DateTime), hashSessionToken(sess.ID),
+	); err != nil {
+		t.Fatalf("forcing last_used_at: %v", err)
+	}
+	if err := s.TouchSession(ctx, sess.ID, "", ""); err != nil {
+		t.Fatalf("TouchSession (empty ip/ua): %v", err)
+	}
+	got3, _ := s.GetSession(ctx, sess.ID)
+	if got3.LastIP != "10.0.0.1" || got3.LastUserAgent != "agent-vault-cli/test" {
+		t.Fatalf("empty ip/ua should preserve previous values, got ip=%q ua=%q", got3.LastIP, got3.LastUserAgent)
 	}
 }
 
@@ -594,7 +617,7 @@ func TestPreMigrationSessionStillUsable(t *testing.T) {
 
 	// Touch a legacy session: should populate last_used_at without
 	// retroactively enabling the idle check.
-	if err := s.TouchSession(ctx, rawToken); err != nil {
+	if err := s.TouchSession(ctx, rawToken, "127.0.0.1", "test"); err != nil {
 		t.Fatalf("TouchSession: %v", err)
 	}
 	got, _ = s.GetSession(ctx, rawToken)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -28,8 +28,8 @@ func TestOpenAndMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("querying schema_migrations: %v", err)
 	}
-	if version != 39 {
-		t.Fatalf("expected migration version 39, got %d", version)
+	if version != 40 {
+		t.Fatalf("expected migration version 40, got %d", version)
 	}
 }
 
@@ -298,11 +298,12 @@ func TestSessionCRUD(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
+	u, _ := s.CreateUser(ctx, "session-crud@test.com", []byte("h"), []byte("s"), "owner", 3, 65536, 4)
 	expires := time.Now().Add(1 * time.Hour).UTC().Truncate(time.Second)
 
-	sess, err := s.CreateSession(ctx, "", expires)
+	sess, err := s.CreateUserSession(ctx, CreateUserSessionParams{UserID: u.ID, ExpiresAt: expires})
 	if err != nil {
-		t.Fatalf("CreateSession: %v", err)
+		t.Fatalf("CreateUserSession: %v", err)
 	}
 	if sess.ID == "" {
 		t.Fatal("expected non-empty session ID")
@@ -364,10 +365,11 @@ func TestGlobalSessionHasEmptyVaultID(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
+	u, _ := s.CreateUser(ctx, "global-session@test.com", []byte("h"), []byte("s"), "owner", 3, 65536, 4)
 	expires := time.Now().Add(1 * time.Hour).UTC().Truncate(time.Second)
-	sess, err := s.CreateSession(ctx, "", expires)
+	sess, err := s.CreateUserSession(ctx, CreateUserSessionParams{UserID: u.ID, ExpiresAt: expires})
 	if err != nil {
-		t.Fatalf("CreateSession: %v", err)
+		t.Fatalf("CreateUserSession: %v", err)
 	}
 
 	got, err := s.GetSession(ctx, sess.ID)
@@ -386,6 +388,159 @@ func TestDeleteSessionNotFound(t *testing.T) {
 	err := s.DeleteSession(ctx, "nonexistent")
 	if err != sql.ErrNoRows {
 		t.Fatalf("expected sql.ErrNoRows, got %v", err)
+	}
+}
+
+func TestSessionIsExpired(t *testing.T) {
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-time.Hour)
+	future := now.Add(time.Hour)
+
+	cases := []struct {
+		name string
+		sess Session
+		want bool
+	}{
+		{"never expires", Session{}, false},
+		{"absolute future", Session{ExpiresAt: &future}, false},
+		{"absolute past", Session{ExpiresAt: &past}, true},
+		{"idle within window", Session{IdleTTL: time.Hour, LastUsedAt: ptrTime(now.Add(-30 * time.Minute))}, false},
+		{"idle past window", Session{IdleTTL: time.Minute, LastUsedAt: ptrTime(now.Add(-time.Hour))}, true},
+		{"idle ttl zero ignored", Session{IdleTTL: 0, LastUsedAt: ptrTime(now.Add(-365 * 24 * time.Hour))}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.sess.IsExpired(now); got != tc.want {
+				t.Fatalf("IsExpired = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
+func TestCreateUserSessionPopulatesMetadata(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	u, _ := s.CreateUser(ctx, "meta@test.com", []byte("h"), []byte("s"), "owner", 3, 65536, 4)
+	exp := time.Now().Add(365 * 24 * time.Hour).UTC().Truncate(time.Second)
+	sess, err := s.CreateUserSession(ctx, CreateUserSessionParams{
+		UserID:        u.ID,
+		ExpiresAt:     exp,
+		IdleTTL:       30 * 24 * time.Hour,
+		DeviceLabel:   "tony-mbp",
+		LastIP:        "127.0.0.1",
+		LastUserAgent: "agent-vault-cli/0.4",
+	})
+	if err != nil {
+		t.Fatalf("CreateUserSession: %v", err)
+	}
+	if sess.PublicID == "" {
+		t.Fatal("expected PublicID to be populated")
+	}
+	got, err := s.GetSession(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if got.DeviceLabel != "tony-mbp" || got.LastIP != "127.0.0.1" || got.LastUserAgent != "agent-vault-cli/0.4" {
+		t.Fatalf("metadata round-trip mismatch: %+v", got)
+	}
+	if got.IdleTTL != 30*24*time.Hour {
+		t.Fatalf("expected IdleTTL %v, got %v", 30*24*time.Hour, got.IdleTTL)
+	}
+	if got.PublicID != sess.PublicID {
+		t.Fatalf("PublicID mismatch: %q vs %q", got.PublicID, sess.PublicID)
+	}
+	if got.LastUsedAt == nil {
+		t.Fatal("expected LastUsedAt to be populated on creation")
+	}
+}
+
+func TestTouchSessionThrottlesAndAdvances(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	u, _ := s.CreateUser(ctx, "touch@test.com", []byte("h"), []byte("s"), "owner", 3, 65536, 4)
+	sess, _ := s.CreateUserSession(ctx, CreateUserSessionParams{
+		UserID:    u.ID,
+		ExpiresAt: time.Now().Add(time.Hour),
+		IdleTTL:   30 * 24 * time.Hour,
+	})
+
+	// Force last_used_at far enough in the past that a touch will succeed.
+	if _, err := s.db.ExecContext(ctx,
+		"UPDATE sessions SET last_used_at = ? WHERE user_id = ?",
+		time.Now().Add(-2*time.Hour).UTC().Format(time.DateTime), u.ID,
+	); err != nil {
+		t.Fatalf("forcing last_used_at: %v", err)
+	}
+
+	if err := s.TouchSession(ctx, sess.ID); err != nil {
+		t.Fatalf("TouchSession: %v", err)
+	}
+
+	got, err := s.GetSession(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if got.LastUsedAt == nil {
+		t.Fatal("LastUsedAt should be populated after Touch")
+	}
+	if time.Since(*got.LastUsedAt) > time.Minute {
+		t.Fatalf("LastUsedAt should be ~now after Touch, got %v ago", time.Since(*got.LastUsedAt))
+	}
+
+	// Throttle: a second touch within touchInterval is a no-op.
+	frozen := *got.LastUsedAt
+	if err := s.TouchSession(ctx, sess.ID); err != nil {
+		t.Fatalf("TouchSession (second): %v", err)
+	}
+	got2, _ := s.GetSession(ctx, sess.ID)
+	if !got2.LastUsedAt.Equal(frozen) {
+		t.Fatalf("expected throttled write to leave last_used_at = %v, got %v", frozen, got2.LastUsedAt)
+	}
+}
+
+func TestListAndRevokeUserSessions(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	u, _ := s.CreateUser(ctx, "multi@test.com", []byte("h"), []byte("s"), "owner", 3, 65536, 4)
+	a, _ := s.CreateUserSession(ctx, CreateUserSessionParams{UserID: u.ID, ExpiresAt: time.Now().Add(time.Hour), DeviceLabel: "a"})
+	b, _ := s.CreateUserSession(ctx, CreateUserSessionParams{UserID: u.ID, ExpiresAt: time.Now().Add(time.Hour), DeviceLabel: "b"})
+
+	rows, err := s.ListUserSessions(ctx, u.ID)
+	if err != nil {
+		t.Fatalf("ListUserSessions: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(rows))
+	}
+
+	// Revoke "a" by its public id.
+	if err := s.RevokeUserSession(ctx, u.ID, a.PublicID); err != nil {
+		t.Fatalf("RevokeUserSession: %v", err)
+	}
+	if _, err := s.GetSession(ctx, a.ID); err != sql.ErrNoRows {
+		t.Fatalf("expected revoked session to be gone, got %v", err)
+	}
+	if _, err := s.GetSession(ctx, b.ID); err != nil {
+		t.Fatalf("other session should still exist: %v", err)
+	}
+
+	// Revoke twice → ErrNoRows.
+	if err := s.RevokeUserSession(ctx, u.ID, a.PublicID); err != sql.ErrNoRows {
+		t.Fatalf("expected sql.ErrNoRows on second revoke, got %v", err)
+	}
+
+	// Cross-account revoke is a no-op (returns ErrNoRows).
+	other, _ := s.CreateUser(ctx, "other@test.com", []byte("h"), []byte("s"), "member", 3, 65536, 4)
+	if err := s.RevokeUserSession(ctx, other.ID, b.PublicID); err != sql.ErrNoRows {
+		t.Fatalf("cross-account revoke should be ErrNoRows, got %v", err)
+	}
+	if _, err := s.GetSession(ctx, b.ID); err != nil {
+		t.Fatalf("session should still exist after cross-account revoke attempt: %v", err)
 	}
 }
 
@@ -1357,7 +1512,7 @@ func TestDeleteUserSessions(t *testing.T) {
 	ctx := context.Background()
 
 	u, _ := s.CreateUser(ctx, "user@test.com", []byte("h"), []byte("s"), "owner", 3, 65536, 4)
-	sess, _ := s.CreateSession(ctx, u.ID, time.Now().Add(24*time.Hour))
+	sess, _ := s.CreateUserSession(ctx, CreateUserSessionParams{UserID: u.ID, ExpiresAt: time.Now().Add(24 * time.Hour)})
 
 	if err := s.DeleteUserSessions(ctx, u.ID); err != nil {
 		t.Fatalf("DeleteUserSessions: %v", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -349,10 +349,12 @@ type Store interface {
 	CreateScopedSession(ctx context.Context, vaultID, vaultRole string, expiresAt *time.Time) (*Session, error)
 	GetSession(ctx context.Context, id string) (*Session, error)
 	DeleteSession(ctx context.Context, id string) error
-	// TouchSession bumps last_used_at for the given raw token; throttled
-	// internally so per-request calls collapse to one write per minute.
-	// Returns no error when the session is missing (best-effort).
-	TouchSession(ctx context.Context, rawToken string) error
+	// TouchSession bumps last_used_at for the given raw token and
+	// refreshes last_ip + last_user_agent (empty values leave the
+	// existing column unchanged). Throttled internally so per-request
+	// calls collapse to one write per minute. Returns no error when the
+	// session is missing (best-effort).
+	TouchSession(ctx context.Context, rawToken, ip, userAgent string) error
 	// ListUserSessions returns every non-expired user session for userID
 	// (ordered most-recent activity first). Used by the auth-sessions UI.
 	ListUserSessions(ctx context.Context, userID string) ([]Session, error)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -73,6 +73,40 @@ type Session struct {
 	VaultRole string     // set for user scoped sessions; empty for agent tokens (resolved per-request)
 	ExpiresAt *time.Time // nil = never expires
 	CreatedAt time.Time
+
+	// User-session sliding-expiry fields. Populated by CreateUserSession;
+	// left zero for scoped sessions and agent tokens.
+	PublicID      string        // short opaque handle for revoke endpoint; empty for scoped/agent
+	LastUsedAt    *time.Time    // last time the token was successfully resolved
+	IdleTTL       time.Duration // 0 = no idle expiry (agent tokens, legacy rows)
+	DeviceLabel   string        // user-visible label, e.g. hostname
+	LastIP        string
+	LastUserAgent string
+}
+
+// IsExpired reports whether the session is past its absolute expiry or its
+// idle window. Single source of truth for expiry checks across the server
+// (requireAuth) and proxy ingress (brokercore.SessionResolver).
+func (s *Session) IsExpired(now time.Time) bool {
+	if s.ExpiresAt != nil && now.After(*s.ExpiresAt) {
+		return true
+	}
+	if s.IdleTTL > 0 && s.LastUsedAt != nil && now.Sub(*s.LastUsedAt) > s.IdleTTL {
+		return true
+	}
+	return false
+}
+
+// CreateUserSessionParams carries all the fields persisted on a fresh
+// user-login session. Captured as a struct so login, OAuth callback, and
+// password-change call sites stay aligned without positional drift.
+type CreateUserSessionParams struct {
+	UserID        string
+	ExpiresAt     time.Time
+	IdleTTL       time.Duration
+	DeviceLabel   string
+	LastIP        string
+	LastUserAgent string
 }
 
 // User represents a human user account.
@@ -311,10 +345,20 @@ type Store interface {
 	DeleteUserSessions(ctx context.Context, userID string) error
 
 	// Sessions
-	CreateSession(ctx context.Context, userID string, expiresAt time.Time) (*Session, error)
+	CreateUserSession(ctx context.Context, p CreateUserSessionParams) (*Session, error)
 	CreateScopedSession(ctx context.Context, vaultID, vaultRole string, expiresAt *time.Time) (*Session, error)
 	GetSession(ctx context.Context, id string) (*Session, error)
 	DeleteSession(ctx context.Context, id string) error
+	// TouchSession bumps last_used_at for the given raw token; throttled
+	// internally so per-request calls collapse to one write per minute.
+	// Returns no error when the session is missing (best-effort).
+	TouchSession(ctx context.Context, rawToken string) error
+	// ListUserSessions returns every non-expired user session for userID
+	// (ordered most-recent activity first). Used by the auth-sessions UI.
+	ListUserSessions(ctx context.Context, userID string) ([]Session, error)
+	// RevokeUserSession deletes a session matching both userID
+	// and publicID. Scoping by userID prevents cross-account revocation.
+	RevokeUserSession(ctx context.Context, userID, publicID string) error
 
 	// Broker configs
 	SetBrokerConfig(ctx context.Context, vaultID string, servicesJSON string) (*BrokerConfig, error)


### PR DESCRIPTION
## Summary

- User logins now last **1 year absolute / 30 days idle** (was 24h flat). Active operators stay logged in indefinitely; an unused `~/.agent-vault/session.json` dies after 30 days.
- New `agent-vault auth sessions list / revoke <id>` subcommand and `GET/DELETE /v1/auth/sessions` endpoints, with `device_label`, `last_ip`, `last_user_agent`, and `last_used_at` per row so operators can spot and kill individual logins.
- `Session.IsExpired(now)` is now the single source of truth, used by both `requireAuth` and the proxy ingress (`brokercore.SessionResolver`).
- An in-memory touch cache on the server collapses per-request `last_used_at` writes — no SQL UPDATE inside the throttle window, keeping the proxy hot path off SQLite's single writer slot.
- Scoped sessions (`vault run`) and agent tokens are unchanged: the new columns stay NULL and they bypass idle expiry.

Migration `040_session_sliding_expiry.sql` adds `last_used_at`, `idle_ttl_seconds`, `device_label`, `last_ip`, `last_user_agent`, `public_id` to `sessions` (UNIQUE index on `public_id`) and wipes any pre-existing user sessions for a clean cutover (no production users yet).

## Test plan

- [x] `go test ./...` passes
- [x] New unit tests cover `Session.IsExpired`, `CreateUserSession` metadata round-trip, `TouchSession` throttle, `ListUserSessions` + `RevokeUserSession`, login records device metadata, and the new HTTP routes (list / revoke / 401 after revoke / 404 on duplicate revoke)
- [ ] End-to-end: log in via CLI, confirm `~/.agent-vault/session.json` works for >24h
- [ ] End-to-end: `agent-vault auth sessions list` shows the active login with hostname; `revoke` invalidates a specific session
- [ ] End-to-end: forcing `last_used_at` to >30 days ago via `sqlite3` triggers the existing password reauth prompt (idle expiry path)
- [ ] Existing `vault run` flow still works (scoped sessions unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)