### PR TITLE
web: bump postcss to 8.5.12 to patch CSS stringify XSS

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1167,13 +1167,6 @@
         "tailwindcss": "4.2.4"
       }
     },
-    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
@@ -1493,13 +1486,6 @@
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
-    },
-    "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tanstack/history": {
       "version": "1.161.6",
@@ -2306,9 +2292,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Bumps transitive `postcss` from 8.5.8 → 8.5.12 in `web/package-lock.json` via `npm update postcss` (the existing `^8.5.3` range from vite already permitted the fix).
- Resolves Dependabot alert #3: postcss < 8.5.10 fails to escape `</style>` sequences when stringifying CSS, enabling XSS in flows that re-embed user-supplied CSS into `<style>` tags.
- Agent Vault does not re-stringify user CSS at runtime — postcss only runs at build time on first-party CSS — so impact here is low. Patching to clear the alert.

## Test plan
- [x] `cd web && npm run build` — frontend builds clean (160 modules, no warnings)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)