### PR TITLE
ci: drop semver cooldown keys from Dependabot docker entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,9 +32,6 @@ updates:
       prefix: "deps"
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 5
 
   - package-ecosystem: docker
     directory: /internal/isolation/assets
@@ -44,9 +41,6 @@ updates:
       prefix: "deps"
     cooldown:
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 5
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- The `semver-major-days` / `semver-minor-days` / `semver-patch-days` cooldown properties aren't supported by Dependabot for `package-ecosystem: docker` — Docker tags aren't strictly semver.
- Including them caused Dependabot to reject the entire `.github/dependabot.yml`, blocking updates for **every** ecosystem (gomod, npm, github-actions too), not just docker.
- Drop those three keys from both docker entries (introduced in #131); keep `default-days: 7` so docker still respects a cooldown. Other ecosystems are unchanged.

## Test plan

- [ ] `git diff` shows only the six expected line removals across the two docker blocks
- [ ] Dependabot config validation check on the PR turns green
- [ ] No new errors on the Dependabot tab after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)