### PR TITLE
ci: use npm ci in node SDK release workflow

### DIFF
--- a/.github/workflows/release-node-sdk.yml
+++ b/.github/workflows/release-node-sdk.yml
@@ -32,7 +32,7 @@ jobs:
                 registry-url: "https://registry.npmjs.org"
 
             - name: Install dependencies
-              run: npm install
+              run: npm ci
 
             - name: Set NPM version
               run: npm version ${GITHUB_REF_NAME#node-sdk/v} --allow-same-version --no-git-tag-version


### PR DESCRIPTION
Part of #108 (item 2 in the supply-chain hardening shortlist).

## Summary
- Switch [.github/workflows/release-node-sdk.yml](.github/workflows/release-node-sdk.yml) install step from `npm install` to `npm ci`.
- `npm ci` installs strictly from `package-lock.json` and refuses to run on lockfile/`package.json` drift, so the published tarball is built from the exact tree CI tested. This closes the install-time mutation window — the vector recently exploited in the Axios-family supply-chain compromise.
- PR CI already uses `npm ci` ([ci.yml#L155](.github/workflows/ci.yml#L155)), so this aligns the release path with the test path.

## Test plan
- [ ] Locally: `cd sdks/sdk-typescript && rm -rf node_modules && npm ci` succeeds with no `package-lock.json` diff (`git diff --exit-code package-lock.json`).
- [ ] Next `node-sdk/v*.*.*` tag push: workflow's `Install dependencies` step runs `npm ci` and publish succeeds. If `package.json` and the lockfile drift in the future, the release will fail loudly at install rather than silently shipping an unverified tree (intended new failure mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)