### PR TITLE
feat: URL credential substitutions for path/query/header surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Traditional secrets management relies on returning credentials directly to the c
 
 Agent Vault takes a different approach: **Agent Vault never reveals vault-stored credentials to agents**. Instead, agents route HTTP requests through a local proxy that injects the right credentials at the network layer.
 
-- **Brokered access, not retrieval** - Your agent gets a scoped session and a local `HTTPS_PROXY`. It calls target APIs normally, and Agent Vault injects the right credential at the network layer. Credentials are never returned to the agent.
+- **Brokered access, not retrieval** - Your agent gets a scoped session and a local `HTTPS_PROXY`. It calls target APIs normally, and Agent Vault injects the right credential at the network layer (headers, or — for APIs like Twilio that need the value in the URL — declared placeholder rewrites in the path or query string). Credentials are never returned to the agent.
 - **Works with any agent** - Custom Python/TypeScript agents, sandboxed processes, and coding agents like Claude Code, Cursor, and Codex. Anything that speaks HTTP.
 - **Encrypted at rest** - Credentials are encrypted with AES-256-GCM using a random data encryption key (DEK). An optional master password wraps the DEK via Argon2id, so rotating the password does not re-encrypt credentials. A passwordless mode is available for PaaS deploys.
 - **Request logs** - Every proxied request is persisted per vault with method, host, path, status, latency, and the credential key names involved. Bodies, headers, and query strings are not recorded. Retention is configurable per vault.

--- a/cmd/proposal.go
+++ b/cmd/proposal.go
@@ -57,6 +57,17 @@ func printServices(w io.Writer, servicesJSON string) {
 			if r.Action == proposal.ActionSet && r.Auth != nil {
 				fmt.Fprintf(w, "      %s: %s\n", mutedText("auth"), r.Auth.Type)
 			}
+			if r.Action == proposal.ActionSet && len(r.Substitutions) > 0 {
+				fmt.Fprintf(w, "      %s:\n", mutedText("substitutions"))
+				for _, sub := range r.Substitutions {
+					in := sub.NormalizedIn()
+					fmt.Fprintf(w, "        %s → %s %s\n",
+						sub.Placeholder,
+						sub.Key,
+						mutedText("in: ["+strings.Join(in, ", ")+"]"),
+					)
+				}
+			}
 		}
 	}
 }

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -109,8 +109,10 @@ How it works:
 - Your request must embed the placeholder verbatim: `GET https://api.twilio.com/2010-04-01/Accounts/__account_sid__/Messages.json`. The broker resolves `key` from the vault, URL-encodes the value, and substitutes it in.
 - `in` declares which surfaces the broker is allowed to scan: subset of `["path", "query", "header"]`. Defaults to `["path", "query"]` if omitted. `header` must be explicit. `body` is not supported.
 - **Scoping is the security boundary.** The broker only scans surfaces in `in`. Embedding the placeholder anywhere else (a non-declared surface, a body) means the literal string passes through unmodified — there is no way to coerce the broker into substituting somewhere the operator did not authorize.
+- When `header` is in `in`, the broker scans **every outbound header** for the placeholder, not a specific named header. Pick a unique placeholder so it can only appear where you intended.
 - Substitutions compose with auth: a Twilio service uses both `auth: basic` (header injection) and a substitution for the path SID.
-- Placeholder safety: must be ≥4 characters, contain a `__` boundary or non-`[A-Za-z0-9_]` character (so bare words like `account_sid` are rejected — they would match legitimate URL words), and use only RFC 3986 unreserved characters `[A-Za-z0-9_-.~]`. The recommended convention is `__name__`.
+- Placeholder safety: must be ≥4 characters, contain at least one alphanumeric character, contain a `__` boundary or non-`[A-Za-z0-9_]` character (so bare words like `account_sid` are rejected — they would match legitimate URL words), and use only RFC 3986 unreserved characters `[A-Za-z0-9_-.~]`. The recommended convention is `__name__`.
+- Updating an existing service: a `set` proposal that omits `substitutions` (or sends an empty list) preserves the service's existing substitutions, even when `auth` is replaced. To change the list, supply the new non-empty list. To clear all substitutions, delete and recreate the service.
 
 Substitutions are configured via JSON only — no flag form. Place a `substitutions` array under any `services[]` entry in `proposal create -f file.json` or `agent-vault service set -f services.yaml`.
 

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -94,6 +94,26 @@ Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic
 
 **Passthrough** allowlists a host but does not store or inject a credential. Use it only when the operator has decided their client already holds the credential and wants netguard / audit / MITM coverage without putting the secret in the vault. For the default case (agent needs the credential from the vault), use one of the credentialed types above.
 
+### URL Substitutions
+
+Some APIs want a credential-derived value in the URL path or query string (Twilio's `/Accounts/{AccountSID}/Messages.json`, legacy `?api_key=` services). Auth types only inject headers, so for these you add a `substitutions` field to the service. The broker rewrites a placeholder string in declared surfaces only.
+
+```json
+"substitutions": [
+  {"key": "TWILIO_ACCOUNT_SID", "placeholder": "__account_sid__", "in": ["path"]}
+]
+```
+
+How it works:
+- The operator declares the exact `placeholder` string (e.g. `__account_sid__`). The broker matches it case-sensitively as a literal — no auto-wrapping, no transformations.
+- Your request must embed the placeholder verbatim: `GET https://api.twilio.com/2010-04-01/Accounts/__account_sid__/Messages.json`. The broker resolves `key` from the vault, URL-encodes the value, and substitutes it in.
+- `in` declares which surfaces the broker is allowed to scan: subset of `["path", "query", "header"]`. Defaults to `["path", "query"]` if omitted. `header` must be explicit. `body` is not supported.
+- **Scoping is the security boundary.** The broker only scans surfaces in `in`. Embedding the placeholder anywhere else (a non-declared surface, a body) means the literal string passes through unmodified — there is no way to coerce the broker into substituting somewhere the operator did not authorize.
+- Substitutions compose with auth: a Twilio service uses both `auth: basic` (header injection) and a substitution for the path SID.
+- Placeholder safety: must be ≥4 characters, contain a `__` boundary or non-`[A-Za-z0-9_]` character (so bare words like `account_sid` are rejected — they would match legitimate URL words), and use only RFC 3986 unreserved characters `[A-Za-z0-9_-.~]`. The recommended convention is `__name__`.
+
+Substitutions are configured via JSON only — no flag form. Place a `substitutions` array under any `services[]` entry in `proposal create -f file.json` or `agent-vault service set -f services.yaml`.
+
 ### Creating a Proposal
 
 **Flag-driven mode (common cases):**
@@ -118,6 +138,25 @@ agent-vault vault proposal create -f - --json <<'EOF'
   "message": "Need Stripe access"
 }
 EOF
+
+# Service with URL substitution (Twilio: SID in path + auth header)
+agent-vault vault proposal create -f - --json <<'EOF'
+{
+  "services": [{
+    "action": "set",
+    "host": "api.twilio.com",
+    "auth": {"type": "basic", "username": "TWILIO_ACCOUNT_SID", "password": "TWILIO_AUTH_TOKEN"},
+    "substitutions": [
+      {"key": "TWILIO_ACCOUNT_SID", "placeholder": "__account_sid__", "in": ["path"]}
+    ]
+  }],
+  "credentials": [
+    {"action": "set", "key": "TWILIO_ACCOUNT_SID", "description": "Twilio Account SID"},
+    {"action": "set", "key": "TWILIO_AUTH_TOKEN", "description": "Twilio Auth Token"}
+  ],
+  "message": "Twilio messaging — agent embeds __account_sid__ in the URL path"
+}
+EOF
 ```
 
 Flag-driven auth flags by type:
@@ -131,6 +170,7 @@ Other flags: `--description` (service description), `--user-message` (shown on b
 Key fields (JSON mode):
 - `services[].action` -- `"set"` (upsert, needs `host` + `auth` **or** an `enabled` change) or `"delete"` (needs `host` only)
 - `services[].auth` -- authentication config. Types: `bearer` (`token`), `basic` (`username`, optional `password`), `api-key` (`key` + `header`, optional `prefix`), `custom` (`headers` map with `{{ KEY }}` templates), `passthrough` (no credential fields)
+- `services[].substitutions` -- optional list of URL/header rewrites. Each entry has `key` (UPPER_SNAKE_CASE credential reference), `placeholder` (the exact wire string the broker matches case-sensitively, e.g. `__account_sid__`), and optional `in` (subset of `["path", "query", "header"]`; defaults to `["path", "query"]`). Surfaces not in `in` are not scanned. Must be paired with an `auth` change in the same proposal — substitutions cannot be added on an enable/disable-only update.
 - `services[].enabled` -- optional boolean. Omitted means "enabled" for new services. A `"set"` proposal may supply `enabled` alone (no `auth`) to toggle an existing service's state without replacing its auth config -- useful for staged rollouts
 - `credentials[].action` -- `"set"` (omit `value` for human to supply; include `value` to store back) or `"delete"`
 - `credentials` -- only declare credentials not already in `available_credentials`. Every credential referenced in auth configs must resolve to a slot or existing credential (400 otherwise)

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -103,6 +103,45 @@ Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic
 
 **Passthrough** allowlists a host but does not store or inject a credential. Use it only when the operator has decided their client already holds the credential and wants netguard / audit / MITM coverage without putting the secret in the vault. For the default case (agent needs the credential from the vault), use one of the credentialed types above. Passthrough auth entries reject all credential fields (`token`, `username`, `password`, `key`, `header`, `prefix`, `headers`).
 
+### URL Substitutions
+
+Auth types only inject headers. For APIs that want a credential value in the URL path or query string (Twilio's `/Accounts/{AccountSID}/Messages.json`, legacy `?api_key=` services), add a `substitutions` field on the service. The broker rewrites a placeholder string in declared surfaces only.
+
+How it works:
+- The operator declares the exact `placeholder` string. The broker matches it case-sensitively as a literal — no auto-wrapping, no transformations.
+- Your request must embed the placeholder verbatim. The broker resolves the credential, URL-encodes the value, and substitutes it in.
+- `in` declares which surfaces the broker is allowed to scan: subset of `["path", "query", "header"]`, defaulting to `["path", "query"]`. `header` must be explicit. `body` is not supported.
+- **Scoping is the security boundary.** The broker only scans surfaces in `in`. Embedding the placeholder anywhere else means the literal string passes through unmodified — the operator's `in` declaration cannot be overridden by request shape.
+- Substitutions compose with all auth types, including `passthrough`.
+
+Example proposal (Twilio: basic auth header + path SID substitution):
+
+```
+POST {AGENT_VAULT_ADDR}/v1/proposals
+Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Content-Type: application/json
+
+{
+  "services": [{
+    "action": "set",
+    "host": "api.twilio.com",
+    "auth": {"type": "basic", "username": "TWILIO_ACCOUNT_SID", "password": "TWILIO_AUTH_TOKEN"},
+    "substitutions": [
+      {"key": "TWILIO_ACCOUNT_SID", "placeholder": "__account_sid__", "in": ["path"]}
+    ]
+  }],
+  "credentials": [
+    {"action": "set", "key": "TWILIO_ACCOUNT_SID", "description": "Twilio Account SID", "obtain": "https://console.twilio.com"},
+    {"action": "set", "key": "TWILIO_AUTH_TOKEN", "description": "Twilio Auth Token"}
+  ],
+  "message": "Twilio messaging — agent embeds __account_sid__ in the URL path"
+}
+```
+
+Once approved, the agent makes requests like `GET https://api.twilio.com/2010-04-01/Accounts/__account_sid__/Messages.json` (via `/proxy/api.twilio.com/...` or `HTTPS_PROXY`). The broker rewrites the path to `/Accounts/AC.../Messages.json` and injects the basic auth header.
+
+Placeholder safety: must be ≥4 characters, contain a `__` boundary or non-`[A-Za-z0-9_]` character (so bare words like `account_sid` are rejected — they would match legitimate URL words), and use only RFC 3986 unreserved characters `[A-Za-z0-9_-.~]`. The recommended convention is `__name__`.
+
 ### Creating a Proposal
 
 ```
@@ -121,6 +160,7 @@ Content-Type: application/json
 Key fields:
 - `services[].action` -- `"set"` (upsert, needs `host` + `auth` **or** an `enabled` change) or `"delete"` (needs `host` only)
 - `services[].auth` -- authentication config. Types: `bearer` (`token`), `basic` (`username`, optional `password`), `api-key` (`key` + `header`, optional `prefix`), `custom` (`headers` map with `{{ KEY }}` templates), `passthrough` (no credential fields)
+- `services[].substitutions` -- optional list of URL/header rewrites. Each entry has `key` (UPPER_SNAKE_CASE credential reference), `placeholder` (the exact wire string the broker matches case-sensitively, e.g. `__account_sid__`), and optional `in` (subset of `["path", "query", "header"]`; defaults to `["path", "query"]`). Surfaces not in `in` are not scanned. Must be paired with an `auth` change in the same proposal — substitutions cannot be added on an enable/disable-only update. See the URL Substitutions section above.
 - `services[].enabled` -- optional boolean. Omitted means "enabled" for new services. A `"set"` proposal may supply `enabled` alone (no `auth`) to flip an existing service's state without replacing its auth config -- useful for staged rollouts where the operator wires credentials before flipping traffic on
 - `credentials[].action` -- `"set"` (omit `value` for human to supply; include `value` to store back) or `"delete"`
 - `credentials` -- only declare credentials not already in `available_credentials`. Every credential referenced in auth configs must resolve to a slot or existing credential (400 otherwise)

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -112,7 +112,9 @@ How it works:
 - Your request must embed the placeholder verbatim. The broker resolves the credential, URL-encodes the value, and substitutes it in.
 - `in` declares which surfaces the broker is allowed to scan: subset of `["path", "query", "header"]`, defaulting to `["path", "query"]`. `header` must be explicit. `body` is not supported.
 - **Scoping is the security boundary.** The broker only scans surfaces in `in`. Embedding the placeholder anywhere else means the literal string passes through unmodified — the operator's `in` declaration cannot be overridden by request shape.
+- When `header` is in `in`, the broker scans every outbound header for the placeholder, not a specific named header. Use a unique placeholder so it cannot land in headers you didn't intend to rewrite.
 - Substitutions compose with all auth types, including `passthrough`.
+- Updating an existing service: a `set` proposal that omits `substitutions` (or sends an empty list) preserves the service's existing substitutions, even when `auth` is replaced. To change the list, supply the new non-empty list. To clear all substitutions, delete and recreate the service.
 
 Example proposal (Twilio: basic auth header + path SID substitution):
 
@@ -140,7 +142,7 @@ Content-Type: application/json
 
 Once approved, the agent makes requests like `GET https://api.twilio.com/2010-04-01/Accounts/__account_sid__/Messages.json` (via `/proxy/api.twilio.com/...` or `HTTPS_PROXY`). The broker rewrites the path to `/Accounts/AC.../Messages.json` and injects the basic auth header.
 
-Placeholder safety: must be ≥4 characters, contain a `__` boundary or non-`[A-Za-z0-9_]` character (so bare words like `account_sid` are rejected — they would match legitimate URL words), and use only RFC 3986 unreserved characters `[A-Za-z0-9_-.~]`. The recommended convention is `__name__`.
+Placeholder safety: must be ≥4 characters, contain at least one alphanumeric character, contain a `__` boundary or non-`[A-Za-z0-9_]` character (so bare words like `account_sid` are rejected — they would match legitimate URL words), and use only RFC 3986 unreserved characters `[A-Za-z0-9_-.~]`. The recommended convention is `__name__`.
 
 ### Creating a Proposal
 

--- a/docs/learn/services.mdx
+++ b/docs/learn/services.mdx
@@ -198,7 +198,12 @@ The validator rejects placeholders that would cause false-positive substitutions
 
 - **Length** ≥ 4 characters.
 - **Must contain a `__` sequence or a non-`[A-Za-z0-9_]` character** — so a bare word like `account_sid` is rejected (it could appear as a real path segment), while `__account_sid__`, `sid.value`, `sid-val`, and `~sid~` all pass.
+- **At least one alphanumeric character** — strings made entirely of delimiters like `____` or `~~~~` are rejected because they would aggressively match URL punctuation.
 - **Only RFC 3986 unreserved characters** `[A-Za-z0-9_-.~]` are permitted, so the placeholder survives any HTTP client / SDK / middlebox without percent-encoding round-trips.
+
+### `header` scope is request-wide
+
+When `in` includes `header`, the broker scans every outbound header for the placeholder — not one specific named header. Pick a unique placeholder so a typo or a copy-pasted value can't accidentally land in a header you didn't intend to rewrite. (Path and query are scoped to those URL components and don't have this concern.)
 
 ### Composes with all auth types
 
@@ -209,10 +214,9 @@ Substitutions and auth are independent. A service can use either, both, or neith
 - A pure-substitution case (e.g. an internal API where the only secret lives in the path): `auth: passthrough` + path substitution.
 
 <Warning>
-  Substitutions and auth must be supplied together when changing a service.
-  An enable/disable-only proposal preserves both, but you cannot add or
-  modify substitutions on an existing service without re-supplying the auth
-  config in the same change.
+  Modifying substitutions requires re-supplying auth in the same proposal.
+  Auth-only or enable/disable-only `set` proposals preserve existing
+  substitutions; to clear them, delete and recreate the service.
 </Warning>
 
 ## Host matching

--- a/docs/learn/services.mdx
+++ b/docs/learn/services.mdx
@@ -156,6 +156,65 @@ Use passthrough when the operator has decided their client already holds the cre
   credentials.
 </Warning>
 
+## Substitutions
+
+Auth types only inject HTTP headers. Some upstream APIs want a credential value in the URL path or query string instead — Twilio's `/Accounts/{AccountSID}/Messages.json`, legacy services that take `?api_key=`. For those, declare a `substitutions` block alongside the auth.
+
+```yaml
+services:
+  - host: api.twilio.com
+    description: Twilio Messaging API
+    auth:
+      type: basic
+      username: TWILIO_ACCOUNT_SID
+      password: TWILIO_AUTH_TOKEN
+    substitutions:
+      - key: TWILIO_ACCOUNT_SID
+        placeholder: __account_sid__
+        in: [path]
+```
+
+The agent then sends `GET https://api.twilio.com/2010-04-01/Accounts/__account_sid__/Messages.json` (via the explicit `/proxy/...` ingress or `HTTPS_PROXY`). Agent Vault:
+
+1. Resolves the basic auth credentials and injects `Authorization: Basic <base64(SID:TOKEN)>`.
+2. Scans only the path (the only surface in `in:`), finds `__account_sid__`, replaces it with the URL-encoded SID.
+3. Forwards the request.
+
+### Field reference
+
+- `key` — UPPER_SNAKE_CASE credential reference. Must resolve to a credential in the vault or a slot in the same proposal.
+- `placeholder` — the exact wire string Agent Vault matches **case-sensitively** as a literal. Operators choose the string; the broker does not auto-wrap delimiters around it. The recommended convention is `__name__` (double-underscore-bounded snake_case).
+- `in` — list of surfaces the broker is allowed to scan. Subset of `path`, `query`, `header`. Defaults to `[path, query]` if omitted. `body` is reserved for a future version.
+
+### Scoping is the security boundary
+
+Agent Vault only scans surfaces listed in `in`. If an agent embeds the placeholder in a non-declared surface (a JSON body to round-trip via an echo upstream, a header that wasn't declared), the literal string passes through to upstream — the broker will not substitute. There is no way to coerce the broker into substituting somewhere the operator did not authorize.
+
+Use this property to pick a narrow `in` for strong secrets that happen to live in URLs (legacy `?api_key=` APIs): keep `in: [query]` and the agent cannot exfiltrate the value through a body or a different header.
+
+### Placeholder safety rules
+
+The validator rejects placeholders that would cause false-positive substitutions in legitimate URL content:
+
+- **Length** ≥ 4 characters.
+- **Must contain a `__` sequence or a non-`[A-Za-z0-9_]` character** — so a bare word like `account_sid` is rejected (it could appear as a real path segment), while `__account_sid__`, `sid.value`, `sid-val`, and `~sid~` all pass.
+- **Only RFC 3986 unreserved characters** `[A-Za-z0-9_-.~]` are permitted, so the placeholder survives any HTTP client / SDK / middlebox without percent-encoding round-trips.
+
+### Composes with all auth types
+
+Substitutions and auth are independent. A service can use either, both, or neither:
+
+- Twilio: `auth: basic` (header) + path substitution for the SID.
+- Legacy `?api_key=` API: `auth: api-key` for an audit header + query substitution for the actual key.
+- A pure-substitution case (e.g. an internal API where the only secret lives in the path): `auth: passthrough` + path substitution.
+
+<Warning>
+  Substitutions and auth must be supplied together when changing a service.
+  An enable/disable-only proposal preserves both, but you cannot add or
+  modify substitutions on an existing service without re-supplying the auth
+  config in the same change.
+</Warning>
+
 ## Host matching
 
 Agent Vault supports two host matching modes:

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -463,6 +463,8 @@ description: "Complete reference for all Agent Vault CLI commands."
     The `passthrough` auth type accepts no credential flags; Agent Vault allowlists the host and forwards the client's request headers unchanged, stripping only hop-by-hop and broker-scoped headers (`X-Vault`, `Proxy-Authorization`).
 
     New services are **enabled by default**. Pass `--disabled` to create the service in a disabled state, or use `agent-vault vault service disable <host>` after creation.
+
+    URL [substitutions](/learn/services#substitutions) are file-only — there are no flags. Configure them under the `substitutions:` block of a service entry in a YAML file passed via `-f`.
   </Accordion>
 
   <Accordion title="agent-vault vault service enable">
@@ -634,6 +636,8 @@ description: "Complete reference for all Agent Vault CLI commands."
     # JSON file: complex multi-service proposal
     agent-vault vault proposal create -f proposal.json
     ```
+
+    URL [substitutions](/learn/services#substitutions) are JSON-only — there are no flags. Add a `substitutions` array under the relevant `services[]` entry in the file passed via `-f`.
   </Accordion>
 
   <Accordion title="agent-vault vault proposal approve">

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -357,10 +357,11 @@ func (s *Service) ValidateSubstitutions() error {
 	return nil
 }
 
-// validatePlaceholder enforces length, character set, and a boundary
+// validatePlaceholder enforces length, character set, a boundary
 // requirement (either "__" or a non-word character) so bare identifiers
 // like "account_sid" — which legitimately appear as URL path segments —
-// cannot be picked as placeholders.
+// cannot be picked as placeholders, and at least one alphanumeric so
+// all-symbol strings like "____" or "~~~~" are rejected.
 func validatePlaceholder(p string) error {
 	if p == "" {
 		return fmt.Errorf("\"placeholder\" is required (recommended convention: __name__)")
@@ -369,16 +370,23 @@ func validatePlaceholder(p string) error {
 		return fmt.Errorf("placeholder %q is too short — must be at least 4 characters (recommended convention: __name__)", p)
 	}
 	hasBoundary := false
+	hasAlnum := false
 	for i := 0; i < len(p); i++ {
 		c := p[i]
 		if !placeholderCharAllowed(c) {
 			return fmt.Errorf("placeholder %q contains disallowed character %q — only RFC 3986 unreserved characters [A-Za-z0-9_-.~] are permitted (recommended convention: __name__)", p, c)
+		}
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			hasAlnum = true
 		}
 		if !placeholderWordChar(c) {
 			hasBoundary = true
 		} else if c == '_' && i+1 < len(p) && p[i+1] == '_' {
 			hasBoundary = true
 		}
+	}
+	if !hasAlnum {
+		return fmt.Errorf("placeholder %q must contain at least one alphanumeric character (recommended convention: __name__)", p)
 	}
 	if !hasBoundary {
 		return fmt.Errorf("placeholder %q must contain a delimiter — either \"__\" or a character outside [A-Za-z0-9_] — to avoid matching legitimate URL words (recommended convention: __name__)", p)

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -21,10 +21,20 @@ type Config struct {
 // live after upgrade. Callers should use IsEnabled() rather than
 // dereferencing the pointer.
 type Service struct {
-	Host        string  `yaml:"host" json:"host"`
-	Description *string `yaml:"description,omitempty" json:"description"`
-	Enabled     *bool   `yaml:"enabled,omitempty" json:"enabled,omitempty"`
-	Auth        Auth    `yaml:"auth" json:"auth"`
+	Host          string         `yaml:"host" json:"host"`
+	Description   *string        `yaml:"description,omitempty" json:"description"`
+	Enabled       *bool          `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Auth          Auth           `yaml:"auth" json:"auth"`
+	Substitutions []Substitution `yaml:"substitutions,omitempty" json:"substitutions,omitempty"`
+}
+
+// Substitution declares a placeholder string the broker rewrites with a
+// credential value at request time, scanned only on surfaces listed in
+// In — that scoping is the security boundary.
+type Substitution struct {
+	Key         string   `yaml:"key" json:"key"`
+	Placeholder string   `yaml:"placeholder" json:"placeholder"`
+	In          []string `yaml:"in,omitempty" json:"in,omitempty"`
 }
 
 // IsEnabled reports whether the service should serve proxy traffic. A
@@ -65,6 +75,30 @@ var SupportedAuthTypes = []string{"bearer", "basic", "api-key", "custom", "passt
 
 // CredentialKeyPattern validates credential key names: UPPER_SNAKE_CASE.
 var CredentialKeyPattern = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+
+// SubstitutionSurfaces lists the surfaces a substitution may declare in
+// its In list. "body" is reserved for a future version.
+var SubstitutionSurfaces = []string{"path", "query", "header"}
+
+// DefaultSubstitutionSurfaces is applied when a substitution omits In.
+// "header" is a deliberate opt-in (CRLF guard required) so it is not
+// in the default set.
+var DefaultSubstitutionSurfaces = []string{"path", "query"}
+
+// placeholderCharAllowed reports whether c may appear inside a
+// substitution placeholder. Restricted to RFC 3986 unreserved
+// characters so encoded and decoded forms are identical — the runtime
+// can match on the wire-encoded path without encoding round-trips.
+func placeholderCharAllowed(c byte) bool {
+	return placeholderWordChar(c) || c == '-' || c == '.' || c == '~'
+}
+
+// placeholderWordChar reports whether c is a word-class character
+// inside a placeholder: alphanumeric or underscore. Used by the
+// boundary check in validatePlaceholder.
+func placeholderWordChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+}
 
 // Validate checks that an Auth configuration is well-formed and returns
 // descriptive errors that help agents self-correct.
@@ -287,8 +321,126 @@ func Validate(cfg *Config) error {
 		if err := s.Auth.Validate(); err != nil {
 			return fmt.Errorf("service %d: %w", i, err)
 		}
+		if err := s.ValidateSubstitutions(); err != nil {
+			return fmt.Errorf("service %d: %w", i, err)
+		}
 	}
 	return nil
+}
+
+// ValidateSubstitutions checks each substitution for length, character
+// set, surface allowlist, and intra-service uniqueness. Errors recommend
+// the __name__ convention by example.
+func (s *Service) ValidateSubstitutions() error {
+	if len(s.Substitutions) == 0 {
+		return nil
+	}
+	seen := make(map[string]int, len(s.Substitutions))
+	for i, sub := range s.Substitutions {
+		if sub.Key == "" {
+			return fmt.Errorf("substitution %d: \"key\" is required", i)
+		}
+		if err := validateCredentialKey("key", sub.Key); err != nil {
+			return fmt.Errorf("substitution %d: %w", i, err)
+		}
+		if err := validatePlaceholder(sub.Placeholder); err != nil {
+			return fmt.Errorf("substitution %d: %w", i, err)
+		}
+		if prev, dup := seen[sub.Placeholder]; dup {
+			return fmt.Errorf("substitution %d: placeholder %q already declared by substitution %d", i, sub.Placeholder, prev)
+		}
+		seen[sub.Placeholder] = i
+		if err := validateSubstitutionSurfaces(sub.In); err != nil {
+			return fmt.Errorf("substitution %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// validatePlaceholder enforces length, character set, and a boundary
+// requirement (either "__" or a non-word character) so bare identifiers
+// like "account_sid" — which legitimately appear as URL path segments —
+// cannot be picked as placeholders.
+func validatePlaceholder(p string) error {
+	if p == "" {
+		return fmt.Errorf("\"placeholder\" is required (recommended convention: __name__)")
+	}
+	if len(p) < 4 {
+		return fmt.Errorf("placeholder %q is too short — must be at least 4 characters (recommended convention: __name__)", p)
+	}
+	hasBoundary := false
+	for i := 0; i < len(p); i++ {
+		c := p[i]
+		if !placeholderCharAllowed(c) {
+			return fmt.Errorf("placeholder %q contains disallowed character %q — only RFC 3986 unreserved characters [A-Za-z0-9_-.~] are permitted (recommended convention: __name__)", p, c)
+		}
+		if !placeholderWordChar(c) {
+			hasBoundary = true
+		} else if c == '_' && i+1 < len(p) && p[i+1] == '_' {
+			hasBoundary = true
+		}
+	}
+	if !hasBoundary {
+		return fmt.Errorf("placeholder %q must contain a delimiter — either \"__\" or a character outside [A-Za-z0-9_] — to avoid matching legitimate URL words (recommended convention: __name__)", p)
+	}
+	return nil
+}
+
+// validateSubstitutionSurfaces checks that every entry of in is a known
+// surface. Empty is accepted (runtime applies DefaultSubstitutionSurfaces).
+func validateSubstitutionSurfaces(in []string) error {
+	allowed := map[string]bool{}
+	for _, s := range SubstitutionSurfaces {
+		allowed[s] = true
+	}
+	seen := make(map[string]bool, len(in))
+	for _, surface := range in {
+		if surface == "body" {
+			return fmt.Errorf("substitution surface \"body\" is reserved for a future version — pick from %s", strings.Join(SubstitutionSurfaces, ", "))
+		}
+		if !allowed[surface] {
+			return fmt.Errorf("invalid substitution surface %q — must be one of %s", surface, strings.Join(SubstitutionSurfaces, ", "))
+		}
+		if seen[surface] {
+			return fmt.Errorf("substitution surface %q listed more than once", surface)
+		}
+		seen[surface] = true
+	}
+	return nil
+}
+
+// NormalizedIn returns the surfaces this substitution applies to,
+// applying DefaultSubstitutionSurfaces when In is empty. Callers must
+// treat the returned slice as read-only.
+func (s *Substitution) NormalizedIn() []string {
+	if len(s.In) == 0 {
+		return DefaultSubstitutionSurfaces
+	}
+	return s.In
+}
+
+// CredentialKeys returns the union of credential keys referenced by
+// auth and substitutions, deduplicated, auth keys first.
+func (s *Service) CredentialKeys() []string {
+	authKeys := s.Auth.CredentialKeys()
+	if len(s.Substitutions) == 0 {
+		return authKeys
+	}
+	seen := make(map[string]bool, len(authKeys)+len(s.Substitutions))
+	out := make([]string, 0, len(authKeys)+len(s.Substitutions))
+	for _, k := range authKeys {
+		if !seen[k] {
+			seen[k] = true
+			out = append(out, k)
+		}
+	}
+	for _, sub := range s.Substitutions {
+		if !seen[sub.Key] {
+			seen[sub.Key] = true
+			out = append(out, sub.Key)
+		}
+	}
+	return out
 }
 
 // CredentialRef matches {{ credential_name }} placeholders in header values.

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -485,6 +485,21 @@ func TestValidateSubstitutionsRejectsReservedURLChars(t *testing.T) {
 	}
 }
 
+func TestValidateSubstitutionsRejectsAllSymbol(t *testing.T) {
+	// All-delimiter strings would aggressively match URL punctuation.
+	cases := []string{"____", "~~~~", "----", "....", "~-.~"}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			s := Service{Host: "api.example.com", Substitutions: []Substitution{
+				{Key: "K_X", Placeholder: p, In: []string{"path"}},
+			}}
+			if err := s.ValidateSubstitutions(); err == nil {
+				t.Fatalf("expected error for all-symbol placeholder %q", p)
+			}
+		})
+	}
+}
+
 func TestValidateSubstitutionsRejectsEmptyPlaceholder(t *testing.T) {
 	s := Service{Host: "api.example.com", Substitutions: []Substitution{
 		{Key: "ACCOUNT_SID", Placeholder: "", In: []string{"path"}},

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -414,3 +414,204 @@ func TestValidateConfigPassthrough(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// --- Substitution validation tests ---
+
+func TestValidateSubstitutionsValid(t *testing.T) {
+	cases := []struct {
+		name string
+		sub  Substitution
+	}{
+		{"underscore convention", Substitution{Key: "TWILIO_ACCOUNT_SID", Placeholder: "__account_sid__", In: []string{"path"}}},
+		{"dot delimiter", Substitution{Key: "ACCOUNT_SID", Placeholder: "sid.value", In: []string{"path", "query"}}},
+		{"hyphen delimiter", Substitution{Key: "ACCOUNT_SID", Placeholder: "sid-val", In: []string{"path"}}},
+		{"tilde delimiter", Substitution{Key: "ACCOUNT_SID", Placeholder: "~sid~val", In: []string{"path"}}},
+		{"in defaulted", Substitution{Key: "ACCOUNT_SID", Placeholder: "__sid__"}},
+		{"header surface", Substitution{Key: "TENANT_ID", Placeholder: "__tenant__", In: []string{"header"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := Service{Host: "api.example.com", Auth: Auth{Type: "passthrough"}, Substitutions: []Substitution{tc.sub}}
+			if err := s.ValidateSubstitutions(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateSubstitutionsRejectsBareWord(t *testing.T) {
+	s := Service{Host: "api.example.com", Auth: Auth{Type: "passthrough"}, Substitutions: []Substitution{
+		{Key: "ACCOUNT_SID", Placeholder: "account_sid", In: []string{"path"}},
+	}}
+	if err := s.ValidateSubstitutions(); err == nil {
+		t.Fatal("expected error for bare alphanumeric placeholder (would match URL words)")
+	}
+}
+
+func TestValidateSubstitutionsRejectsTooShort(t *testing.T) {
+	s := Service{Host: "api.example.com", Substitutions: []Substitution{
+		{Key: "K", Placeholder: "__x", In: []string{"path"}},
+	}}
+	if err := s.ValidateSubstitutions(); err == nil {
+		t.Fatal("expected error for placeholder shorter than 4 chars")
+	}
+}
+
+func TestValidateSubstitutionsRejectsControlChars(t *testing.T) {
+	cases := []string{"__a\nb__", "__a\rb__", "__a b__", "__a\tb__"}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			s := Service{Host: "api.example.com", Substitutions: []Substitution{
+				{Key: "K_X", Placeholder: p, In: []string{"path"}},
+			}}
+			if err := s.ValidateSubstitutions(); err == nil {
+				t.Fatalf("expected error for placeholder containing control/whitespace char: %q", p)
+			}
+		})
+	}
+}
+
+func TestValidateSubstitutionsRejectsReservedURLChars(t *testing.T) {
+	cases := []string{"__a/b__", "__a?b__", "__a#b__", "__a&b__", "{sid}", "<sid>", "%%SID%%"}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			s := Service{Host: "api.example.com", Substitutions: []Substitution{
+				{Key: "K_X", Placeholder: p, In: []string{"path"}},
+			}}
+			if err := s.ValidateSubstitutions(); err == nil {
+				t.Fatalf("expected error for placeholder containing URL-reserved char: %q", p)
+			}
+		})
+	}
+}
+
+func TestValidateSubstitutionsRejectsEmptyPlaceholder(t *testing.T) {
+	s := Service{Host: "api.example.com", Substitutions: []Substitution{
+		{Key: "ACCOUNT_SID", Placeholder: "", In: []string{"path"}},
+	}}
+	if err := s.ValidateSubstitutions(); err == nil {
+		t.Fatal("expected error for empty placeholder")
+	}
+}
+
+func TestValidateSubstitutionsRejectsEmptyKey(t *testing.T) {
+	s := Service{Host: "api.example.com", Substitutions: []Substitution{
+		{Key: "", Placeholder: "__sid__", In: []string{"path"}},
+	}}
+	if err := s.ValidateSubstitutions(); err == nil {
+		t.Fatal("expected error for empty key")
+	}
+}
+
+func TestValidateSubstitutionsRejectsLowerCaseKey(t *testing.T) {
+	s := Service{Host: "api.example.com", Substitutions: []Substitution{
+		{Key: "account_sid", Placeholder: "__sid__", In: []string{"path"}},
+	}}
+	if err := s.ValidateSubstitutions(); err == nil {
+		t.Fatal("expected error for non-UPPER_SNAKE_CASE key")
+	}
+}
+
+func TestValidateSubstitutionsRejectsBodySurface(t *testing.T) {
+	s := Service{Host: "api.example.com", Substitutions: []Substitution{
+		{Key: "K_X", Placeholder: "__sid__", In: []string{"body"}},
+	}}
+	if err := s.ValidateSubstitutions(); err == nil {
+		t.Fatal("expected error for body surface (deferred in v1)")
+	}
+}
+
+func TestValidateSubstitutionsRejectsUnknownSurface(t *testing.T) {
+	s := Service{Host: "api.example.com", Substitutions: []Substitution{
+		{Key: "K_X", Placeholder: "__sid__", In: []string{"cookie"}},
+	}}
+	if err := s.ValidateSubstitutions(); err == nil {
+		t.Fatal("expected error for unknown surface")
+	}
+}
+
+func TestValidateSubstitutionsRejectsDuplicatePlaceholder(t *testing.T) {
+	s := Service{Host: "api.example.com", Substitutions: []Substitution{
+		{Key: "K_ONE", Placeholder: "__sid__", In: []string{"path"}},
+		{Key: "K_TWO", Placeholder: "__sid__", In: []string{"query"}},
+	}}
+	if err := s.ValidateSubstitutions(); err == nil {
+		t.Fatal("expected error for duplicate placeholder within service")
+	}
+}
+
+func TestValidateSubstitutionsRejectsDuplicateSurface(t *testing.T) {
+	s := Service{Host: "api.example.com", Substitutions: []Substitution{
+		{Key: "K_X", Placeholder: "__sid__", In: []string{"path", "path"}},
+	}}
+	if err := s.ValidateSubstitutions(); err == nil {
+		t.Fatal("expected error for duplicate surface in In")
+	}
+}
+
+func TestValidateSubstitutionsEmptyOk(t *testing.T) {
+	s := Service{Host: "api.example.com"}
+	if err := s.ValidateSubstitutions(); err != nil {
+		t.Fatalf("unexpected error for empty substitutions: %v", err)
+	}
+}
+
+func TestValidateConfigInvalidSubstitution(t *testing.T) {
+	cfg := &Config{
+		Vault: "default",
+		Services: []Service{
+			{
+				Host: "api.example.com",
+				Auth: Auth{Type: "bearer", Token: "MY_KEY"},
+				Substitutions: []Substitution{
+					{Key: "MY_KEY", Placeholder: "tooshort", In: []string{"path"}}, // no non-alnum char
+				},
+			},
+		},
+	}
+	if err := Validate(cfg); err == nil {
+		t.Fatal("expected Validate to surface substitution error")
+	}
+}
+
+func TestSubstitutionNormalizedInDefaults(t *testing.T) {
+	s := Substitution{Key: "K", Placeholder: "__x__"}
+	got := s.NormalizedIn()
+	if len(got) != 2 || got[0] != "path" || got[1] != "query" {
+		t.Fatalf("expected default [path query], got %v", got)
+	}
+}
+
+func TestSubstitutionNormalizedInExplicit(t *testing.T) {
+	s := Substitution{Key: "K", Placeholder: "__x__", In: []string{"header"}}
+	got := s.NormalizedIn()
+	if len(got) != 1 || got[0] != "header" {
+		t.Fatalf("expected [header], got %v", got)
+	}
+}
+
+func TestServiceCredentialKeysCombines(t *testing.T) {
+	s := Service{
+		Host: "api.twilio.com",
+		Auth: Auth{Type: "basic", Username: "TWILIO_ACCOUNT_SID", Password: "TWILIO_AUTH_TOKEN"},
+		Substitutions: []Substitution{
+			{Key: "TWILIO_ACCOUNT_SID", Placeholder: "__account_sid__", In: []string{"path"}}, // dup of auth
+			{Key: "TWILIO_REGION", Placeholder: "__region__", In: []string{"path"}},           // unique
+		},
+	}
+	keys := s.CredentialKeys()
+	if len(keys) != 3 {
+		t.Fatalf("expected 3 unique keys, got %v", keys)
+	}
+	if keys[0] != "TWILIO_ACCOUNT_SID" || keys[1] != "TWILIO_AUTH_TOKEN" || keys[2] != "TWILIO_REGION" {
+		t.Fatalf("expected auth keys first then unique substitution keys, got %v", keys)
+	}
+}
+
+func TestServiceCredentialKeysOnlyAuth(t *testing.T) {
+	s := Service{Host: "api.example.com", Auth: Auth{Type: "bearer", Token: "MY_KEY"}}
+	keys := s.CredentialKeys()
+	if len(keys) != 1 || keys[0] != "MY_KEY" {
+		t.Fatalf("expected [MY_KEY], got %v", keys)
+	}
+}

--- a/internal/brokercore/credential.go
+++ b/internal/brokercore/credential.go
@@ -24,18 +24,24 @@ type InjectResult struct {
 	// target (e.g. "api.github.com"). Safe to log.
 	MatchedHost string
 
-	// CredentialKeys are the upper-snake-case credential key names the
-	// matched service references. These are names, not values — safe to
-	// log. Populated before credential resolution, so a credential-missing
-	// failure still carries this metadata. Empty for passthrough services.
+	// CredentialKeys are the credential key names referenced by the
+	// matched service (auth + substitutions). Names only — safe to log.
+	// Populated before resolution so credential-missing errors still
+	// carry this for diagnostic logging.
 	CredentialKeys []string
 
 	// Passthrough indicates the matched service opts out of credential
 	// injection. The ingress should forward client request headers via
 	// the denylist (CopyPassthroughRequestHeaders) rather than the
 	// PassthroughHeaders allowlist, and must not perform the injection
-	// merge step.
+	// merge step. A passthrough service may still have Substitutions —
+	// those apply independently of header injection.
 	Passthrough bool
+
+	// Substitutions are resolved placeholder rewrites the ingress must
+	// apply via ApplySubstitutions before forwarding. Each entry carries
+	// a SECRET Value — never log; placeholder names are safe.
+	Substitutions []ResolvedSubstitution
 }
 
 // CredentialProvider resolves a broker service for targetHost inside vaultID
@@ -90,24 +96,13 @@ func (p *StoreCredentialProvider) Inject(ctx context.Context, vaultID, targetHos
 		return nil, ErrServiceDisabled
 	}
 
-	// Passthrough services opt out of credential injection entirely. No
-	// vault read, no CredentialKeys (nothing to resolve). The ingress
-	// branches on Passthrough to forward client headers via the denylist.
-	if matched.Auth.Type == "passthrough" {
-		return &InjectResult{
-			MatchedHost: matched.Host,
-			Passthrough: true,
-		}, nil
-	}
-
-	// Capture non-secret metadata up front so a downstream credential-missing
-	// error still carries it for the caller (e.g. for debug logging).
-	result := &InjectResult{
-		MatchedHost:    matched.Host,
-		CredentialKeys: matched.Auth.CredentialKeys(),
-	}
-
-	headers, err := matched.Auth.Resolve(func(key string) (string, error) {
+	// Memoize per-key lookups so a credential shared by auth and a
+	// substitution decrypts only once.
+	cache := make(map[string]string)
+	getCredential := func(key string) (string, error) {
+		if v, ok := cache[key]; ok {
+			return v, nil
+		}
 		cred, err := p.Store.GetCredential(ctx, vaultID, key)
 		if err != nil || cred == nil {
 			return "", fmt.Errorf("credential %q not found", key)
@@ -116,8 +111,42 @@ func (p *StoreCredentialProvider) Inject(ctx context.Context, vaultID, targetHos
 		if err != nil {
 			return "", fmt.Errorf("failed to decrypt credential %q", key)
 		}
-		return string(plaintext), nil
-	})
+		s := string(plaintext)
+		cache[key] = s
+		return s, nil
+	}
+
+	// Capture non-secret metadata up front so a downstream credential-missing
+	// error still carries it for diagnostic logging.
+	result := &InjectResult{
+		MatchedHost:    matched.Host,
+		CredentialKeys: matched.CredentialKeys(),
+		Passthrough:    matched.Auth.Type == "passthrough",
+	}
+
+	// Resolve substitutions before auth so passthrough services (which
+	// skip the auth branch) still surface ErrCredentialMissing here.
+	if len(matched.Substitutions) > 0 {
+		resolved := make([]ResolvedSubstitution, 0, len(matched.Substitutions))
+		for _, sub := range matched.Substitutions {
+			val, err := getCredential(sub.Key)
+			if err != nil {
+				return result, fmt.Errorf("%w: %v", ErrCredentialMissing, err)
+			}
+			resolved = append(resolved, ResolvedSubstitution{
+				Placeholder: sub.Placeholder,
+				Value:       val,
+				In:          sub.NormalizedIn(),
+			})
+		}
+		result.Substitutions = resolved
+	}
+
+	if matched.Auth.Type == "passthrough" {
+		return result, nil
+	}
+
+	headers, err := matched.Auth.Resolve(getCredential)
 	if err != nil {
 		return result, fmt.Errorf("%w: %v", ErrCredentialMissing, err)
 	}

--- a/internal/brokercore/credential.go
+++ b/internal/brokercore/credential.go
@@ -126,23 +126,26 @@ func (p *StoreCredentialProvider) Inject(ctx context.Context, vaultID, targetHos
 
 	// Resolve substitutions before auth so passthrough services (which
 	// skip the auth branch) still surface ErrCredentialMissing here.
+	// Hold locally and attach only on success — error returns must not
+	// expose resolved secret values via result.
+	var resolvedSubs []ResolvedSubstitution
 	if len(matched.Substitutions) > 0 {
-		resolved := make([]ResolvedSubstitution, 0, len(matched.Substitutions))
+		resolvedSubs = make([]ResolvedSubstitution, 0, len(matched.Substitutions))
 		for _, sub := range matched.Substitutions {
 			val, err := getCredential(sub.Key)
 			if err != nil {
 				return result, fmt.Errorf("%w: %v", ErrCredentialMissing, err)
 			}
-			resolved = append(resolved, ResolvedSubstitution{
+			resolvedSubs = append(resolvedSubs, ResolvedSubstitution{
 				Placeholder: sub.Placeholder,
 				Value:       val,
 				In:          sub.NormalizedIn(),
 			})
 		}
-		result.Substitutions = resolved
 	}
 
 	if matched.Auth.Type == "passthrough" {
+		result.Substitutions = resolvedSubs
 		return result, nil
 	}
 
@@ -152,5 +155,6 @@ func (p *StoreCredentialProvider) Inject(ctx context.Context, vaultID, targetHos
 	}
 
 	result.Headers = headers
+	result.Substitutions = resolvedSubs
 	return result, nil
 }

--- a/internal/brokercore/credential_test.go
+++ b/internal/brokercore/credential_test.go
@@ -443,6 +443,36 @@ func TestInject_SubstitutionMissingCredentialErrorsLikeAuth(t *testing.T) {
 	}
 }
 
+func TestInject_AuthFailureLeavesSubstitutionsNil(t *testing.T) {
+	// Substitution resolves successfully, then auth resolution fails.
+	// The error path must NOT leak the resolved (secret) substitution
+	// values via result.Substitutions — callers that log result on
+	// errors would otherwise expose plaintext credential values.
+	key32 := make32(0x77)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.twilio.com",
+		Auth: broker.Auth{Type: "bearer", Token: "MISSING_AUTH_KEY"},
+		Substitutions: []broker.Substitution{
+			{Key: "PRESENT_SUB_KEY", Placeholder: "__sid__", In: []string{"path"}},
+		},
+	}})
+	f.setCred(t, key32, "v1", "PRESENT_SUB_KEY", "SECRET-VALUE")
+	// MISSING_AUTH_KEY is intentionally not set.
+
+	p := NewStoreCredentialProvider(f, key32)
+	res, err := p.Inject(context.Background(), "v1", "api.twilio.com")
+	if !errors.Is(err, ErrCredentialMissing) {
+		t.Fatalf("expected ErrCredentialMissing, got %v", err)
+	}
+	if res == nil {
+		t.Fatal("expected result returned alongside error for diagnostic logging")
+	}
+	if res.Substitutions != nil {
+		t.Fatalf("expected res.Substitutions=nil on auth error to avoid leaking secrets, got %+v", res.Substitutions)
+	}
+}
+
 func TestInject_CredentialKeysIncludesSubstitution(t *testing.T) {
 	key32 := make32(0x12)
 	f := newFakeCredStore()

--- a/internal/brokercore/credential_test.go
+++ b/internal/brokercore/credential_test.go
@@ -358,3 +358,110 @@ func TestInject_PassthroughPortStripped(t *testing.T) {
 		t.Fatal("expected Passthrough=true for host:port match")
 	}
 }
+
+// --- Substitution resolution tests ---
+
+func TestInject_ResolvesSubstitutionAlongsideAuth(t *testing.T) {
+	key32 := make32(0xAB)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.twilio.com",
+		Auth: broker.Auth{Type: "basic", Username: "TWILIO_ACCOUNT_SID", Password: "TWILIO_AUTH_TOKEN"},
+		Substitutions: []broker.Substitution{
+			{Key: "TWILIO_ACCOUNT_SID", Placeholder: "__account_sid__", In: []string{"path"}},
+		},
+	}})
+	f.setCred(t, key32, "v1", "TWILIO_ACCOUNT_SID", "AC12345")
+	f.setCred(t, key32, "v1", "TWILIO_AUTH_TOKEN", "tok-shh")
+
+	p := NewStoreCredentialProvider(f, key32)
+	res, err := p.Inject(context.Background(), "v1", "api.twilio.com")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(res.Substitutions) != 1 {
+		t.Fatalf("expected 1 resolved substitution, got %+v", res.Substitutions)
+	}
+	if res.Substitutions[0].Placeholder != "__account_sid__" || res.Substitutions[0].Value != "AC12345" {
+		t.Fatalf("unexpected substitution: %+v", res.Substitutions[0])
+	}
+	if got := res.Substitutions[0].In; len(got) != 1 || got[0] != "path" {
+		t.Fatalf("expected normalized In=[path], got %v", got)
+	}
+	// Cred shared with auth should be decrypted only once thanks to memo.
+	if f.getCredentialCalls != 2 {
+		t.Fatalf("expected exactly 2 credential lookups (one per unique key), got %d", f.getCredentialCalls)
+	}
+	if res.Headers["Authorization"] == "" {
+		t.Fatal("expected basic auth header still injected")
+	}
+}
+
+func TestInject_ResolvesSubstitutionOnPassthrough(t *testing.T) {
+	key32 := make32(0xCD)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.twilio.com",
+		Auth: broker.Auth{Type: "passthrough"},
+		Substitutions: []broker.Substitution{
+			{Key: "TWILIO_ACCOUNT_SID", Placeholder: "__account_sid__", In: []string{"path"}},
+		},
+	}})
+	f.setCred(t, key32, "v1", "TWILIO_ACCOUNT_SID", "AC12345")
+
+	p := NewStoreCredentialProvider(f, key32)
+	res, err := p.Inject(context.Background(), "v1", "api.twilio.com")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !res.Passthrough {
+		t.Fatal("expected Passthrough=true")
+	}
+	if res.Headers != nil {
+		t.Fatalf("expected nil headers on passthrough, got %v", res.Headers)
+	}
+	if len(res.Substitutions) != 1 || res.Substitutions[0].Value != "AC12345" {
+		t.Fatalf("expected substitution resolved on passthrough service, got %+v", res.Substitutions)
+	}
+}
+
+func TestInject_SubstitutionMissingCredentialErrorsLikeAuth(t *testing.T) {
+	key32 := make32(0xEF)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.twilio.com",
+		Auth: broker.Auth{Type: "passthrough"},
+		Substitutions: []broker.Substitution{
+			{Key: "TWILIO_ACCOUNT_SID", Placeholder: "__account_sid__", In: []string{"path"}},
+		},
+	}})
+	// No credential set → lookup returns "not found".
+	p := NewStoreCredentialProvider(f, key32)
+	_, err := p.Inject(context.Background(), "v1", "api.twilio.com")
+	if !errors.Is(err, ErrCredentialMissing) {
+		t.Fatalf("expected ErrCredentialMissing, got %v", err)
+	}
+}
+
+func TestInject_CredentialKeysIncludesSubstitution(t *testing.T) {
+	key32 := make32(0x12)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.twilio.com",
+		Auth: broker.Auth{Type: "bearer", Token: "TWILIO_AUTH_TOKEN"},
+		Substitutions: []broker.Substitution{
+			{Key: "TWILIO_ACCOUNT_SID", Placeholder: "__account_sid__", In: []string{"path"}},
+		},
+	}})
+	f.setCred(t, key32, "v1", "TWILIO_AUTH_TOKEN", "tok")
+	// No SID credential → expect ErrCredentialMissing, but CredentialKeys
+	// must already be populated for diagnostic logging.
+	p := NewStoreCredentialProvider(f, key32)
+	res, err := p.Inject(context.Background(), "v1", "api.twilio.com")
+	if !errors.Is(err, ErrCredentialMissing) {
+		t.Fatalf("expected ErrCredentialMissing, got %v", err)
+	}
+	if res == nil || len(res.CredentialKeys) != 2 {
+		t.Fatalf("expected CredentialKeys to include both auth and substitution keys, got %+v", res)
+	}
+}

--- a/internal/brokercore/substitution.go
+++ b/internal/brokercore/substitution.go
@@ -1,0 +1,69 @@
+package brokercore
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ResolvedSubstitution is a placeholder rewrite ready to apply to an
+// outbound request. Value is SECRET — never log it.
+type ResolvedSubstitution struct {
+	Placeholder string
+	Value       string
+	In          []string // subset of {"path","query","header"} — security boundary
+}
+
+// ApplySubstitutions rewrites declared surfaces of an outbound request
+// in-place. Path uses url.PathEscape, query uses url.QueryEscape, header
+// uses the raw value with a CRLF guard. On error, callers must not
+// forward the request — partial mutations may have been applied.
+func ApplySubstitutions(u *url.URL, headers http.Header, subs []ResolvedSubstitution) error {
+	if len(subs) == 0 {
+		return nil
+	}
+	for _, sub := range subs {
+		for _, surface := range sub.In {
+			switch surface {
+			case "path":
+				if u == nil {
+					continue
+				}
+				// Operate on the wire-encoded path so PathEscape'd values
+				// land in the URL exactly once and don't get re-encoded
+				// by String(). Placeholder characters are restricted to
+				// RFC 3986 unreserved by the validator, so they appear
+				// identically in encoded and decoded forms.
+				escaped := u.EscapedPath()
+				rewritten := strings.ReplaceAll(escaped, sub.Placeholder, url.PathEscape(sub.Value))
+				if rewritten == escaped {
+					continue
+				}
+				decoded, err := url.PathUnescape(rewritten)
+				if err != nil {
+					return fmt.Errorf("substitution into path produced invalid encoding for placeholder %q: %w", sub.Placeholder, err)
+				}
+				u.Path = decoded
+				u.RawPath = rewritten
+			case "query":
+				if u != nil {
+					u.RawQuery = strings.ReplaceAll(u.RawQuery, sub.Placeholder, url.QueryEscape(sub.Value))
+				}
+			case "header":
+				if headers == nil {
+					continue
+				}
+				if strings.ContainsAny(sub.Value, "\r\n") {
+					return fmt.Errorf("substitution into header surface rejected: resolved value for placeholder %q contains CR or LF (header injection guard)", sub.Placeholder)
+				}
+				for _, vals := range headers {
+					for i, v := range vals {
+						vals[i] = strings.ReplaceAll(v, sub.Placeholder, sub.Value)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/internal/brokercore/substitution_test.go
+++ b/internal/brokercore/substitution_test.go
@@ -1,0 +1,182 @@
+package brokercore
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return u
+}
+
+func TestApplySubstitutionsPath(t *testing.T) {
+	u := mustParseURL(t, "https://api.twilio.com/2010-04-01/Accounts/__account_sid__/Messages.json")
+	subs := []ResolvedSubstitution{{
+		Placeholder: "__account_sid__",
+		Value:       "AC12345",
+		In:          []string{"path"},
+	}}
+	if err := ApplySubstitutions(u, nil, subs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := u.String()
+	want := "https://api.twilio.com/2010-04-01/Accounts/AC12345/Messages.json"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestApplySubstitutionsPathEncodesValue(t *testing.T) {
+	// A value with "/" must be escaped so it stays inside the path segment
+	// and cannot escape into a different path segment.
+	u := mustParseURL(t, "https://api.example.com/items/__id__/get")
+	subs := []ResolvedSubstitution{{
+		Placeholder: "__id__",
+		Value:       "abc/def",
+		In:          []string{"path"},
+	}}
+	if err := ApplySubstitutions(u, nil, subs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(u.String(), "abc%2Fdef") {
+		t.Fatalf("expected '/' encoded as %%2F, got %s", u.String())
+	}
+}
+
+func TestApplySubstitutionsQuery(t *testing.T) {
+	u := mustParseURL(t, "https://api.example.com/data?api_key=__api_key__&format=json")
+	subs := []ResolvedSubstitution{{
+		Placeholder: "__api_key__",
+		Value:       "secret&value=oops",
+		In:          []string{"query"},
+	}}
+	if err := ApplySubstitutions(u, nil, subs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	q := u.Query()
+	if q.Get("api_key") != "secret&value=oops" {
+		t.Fatalf("expected query parser to round-trip the encoded value, got %q", q.Get("api_key"))
+	}
+	if q.Get("format") != "json" {
+		t.Fatalf("expected non-substituted segment preserved, got %q", q.Get("format"))
+	}
+}
+
+func TestApplySubstitutionsHeader(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Tenant", "tenant=__tenant_id__")
+	subs := []ResolvedSubstitution{{
+		Placeholder: "__tenant_id__",
+		Value:       "acme",
+		In:          []string{"header"},
+	}}
+	if err := ApplySubstitutions(nil, headers, subs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := headers.Get("X-Tenant"); got != "tenant=acme" {
+		t.Fatalf("expected 'tenant=acme', got %q", got)
+	}
+}
+
+func TestApplySubstitutionsHeaderRejectsCRLF(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("X-Tenant", "__tenant_id__")
+	subs := []ResolvedSubstitution{{
+		Placeholder: "__tenant_id__",
+		Value:       "acme\r\nX-Injected: yes",
+		In:          []string{"header"},
+	}}
+	err := ApplySubstitutions(nil, headers, subs)
+	if err == nil || !strings.Contains(err.Error(), "header injection guard") {
+		t.Fatalf("expected CRLF injection guard error, got %v", err)
+	}
+}
+
+func TestApplySubstitutionsScopingSkipsUndeclaredSurfaces(t *testing.T) {
+	// Substitution declared only for "path"; placeholder also appears
+	// in query, header, and would-be body. Only the path is rewritten;
+	// the others retain the literal token.
+	u := mustParseURL(t, "https://api.example.com/items/__sid__?id=__sid__")
+	headers := http.Header{}
+	headers.Set("X-Echo", "__sid__")
+
+	subs := []ResolvedSubstitution{{
+		Placeholder: "__sid__",
+		Value:       "REAL",
+		In:          []string{"path"},
+	}}
+	if err := ApplySubstitutions(u, headers, subs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(u.Path, "REAL") {
+		t.Fatalf("expected path rewritten, got %q", u.Path)
+	}
+	if u.RawQuery != "id=__sid__" {
+		t.Fatalf("expected query untouched, got %q", u.RawQuery)
+	}
+	if headers.Get("X-Echo") != "__sid__" {
+		t.Fatalf("expected header untouched, got %q", headers.Get("X-Echo"))
+	}
+}
+
+func TestApplySubstitutionsCaseSensitive(t *testing.T) {
+	u := mustParseURL(t, "https://api.example.com/items/__SID__")
+	subs := []ResolvedSubstitution{{
+		Placeholder: "__sid__",
+		Value:       "REAL",
+		In:          []string{"path"},
+	}}
+	if err := ApplySubstitutions(u, nil, subs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(u.Path, "__SID__") {
+		t.Fatalf("expected uppercase placeholder NOT to match (case-sensitive), got %q", u.Path)
+	}
+}
+
+func TestApplySubstitutionsMultiple(t *testing.T) {
+	u := mustParseURL(t, "https://api.example.com/__org__/items/__id__?v=1")
+	subs := []ResolvedSubstitution{
+		{Placeholder: "__org__", Value: "acme", In: []string{"path"}},
+		{Placeholder: "__id__", Value: "42", In: []string{"path"}},
+	}
+	if err := ApplySubstitutions(u, nil, subs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u.Path != "/acme/items/42" {
+		t.Fatalf("expected both substitutions applied, got %q", u.Path)
+	}
+}
+
+func TestApplySubstitutionsNoMatchIsNoop(t *testing.T) {
+	u := mustParseURL(t, "https://api.example.com/items/123")
+	subs := []ResolvedSubstitution{{
+		Placeholder: "__sid__",
+		Value:       "REAL",
+		In:          []string{"path", "query"},
+	}}
+	before := u.String()
+	if err := ApplySubstitutions(u, nil, subs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u.String() != before {
+		t.Fatalf("expected no-op, got %q", u.String())
+	}
+}
+
+func TestApplySubstitutionsEmpty(t *testing.T) {
+	u := mustParseURL(t, "https://api.example.com/items/__sid__")
+	if err := ApplySubstitutions(u, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u.Path != "/items/__sid__" {
+		t.Fatal("nil subs slice should not mutate URL")
+	}
+}

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -99,6 +99,15 @@ func (p *Proxy) forwardHandler(target, host string, scope *brokercore.ProxyScope
 		// Authorization is the client's own upstream header.
 		brokercore.ApplyInjection(r.Header, outReq.Header, inject)
 
+		// Apply any declared substitutions to the outbound URL and
+		// headers. Surfaces not listed in the substitution's `in:` are
+		// not scanned — scope is the security boundary.
+		if err := brokercore.ApplySubstitutions(outReq.URL, outReq.Header, inject.Substitutions); err != nil {
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			emit(http.StatusBadGateway, "substitution_error")
+			return
+		}
+
 		resp, err := p.upstream.RoundTrip(outReq)
 		if err != nil {
 			http.Error(w, "bad gateway", http.StatusBadGateway)

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -445,6 +445,105 @@ func TestMITMRejectsNonConnectRequests(t *testing.T) {
 	}
 }
 
+func TestMITMSubstitutionRewritesPath(t *testing.T) {
+	var sawPath, sawQuery, sawAuth string
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawPath = r.URL.Path
+		sawQuery = r.URL.RawQuery
+		sawAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
+
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{
+			Headers: map[string]string{"Authorization": "Basic " + base64.StdEncoding.EncodeToString([]byte("AC12345:tok-shh"))},
+			Substitutions: []brokercore.ResolvedSubstitution{{
+				Placeholder: "__account_sid__",
+				Value:       "AC12345",
+				In:          []string{"path"},
+			}},
+		}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: upstreamRoots}
+
+	client := newTrustingClient(proxyURL, url.User("av_sess_ok"), clientRoots)
+
+	// Agent embeds placeholder in path AND query — only path is in `in:`,
+	// so the query token must reach upstream untouched.
+	req, err := http.NewRequest("GET", upstream.URL+"/2010-04-01/Accounts/__account_sid__/Messages.json?id=__account_sid__", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if sawPath != "/2010-04-01/Accounts/AC12345/Messages.json" {
+		t.Fatalf("upstream path: got %q", sawPath)
+	}
+	if sawQuery != "id=__account_sid__" {
+		t.Fatalf("query is not in `in:`, must reach upstream untouched: got %q", sawQuery)
+	}
+	if !strings.HasPrefix(sawAuth, "Basic ") {
+		t.Fatalf("auth header should be injected: got %q", sawAuth)
+	}
+}
+
+func TestMITMSubstitutionCaseSensitive(t *testing.T) {
+	var sawPath string
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
+
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{
+			Substitutions: []brokercore.ResolvedSubstitution{{
+				Placeholder: "__account_sid__",
+				Value:       "AC12345",
+				In:          []string{"path"},
+			}},
+			Passthrough: true,
+		}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: upstreamRoots}
+
+	client := newTrustingClient(proxyURL, url.User("av_sess_ok"), clientRoots)
+	// Uppercase placeholder should NOT match the lowercase declaration.
+	req, _ := http.NewRequest("GET", upstream.URL+"/items/__ACCOUNT_SID__", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if !strings.Contains(sawPath, "__ACCOUNT_SID__") {
+		t.Fatalf("expected uppercase placeholder to pass through unmodified, got %q", sawPath)
+	}
+}
+
 func TestIsValidHost(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -544,6 +544,61 @@ func TestMITMSubstitutionCaseSensitive(t *testing.T) {
 	}
 }
 
+func TestMITMSubstitutionRewritesQueryAndHeader(t *testing.T) {
+	var sawQuery, sawTenant string
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawQuery = r.URL.RawQuery
+		sawTenant = r.Header.Get("X-Tenant")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
+
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{
+			Substitutions: []brokercore.ResolvedSubstitution{
+				{Placeholder: "__api_key__", Value: "real&secret", In: []string{"query"}},
+				{Placeholder: "__tenant__", Value: "acme-co", In: []string{"header"}},
+			},
+			Passthrough: true,
+		}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: upstreamRoots}
+
+	client := newTrustingClient(proxyURL, url.User("av_sess_ok"), clientRoots)
+	req, _ := http.NewRequest("GET", upstream.URL+"/data?api_key=__api_key__&format=json", nil)
+	req.Header.Set("X-Tenant", "tenant=__tenant__")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	parsed, err := url.ParseQuery(sawQuery)
+	if err != nil {
+		t.Fatalf("parse query %q: %v", sawQuery, err)
+	}
+	if parsed.Get("api_key") != "real&secret" {
+		t.Fatalf("query api_key: got %q, want round-tripped 'real&secret'", parsed.Get("api_key"))
+	}
+	if parsed.Get("format") != "json" {
+		t.Fatalf("non-substituted query param dropped: got %q", parsed.Get("format"))
+	}
+	if sawTenant != "tenant=acme-co" {
+		t.Fatalf("X-Tenant header: got %q, want 'tenant=acme-co'", sawTenant)
+	}
+}
+
 func TestIsValidHost(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/internal/proposal/merge.go
+++ b/internal/proposal/merge.go
@@ -78,5 +78,9 @@ func toBrokerService(p Service) broker.Service {
 	if p.Auth != nil {
 		svc.Auth = *p.Auth
 	}
+	if len(p.Substitutions) > 0 {
+		svc.Substitutions = make([]broker.Substitution, len(p.Substitutions))
+		copy(svc.Substitutions, p.Substitutions)
+	}
 	return svc
 }

--- a/internal/proposal/merge.go
+++ b/internal/proposal/merge.go
@@ -42,7 +42,15 @@ func MergeServices(existing []broker.Service, proposed []Service) ([]broker.Serv
 				// preserve Auth and Description, overlay just the flag.
 				merged[idx].Enabled = p.Enabled
 			case exists:
-				merged[idx] = toBrokerService(p)
+				next := toBrokerService(p)
+				// Empty Substitutions means "leave existing alone"; clear
+				// by delete+recreate. The aliased slice is safe — the
+				// caller marshals the merged config to JSON and does not
+				// mutate it.
+				if len(p.Substitutions) == 0 {
+					next.Substitutions = merged[idx].Substitutions
+				}
+				merged[idx] = next
 			default:
 				hostIndex[p.Host] = len(merged)
 				merged = append(merged, toBrokerService(p))

--- a/internal/proposal/merge_test.go
+++ b/internal/proposal/merge_test.go
@@ -219,3 +219,49 @@ func TestMergeServicesEnableOnlyPreservesSubstitutions(t *testing.T) {
 		t.Fatalf("expected enabled overlay applied, got %+v", merged[0].Enabled)
 	}
 }
+
+func TestMergeServicesAuthOnlyUpdatePreservesSubstitutions(t *testing.T) {
+	// Operators rotating credentials shouldn't lose URL rewriting as a
+	// side effect.
+	existing := []broker.Service{{
+		Host: "api.twilio.com",
+		Auth: broker.Auth{Type: "basic", Username: "TWILIO_ACCOUNT_SID", Password: "TWILIO_AUTH_TOKEN"},
+		Substitutions: []broker.Substitution{
+			{Key: "TWILIO_ACCOUNT_SID", Placeholder: "__account_sid__", In: []string{"path"}},
+		},
+	}}
+	proposed := []Service{{
+		Action: ActionSet,
+		Host:   "api.twilio.com",
+		Auth:   &broker.Auth{Type: "bearer", Token: "TWILIO_AUTH_TOKEN"},
+	}}
+	merged, _ := MergeServices(existing, proposed)
+	if merged[0].Auth.Type != "bearer" {
+		t.Fatalf("expected auth replaced with bearer, got %+v", merged[0].Auth)
+	}
+	if len(merged[0].Substitutions) != 1 || merged[0].Substitutions[0].Placeholder != "__account_sid__" {
+		t.Fatalf("expected existing substitutions preserved, got %+v", merged[0].Substitutions)
+	}
+}
+
+func TestMergeServicesAuthAndSubsReplacesSubstitutions(t *testing.T) {
+	existing := []broker.Service{{
+		Host: "api.twilio.com",
+		Auth: broker.Auth{Type: "passthrough"},
+		Substitutions: []broker.Substitution{
+			{Key: "OLD_KEY", Placeholder: "__old__", In: []string{"path"}},
+		},
+	}}
+	proposed := []Service{{
+		Action: ActionSet,
+		Host:   "api.twilio.com",
+		Auth:   &broker.Auth{Type: "passthrough"},
+		Substitutions: []broker.Substitution{
+			{Key: "NEW_KEY", Placeholder: "__new__", In: []string{"path"}},
+		},
+	}}
+	merged, _ := MergeServices(existing, proposed)
+	if len(merged[0].Substitutions) != 1 || merged[0].Substitutions[0].Placeholder != "__new__" {
+		t.Fatalf("expected substitutions replaced, got %+v", merged[0].Substitutions)
+	}
+}

--- a/internal/proposal/merge_test.go
+++ b/internal/proposal/merge_test.go
@@ -177,3 +177,45 @@ func TestMergeServicesBasicAuth(t *testing.T) {
 		t.Fatalf("expected username ASHBY_KEY, got %s", merged[0].Auth.Username)
 	}
 }
+
+func TestMergeServicesCopiesSubstitutions(t *testing.T) {
+	proposed := []Service{{
+		Action: ActionSet,
+		Host:   "api.twilio.com",
+		Auth:   &broker.Auth{Type: "basic", Username: "TWILIO_ACCOUNT_SID", Password: "TWILIO_AUTH_TOKEN"},
+		Substitutions: []broker.Substitution{
+			{Key: "TWILIO_ACCOUNT_SID", Placeholder: "__account_sid__", In: []string{"path"}},
+		},
+	}}
+	merged, _ := MergeServices(nil, proposed)
+	if len(merged) != 1 || len(merged[0].Substitutions) != 1 {
+		t.Fatalf("expected 1 substitution carried through, got %+v", merged)
+	}
+	if merged[0].Substitutions[0].Placeholder != "__account_sid__" {
+		t.Fatalf("expected placeholder copied, got %+v", merged[0].Substitutions[0])
+	}
+	// Mutating proposed must not affect merged (defensive copy).
+	proposed[0].Substitutions[0].Placeholder = "__mutated__"
+	if merged[0].Substitutions[0].Placeholder != "__account_sid__" {
+		t.Fatal("merged service substitution aliased the proposal slice")
+	}
+}
+
+func TestMergeServicesEnableOnlyPreservesSubstitutions(t *testing.T) {
+	on := false
+	existing := []broker.Service{{
+		Host: "api.twilio.com",
+		Auth: broker.Auth{Type: "basic", Username: "TWILIO_ACCOUNT_SID", Password: "TWILIO_AUTH_TOKEN"},
+		Substitutions: []broker.Substitution{
+			{Key: "TWILIO_ACCOUNT_SID", Placeholder: "__account_sid__", In: []string{"path"}},
+		},
+	}}
+	proposed := []Service{{Action: ActionSet, Host: "api.twilio.com", Enabled: &on}}
+	merged, _ := MergeServices(existing, proposed)
+	if len(merged[0].Substitutions) != 1 || merged[0].Substitutions[0].Placeholder != "__account_sid__" {
+		t.Fatalf("expected substitutions preserved on enable-only update, got %+v", merged[0])
+	}
+	if merged[0].Enabled == nil || *merged[0].Enabled != false {
+		t.Fatalf("expected enabled overlay applied, got %+v", merged[0].Enabled)
+	}
+}

--- a/internal/proposal/proposal.go
+++ b/internal/proposal/proposal.go
@@ -28,12 +28,15 @@ const (
 // When Enabled is provided without Auth and the host already exists,
 // the merge preserves the existing service's Auth/Description and
 // overlays only the Enabled flag — this is the enable/disable flow.
+// Substitutions must accompany Auth (Validate rejects set+Substitutions
+// without Auth) since the merge only carries them on full replacements.
 type Service struct {
-	Action      Action       `json:"action"`
-	Host        string       `json:"host"`
-	Description string       `json:"description,omitempty"`
-	Enabled     *bool        `json:"enabled,omitempty"`
-	Auth        *broker.Auth `json:"auth,omitempty"`
+	Action        Action                `json:"action"`
+	Host          string                `json:"host"`
+	Description   string                `json:"description,omitempty"`
+	Enabled       *bool                 `json:"enabled,omitempty"`
+	Auth          *broker.Auth          `json:"auth,omitempty"`
+	Substitutions []broker.Substitution `json:"substitutions,omitempty"`
 }
 
 // CredentialSlot declares a credential operation in a proposal.

--- a/internal/proposal/validate.go
+++ b/internal/proposal/validate.go
@@ -141,10 +141,23 @@ func Validate(services []Service, credentials []CredentialSlot) error {
 					return fmt.Errorf("service %d: %w", i, err)
 				}
 			}
+			if len(s.Substitutions) > 0 {
+				// Coupled to Auth here (not in broker.Validate) because
+				// broker.Service.Auth is non-pointer — the direct write
+				// path can't express "substitutions without auth", but
+				// proposals can via Auth==nil enable-only updates.
+				if s.Auth == nil {
+					return fmt.Errorf("service %d: substitutions require auth — to change substitutions on an existing service, re-supply the auth config", i)
+				}
+				synthetic := broker.Service{Host: s.Host, Substitutions: s.Substitutions}
+				if err := synthetic.ValidateSubstitutions(); err != nil {
+					return fmt.Errorf("service %d: %w", i, err)
+				}
+			}
 		}
 	}
 
-	// Collect all credential references from set-action services.
+	// Collect all credential references from set-action services (auth + substitutions).
 	refs := make(map[string]bool)
 	for _, s := range services {
 		if s.Action != ActionSet || s.Auth == nil {
@@ -152,6 +165,9 @@ func Validate(services []Service, credentials []CredentialSlot) error {
 		}
 		for _, key := range s.Auth.CredentialKeys() {
 			refs[key] = true
+		}
+		for _, sub := range s.Substitutions {
+			refs[sub.Key] = true
 		}
 	}
 
@@ -214,7 +230,8 @@ func ValidateCredentialRefs(services []Service, slots []CredentialSlot, existing
 		available[k] = true
 	}
 
-	// Check every credential key ref in set-action service auth configs resolves.
+	// Check every credential key ref in set-action service auth configs and
+	// substitutions resolves to either a proposal slot or an existing key.
 	for _, svc := range services {
 		if svc.Action != ActionSet || svc.Auth == nil {
 			continue
@@ -222,6 +239,11 @@ func ValidateCredentialRefs(services []Service, slots []CredentialSlot, existing
 		for _, key := range svc.Auth.CredentialKeys() {
 			if !available[key] {
 				return fmt.Errorf("credential %q referenced in service for %q is not provided in this proposal and does not exist in the vault", key, svc.Host)
+			}
+		}
+		for _, sub := range svc.Substitutions {
+			if !available[sub.Key] {
+				return fmt.Errorf("credential %q referenced in substitution for %q is not provided in this proposal and does not exist in the vault", sub.Key, svc.Host)
 			}
 		}
 	}

--- a/internal/proposal/validate_test.go
+++ b/internal/proposal/validate_test.go
@@ -291,3 +291,88 @@ func TestValidateCredentialRefsBasicAuth(t *testing.T) {
 		t.Fatalf("expected valid, got %v", err)
 	}
 }
+
+// --- Substitution proposal tests ---
+
+func TestValidateProposalSubstitutionWithAuth(t *testing.T) {
+	services := []Service{{
+		Action: ActionSet,
+		Host:   "api.twilio.com",
+		Auth:   &broker.Auth{Type: "basic", Username: "TWILIO_ACCOUNT_SID", Password: "TWILIO_AUTH_TOKEN"},
+		Substitutions: []broker.Substitution{
+			{Key: "TWILIO_ACCOUNT_SID", Placeholder: "__account_sid__", In: []string{"path"}},
+		},
+	}}
+	creds := []CredentialSlot{
+		{Action: ActionSet, Key: "TWILIO_ACCOUNT_SID"},
+		{Action: ActionSet, Key: "TWILIO_AUTH_TOKEN"},
+	}
+	if err := Validate(services, creds); err != nil {
+		t.Fatalf("expected valid, got %v", err)
+	}
+}
+
+func TestValidateProposalSubstitutionWithoutAuth(t *testing.T) {
+	on := true
+	services := []Service{{
+		Action:  ActionSet,
+		Host:    "api.twilio.com",
+		Enabled: &on,
+		Substitutions: []broker.Substitution{
+			{Key: "TWILIO_ACCOUNT_SID", Placeholder: "__account_sid__", In: []string{"path"}},
+		},
+	}}
+	err := Validate(services, nil)
+	if err == nil || !strings.Contains(err.Error(), "substitutions require auth") {
+		t.Fatalf("expected error coupling substitutions to auth, got %v", err)
+	}
+}
+
+func TestValidateProposalSubstitutionInvalidPlaceholder(t *testing.T) {
+	services := []Service{{
+		Action: ActionSet,
+		Host:   "api.twilio.com",
+		Auth:   bearerAuth("TWILIO_ACCOUNT_SID"),
+		Substitutions: []broker.Substitution{
+			{Key: "TWILIO_ACCOUNT_SID", Placeholder: "account_sid", In: []string{"path"}},
+		},
+	}}
+	creds := []CredentialSlot{{Action: ActionSet, Key: "TWILIO_ACCOUNT_SID"}}
+	err := Validate(services, creds)
+	if err == nil || !strings.Contains(err.Error(), "delimiter") {
+		t.Fatalf("expected delimiter error for bare-word placeholder, got %v", err)
+	}
+}
+
+func TestValidateProposalSubstitutionRequiresCredSlot(t *testing.T) {
+	services := []Service{{
+		Action: ActionSet,
+		Host:   "api.twilio.com",
+		Auth:   bearerAuth("TWILIO_AUTH_TOKEN"),
+		Substitutions: []broker.Substitution{
+			{Key: "TWILIO_ACCOUNT_SID", Placeholder: "__account_sid__", In: []string{"path"}},
+		},
+	}}
+	creds := []CredentialSlot{{Action: ActionSet, Key: "TWILIO_AUTH_TOKEN"}}
+	if err := Validate(services, creds); err != nil {
+		t.Fatalf("intra-proposal Validate should accept the slot via the auth ref check; got %v", err)
+	}
+	if err := ValidateCredentialRefs(services, creds, nil); err == nil || !strings.Contains(err.Error(), "TWILIO_ACCOUNT_SID") {
+		t.Fatalf("expected ValidateCredentialRefs to flag missing substitution credential, got %v", err)
+	}
+}
+
+func TestValidateCredentialRefsSubstitutionResolvesFromExisting(t *testing.T) {
+	services := []Service{{
+		Action: ActionSet,
+		Host:   "api.twilio.com",
+		Auth:   bearerAuth("TWILIO_AUTH_TOKEN"),
+		Substitutions: []broker.Substitution{
+			{Key: "TWILIO_ACCOUNT_SID", Placeholder: "__account_sid__", In: []string{"path"}},
+		},
+	}}
+	creds := []CredentialSlot{{Action: ActionSet, Key: "TWILIO_AUTH_TOKEN"}}
+	if err := ValidateCredentialRefs(services, creds, []string{"TWILIO_ACCOUNT_SID"}); err != nil {
+		t.Fatalf("expected substitution credential to resolve from existing vault keys, got %v", err)
+	}
+}

--- a/internal/server/handle_proxy.go
+++ b/internal/server/handle_proxy.go
@@ -231,6 +231,15 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// use the MITM ingress, where Proxy-Authorization is broker-scoped.
 	brokercore.ApplyInjection(r.Header, outReq.Header, inject, "Authorization")
 
+	// Apply any declared substitutions to the outbound URL and headers.
+	// Surfaces not listed in the substitution's `in:` are not scanned —
+	// scope is the security boundary.
+	if err := brokercore.ApplySubstitutions(outReq.URL, outReq.Header, inject.Substitutions); err != nil {
+		proxyError(w, http.StatusBadGateway, "substitution_error", "Substitution failed before forwarding")
+		emit(http.StatusBadGateway, "substitution_error")
+		return
+	}
+
 	// 9. Forward request to target.
 	resp, err := proxyClient.Do(outReq)
 	if err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -2809,6 +2810,135 @@ func TestProxyHeaderMerge(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// --- Substitution proxy tests ---
+
+func TestProxySubstitutionRewritesPathAndInjectsAuth(t *testing.T) {
+	var (
+		sawAuth string
+		sawPath string
+	)
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		sawPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
+	serviceHost, _, _ := net.SplitHostPort(upstreamHost)
+	services := fmt.Sprintf(`[{"host":"%s","auth":{"type":"basic","username":"TWILIO_ACCOUNT_SID","password":"TWILIO_AUTH_TOKEN"},"substitutions":[{"key":"TWILIO_ACCOUNT_SID","placeholder":"__account_sid__","in":["path"]}]}]`, serviceHost)
+	ms, token, encKey := setupProxyTest(t, services)
+
+	for k, v := range map[string]string{"TWILIO_ACCOUNT_SID": "AC12345", "TWILIO_AUTH_TOKEN": "tok-shh"} {
+		ct, nonce, err := crypto.Encrypt([]byte(v), encKey)
+		if err != nil {
+			t.Fatalf("encrypt %s: %v", k, err)
+		}
+		ms.credentials["root-ns-id:"+k] = &store.Credential{ID: "c-" + k, VaultID: "root-ns-id", Key: k, Ciphertext: ct, Nonce: nonce}
+	}
+
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+	origClient := proxyClient
+	proxyClient = upstream.Client()
+	defer func() { proxyClient = origClient }()
+
+	req := httptest.NewRequest(http.MethodGet, "/proxy/"+upstreamHost+"/2010-04-01/Accounts/__account_sid__/Messages.json", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("AC12345:tok-shh"))
+	if sawAuth != want {
+		t.Fatalf("upstream Authorization: got %q want %q", sawAuth, want)
+	}
+	if sawPath != "/2010-04-01/Accounts/AC12345/Messages.json" {
+		t.Fatalf("upstream path: got %q", sawPath)
+	}
+}
+
+func TestProxySubstitutionScopingSkipsUndeclaredSurfaces(t *testing.T) {
+	var (
+		sawPath  string
+		sawQuery string
+		sawEcho  string
+	)
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawPath = r.URL.Path
+		sawQuery = r.URL.RawQuery
+		sawEcho = r.Header.Get("X-Echo")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
+	serviceHost, _, _ := net.SplitHostPort(upstreamHost)
+	// Substitution declared only for "path".
+	services := fmt.Sprintf(`[{"host":"%s","auth":{"type":"passthrough"},"substitutions":[{"key":"ACCOUNT_SID","placeholder":"__account_sid__","in":["path"]}]}]`, serviceHost)
+	ms, token, encKey := setupProxyTest(t, services)
+	ct, nonce, _ := crypto.Encrypt([]byte("AC-REAL"), encKey)
+	ms.credentials["root-ns-id:ACCOUNT_SID"] = &store.Credential{ID: "c-sid", VaultID: "root-ns-id", Key: "ACCOUNT_SID", Ciphertext: ct, Nonce: nonce}
+
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+	origClient := proxyClient
+	proxyClient = upstream.Client()
+	defer func() { proxyClient = origClient }()
+
+	// Agent embeds the placeholder in path (declared), query (NOT declared),
+	// and a header (NOT declared). Only the path should be rewritten.
+	req := httptest.NewRequest(http.MethodGet, "/proxy/"+upstreamHost+"/items/__account_sid__?id=__account_sid__", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-Echo", "__account_sid__")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if sawPath != "/items/AC-REAL" {
+		t.Fatalf("path should be rewritten, got %q", sawPath)
+	}
+	if sawQuery != "id=__account_sid__" {
+		t.Fatalf("query is not in `in:`, must reach upstream untouched, got %q", sawQuery)
+	}
+	if sawEcho != "__account_sid__" {
+		t.Fatalf("header is not in `in:`, must reach upstream untouched, got %q", sawEcho)
+	}
+}
+
+func TestProxySubstitutionMissingCredentialReturns502(t *testing.T) {
+	upstreamHit := false
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
+	serviceHost, _, _ := net.SplitHostPort(upstreamHost)
+	services := fmt.Sprintf(`[{"host":"%s","auth":{"type":"passthrough"},"substitutions":[{"key":"MISSING_KEY","placeholder":"__sid__","in":["path"]}]}]`, serviceHost)
+	ms, token, encKey := setupProxyTest(t, services)
+
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+	origClient := proxyClient
+	proxyClient = upstream.Client()
+	defer func() { proxyClient = origClient }()
+
+	req := httptest.NewRequest(http.MethodGet, "/proxy/"+upstreamHost+"/items/__sid__", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502 for missing substitution credential, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if upstreamHit {
+		t.Fatal("upstream must not be contacted when substitution credential is missing")
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -2939,6 +2940,80 @@ func TestProxySubstitutionMissingCredentialReturns502(t *testing.T) {
 	}
 	if upstreamHit {
 		t.Fatal("upstream must not be contacted when substitution credential is missing")
+	}
+}
+
+func TestProxySubstitutionRewritesQuery(t *testing.T) {
+	var sawQuery string
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
+	serviceHost, _, _ := net.SplitHostPort(upstreamHost)
+	services := fmt.Sprintf(`[{"host":"%s","auth":{"type":"passthrough"},"substitutions":[{"key":"LEGACY_API_KEY","placeholder":"__api_key__","in":["query"]}]}]`, serviceHost)
+	ms, token, encKey := setupProxyTest(t, services)
+	ct, nonce, _ := crypto.Encrypt([]byte("real-key&with=specials"), encKey)
+	ms.credentials["root-ns-id:LEGACY_API_KEY"] = &store.Credential{ID: "c-key", VaultID: "root-ns-id", Key: "LEGACY_API_KEY", Ciphertext: ct, Nonce: nonce}
+
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+	origClient := proxyClient
+	proxyClient = upstream.Client()
+	defer func() { proxyClient = origClient }()
+
+	req := httptest.NewRequest(http.MethodGet, "/proxy/"+upstreamHost+"/data?api_key=__api_key__&format=json", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	parsed, err := url.ParseQuery(sawQuery)
+	if err != nil {
+		t.Fatalf("parse query %q: %v", sawQuery, err)
+	}
+	if parsed.Get("api_key") != "real-key&with=specials" {
+		t.Fatalf("expected query api_key to round-trip the encoded secret, got %q", parsed.Get("api_key"))
+	}
+	if parsed.Get("format") != "json" {
+		t.Fatalf("expected non-substituted query param preserved, got %q", parsed.Get("format"))
+	}
+}
+
+func TestProxySubstitutionRewritesHeader(t *testing.T) {
+	var sawTenant string
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawTenant = r.Header.Get("X-Tenant")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
+	serviceHost, _, _ := net.SplitHostPort(upstreamHost)
+	services := fmt.Sprintf(`[{"host":"%s","auth":{"type":"passthrough"},"substitutions":[{"key":"TENANT_ID","placeholder":"__tenant__","in":["header"]}]}]`, serviceHost)
+	ms, token, encKey := setupProxyTest(t, services)
+	ct, nonce, _ := crypto.Encrypt([]byte("acme-co"), encKey)
+	ms.credentials["root-ns-id:TENANT_ID"] = &store.Credential{ID: "c-tenant", VaultID: "root-ns-id", Key: "TENANT_ID", Ciphertext: ct, Nonce: nonce}
+
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+	origClient := proxyClient
+	proxyClient = upstream.Client()
+	defer func() { proxyClient = origClient }()
+
+	req := httptest.NewRequest(http.MethodGet, "/proxy/"+upstreamHost+"/items", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-Tenant", "tenant=__tenant__")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if sawTenant != "tenant=acme-co" {
+		t.Fatalf("expected header rewritten to 'tenant=acme-co', got %q", sawTenant)
 	}
 }
 

--- a/web/src/components/ProposalPreview.tsx
+++ b/web/src/components/ProposalPreview.tsx
@@ -11,12 +11,24 @@ export interface Auth {
   headers?: Record<string, string>;
 }
 
+export interface Substitution {
+  key: string;
+  placeholder: string;
+  in?: string[];
+}
+
+export const SUBSTITUTION_SURFACES = ["path", "query", "header"] as const;
+// Mutable-typed so callers can spread directly into Substitution.in
+// state. Treat as the source-of-truth default — do not push/splice.
+export const DEFAULT_SUBSTITUTION_SURFACES: string[] = ["path", "query"];
+
 export interface Service {
   action: string;
   host: string;
   description?: string;
   enabled?: boolean;
   auth?: Auth;
+  substitutions?: Substitution[];
 }
 
 export interface CredentialSlot {
@@ -97,6 +109,32 @@ function AuthDisplay({ auth }: { auth: Auth }) {
             ))}
           </div>
         )}
+    </div>
+  );
+}
+
+function SubstitutionsDisplay({ subs }: { subs: Substitution[] }) {
+  return (
+    <div className="mt-2 pt-2 border-t border-border">
+      <div className="text-[10px] font-semibold text-text-muted uppercase tracking-wider mb-1.5">
+        URL substitutions
+      </div>
+      <p className="text-xs text-text-muted leading-relaxed mb-1.5">
+        The broker rewrites the placeholder string with the credential value
+        only in the surfaces listed below. Anywhere else, the literal string
+        passes through unmodified.
+      </p>
+      {subs.map((sub, i) => {
+        const surfaces = sub.in && sub.in.length > 0 ? sub.in : DEFAULT_SUBSTITUTION_SURFACES;
+        return (
+          <div key={i} className="flex items-start gap-1.5 text-xs font-mono leading-relaxed">
+            <span className="text-text break-all">{sub.placeholder}</span>
+            <span className="text-text-muted">→</span>
+            <span className="text-text break-all">{sub.key}</span>
+            <span className="text-text-muted">in: [{surfaces.join(", ")}]</span>
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -190,6 +228,9 @@ export default function ProposalPreview({ data }: { data: ProposalData }) {
                   </div>
                 )}
                 {service.auth && <AuthDisplay auth={service.auth} />}
+                {service.substitutions && service.substitutions.length > 0 && (
+                  <SubstitutionsDisplay subs={service.substitutions} />
+                )}
               </div>
             ))}
           </div>

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -12,7 +12,13 @@ import Input from "../../components/Input";
 import FormField from "../../components/FormField";
 import Select from "../../components/Select";
 import Toggle from "../../components/Toggle";
-import { type Auth, AUTH_TYPE_LABELS } from "../../components/ProposalPreview";
+import {
+  type Auth,
+  type Substitution,
+  AUTH_TYPE_LABELS,
+  SUBSTITUTION_SURFACES,
+  DEFAULT_SUBSTITUTION_SURFACES,
+} from "../../components/ProposalPreview";
 import { apiFetch, apiRequest } from "../../lib/api";
 
 interface Service {
@@ -20,7 +26,10 @@ interface Service {
   description?: string;
   enabled?: boolean;
   auth: Auth;
+  substitutions?: Substitution[];
 }
+
+type SubstitutionSurface = (typeof SUBSTITUTION_SURFACES)[number];
 
 interface CatalogTemplate {
   id: string;
@@ -171,9 +180,15 @@ export default function ServicesTab() {
       header: "Auth",
       render: (service) => {
         const label = AUTH_TYPE_LABELS[service.auth?.type] || service.auth?.type || "\u2014";
+        const subCount = service.substitutions?.length ?? 0;
         return (
           <div className="text-sm text-text">
             {label}
+            {subCount > 0 && (
+              <span className="ml-2 text-xs text-text-muted">
+                + {subCount} substitution{subCount === 1 ? "" : "s"}
+              </span>
+            )}
           </div>
         );
       },
@@ -346,6 +361,18 @@ function ServiceModal({
     return [{ name: "", value: "" }];
   });
 
+  // Substitution editor state — independent of auth type so it composes
+  // with all of them (including passthrough).
+  const [subs, setSubs] = useState<Substitution[]>(() =>
+    initial?.substitutions
+      ? initial.substitutions.map((s) => ({
+          key: s.key,
+          placeholder: s.placeholder,
+          in: s.in && s.in.length > 0 ? [...s.in] : [...DEFAULT_SUBSTITUTION_SURFACES],
+        }))
+      : []
+  );
+
   // Snapshot the catalog at open time so a fetch resolving mid-form doesn't
   // shift the preset picker into view above fields the user is already editing.
   const [catalogSnapshot] = useState<CatalogTemplate[]>(() => catalog);
@@ -363,6 +390,7 @@ function ServiceModal({
     setApiKeyHeader("");
     setApiKeyPrefix("");
     setCustomHeaders([{ name: "", value: "" }]);
+    setSubs([]);
   }
 
   function applyPreset(id: string) {
@@ -435,8 +463,17 @@ function ServiceModal({
     }
   }
 
+  const cleanedSubs = subs
+    .map((s) => ({
+      key: s.key.trim(),
+      placeholder: s.placeholder.trim(),
+      in: s.in && s.in.length > 0 ? s.in : DEFAULT_SUBSTITUTION_SURFACES,
+    }))
+    .filter((s) => s.key !== "" || s.placeholder !== "");
+  const subsValid = cleanedSubs.every((s) => s.key !== "" && s.placeholder !== "");
+
   async function handleSubmit() {
-    if (!canSubmit) return;
+    if (!canSubmit || !subsValid) return;
     setSaving(true);
     setError("");
     try {
@@ -445,6 +482,7 @@ function ServiceModal({
         ...(description.trim() && { description: description.trim() }),
         ...(enabled ? {} : { enabled: false }),
         auth: buildAuth(),
+        ...(cleanedSubs.length > 0 && { substitutions: cleanedSubs }),
       };
       await onSave(service);
     } catch (err: unknown) {
@@ -467,7 +505,7 @@ function ServiceModal({
           </Button>
           <Button
             onClick={handleSubmit}
-            disabled={!canSubmit}
+            disabled={!canSubmit || !subsValid}
             loading={saving}
           >
             {initial ? "Save" : "Add service"}
@@ -683,6 +721,82 @@ function ServiceModal({
             </button>
           </div>
         )}
+
+        <FormField
+          label="URL substitutions"
+          helperText="Optional. Lets the broker rewrite a placeholder string in the request path, query, or header with a stored credential value. Surfaces not declared in 'in' are not scanned."
+        >
+          <div className="space-y-3">
+            {subs.map((sub, i) => (
+                <div key={i} className="rounded-lg border border-border bg-bg p-3 space-y-2">
+                  <div className="flex gap-3 items-center">
+                    <Input
+                      placeholder="Placeholder, e.g. __account_sid__"
+                      value={sub.placeholder}
+                      onChange={(e) =>
+                        setSubs((prev) =>
+                          prev.map((s, j) => (j === i ? { ...s, placeholder: e.target.value } : s))
+                        )
+                      }
+                    />
+                    <span className="text-text-muted">→</span>
+                    <Input
+                      placeholder="Credential key, e.g. TWILIO_ACCOUNT_SID"
+                      value={sub.key}
+                      onChange={(e) =>
+                        setSubs((prev) =>
+                          prev.map((s, j) => (j === i ? { ...s, key: e.target.value } : s))
+                        )
+                      }
+                    />
+                    <button
+                      onClick={() => setSubs((prev) => prev.filter((_, j) => j !== i))}
+                      className="w-8 h-8 flex-shrink-0 flex items-center justify-center rounded-lg text-text-dim hover:text-danger hover:bg-danger-bg transition-colors"
+                      aria-label="Remove substitution"
+                    >
+                      <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <line x1="18" y1="6" x2="6" y2="18" />
+                        <line x1="6" y1="6" x2="18" y2="18" />
+                      </svg>
+                    </button>
+                  </div>
+                  <div className="flex gap-3 items-center text-xs text-text-muted">
+                    <span>Allowed in:</span>
+                    {SUBSTITUTION_SURFACES.map((surface) => {
+                      const checked = (sub.in ?? DEFAULT_SUBSTITUTION_SURFACES).includes(surface);
+                      return (
+                        <label key={surface} className="inline-flex items-center gap-1 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={(e) => {
+                              const want = e.target.checked;
+                              setSubs((prev) =>
+                                prev.map((s, j) => {
+                                  if (j !== i) return s;
+                                  const current = new Set<SubstitutionSurface>((s.in ?? DEFAULT_SUBSTITUTION_SURFACES) as SubstitutionSurface[]);
+                                  if (want) current.add(surface);
+                                  else current.delete(surface);
+                                  return { ...s, in: SUBSTITUTION_SURFACES.filter((sf) => current.has(sf)) };
+                                })
+                              );
+                            }}
+                          />
+                          <span className="font-mono">{surface}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+            ))}
+            <button
+              onClick={() => setSubs((prev) => [...prev, { key: "", placeholder: "", in: [...DEFAULT_SUBSTITUTION_SURFACES] }])}
+              className="text-sm font-medium text-primary hover:text-primary-hover transition-colors"
+            >
+              + Add substitution
+            </button>
+          </div>
+        </FormField>
 
         {error && <ErrorBanner message={error} />}
       </div>


### PR DESCRIPTION
## Summary

- Adds `substitutions` block on services so credential values can be injected into the **URL path, query, or headers** — not just auth headers. Targets APIs like Twilio (`/Accounts/{AccountSID}/Messages.json`) and legacy `?api_key=` services that the existing auth types can't express.
- The broker only scans surfaces declared in `in:` — that scoping is the security boundary. A placeholder anywhere else (a body, a non-declared header) passes through untouched. There is no way to coerce the broker into substituting somewhere the operator did not authorize.
- Composes with every auth type, including `passthrough`. A Twilio service uses `auth: basic` (header) **and** a path substitution for the SID; a pure-substitution service uses `auth: passthrough` + path substitution.

### Placeholder safety

Validated to prevent false-positive rewrites:
- Length ≥ 4 characters
- Must contain `__` or a non-`[A-Za-z0-9_]` character (so bare `account_sid` is rejected — it could appear as a real path segment)
- Only RFC 3986 unreserved characters `[A-Za-z0-9_-.~]` (so encoded and decoded forms are identical — no percent-encoding round-trips)
- Recommended convention: `__name__`

### Wire-encoded path rewriting

`ApplySubstitutions` in [internal/brokercore/substitution.go](internal/brokercore/substitution.go) operates on `u.EscapedPath()` and writes both `u.Path` and `u.RawPath`, so a `url.PathEscape`'d value lands in the URL exactly once and isn't re-encoded by `URL.String()`. Headers get a CRLF guard (header injection prevention).

### Surface coverage

- Validation: [internal/broker/broker.go](internal/broker/broker.go) (`Service.ValidateSubstitutions`), with proposal-level coupling enforced in [internal/proposal/validate.go](internal/proposal/validate.go) (substitutions require auth — see code comment for why)
- Proposal types: [internal/proposal/proposal.go](internal/proposal/proposal.go), merge: [internal/proposal/merge.go](internal/proposal/merge.go)
- Resolution + memoization: [internal/brokercore/credential.go](internal/brokercore/credential.go) (a credential shared by auth and a substitution decrypts only once)
- Application: [internal/server/handle_proxy.go](internal/server/handle_proxy.go), [internal/mitm/forward.go](internal/mitm/forward.go)
- Frontend: [web/src/pages/vault/ServicesTab.tsx](web/src/pages/vault/ServicesTab.tsx) (editor with surface checkboxes), [web/src/components/ProposalPreview.tsx](web/src/components/ProposalPreview.tsx) (display)
- CLI proposal printer: [cmd/proposal.go](cmd/proposal.go)
- Agent skills + docs updated together: [cmd/skill_cli.md](cmd/skill_cli.md), [cmd/skill_http.md](cmd/skill_http.md), [docs/learn/services.mdx](docs/learn/services.mdx), [docs/reference/cli.mdx](docs/reference/cli.mdx), [README.md](README.md)

## Test plan

- [x] `go test ./...` (all packages green)
- [x] Unit tests for validator (length, character set, boundary, duplicate placeholder, duplicate surface, body/unknown surface rejection)
- [x] Unit tests for `ApplySubstitutions` (path encoding, query encoding, header CRLF guard, no-op when surface not declared)
- [x] Proposal validation tests (substitutions without auth rejected; credential refs from substitutions resolve)
- [x] End-to-end tests through `/proxy` handler and MITM forward path
- [ ] Manual: create a Twilio service via the web UI, approve via CLI, send a request with `__account_sid__` in the path through `HTTPS_PROXY`, confirm rewrite + basic auth header land upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)