### PR TITLE
ci: add Dependabot cooldown for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: weekly
     commit-message:
       prefix: "deps"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 5
 
   - package-ecosystem: npm
     directory: /web
@@ -13,6 +18,11 @@ updates:
       interval: weekly
     commit-message:
       prefix: "deps"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 5
 
   - package-ecosystem: github-actions
     directory: /
@@ -20,3 +30,5 @@ updates:
       interval: weekly
     commit-message:
       prefix: "ci"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

- Adds a `cooldown:` block to each ecosystem in [`.github/dependabot.yml`](.github/dependabot.yml) (`gomod`, `npm`, `github-actions`) so Dependabot waits before opening PRs for newly-published versions.
- Durations: `semver-major-days: 14`, `semver-minor-days: 7`, `semver-patch-days: 5`, `default-days: 7` (the last covers `github-actions`, which doesn't use SemVer). Aligned with public guidance (GitHub examples, Aikido, StepSecurity).
- Goal: catch freshly-published malicious versions before they land in auto-PRs — a recurring supply-chain pattern where compromised maintainer accounts publish trojan minor releases that the registry detects and yanks within hours-to-days.
- **GHSA-tracked security updates bypass cooldown** by GitHub's design, so CVE response time is unaffected.

Part of addressing item 1 of #108 (supply-chain hardening shortlist).

## Test plan

- [ ] Confirm GitHub accepts the YAML — check `Insights → Dependency graph → Dependabot → Recent jobs` for parse errors after the branch lands.
- [ ] After merge, observe the next weekly Dependabot run: any PRs raised should reference versions whose publish date is older than the configured cooldown window.
- [ ] No code paths change; no unit/integration tests apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)