### PR TITLE
ci: pin Dockerfile base images by digest + Dependabot docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,30 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 5
 
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 5
+
+  - package-ecosystem: docker
+    directory: /internal/sandbox/assets
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 5
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Frontend build ----
-FROM node:22-alpine AS frontend
+FROM node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f AS frontend
 
 WORKDIR /app
 COPY web/package.json web/package-lock.json ./
@@ -8,7 +8,7 @@ COPY web/ .
 RUN npm run build
 
 # ---- Go build stage ----
-FROM golang:1.25-alpine AS builder
+FROM golang:1.25-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f AS builder
 
 ARG VERSION=dev
 ARG COMMIT=unknown
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w \
     -o /agent-vault .
 
 # ---- Runtime stage ----
-FROM alpine:3.21
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
 RUN apk add --no-cache ca-certificates \
     && addgroup -S agentvault && adduser -S -G agentvault -u 65532 agentvault \

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,5 @@
 # Minimal runtime image for GoReleaser — the binary is pre-built.
-FROM alpine:3.21
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
 RUN apk add --no-cache ca-certificates \
     && addgroup -S agentvault && adduser -S -G agentvault -u 65532 agentvault \

--- a/internal/sandbox/assets/Dockerfile
+++ b/internal/sandbox/assets/Dockerfile
@@ -1,8 +1,5 @@
 # Agent Vault sandbox image. Built locally on first use by EnsureImage.
-#
-# TODO(v2): pin FROM by @sha256:... digest. Today the content-hash tag
-# covers the Dockerfile + scripts only, not the resolved base image.
-FROM node:22-bookworm-slim
+FROM node:22-bookworm-slim@sha256:d415caac2f1f77b98caaf9415c5f807e14bc8d7bdea62561ea2fef4fbd08a73c
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/internal/sandbox/image_test.go
+++ b/internal/sandbox/image_test.go
@@ -28,7 +28,7 @@ func TestAssetsHash_Format(t *testing.T) {
 // Treat a diff on this constant as intentional. Update when changing
 // Dockerfile / init-firewall.sh / entrypoint.sh.
 func TestAssetsHash_Stable(t *testing.T) {
-	const want = "94a43a01c1e0"
+	const want = "17980b6cccb1"
 	got, err := assetsHash()
 	if err != nil {
 		t.Fatalf("assetsHash: %v", err)


### PR DESCRIPTION
## Summary

- Pin every `FROM` line across the three Dockerfiles to the upstream **manifest-list (index) digest** — `Dockerfile` (3 stages), `Dockerfile.goreleaser`, and the embedded sandbox `internal/sandbox/assets/Dockerfile`. Floating tags are mutable upstream; pinning makes any base-image change opt-in via a reviewable diff.
- Add the `docker` ecosystem to `.github/dependabot.yml` (root + `/internal/sandbox/assets`), mirroring the existing 7/14/7/5-day cooldown tiers from PR #128. Keeps the pins fresh without subverting the opt-in property.
- Resolves the existing `TODO(v2)` comment in the sandbox Dockerfile and bumps the `TestAssetsHash_Stable` constant to acknowledge the embedded-asset edit.

Addresses item 7 of the supply-chain hardening shortlist in #108.

### Why index digests, not per-arch digests

GoReleaser builds amd64 and arm64 via `docker buildx build --platform=...`. A per-arch digest would break the non-matching leg; the manifest-list (index) digest covers all platforms — verified against the pinned `alpine:3.21@sha256:48b0309c...` which advertises `linux/amd64`, `linux/arm64/v8`, and seven other platforms.

## Test plan

- [x] `make docker` — multi-stage build succeeds against all three pinned bases.
- [x] `make test` — full Go suite green; `TestAssetsHash_Stable` updated to the new asset hash and passes.
- [x] `docker buildx imagetools inspect` confirms the pinned alpine index covers both `linux/amd64` and `linux/arm64/v8` (GoReleaser's two release platforms).
- [ ] First post-merge Dependabot run: confirm both new docker entries show "last checked" in the repo Dependabot tab and that PRs cover both `Dockerfile` and `Dockerfile.goreleaser` (default `Dockerfile.*` matching).
- [ ] Next tagged release: GoReleaser snapshot/build picks up the pinned digest in `Dockerfile.goreleaser` for the published `infisical/agent-vault` image.

## Follow-ups (intentionally out of scope)

- Drift detection between the matching `alpine:3.21` digest pins in `Dockerfile` and `Dockerfile.goreleaser` (Dependabot opens separate PRs per file).
- Pinning the `npm install -g @anthropic-ai/claude-code` invocation in the sandbox image — pre-existing supply-chain gap, separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)