### PR TITLE
ci: disable persist-credentials on actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Detect changed paths
         id: filter
@@ -57,6 +59,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -77,6 +81,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -99,6 +105,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -124,6 +132,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -143,6 +153,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/release-node-sdk.yml
+++ b/.github/workflows/release-node-sdk.yml
@@ -22,6 +22,8 @@ jobs:
         steps:
             - name: Checkout repo
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                persist-credentials: false
 
             - name: Setup Node
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # GoReleaser needs full history for changelog
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0


### PR DESCRIPTION
Part of #108 (zizmor `artipacked` finding).

## Summary
- Set `persist-credentials: false` on every `actions/checkout` step across [ci.yml](.github/workflows/ci.yml) (6 steps), [release.yml](.github/workflows/release.yml) (1 step, alongside the existing `fetch-depth: 0`), and [release-node-sdk.yml](.github/workflows/release-node-sdk.yml) (1 step).
- By default `actions/checkout` writes the `GITHUB_TOKEN` into `.git/config` via `http.<host>.extraheader` and leaves it there for the rest of the job. Any later step that uploads the workspace as an artifact, runs untrusted code, or otherwise leaks files would also leak the token. `persist-credentials: false` removes the token from `.git/config` after the initial fetch.
- Safe across all three workflows because none of them write back to the repo over git:
  - `ci.yml` is read-only — the lone `git diff --exit-code` on go.mod/go.sum ([ci.yml#L136](.github/workflows/ci.yml#L136)) needs no auth.
  - `release.yml` keeps `fetch-depth: 0` so GoReleaser can read git history for the changelog, but releases are cut via the GitHub API using `GITHUB_TOKEN` as an *env var*, not via git push. The brews/tap block in [.goreleaser.yml](.goreleaser.yml) is commented out.
  - `release-node-sdk.yml` already uses `npm version --no-git-tag-version` and publishes via NPM OIDC; no git ops.

## Test plan
- [ ] `actionlint` parses all three files cleanly.
- [ ] Re-run `zizmor .github/workflows/` and confirm the `artipacked` finding is gone.
- [ ] Open this PR and confirm every `ci.yml` job (changes, frontend-build, go-test, go-lint, go-mod-tidy, sdk-ts) still passes — in particular `go-mod-tidy`'s `git diff --exit-code` (proves the read-only diff doesn't depend on persisted credentials).
- [ ] On the next `v*` tag push, watch GoReleaser still produces a changelog from local git history and uploads release assets via the API.
- [ ] On the next `node-sdk/v*.*.*` tag push, confirm `npm publish --provenance` still authenticates via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)