### PR TITLE
install: harden curl against HTTP redirect downgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ See the [installation guide](https://docs.agent-vault.dev/installation) for full
 ### Script (macOS / Linux)
 
 ```bash
-curl -fsSL https://get.agent-vault.dev | sh
+curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | sh
 agent-vault server -d
 ```
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -13,7 +13,7 @@ Agent Vault ships as a single binary that acts as both a server and CLI client. 
     Works for both fresh installs and upgrades (backs up your database before upgrading).
 
     ```bash
-    curl -fsSL https://get.agent-vault.dev | sh
+    curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | sh
     ```
 
     Supports macOS (Intel + Apple Silicon) and Linux (x86\_64 + ARM64).
@@ -22,7 +22,7 @@ Agent Vault ships as a single binary that acts as both a server and CLI client. 
       On a successful install the script sends an anonymous ping (OS, architecture, version — nothing else) so we can count installs for the launch. Opt out by placing `AGENT_VAULT_NO_TELEMETRY=1` in front of `sh`, not `curl`:
 
       ```bash
-      curl -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
+      curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
       ```
     </Note>
 
@@ -81,7 +81,7 @@ cosign verify-blob \
     Re-run the same install command — the script detects your existing installation, stops the running server, backs up your database, and installs the latest version:
 
     ```bash
-    curl -fsSL https://get.agent-vault.dev | sh
+    curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | sh
     ```
 
     Restart the server afterward:

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1008,8 +1008,8 @@ Manage the master password that wraps the data encryption key (DEK). All command
 
 ## Installer
 
-The [`install.sh`](https://github.com/Infisical/agent-vault/blob/main/install.sh) script (`curl -fsSL https://get.agent-vault.dev | sh`) is not part of the `agent-vault` binary but reads one environment variable:
+The [`install.sh`](https://github.com/Infisical/agent-vault/blob/main/install.sh) script (`curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | sh`) is not part of the `agent-vault` binary but reads one environment variable:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AGENT_VAULT_NO_TELEMETRY` | (unset) | When set to any non-empty value, skips the anonymous install/upgrade beacon (OS, architecture, version — nothing else). Must be placed in front of `sh`, not `curl`: `curl -fsSL https://get.agent-vault.dev \| AGENT_VAULT_NO_TELEMETRY=1 sh`. |
+| `AGENT_VAULT_NO_TELEMETRY` | (unset) | When set to any non-empty value, skips the anonymous install/upgrade beacon (OS, architecture, version — nothing else). Must be placed in front of `sh`, not `curl`: `curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev \| AGENT_VAULT_NO_TELEMETRY=1 sh`. |

--- a/docs/self-hosting/environment-variables.mdx
+++ b/docs/self-hosting/environment-variables.mdx
@@ -39,7 +39,7 @@ Read by [`install.sh`](https://github.com/Infisical/agent-vault/blob/main/instal
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AGENT_VAULT_NO_TELEMETRY` | (unset) | When set to any non-empty value, skips the anonymous install/upgrade beacon that reports OS, architecture, and version. Must be placed in front of `sh`, not `curl`: `curl -fsSL https://get.agent-vault.dev \| AGENT_VAULT_NO_TELEMETRY=1 sh`. |
+| `AGENT_VAULT_NO_TELEMETRY` | (unset) | When set to any non-empty value, skips the anonymous install/upgrade beacon that reports OS, architecture, and version. Must be placed in front of `sh`, not `curl`: `curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev \| AGENT_VAULT_NO_TELEMETRY=1 sh`. |
 
 ## Email SMTP configuration
 

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -8,7 +8,7 @@ description: "Install and run Agent Vault on Linux or macOS using the install sc
 Auto-detects your OS and architecture, downloads the latest release, and installs. Works for both fresh installs and upgrades.
 
 ```bash
-curl -fsSL https://get.agent-vault.dev | sh
+curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | sh
 ```
 
 Supports macOS (Intel + Apple Silicon) and Linux (x86\_64 + ARM64).
@@ -17,7 +17,7 @@ Supports macOS (Intel + Apple Silicon) and Linux (x86\_64 + ARM64).
   On a successful install the script sends an anonymous ping (OS, architecture, version — nothing else) so we can count installs for the launch. Opt out by placing `AGENT_VAULT_NO_TELEMETRY=1` in front of `sh`, not `curl`:
 
   ```bash
-  curl -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
+  curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
   ```
 </Note>
 
@@ -122,14 +122,14 @@ See the [CLI reference](/reference/cli#ca) for all `agent-vault ca fetch` flags.
 Re-run the same install command — the script detects your existing installation, stops the running server, backs up your database, and installs the latest version:
 
 ```bash
-curl -fsSL https://get.agent-vault.dev | sh
+curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | sh
 ```
 
 <Note>
   On a successful upgrade the script sends the same anonymous ping (OS, architecture, version). Opt out by placing `AGENT_VAULT_NO_TELEMETRY=1` in front of `sh`, not `curl`:
 
   ```bash
-  curl -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
+  curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
   ```
 </Note>
 

--- a/install.sh
+++ b/install.sh
@@ -2,20 +2,24 @@
 set -e
 
 # Agent Vault installer
-# Usage: curl -fsSL https://get.agent-vault.dev | sh
+# Usage: curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | sh
 #
 # Supports: macOS (Intel + Apple Silicon), Linux (amd64 + arm64)
 # Works for both fresh install and upgrade.
 #
 # Privacy: on successful install, sends an anonymous ping with OS, arch,
 # and version only — no identifiers, no IP retention. Opt out with:
-#   curl -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
+#   curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
 
 REPO="Infisical/agent-vault"
 INSTALL_DIR="/usr/local/bin"
 DATA_DIR="$HOME/.agent-vault"
 PID_FILE="$DATA_DIR/agent-vault.pid"
 DB_FILE="$DATA_DIR/agent-vault.db"
+
+# HTTPS-only on initial request and on any redirect; refuse legacy TLS.
+# Defends against an HTTP redirect-downgrade on the supply-chain path.
+CURL_HARDEN="--proto =https --proto-redir =https --tlsv1.2"
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -121,7 +125,7 @@ main() {
     # ── Fetch latest version ─────────────────────────────────────────────
 
     info "Fetching latest release..."
-    LATEST="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    LATEST="$(curl $CURL_HARDEN -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
         | grep '"tag_name"' | head -1 | sed 's/.*"tag_name":[[:space:]]*"v\{0,1\}\([^"]*\)".*/\1/')"
 
     if [ -z "$LATEST" ]; then
@@ -138,7 +142,7 @@ main() {
     TMP_DIR="$(mktemp -d)"
     info "Downloading ${ARCHIVE}..."
 
-    if ! curl -fSL --progress-bar -o "${TMP_DIR}/${ARCHIVE}" "$URL"; then
+    if ! curl $CURL_HARDEN -fSL --progress-bar -o "${TMP_DIR}/${ARCHIVE}" "$URL"; then
         error "Download failed. The release may not include a binary for ${OS}/${ARCH}."
     fi
 
@@ -190,7 +194,7 @@ main() {
         if [ -n "$EXISTING_VERSION" ] && [ "$EXISTING_VERSION" != "unknown" ]; then
             EVENT="upgrade"
         fi
-        curl -fsS -m 3 "https://get.agent-vault.dev/ok?os=${OS}&arch=${ARCH}&v=${LATEST}&event=${EVENT}" >/dev/null 2>&1 || true
+        curl $CURL_HARDEN -fsS -m 3 "https://get.agent-vault.dev/ok?os=${OS}&arch=${ARCH}&v=${LATEST}&event=${EVENT}" >/dev/null 2>&1 || true
     fi
 }
 

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -63,7 +63,7 @@ function InviteOnlyNotice() {
   );
 }
 
-const INSTALL_COMMAND = "curl -fsSL https://get.agent-vault.dev | sh";
+const INSTALL_COMMAND = "curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | sh";
 
 function CommandBlock({ command }: { command: string }) {
   const [copied, setCopied] = useState(false);


### PR DESCRIPTION
## Summary

- Adds `--proto '=https' --proto-redir '=https' --tlsv1.2` to all three `curl` calls inside [install.sh](install.sh) (release-tag lookup, archive download, telemetry beacon) via a `CURL_HARDEN` shell var.
- Updates the documented bootstrap one-liner everywhere it appears (README, `docs/installation.mdx`, `docs/self-hosting/local.mdx`, `docs/reference/cli.mdx`, `docs/self-hosting/environment-variables.mdx`, `web/src/pages/Register.tsx`) to use the same hardened flag set, so what users copy/paste matches what the script does internally.

## Why these flags

- `--proto '=https'` — initial request must be HTTPS.
- `--proto-redir '=https'` — **the flag that actually blocks an HTTP redirect downgrade**. curl's default `--proto-redir` allows `http,https` since 7.65.2, so `--proto '=https'` alone is not sufficient against the named threat.
- `--tlsv1.2` — minimum TLS 1.2 (a floor, not a pin — TLS 1.3 still negotiates). Canonical defense-in-depth companion (rustup et al.).

## Compatibility

All three flags are old enough to be safe on every supported target: `--proto` since curl 7.20.0 (2010), `--proto-redir` since 7.20.1 (2010), `--tlsv1.2` since 7.34.0 (2013). No new prerequisites.

The previous short bootstrap command (`curl -fsSL ... | sh`) still works — anyone running it from a blog post, screenshot, or muscle memory keeps working unchanged. The script's *internal* curl calls are hardened regardless.

## Test plan

- [x] `sh -n install.sh` clean
- [x] `make test` green (full Go suite)
- [x] Live happy-path: hardened flags return 200 from `https://api.github.com/repos/Infisical/agent-vault/releases/latest`
- [x] Negative check: `curl --proto '=https' http://example.com` errors with `Protocol "http" disabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)