### PR TITLE
ci: drop contents:write from node SDK release workflow

### DIFF
--- a/.github/workflows/release-node-sdk.yml
+++ b/.github/workflows/release-node-sdk.yml
@@ -8,7 +8,7 @@ on:
             - "node-sdk/v*.*.*" # version, e.g. 1.0.0
 
 permissions:
-  contents: read   # checkout only; nothing in this job writes to the repo
+  contents: read
   id-token: write  # Required for NPM OIDC auth for releases
 
 defaults:

--- a/.github/workflows/release-node-sdk.yml
+++ b/.github/workflows/release-node-sdk.yml
@@ -8,7 +8,7 @@ on:
             - "node-sdk/v*.*.*" # version, e.g. 1.0.0
 
 permissions:
-  contents: write
+  contents: read   # checkout only; nothing in this job writes to the repo
   id-token: write  # Required for NPM OIDC auth for releases
 
 defaults:


### PR DESCRIPTION
Part of #108 (item 4 — `contents: write` → `contents: read` on node-sdk publish).

## Summary
- Downgrade workflow-level `permissions` from `contents: write` to `contents: read` in [.github/workflows/release-node-sdk.yml](.github/workflows/release-node-sdk.yml).
- The job only checks out the repo and runs `npm publish --provenance` — no commits pushed, no tags created, no GitHub releases cut. `actions/checkout` needs `contents: read`; npm OIDC provenance needs `id-token: write`. Nothing in the job writes back to the repo, so `contents: write` was over-scoped.
- Sibling [.github/workflows/release.yml](.github/workflows/release.yml) keeps `contents: write` because GoReleaser legitimately creates GitHub releases — that one is unchanged.

## Test plan
- [ ] `actionlint` (or the [online linter](https://rhysd.github.io/actionlint/)) parses the file cleanly.
- [ ] On the next `node-sdk/v*.*.*` tag push, confirm the workflow run reaches `Publish NPM` and that `npm publish --provenance` mints a provenance attestation (proves `id-token: write` is still wired correctly and that dropping `contents: write` did not break anything).
- [ ] Optional pre-merge dry-run: push a throwaway tag like `node-sdk/v0.0.0-perm-test` against this branch with the publish step temporarily swapped to `npm publish --dry-run --provenance` to exercise the OIDC exchange without polluting the registry.

> Note for future work: if we ever add auto-bumping `package.json` + pushing a commit, auto-tagging, or creating a GitHub release alongside the npm publish, `contents: write` will need to come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
