### PR TITLE
install: dedupe doc snippet, slim telemetry note

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -3,6 +3,8 @@ title: "Installation"
 description: "Install Agent Vault, start a server, and log in."
 ---
 
+import InstallCommand from "/snippets/install-command.mdx";
+
 Agent Vault ships as a single binary that acts as both a server and CLI client. Install it once, then use `agent-vault server` to run a server and `agent-vault auth login` to interact with it.
 
 ## Install
@@ -12,18 +14,12 @@ Agent Vault ships as a single binary that acts as both a server and CLI client. 
     Auto-detects your OS and architecture, downloads the latest release, and installs.
     Works for both fresh installs and upgrades (backs up your database before upgrading).
 
-    ```bash
-    curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | sh
-    ```
+    <InstallCommand />
 
     Supports macOS (Intel + Apple Silicon) and Linux (x86\_64 + ARM64).
 
     <Note>
-      On a successful install the script sends an anonymous ping (OS, architecture, version — nothing else) so we can count installs for the launch. Opt out by placing `AGENT_VAULT_NO_TELEMETRY=1` in front of `sh`, not `curl`:
-
-      ```bash
-      curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
-      ```
+      The install script sends an anonymous beacon (OS, architecture, version). Set `AGENT_VAULT_NO_TELEMETRY=1` in front of `sh` to opt out.
     </Note>
 
   </Tab>
@@ -80,9 +76,7 @@ cosign verify-blob \
   <Tab title="Script">
     Re-run the same install command — the script detects your existing installation, stops the running server, backs up your database, and installs the latest version:
 
-    ```bash
-    curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | sh
-    ```
+    <InstallCommand />
 
     Restart the server afterward:
 

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -3,22 +3,18 @@ title: "Linux & macOS"
 description: "Install and run Agent Vault on Linux or macOS using the install script"
 ---
 
+import InstallCommand from "/snippets/install-command.mdx";
+
 ## Install
 
 Auto-detects your OS and architecture, downloads the latest release, and installs. Works for both fresh installs and upgrades.
 
-```bash
-curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | sh
-```
+<InstallCommand />
 
 Supports macOS (Intel + Apple Silicon) and Linux (x86\_64 + ARM64).
 
 <Note>
-  On a successful install the script sends an anonymous ping (OS, architecture, version — nothing else) so we can count installs for the launch. Opt out by placing `AGENT_VAULT_NO_TELEMETRY=1` in front of `sh`, not `curl`:
-
-  ```bash
-  curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
-  ```
+  The install script sends an anonymous beacon (OS, architecture, version). Set `AGENT_VAULT_NO_TELEMETRY=1` in front of `sh` to opt out.
 </Note>
 
 Verify the installation:
@@ -121,16 +117,10 @@ See the [CLI reference](/reference/cli#ca) for all `agent-vault ca fetch` flags.
 
 Re-run the same install command — the script detects your existing installation, stops the running server, backs up your database, and installs the latest version:
 
-```bash
-curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | sh
-```
+<InstallCommand />
 
 <Note>
-  On a successful upgrade the script sends the same anonymous ping (OS, architecture, version). Opt out by placing `AGENT_VAULT_NO_TELEMETRY=1` in front of `sh`, not `curl`:
-
-  ```bash
-  curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | AGENT_VAULT_NO_TELEMETRY=1 sh
-  ```
+  The upgrade sends the same anonymous beacon as install. Set `AGENT_VAULT_NO_TELEMETRY=1` in front of `sh` to opt out.
 </Note>
 
 Restart the server afterward:

--- a/docs/snippets/install-command.mdx
+++ b/docs/snippets/install-command.mdx
@@ -1,0 +1,3 @@
+```bash
+curl --proto '=https' --proto-redir '=https' --tlsv1.2 -fsSL https://get.agent-vault.dev | sh
+```

--- a/install.sh
+++ b/install.sh
@@ -125,6 +125,7 @@ main() {
     # ── Fetch latest version ─────────────────────────────────────────────
 
     info "Fetching latest release..."
+    # shellcheck disable=SC2086 # CURL_HARDEN is a flag list — word-splitting is intentional
     LATEST="$(curl $CURL_HARDEN -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
         | grep '"tag_name"' | head -1 | sed 's/.*"tag_name":[[:space:]]*"v\{0,1\}\([^"]*\)".*/\1/')"
 
@@ -142,6 +143,7 @@ main() {
     TMP_DIR="$(mktemp -d)"
     info "Downloading ${ARCHIVE}..."
 
+    # shellcheck disable=SC2086 # CURL_HARDEN is a flag list — word-splitting is intentional
     if ! curl $CURL_HARDEN -fSL --progress-bar -o "${TMP_DIR}/${ARCHIVE}" "$URL"; then
         error "Download failed. The release may not include a binary for ${OS}/${ARCH}."
     fi
@@ -194,6 +196,7 @@ main() {
         if [ -n "$EXISTING_VERSION" ] && [ "$EXISTING_VERSION" != "unknown" ]; then
             EVENT="upgrade"
         fi
+        # shellcheck disable=SC2086 # CURL_HARDEN is a flag list — word-splitting is intentional
         curl $CURL_HARDEN -fsS -m 3 "https://get.agent-vault.dev/ok?os=${OS}&arch=${ARCH}&v=${LATEST}&event=${EVENT}" >/dev/null 2>&1 || true
     fi
 }


### PR DESCRIPTION
Follow-ups from the #129 review.

## Summary

- **Single-source the install one-liner.** Adds [`docs/snippets/install-command.mdx`](docs/snippets/install-command.mdx) and imports it as `<InstallCommand />` from [`docs/installation.mdx`](docs/installation.mdx) and [`docs/self-hosting/local.mdx`](docs/self-hosting/local.mdx). Replaces seven duplicated fenced code blocks; if the flag set ever changes again, the snippet is the only file to edit. Inline-prose mentions inside markdown table cells in [`docs/reference/cli.mdx`](docs/reference/cli.mdx) and [`docs/self-hosting/environment-variables.mdx`](docs/self-hosting/environment-variables.mdx) stay literal — snippets don't fit inside backtick-quoted inline code.
- **Slim the telemetry `<Note>`s.** After the curl flag set grew, the opt-out code block in the install pages roughly doubled in visual weight and was reading as aggressive next to the install command itself. Each Note is now one sentence: *"The install script sends an anonymous beacon (OS, architecture, version). Set `AGENT_VAULT_NO_TELEMETRY=1` in front of `sh` to opt out."* The full env-var entry remains in [`docs/self-hosting/environment-variables.mdx`](docs/self-hosting/environment-variables.mdx) for operators who want details.
- **Document intentional word-splitting in install.sh.** Adds per-call-site `# shellcheck disable=SC2086` directives above the three `curl $CURL_HARDEN ...` expansions. No CI shellcheck step today, but the directives signal intent for anyone running shellcheck locally and prevent a future maintainer from reflexively quoting the variable (which would break it).

## Test plan

- [x] `sh -n install.sh` clean
- [x] `grep` confirms zero stale `<InstallCommandOptOut />` references and that the only fenced bash blocks containing `get.agent-vault.dev` now live inside the snippet
- [ ] CI passes
- [ ] Mintlify preview confirms `<InstallCommand />` renders identically across both pages and both Tabs/Note nesting levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)