### PR TITLE
broker: forward all client headers, only override the auth slot

### DIFF
--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -87,10 +87,12 @@ bearer      -- Authorization: Bearer <token>          {"auth": {"type": "bearer"
 basic       -- HTTP Basic (user, optional password)    {"auth": {"type": "basic", "username": "API_KEY"}}
 api-key     -- key in a named header, optional prefix  {"auth": {"type": "api-key", "key": "SECRET", "header": "x-api-key"}}
 custom      -- freeform header templates               {"auth": {"type": "custom", "headers": {"X-Key": "{{ SECRET }}"}}}
-passthrough -- forward client headers, inject nothing  {"auth": {"type": "passthrough"}}
+passthrough -- allowlist host only, no credential   {"auth": {"type": "passthrough"}}
 ```
 
 Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic -- API key as username), Jira (basic -- email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
+
+**Header forwarding.** Agent Vault forwards your request headers to the upstream unchanged, except for hop-by-hop headers (RFC 7230, including `Proxy-Connection`), broker-scoped headers (`X-Vault`, `Proxy-Authorization`), and the specific header(s) the configured auth type manages. With `auth.type: bearer`, for example, the broker overrides `Authorization` and leaves all other client headers untouched — so vendor headers like `anthropic-version` and `OpenAI-Beta` reach the upstream. Custom auth strips every header listed in `auth.headers` and replaces them with the resolved values.
 
 **Passthrough** allowlists a host but does not store or inject a credential. Use it only when the operator has decided their client already holds the credential and wants netguard / audit / MITM coverage without putting the secret in the vault. For the default case (agent needs the credential from the vault), use one of the credentialed types above.
 

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -96,10 +96,12 @@ bearer      -- Authorization: Bearer <token>          {"auth": {"type": "bearer"
 basic       -- HTTP Basic (user, optional password)    {"auth": {"type": "basic", "username": "API_KEY"}}
 api-key     -- key in a named header, optional prefix  {"auth": {"type": "api-key", "key": "SECRET", "header": "x-api-key"}}
 custom      -- freeform header templates               {"auth": {"type": "custom", "headers": {"X-Key": "{{ SECRET }}"}}}
-passthrough -- forward client headers, inject nothing  {"auth": {"type": "passthrough"}}
+passthrough -- allowlist host only, no credential   {"auth": {"type": "passthrough"}}
 ```
 
 Common services: Stripe (bearer), GitHub (bearer), OpenAI (bearer), Ashby (basic -- API key as username), Jira (basic -- email + token), Anthropic (api-key, header: x-api-key). If unlisted, check the API docs.
+
+**Header forwarding.** Agent Vault forwards your request headers to the upstream unchanged, except for hop-by-hop headers (RFC 7230, including `Proxy-Connection`), broker-scoped headers (`X-Vault`, `Proxy-Authorization`), and the specific header(s) the configured auth type manages. With `auth.type: bearer`, for example, the broker overrides `Authorization` and leaves all other client headers untouched — so vendor headers like `anthropic-version` and `OpenAI-Beta` reach the upstream. Custom auth strips every header listed in `auth.headers` and replaces them with the resolved values.
 
 **Passthrough** allowlists a host but does not store or inject a credential. Use it only when the operator has decided their client already holds the credential and wants netguard / audit / MITM coverage without putting the secret in the vault. For the default case (agent needs the credential from the vault), use one of the credentialed types above. Passthrough auth entries reject all credential fields (`token`, `username`, `password`, `key`, `header`, `prefix`, `headers`).
 

--- a/docs/agents/protocol.mdx
+++ b/docs/agents/protocol.mdx
@@ -76,7 +76,7 @@ The `X-Vault` header is required for instance-level agent tokens. Vault-scoped s
 
 ## Route requests through HTTPS_PROXY
 
-The canonical way for an agent to reach an upstream host is to call the real URL directly. `agent-vault vault run` pre-configures `HTTPS_PROXY` and the CA trust chain on the child process, so every standard HTTP client — `curl`, `fetch`, `requests`, `axios`, the Go stdlib, SDKs like `stripe-node`, CLIs like `gh` and `stripe` — transparently routes through the broker. Agent Vault intercepts the CONNECT, matches the target host against the vault's [services](/learn/services), strips any client-supplied auth, and injects the stored credential.
+The canonical way for an agent to reach an upstream host is to call the real URL directly. `agent-vault vault run` pre-configures `HTTPS_PROXY` and the CA trust chain on the child process, so every standard HTTP client — `curl`, `fetch`, `requests`, `axios`, the Go stdlib, SDKs like `stripe-node`, CLIs like `gh` and `stripe` — transparently routes through the broker. Agent Vault intercepts the CONNECT, matches the target host against the vault's [services](/learn/services), and injects the stored credential into the auth header for that service. Other client headers (vendor headers like `anthropic-version`, tracing IDs, etc.) flow through unchanged — see [Header forwarding](/learn/services#header-forwarding) for the precise rules.
 
 ```
 GET https://api.stripe.com/v1/charges?limit=10

--- a/docs/guides/connect-custom-agent.mdx
+++ b/docs/guides/connect-custom-agent.mdx
@@ -67,7 +67,7 @@ When the agent is launched via `vault run`, these additional variables are also 
 
 ## Make requests
 
-When your agent is launched via `vault run`, HTTPS traffic already routes through Agent Vault transparently. Call the real API URL — standard HTTP clients honor `HTTPS_PROXY` automatically. Agent Vault intercepts the CONNECT, matches the host against the vault's [services](/learn/services), strips client auth, and injects the stored credential over HTTPS.
+When your agent is launched via `vault run`, HTTPS traffic already routes through Agent Vault transparently. Call the real API URL — standard HTTP clients honor `HTTPS_PROXY` automatically. Agent Vault intercepts the CONNECT, matches the host against the vault's [services](/learn/services), and injects the stored credential into the auth header for that service over HTTPS.
 
 <CodeGroup>
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -23,7 +23,7 @@ Enter Agent Vault - a new credential management solution built for agents that p
 
 1. You point the agent at Agent Vault by setting `HTTPS_PROXY` and trusting the Agent Vault CA certificate.
 2. The agent makes API calls the way it normally would — direct `fetch`, a vendor SDK, a CLI like `gh` or `stripe`, or an MCP server. All outbound HTTPS transparently routes through the Agent Vault proxy.
-3. Agent Vault matches the target host against the services in the [vault](/learn/vaults), strips any client-supplied auth, injects the stored credential, and forwards the request upstream.
+3. Agent Vault matches the target host against the services in the [vault](/learn/vaults), injects the stored credential into the auth header for that service, and forwards the request upstream with the agent's other headers intact.
 4. If no service matches the host, the agent can raise a [**proposal**](/learn/proposals) requesting access. You review and approve in the browser, pasting in the API key, and the next request succeeds.
 
 The agent never sees or handles your secrets. Learn more about [vaults](/learn/vaults), [services](/learn/services), [proposals](/learn/proposals), and [agents](/agents/overview).

--- a/docs/learn/security.mdx
+++ b/docs/learn/security.mdx
@@ -9,12 +9,11 @@ This page covers the cryptographic primitives, token model, network protections,
 
 <Note>
   [Passthrough services](/learn/services#passthrough) are an operator-chosen
-  exception: they allowlist a host without storing or injecting any credential,
-  so the client's own request headers flow through unchanged. The guarantees
-  below apply to credentials *stored in the vault* — a credential the client
-  holds outside the vault is not protected by Agent Vault, but the host
-  allowlist, [netguard](#network-security), TLS interception, and audit
-  logging still apply.
+  exception: they allowlist a host without storing or injecting any credential.
+  The guarantees below apply to credentials *stored in the vault* — a
+  credential the client holds outside the vault is not protected by Agent
+  Vault, but the host allowlist, [netguard](#network-security), TLS
+  interception, and audit logging still apply.
 </Note>
 
 ## Encryption at rest
@@ -107,7 +106,9 @@ Agent Vault resolves hostnames to IP addresses, validates every resolved IP agai
 
 ## Transport security
 
-All proxied requests are forwarded over **HTTPS**, regardless of how the agent connects to Agent Vault locally. The agent's `Authorization` header (containing its Agent Vault token) is stripped before forwarding; real credentials are injected server-side based on the vault's [services](/learn/services).
+All proxied requests are forwarded over **HTTPS**, regardless of how the agent connects to Agent Vault locally. The agent's session token never reaches the target service: on the explicit `/proxy` ingress it travels in `Authorization` and is stripped; on the transparent `HTTPS_PROXY` ingress it travels in `Proxy-Authorization` (which is hop-by-hop and never forwarded). Real credentials are injected server-side based on the vault's [services](/learn/services).
+
+Other client request headers — vendor headers like `anthropic-version`, conditional request headers, tracing IDs — flow through to the upstream unchanged. The broker only takes over the headers it is responsible for injecting (the auth slot for the configured auth type) plus hop-by-hop and broker-scoped headers; see [Header forwarding](/learn/services#header-forwarding) for the precise rules.
 
 This means:
 - Agents authenticate to Agent Vault with a token that grants no direct access to credentials.

--- a/docs/learn/services.mdx
+++ b/docs/learn/services.mdx
@@ -128,7 +128,7 @@ services:
 
 ### Passthrough
 
-Allowlists the host without injecting a credential. The client's request headers (including `Authorization` and `Cookie`) flow through to the target unchanged; Agent Vault strips only hop-by-hop headers and broker-scoped headers (`X-Vault`, `Proxy-Authorization`). No credential is stored, read, or attached.
+Allowlists the host without injecting a credential. No credential is stored, read, or attached; client request headers (including `Authorization` and `Cookie`) flow through to the upstream — same as for credentialed services, just without a broker-injected auth header on top.
 
 ```yaml
 services:
@@ -139,6 +139,16 @@ services:
 ```
 
 Use passthrough when the operator has decided their client already holds the credential (for example, an existing tool that manages its own token) and wants Agent Vault to provide the host allowlist, [netguard](/learn/security), TLS interception, and audit logging without putting the secret in the vault. All the other auth types are the default — reach for passthrough only when you explicitly want Agent Vault *not* to broker the credential.
+
+### Header forwarding
+
+Agent Vault forwards your client's request headers to the upstream unchanged, except for:
+
+- **Hop-by-hop headers** per RFC 7230 (`Connection`, `Keep-Alive`, `Proxy-Authenticate`, `Proxy-Authorization`, `Proxy-Connection`, `Te`, `Trailer`, `Transfer-Encoding`, `Upgrade`).
+- **Broker-scoped headers** that authenticate the client to Agent Vault itself (`X-Vault`, `Proxy-Authorization`).
+- **The auth slot** — the specific header(s) the configured auth type manages. With `auth.type: bearer` or `basic`, the broker overrides `Authorization`. With `api-key`, it overrides whatever you named in `auth.header`. With `custom`, it overrides every key in `auth.headers`. With `passthrough`, nothing.
+
+This means vendor headers like `anthropic-version`, `OpenAI-Beta`, `If-Match`, and tracing IDs reach the upstream regardless of auth type. The broker only takes over the headers it's responsible for injecting.
 
 <Warning>
   Passthrough auth configs reject every credential field (`token`, `username`,

--- a/docs/quickstart/custom-agent.mdx
+++ b/docs/quickstart/custom-agent.mdx
@@ -24,7 +24,7 @@ agent-vault vault run --vault myproject -- my-agent
 
 ## Try it out
 
-Your agent calls real API URLs directly. `HTTPS_PROXY` routes the request through Agent Vault, which matches the host against the vault's [services](/learn/services), strips client auth, and injects the stored credential.
+Your agent calls real API URLs directly. `HTTPS_PROXY` routes the request through Agent Vault, which matches the host against the vault's [services](/learn/services) and injects the stored credential into the auth header for that service.
 
 <CodeGroup>
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -460,7 +460,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `--api-key-prefix` | | Prefix for api-key value |
     | `--disabled` | `false` | Create the service in a disabled state (proxy traffic returns 403 until enabled) |
 
-    The `passthrough` auth type accepts no credential flags; Agent Vault allowlists the host and forwards the client's request headers unchanged, stripping only hop-by-hop and broker-scoped headers (`X-Vault`, `Proxy-Authorization`).
+    The `passthrough` auth type accepts no credential flags; Agent Vault allowlists the host but does not store or inject a credential. See [Header forwarding](/learn/services#header-forwarding) for the rules that apply across every auth type — passthrough simply has no auth slot to override.
 
     New services are **enabled by default**. Pass `--disabled` to create the service in a disabled state, or use `agent-vault vault service disable <host>` after creation.
 

--- a/internal/brokercore/brokercore.go
+++ b/internal/brokercore/brokercore.go
@@ -30,12 +30,14 @@ const MaxResponseBytes = 100 << 20
 const ProxyErrorHeader = "X-Agent-Vault-Proxy-Error"
 
 // HopByHopHeaders are HTTP/1.1 hop-by-hop headers that must not be
-// forwarded by a proxy.
+// forwarded by a proxy. Includes Proxy-Connection — non-RFC but emitted
+// by some HTTP/1.0 clients and conventionally treated as hop-by-hop.
 var HopByHopHeaders = map[string]bool{
 	"Connection":          true,
 	"Keep-Alive":          true,
 	"Proxy-Authenticate":  true,
 	"Proxy-Authorization": true,
+	"Proxy-Connection":    true,
 	"Te":                  true,
 	"Trailer":             true,
 	"Transfer-Encoding":   true,
@@ -64,30 +66,10 @@ func IsValidHost(h string) bool {
 	return !strings.HasPrefix(h, ".") && !strings.HasSuffix(h, ".")
 }
 
-// PassthroughHeaders is the allowlist of headers forwarded from agent
-// requests to upstream services for credentialed (non-passthrough) auth
-// types. All other agent headers are dropped; in particular Authorization
-// is NOT on this list so injected credentials always win over any
-// client-supplied value.
-//
-// Passthrough services use CopyPassthroughRequestHeaders instead, which
-// is a denylist — the client's request is forwarded unchanged apart from
-// hop-by-hop headers and broker-scoped headers.
-var PassthroughHeaders = []string{
-	"Content-Type",
-	"Content-Encoding",
-	"Accept",
-	"Accept-Encoding",
-	"Accept-Language",
-	"User-Agent",
-	"Idempotency-Key",
-	"X-Request-Id",
-}
-
 // brokerScopedRequestHeaders are headers that authenticate the client to
 // Agent Vault itself (explicit /proxy ingress uses X-Vault;
 // HTTPS_PROXY-compatible ingress uses Proxy-Authorization). They must
-// never traverse the broker → target hop, even on passthrough services.
+// never traverse the broker → target hop.
 var brokerScopedRequestHeaders = map[string]bool{
 	"X-Vault":             true,
 	"Proxy-Authorization": true,
@@ -100,15 +82,20 @@ func IsBrokerScopedRequestHeader(name string) bool {
 	return brokerScopedRequestHeaders[http.CanonicalHeaderKey(name)]
 }
 
-// CopyPassthroughRequestHeaders forwards headers from src to dst for
-// passthrough services: everything except hop-by-hop, broker-scoped
-// (X-Vault, Proxy-Authorization), and any extra names in extraStrip.
-// Callers pass the header that authenticates the client to Agent Vault
-// on their ingress so that credential never reaches the target.
-func CopyPassthroughRequestHeaders(src, dst http.Header, extraStrip ...string) {
-	strip := make(map[string]bool, len(extraStrip))
+// ApplyInjection writes outbound headers for a resolved InjectResult.
+// Client headers pass through except hop-by-hop, broker-scoped (X-Vault,
+// Proxy-Authorization), the keys of inject.Headers, and any names in
+// extraStrip (the ingress's session-token header). Pre-stripping
+// inject.Headers keys is what preserves the "injected always wins"
+// security invariant; it is not a perf shortcut. Both ingresses share
+// this so their header handling stays in lockstep.
+func ApplyInjection(src, dst http.Header, inject *InjectResult, extraStrip ...string) {
+	strip := make(map[string]bool, len(extraStrip)+len(inject.Headers))
 	for _, s := range extraStrip {
 		strip[http.CanonicalHeaderKey(s)] = true
+	}
+	for k := range inject.Headers {
+		strip[http.CanonicalHeaderKey(k)] = true
 	}
 	for k, vv := range src {
 		ck := http.CanonicalHeaderKey(k)
@@ -117,24 +104,6 @@ func CopyPassthroughRequestHeaders(src, dst http.Header, extraStrip ...string) {
 		}
 		for _, v := range vv {
 			dst.Add(ck, v)
-		}
-	}
-}
-
-// ApplyInjection writes the outbound request headers for a resolved
-// InjectResult. Passthrough services forward client headers via the
-// denylist (hop-by-hop + broker-scoped + extraStrip); credentialed
-// services copy the PassthroughHeaders allowlist and then overlay
-// injected credentials. Used by both ingress paths so header handling
-// for the two branches stays in lockstep.
-func ApplyInjection(src, dst http.Header, inject *InjectResult, extraStrip ...string) {
-	if inject.Passthrough {
-		CopyPassthroughRequestHeaders(src, dst, extraStrip...)
-		return
-	}
-	for _, k := range PassthroughHeaders {
-		for _, v := range src.Values(k) {
-			dst.Add(k, v)
 		}
 	}
 	for k, v := range inject.Headers {

--- a/internal/brokercore/brokercore.go
+++ b/internal/brokercore/brokercore.go
@@ -87,8 +87,10 @@ func IsBrokerScopedRequestHeader(name string) bool {
 // Proxy-Authorization), the keys of inject.Headers, and any names in
 // extraStrip (the ingress's session-token header). Pre-stripping
 // inject.Headers keys is what preserves the "injected always wins"
-// security invariant; it is not a perf shortcut. Both ingresses share
-// this so their header handling stays in lockstep.
+// security invariant; it is not a perf shortcut. Per RFC 7230 §6.1,
+// any header named in the client's Connection field is also hop-by-hop
+// for that connection and is stripped. Both ingresses share this so
+// their header handling stays in lockstep.
 func ApplyInjection(src, dst http.Header, inject *InjectResult, extraStrip ...string) {
 	strip := make(map[string]bool, len(extraStrip)+len(inject.Headers))
 	for _, s := range extraStrip {
@@ -96,6 +98,13 @@ func ApplyInjection(src, dst http.Header, inject *InjectResult, extraStrip ...st
 	}
 	for k := range inject.Headers {
 		strip[http.CanonicalHeaderKey(k)] = true
+	}
+	for _, c := range src.Values("Connection") {
+		for _, f := range strings.Split(c, ",") {
+			if f = strings.TrimSpace(f); f != "" {
+				strip[http.CanonicalHeaderKey(f)] = true
+			}
+		}
 	}
 	for k, vv := range src {
 		ck := http.CanonicalHeaderKey(k)

--- a/internal/brokercore/brokercore_test.go
+++ b/internal/brokercore/brokercore_test.go
@@ -11,6 +11,8 @@ func TestIsHopByHop(t *testing.T) {
 	cases := map[string]bool{
 		"Proxy-Authorization": true,
 		"proxy-authorization": true,
+		"Proxy-Connection":    true,
+		"proxy-connection":    true,
 		"Connection":          true,
 		"Upgrade":             true,
 		"Content-Type":        false,
@@ -19,17 +21,6 @@ func TestIsHopByHop(t *testing.T) {
 	for name, want := range cases {
 		if got := IsHopByHop(name); got != want {
 			t.Errorf("IsHopByHop(%q) = %v, want %v", name, got, want)
-		}
-	}
-}
-
-func TestPassthroughHeadersExcludesAuthorization(t *testing.T) {
-	for _, h := range PassthroughHeaders {
-		if strings.EqualFold(h, "Authorization") {
-			t.Fatalf("PassthroughHeaders must not include Authorization; clients must not be able to shadow injected credentials")
-		}
-		if strings.EqualFold(h, "Proxy-Authorization") {
-			t.Fatalf("PassthroughHeaders must not include Proxy-Authorization")
 		}
 	}
 }
@@ -52,79 +43,206 @@ func TestIsBrokerScopedRequestHeader(t *testing.T) {
 	}
 }
 
-func TestCopyPassthroughRequestHeaders_ForwardsClientCredentials(t *testing.T) {
+func TestApplyInjection_StripsHopByHop(t *testing.T) {
+	src := http.Header{}
+	src.Set("Connection", "keep-alive")
+	src.Set("Keep-Alive", "timeout=5")
+	src.Set("Proxy-Connection", "keep-alive")
+	src.Set("Te", "trailers")
+	src.Set("Trailer", "Expires")
+	src.Set("Transfer-Encoding", "chunked")
+	src.Set("Upgrade", "h2c")
+	src.Set("Content-Type", "application/json")
+
+	dst := http.Header{}
+	ApplyInjection(src, dst, &InjectResult{})
+
+	for _, h := range []string{"Connection", "Keep-Alive", "Proxy-Connection", "Te", "Trailer", "Transfer-Encoding", "Upgrade"} {
+		if dst.Get(h) != "" {
+			t.Errorf("hop-by-hop header %q should have been stripped, got %q", h, dst.Get(h))
+		}
+	}
+	if dst.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type should pass through, got %q", dst.Get("Content-Type"))
+	}
+}
+
+func TestApplyInjection_StripsBrokerScoped(t *testing.T) {
+	src := http.Header{}
+	src.Set("X-Vault", "default")
+	src.Set("Proxy-Authorization", "Basic xxx")
+	src.Set("X-Trace-Id", "trace-123")
+
+	dst := http.Header{}
+	ApplyInjection(src, dst, &InjectResult{})
+
+	if dst.Get("X-Vault") != "" {
+		t.Errorf("X-Vault must never reach upstream, got %q", dst.Get("X-Vault"))
+	}
+	if dst.Get("Proxy-Authorization") != "" {
+		t.Errorf("Proxy-Authorization must never reach upstream, got %q", dst.Get("Proxy-Authorization"))
+	}
+	if dst.Get("X-Trace-Id") != "trace-123" {
+		t.Errorf("X-Trace-Id should pass through, got %q", dst.Get("X-Trace-Id"))
+	}
+}
+
+func TestApplyInjection_StripsExtraStrip(t *testing.T) {
+	// extraStrip lets an ingress drop the header that carries its
+	// session token so it never reaches the upstream.
+	src := http.Header{}
+	src.Set("Authorization", "Bearer session-token")
+	src.Set("X-Trace-Id", "trace-123")
+
+	dst := http.Header{}
+	ApplyInjection(src, dst, &InjectResult{Headers: map[string]string{"X-Api-Key": "real"}}, "Authorization")
+
+	if dst.Get("Authorization") != "" {
+		t.Errorf("Authorization should be stripped via extraStrip, got %q", dst.Get("Authorization"))
+	}
+	if dst.Get("X-Api-Key") != "real" {
+		t.Errorf("injected X-Api-Key not set, got %q", dst.Get("X-Api-Key"))
+	}
+	if dst.Get("X-Trace-Id") != "trace-123" {
+		t.Errorf("X-Trace-Id should pass through, got %q", dst.Get("X-Trace-Id"))
+	}
+}
+
+func TestApplyInjection_PassthroughForwardsArbitraryHeaders(t *testing.T) {
+	// Passthrough auth: inject.Headers is nil, no extraStrip — client
+	// headers (including Authorization, Cookie) flow through unchanged
+	// modulo hop-by-hop and broker-scoped.
 	src := http.Header{}
 	src.Set("Authorization", "Bearer client-token")
 	src.Set("Cookie", "session=abc")
 	src.Set("X-Trace-Id", "trace-123")
-	src.Set("Content-Type", "application/json")
-	src.Set("User-Agent", "client/1.0")
+	src.Set("Anthropic-Version", "2023-06-01")
 
 	dst := http.Header{}
-	CopyPassthroughRequestHeaders(src, dst)
+	ApplyInjection(src, dst, &InjectResult{})
 
-	for _, h := range []string{"Authorization", "Cookie", "X-Trace-Id", "Content-Type", "User-Agent"} {
+	for _, h := range []string{"Authorization", "Cookie", "X-Trace-Id", "Anthropic-Version"} {
 		if dst.Get(h) != src.Get(h) {
 			t.Errorf("header %q: got %q, want %q", h, dst.Get(h), src.Get(h))
 		}
 	}
 }
 
-func TestCopyPassthroughRequestHeaders_StripsBrokerScoped(t *testing.T) {
+func TestApplyInjection_BearerForwardsAnthropicVersion(t *testing.T) {
+	// Vendor headers must reach the upstream on credentialed auth.
 	src := http.Header{}
-	src.Set("Authorization", "Bearer client-token")
-	src.Set("X-Vault", "default")
-	src.Set("Proxy-Authorization", "Basic xxx")
-	src.Set("Connection", "keep-alive")
-	src.Set("Te", "trailers")
+	src.Set("Anthropic-Version", "2023-06-01")
+	src.Set("Anthropic-Beta", "messages-2024-04-04")
+	src.Set("Content-Type", "application/json")
 
 	dst := http.Header{}
-	CopyPassthroughRequestHeaders(src, dst)
+	ApplyInjection(src, dst, &InjectResult{
+		Headers: map[string]string{"Authorization": "Bearer real"},
+	})
 
-	if dst.Get("Authorization") == "" {
-		t.Error("Authorization should be forwarded on passthrough")
+	if dst.Get("Anthropic-Version") != "2023-06-01" {
+		t.Errorf("Anthropic-Version should reach upstream, got %q", dst.Get("Anthropic-Version"))
 	}
-	for _, h := range []string{"X-Vault", "Proxy-Authorization", "Connection", "Te"} {
-		if dst.Get(h) != "" {
-			t.Errorf("header %q should have been stripped, got %q", h, dst.Get(h))
-		}
+	if dst.Get("Anthropic-Beta") != "messages-2024-04-04" {
+		t.Errorf("Anthropic-Beta should reach upstream, got %q", dst.Get("Anthropic-Beta"))
+	}
+	if dst.Get("Authorization") != "Bearer real" {
+		t.Errorf("injected Authorization not set, got %q", dst.Get("Authorization"))
 	}
 }
 
-func TestCopyPassthroughRequestHeaders_PreservesMultipleValues(t *testing.T) {
+func TestApplyInjection_InjectedWinsOverClient(t *testing.T) {
 	src := http.Header{}
+	src.Set("Authorization", "Bearer attacker")
+
+	dst := http.Header{}
+	ApplyInjection(src, dst, &InjectResult{
+		Headers: map[string]string{"Authorization": "Bearer real"},
+	})
+
+	got := dst.Values("Authorization")
+	if len(got) != 1 || got[0] != "Bearer real" {
+		t.Fatalf("Authorization values = %v, want exactly [Bearer real]", got)
+	}
+}
+
+func TestApplyInjection_InjectedWinsOverClient_NonCanonicalKey(t *testing.T) {
+	// custom auth lets operators choose header names; a non-canonical
+	// inject.Headers key must still shadow the canonicalized client copy.
+	src := http.Header{}
+	src.Set("Authorization", "Bearer attacker")
+
+	dst := http.Header{}
+	ApplyInjection(src, dst, &InjectResult{
+		Headers: map[string]string{"authorization": "Bearer real"},
+	})
+
+	got := dst.Values("Authorization")
+	if len(got) != 1 || got[0] != "Bearer real" {
+		t.Fatalf("Authorization values = %v, want exactly [Bearer real]", got)
+	}
+}
+
+func TestApplyInjection_ApiKeyStripsConfiguredHeader(t *testing.T) {
+	// api-key with a custom auth.header — client-supplied value must
+	// not shadow the injected one.
+	src := http.Header{}
+	src.Set("X-Api-Key", "client-supplied")
+	src.Set("Anthropic-Version", "2023-06-01")
+
+	dst := http.Header{}
+	ApplyInjection(src, dst, &InjectResult{
+		Headers: map[string]string{"X-Api-Key": "real"},
+	})
+
+	got := dst.Values("X-Api-Key")
+	if len(got) != 1 || got[0] != "real" {
+		t.Fatalf("X-Api-Key values = %v, want exactly [real]", got)
+	}
+	if dst.Get("Anthropic-Version") != "2023-06-01" {
+		t.Errorf("Anthropic-Version should still pass through, got %q", dst.Get("Anthropic-Version"))
+	}
+}
+
+func TestApplyInjection_CustomMultiHeaderAuthStripsAllConfigured(t *testing.T) {
+	// custom auth with multiple managed headers — every key in
+	// inject.Headers must be stripped from the client copy.
+	src := http.Header{}
+	src.Set("X-Foo", "client-foo")
+	src.Set("X-Bar", "client-bar")
+	src.Set("X-Other", "client-other")
+
+	dst := http.Header{}
+	ApplyInjection(src, dst, &InjectResult{
+		Headers: map[string]string{"X-Foo": "real-foo", "X-Bar": "real-bar"},
+	})
+
+	if got := dst.Values("X-Foo"); len(got) != 1 || got[0] != "real-foo" {
+		t.Errorf("X-Foo = %v, want [real-foo]", got)
+	}
+	if got := dst.Values("X-Bar"); len(got) != 1 || got[0] != "real-bar" {
+		t.Errorf("X-Bar = %v, want [real-bar]", got)
+	}
+	if dst.Get("X-Other") != "client-other" {
+		t.Errorf("X-Other should pass through, got %q", dst.Get("X-Other"))
+	}
+}
+
+func TestApplyInjection_PreservesMultiValueClientHeaders(t *testing.T) {
+	src := http.Header{}
+	src.Add("Accept", "application/json")
+	src.Add("Accept", "text/plain")
 	src.Add("X-Multi", "a")
 	src.Add("X-Multi", "b")
-	src.Add("X-Multi", "c")
 
 	dst := http.Header{}
-	CopyPassthroughRequestHeaders(src, dst)
+	ApplyInjection(src, dst, &InjectResult{})
 
-	got := dst.Values("X-Multi")
-	if len(got) != 3 || got[0] != "a" || got[1] != "b" || got[2] != "c" {
-		t.Fatalf("X-Multi values = %v, want [a b c]", got)
+	if got := dst.Values("Accept"); len(got) != 2 || got[0] != "application/json" || got[1] != "text/plain" {
+		t.Errorf("Accept values = %v", got)
 	}
-}
-
-func TestCopyPassthroughRequestHeaders_ExtraStrip(t *testing.T) {
-	// Explicit /proxy ingress passes "Authorization" as extra strip so the
-	// Agent Vault session token never leaks upstream.
-	src := http.Header{}
-	src.Set("Authorization", "Bearer session-token")
-	src.Set("Cookie", "session=abc")
-	src.Set("X-Trace-Id", "trace-123")
-
-	dst := http.Header{}
-	CopyPassthroughRequestHeaders(src, dst, "Authorization")
-
-	if got := dst.Get("Authorization"); got != "" {
-		t.Errorf("Authorization should be stripped when listed in extraStrip, got %q", got)
-	}
-	if dst.Get("Cookie") != "session=abc" {
-		t.Error("Cookie should still pass through")
-	}
-	if dst.Get("X-Trace-Id") != "trace-123" {
-		t.Error("X-Trace-Id should still pass through")
+	if got := dst.Values("X-Multi"); len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("X-Multi values = %v", got)
 	}
 }
 

--- a/internal/brokercore/brokercore_test.go
+++ b/internal/brokercore/brokercore_test.go
@@ -67,6 +67,29 @@ func TestApplyInjection_StripsHopByHop(t *testing.T) {
 	}
 }
 
+func TestApplyInjection_StripsConnectionExtensionHeaders(t *testing.T) {
+	// RFC 7230 §6.1: any header named in the Connection field is
+	// hop-by-hop for that connection and must not be forwarded.
+	src := http.Header{}
+	src.Set("Connection", "X-Custom-Hop, Upgrade")
+	src.Set("X-Custom-Hop", "should-be-stripped")
+	src.Set("Upgrade", "h2c")
+	src.Set("X-Trace-Id", "trace-123")
+
+	dst := http.Header{}
+	ApplyInjection(src, dst, &InjectResult{})
+
+	if dst.Get("X-Custom-Hop") != "" {
+		t.Errorf("X-Custom-Hop named in Connection must be stripped, got %q", dst.Get("X-Custom-Hop"))
+	}
+	if dst.Get("Connection") != "" {
+		t.Errorf("Connection itself must not be forwarded, got %q", dst.Get("Connection"))
+	}
+	if dst.Get("X-Trace-Id") != "trace-123" {
+		t.Errorf("unrelated headers should pass through, X-Trace-Id = %q", dst.Get("X-Trace-Id"))
+	}
+}
+
 func TestApplyInjection_StripsBrokerScoped(t *testing.T) {
 	src := http.Header{}
 	src.Set("X-Vault", "default")

--- a/internal/brokercore/credential.go
+++ b/internal/brokercore/credential.go
@@ -30,14 +30,6 @@ type InjectResult struct {
 	// carry this for diagnostic logging.
 	CredentialKeys []string
 
-	// Passthrough indicates the matched service opts out of credential
-	// injection. The ingress should forward client request headers via
-	// the denylist (CopyPassthroughRequestHeaders) rather than the
-	// PassthroughHeaders allowlist, and must not perform the injection
-	// merge step. A passthrough service may still have Substitutions —
-	// those apply independently of header injection.
-	Passthrough bool
-
 	// Substitutions are resolved placeholder rewrites the ingress must
 	// apply via ApplySubstitutions before forwarding. Each entry carries
 	// a SECRET Value — never log; placeholder names are safe.
@@ -121,7 +113,6 @@ func (p *StoreCredentialProvider) Inject(ctx context.Context, vaultID, targetHos
 	result := &InjectResult{
 		MatchedHost:    matched.Host,
 		CredentialKeys: matched.CredentialKeys(),
-		Passthrough:    matched.Auth.Type == "passthrough",
 	}
 
 	// Resolve substitutions before auth so passthrough services (which

--- a/internal/brokercore/credential_test.go
+++ b/internal/brokercore/credential_test.go
@@ -269,11 +269,8 @@ func TestInject_Passthrough(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if !res.Passthrough {
-		t.Fatal("expected Passthrough=true")
-	}
 	if res.Headers != nil {
-		t.Fatalf("expected nil Headers, got %v", res.Headers)
+		t.Fatalf("expected nil Headers on passthrough, got %v", res.Headers)
 	}
 	if res.MatchedHost != "api.example.com" {
 		t.Fatalf("MatchedHost = %q, want %q", res.MatchedHost, "api.example.com")
@@ -354,8 +351,11 @@ func TestInject_PassthroughPortStripped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if !res.Passthrough {
-		t.Fatal("expected Passthrough=true for host:port match")
+	if res.Headers != nil {
+		t.Fatalf("expected nil Headers on passthrough host:port match, got %v", res.Headers)
+	}
+	if res.MatchedHost != "api.example.com" {
+		t.Fatalf("MatchedHost = %q, want %q", res.MatchedHost, "api.example.com")
 	}
 }
 
@@ -414,11 +414,8 @@ func TestInject_ResolvesSubstitutionOnPassthrough(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if !res.Passthrough {
-		t.Fatal("expected Passthrough=true")
-	}
 	if res.Headers != nil {
-		t.Fatalf("expected nil headers on passthrough, got %v", res.Headers)
+		t.Fatalf("expected nil Headers on passthrough, got %v", res.Headers)
 	}
 	if len(res.Substitutions) != 1 || res.Substitutions[0].Value != "AC12345" {
 		t.Fatalf("expected substitution resolved on passthrough service, got %+v", res.Substitutions)

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -137,10 +137,10 @@ func newTrustingClient(proxyURL *url.URL, userInfo *url.Userinfo, roots *x509.Ce
 }
 
 func TestMITMInjectsCredentials(t *testing.T) {
-	var sawAuth, sawClientAuth, sawProxyAuth string
+	var sawAuth, sawClientHeader, sawProxyAuth string
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sawAuth = r.Header.Get("Authorization")
-		sawClientAuth = r.Header.Get("X-Client-Auth")
+		sawClientHeader = r.Header.Get("X-Client-Header")
 		sawProxyAuth = r.Header.Get("Proxy-Authorization")
 		w.Header().Set("X-Upstream", "hello")
 		_, _ = io.WriteString(w, "upstream-body")
@@ -172,10 +172,12 @@ func TestMITMInjectsCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new request: %v", err)
 	}
-	// Client-supplied Authorization must be dropped and replaced by injection.
+	// Client-supplied Authorization must be dropped and replaced by injection
+	// (the auth slot is the only header the broker shadows).
 	req.Header.Set("Authorization", "Bearer client-should-not-win")
-	// Arbitrary non-allowlisted header must also be dropped.
-	req.Header.Set("X-Client-Auth", "leaked")
+	// Arbitrary client headers must flow through to the upstream — the
+	// broker only owns the auth slot.
+	req.Header.Set("X-Client-Header", "client-value")
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -193,8 +195,8 @@ func TestMITMInjectsCredentials(t *testing.T) {
 	if sawAuth != "Bearer injected-secret" {
 		t.Fatalf("upstream saw Authorization %q, want injected value", sawAuth)
 	}
-	if sawClientAuth != "" {
-		t.Fatalf("upstream saw X-Client-Auth %q; non-allowlisted header must be dropped", sawClientAuth)
+	if sawClientHeader != "client-value" {
+		t.Fatalf("upstream X-Client-Header = %q, want passthrough of client value", sawClientHeader)
 	}
 	if sawProxyAuth != "" {
 		t.Fatalf("upstream saw Proxy-Authorization %q; must be stripped", sawProxyAuth)
@@ -223,7 +225,6 @@ func TestMITMPassthroughForwardsClientAuthorization(t *testing.T) {
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			MatchedHost: upstreamHost,
-			Passthrough: true,
 		}},
 	}}
 
@@ -275,6 +276,72 @@ func TestMITMPassthroughForwardsClientAuthorization(t *testing.T) {
 	}
 	if sawProxyAuth != "" {
 		t.Fatalf("upstream saw Proxy-Authorization %q; must be stripped on passthrough", sawProxyAuth)
+	}
+}
+
+func TestMITMBearerForwardsArbitraryClientHeaders(t *testing.T) {
+	// On credentialed auth, only the auth-slot header is shadowed by the
+	// broker; vendor and tracing headers reach the upstream.
+	var sawAuth, sawAnthropicVersion, sawAnthropicBeta, sawTrace string
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		sawAnthropicVersion = r.Header.Get("Anthropic-Version")
+		sawAnthropicBeta = r.Header.Get("Anthropic-Beta")
+		sawTrace = r.Header.Get("X-Trace-Id")
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+
+	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
+
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{
+			MatchedHost: upstreamHost,
+			Headers:     map[string]string{"Authorization": "Bearer real-token"},
+		}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    upstreamRoots,
+	}
+
+	client := newTrustingClient(proxyURL, url.User("av_sess_ok"), clientRoots)
+	req, err := http.NewRequest("GET", upstream.URL+"/v1/messages", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer client-supplied-should-be-shadowed")
+	req.Header.Set("Anthropic-Version", "2023-06-01")
+	req.Header.Set("Anthropic-Beta", "messages-2024-04-04")
+	req.Header.Set("X-Trace-Id", "trace-123")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if sawAuth != "Bearer real-token" {
+		t.Fatalf("upstream Authorization = %q, want injected value (client must not shadow)", sawAuth)
+	}
+	if sawAnthropicVersion != "2023-06-01" {
+		t.Fatalf("upstream Anthropic-Version = %q, want passthrough of client value", sawAnthropicVersion)
+	}
+	if sawAnthropicBeta != "messages-2024-04-04" {
+		t.Fatalf("upstream Anthropic-Beta = %q, want passthrough", sawAnthropicBeta)
+	}
+	if sawTrace != "trace-123" {
+		t.Fatalf("upstream X-Trace-Id = %q, want passthrough", sawTrace)
 	}
 }
 
@@ -522,7 +589,6 @@ func TestMITMSubstitutionCaseSensitive(t *testing.T) {
 				Value:       "AC12345",
 				In:          []string{"path"},
 			}},
-			Passthrough: true,
 		}},
 	}}
 
@@ -563,7 +629,6 @@ func TestMITMSubstitutionRewritesQueryAndHeader(t *testing.T) {
 				{Placeholder: "__api_key__", Value: "real&secret", In: []string{"query"}},
 				{Placeholder: "__tenant__", Value: "acme-co", In: []string{"header"}},
 			},
-			Passthrough: true,
 		}},
 	}}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2662,6 +2662,52 @@ func TestProxyPassthroughDoesNotReadCredentials(t *testing.T) {
 	}
 }
 
+func TestProxyBearerForwardsArbitraryClientHeaders(t *testing.T) {
+	// /proxy ingress: client's Authorization carries the AV session
+	// token and must be replaced by the injected credential, not leaked.
+	// Vendor headers must still reach the upstream.
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer sk_live_xxx" {
+			t.Errorf("Authorization: got %q, want injected stored credential", got)
+		}
+		if got := r.Header.Get("Anthropic-Version"); got != "2023-06-01" {
+			t.Errorf("Anthropic-Version: got %q, want passthrough", got)
+		}
+		if got := r.Header.Get("X-Trace-Id"); got != "trace-123" {
+			t.Errorf("X-Trace-Id: got %q, want passthrough", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`bearer-ok`))
+	}))
+	defer upstream.Close()
+
+	upstreamHost := strings.TrimPrefix(upstream.URL, "https://")
+	serviceHost, _, _ := net.SplitHostPort(upstreamHost)
+	services := fmt.Sprintf(`[{"host":"%s","auth":{"type":"bearer","token":"STRIPE_KEY"}}]`, serviceHost)
+	ms, token, encKey := setupProxyTest(t, services)
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+
+	origClient := proxyClient
+	proxyClient = upstream.Client()
+	defer func() { proxyClient = origClient }()
+
+	req := httptest.NewRequest(http.MethodGet, "/proxy/"+upstreamHost+"/v1/messages", nil)
+	req.Header.Set("Authorization", "Bearer "+token) // session auth — must not leak
+	req.Header.Set("Anthropic-Version", "2023-06-01")
+	req.Header.Set("X-Trace-Id", "trace-123")
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	body, _ := io.ReadAll(rec.Body)
+	if string(body) != "bearer-ok" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
 func TestProxyMissingCredential(t *testing.T) {
 	services := `[{"host":"api.stripe.com","auth":{"type":"bearer","token":"nonexistent_key"}}]`
 	ms, token, encKey := setupProxyTest(t, services)

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -645,12 +645,10 @@ function ServiceModal({
 
           {authType === "passthrough" && (
             <div className="rounded-lg border border-border bg-bg p-3 text-sm text-text-muted leading-relaxed">
-              Passthrough forwards your client's request headers unchanged to
-              the target. Agent Vault will not look up or inject a credential,
-              and will strip only hop-by-hop headers and broker-scoped headers
-              (<span className="font-mono">X-Vault</span>,{" "}
-              <span className="font-mono">Proxy-Authorization</span>). Use this
-              when the agent already holds the credential.
+              Passthrough allowlists the host without injecting a credential —
+              same header forwarding as every other auth type, just with no
+              broker-injected auth header on top. Use this when the agent
+              already holds the credential.
             </div>
           )}
 


### PR DESCRIPTION
Closes #104.

## Summary

- Removes the 8-header allowlist (`Content-Type`, `Content-Encoding`, `Accept`, `Accept-Encoding`, `Accept-Language`, `User-Agent`, `Idempotency-Key`, `X-Request-Id`) that dropped non-allowlisted client headers on credentialed services. This was breaking upstreams that mandate vendor headers — most notably the Anthropic API (`anthropic-version` is required on every `/v1/messages` request).
- Both ingress paths (`/proxy` and transparent MITM) now share a single denylist in `ApplyInjection`. Client headers flow through except for hop-by-hop (RFC 7230, now including `Proxy-Connection`), broker-scoped (`X-Vault`, `Proxy-Authorization`), the keys of `inject.Headers` (the auth slot for the configured auth type), and any names passed via `extraStrip` (the ingress's session-token header).
- Pre-stripping `inject.Headers` keys from the copy loop is what preserves the *injected always wins* invariant — same outcome as the old allowlist approach, derived from data instead of a hardcoded list.
- `InjectResult.Passthrough` is removed (vestigial after dispatch unified). `res.Headers == nil` is the new passthrough signal.

## Approach vs. the issue's suggested fix

#104 suggested a per-service `extra_passthrough_headers` opt-in. This PR takes the inverse approach: forward everything by default, since header policy is a separate concern the broker had implicitly taken on, and the credential-brokering role only requires control over the headers the broker is itself injecting. A permissive default is the flexible foundation; restrictive opt-ins (`strip_headers`, `allow_headers`) can be added later if real customer need surfaces. The reverse is not true.

## Behavior delta

- **Loosening only.** No request that succeeds today fails after this change.
- **`anthropic-version`, `anthropic-beta`, `If-Match`, `Prefer`, custom tracing/signing headers, etc.** — now reach the upstream on every auth type.
- **Cookie** now also flows through on credentialed services. `Set-Cookie` response stripping is unchanged, so upstream-set cookies still don't reach the client.
- Schema unchanged: no new YAML fields, no per-service overrides.

## Auth-slot stripping by auth type

| Auth type | Headers stripped from client | Headers injected by broker |
|-----------|------------------------------|----------------------------|
| `bearer`  | `Authorization` | `Authorization: Bearer <token>` |
| `basic`   | `Authorization` | `Authorization: Basic <b64>` |
| `api-key` | the header named in `auth.header` | `<auth.header>: <prefix><value>` |
| `custom`  | each header in `auth.headers` map keys | resolved values for those keys |
| `passthrough` | none | none |

## Test plan

- [x] `go test ./...` — full suite green, including new `TestApplyInjection_*` matrix and `Test{MITM,Proxy}BearerForwardsArbitraryClientHeaders` integration tests on both ingresses.
- [ ] Manual end-to-end with Anthropic (the #104 repro): `bearer` service for `api.anthropic.com`, real `/v1/messages` POST with `anthropic-version: 2023-06-01`. Expect 200 (today: 400 missing-version).
- [ ] Confirm injected wins: same request with bogus client `Authorization: Bearer wrong` returns 200 — broker's stored credential shadows the client value on both `/proxy` and MITM ingresses.
- [ ] Existing `Test{Proxy,MITM}PassthroughForwards*` integration tests pass without source changes.

## Docs

Per [CLAUDE.md](CLAUDE.md) lockstep: [`cmd/skill_cli.md`](cmd/skill_cli.md), [`cmd/skill_http.md`](cmd/skill_http.md), [`docs/learn/services.mdx`](docs/learn/services.mdx) (new "Header forwarding" section), [`docs/learn/security.mdx`](docs/learn/security.mdx), [`docs/agents/protocol.mdx`](docs/agents/protocol.mdx), [`docs/index.mdx`](docs/index.mdx), [`docs/quickstart/custom-agent.mdx`](docs/quickstart/custom-agent.mdx), [`docs/guides/connect-custom-agent.mdx`](docs/guides/connect-custom-agent.mdx), [`docs/reference/cli.mdx`](docs/reference/cli.mdx) all updated. UI tooltip for the passthrough auth type rephrased to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
