### PR TITLE
Feat/vault run no proxy extension

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,12 @@
 # host (default, cooperative — runs on the host with HTTPS_PROXY) | container (non-cooperative Docker container with iptables egress lock)
 # AGENT_VAULT_ISOLATION=host
 
+# Hosts to add to NO_PROXY for `agent-vault vault run` so they bypass the broker
+# (comma-separated). Defaults (localhost,127.0.0.1) are always preserved. Use for
+# tailnet sidecars on plain http:// (e.g. Tailscale Aperture) that would otherwise
+# hit the broker as forward-proxy POSTs and 405.
+# AGENT_VAULT_NO_PROXY=ai,*.ts.net
+
 # Observability (optional)
 # AGENT_VAULT_LOG_LEVEL=info               # info (default) | debug — debug emits one line per proxied request (no secret values)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -52,10 +52,16 @@ HTTPS (CONNECT) and would 405 any plain http:// request. The root CA PEM
 is written to ~/.agent-vault/mitm-ca.pem. Pass --no-mitm to disable
 injection and rely solely on the explicit /proxy/{host}/{path} endpoint.
 
+NO_PROXY defaults to "localhost,127.0.0.1". Use --no-proxy (repeatable, also
+comma-separated) or AGENT_VAULT_NO_PROXY=host1,host2 to extend it — e.g. for a
+Tailscale Aperture node on plain http:// that should bypass the broker entirely.
+The defaults are always preserved.
+
 Example:
   ` + examplePrefix + ` -- claude
   ` + examplePrefix + ` --vault myproject -- claude
-  ` + examplePrefix + ` --no-mitm -- claude`,
+  ` + examplePrefix + ` --no-mitm -- claude
+  ` + examplePrefix + ` --no-proxy ai -- hermes`,
 		Args:                  cobra.MinimumNArgs(1),
 		DisableFlagsInUseLine: true,
 		RunE:                  runCmdRunE,
@@ -68,6 +74,7 @@ Example:
 	c.Flags().String("role", "", "Vault role for the agent session (proxy, member, admin; default: proxy)")
 	c.Flags().Int("ttl", 0, "Session TTL in seconds (300–604800; default: server default 24h)")
 	c.Flags().Bool("no-mitm", false, "Skip HTTPS_PROXY/CA env injection for the child (explicit /proxy only)")
+	c.Flags().StringSlice("no-proxy", nil, "Hosts to add to NO_PROXY so they bypass the broker (repeatable, also comma-separated). Also read from AGENT_VAULT_NO_PROXY. Defaults (localhost,127.0.0.1) are always preserved.")
 
 	c.Flags().String("image", "", "Container image override (requires --isolation=container)")
 	c.Flags().StringArray("mount", nil, "Extra bind mount src:dst[:ro] (repeatable; requires --isolation=container)")
@@ -142,7 +149,7 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 	// 6. Route the child's HTTPS traffic through the transparent MITM
 	//    proxy. Explicit /proxy stays available as a fallback.
 	if noMITM, _ := cmd.Flags().GetBool("no-mitm"); !noMITM {
-		newEnv, mitmPort, ok, err := augmentEnvWithMITM(env, addr, scopedToken, vault, "")
+		newEnv, mitmPort, ok, err := augmentEnvWithMITM(env, addr, scopedToken, vault, "", resolveExtraNoProxy(cmd))
 		switch {
 		case err != nil:
 			fmt.Fprintf(os.Stderr, "agent-vault: MITM setup failed (%v); continuing with explicit proxy only\n", err)
@@ -375,6 +382,21 @@ func stripEnvKeys(env []string, keys map[string]struct{}) []string {
 	return out
 }
 
+// resolveExtraNoProxy collects additional NO_PROXY hosts from the
+// --no-proxy flag and the AGENT_VAULT_NO_PROXY env var. Order: flag
+// values first (already comma-split by pflag's StringSlice), env-var
+// values appended (split here since env vars arrive as a single string).
+// Trim, empty-drop, and dedup happen downstream in buildNoProxy — this
+// function deliberately stays a pass-through so there's a single source
+// of truth for sanitization.
+func resolveExtraNoProxy(cmd *cobra.Command) []string {
+	hosts, _ := cmd.Flags().GetStringSlice("no-proxy")
+	if env := os.Getenv("AGENT_VAULT_NO_PROXY"); env != "" {
+		hosts = append(hosts, strings.Split(env, ",")...)
+	}
+	return hosts
+}
+
 // augmentEnvWithMITM extends env so the child transparently routes HTTPS
 // through the broker. Returns (env, 0, false, nil) when the server has
 // MITM disabled. The second return value is the port the server reported;
@@ -384,7 +406,11 @@ func stripEnvKeys(env []string, keys map[string]struct{}) []string {
 // Only HTTPS_PROXY is injected — not HTTP_PROXY. The MITM proxy handles
 // HTTP CONNECT only and returns 405 for every other method, so setting
 // HTTP_PROXY would route plain http:// requests into a dead end.
-func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]string, int, bool, error) {
+//
+// extraNoProxy is appended to the NO_PROXY default (loopback) so callers
+// can carve specific hosts (e.g. tailnet sidecars on plain http://) out
+// of the broker path.
+func augmentEnvWithMITM(env []string, addr, token, vault, caPath string, extraNoProxy []string) ([]string, int, bool, error) {
 	pem, port, enabled, mitmTLS, err := fetchMITMCA(addr)
 	if err != nil {
 		return env, 0, false, err
@@ -424,12 +450,13 @@ func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]stri
 
 	env = stripEnvKeys(env, mitmInjectedKeys)
 	env = append(env, isolation.BuildProxyEnv(isolation.ProxyEnvParams{
-		Host:    mitmHost,
-		Port:    port,
-		Token:   token,
-		Vault:   vault,
-		CAPath:  caPath,
-		MITMTLS: mitmTLS,
+		Host:         mitmHost,
+		Port:         port,
+		Token:        token,
+		Vault:        vault,
+		CAPath:       caPath,
+		MITMTLS:      mitmTLS,
+		ExtraNoProxy: extraNoProxy,
 	})...)
 	return env, port, true, nil
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -27,6 +27,11 @@ var skillCLI string
 //go:embed skill_http.md
 var skillHTTP string
 
+const (
+	noProxyFlag = "no-proxy"
+	noProxyEnv  = "AGENT_VAULT_NO_PROXY"
+)
+
 // newRunCmd is called twice — for `vault run` and top-level `run` — so each
 // command gets its own pflag state. examplePrefix parameterizes the Example
 // section of Long.
@@ -74,7 +79,7 @@ Example:
 	c.Flags().String("role", "", "Vault role for the agent session (proxy, member, admin; default: proxy)")
 	c.Flags().Int("ttl", 0, "Session TTL in seconds (300–604800; default: server default 24h)")
 	c.Flags().Bool("no-mitm", false, "Skip HTTPS_PROXY/CA env injection for the child (explicit /proxy only)")
-	c.Flags().StringSlice("no-proxy", nil, "Hosts to add to NO_PROXY so they bypass the broker (repeatable, also comma-separated). Also read from AGENT_VAULT_NO_PROXY. Defaults (localhost,127.0.0.1) are always preserved.")
+	c.Flags().StringSlice(noProxyFlag, nil, "Hosts to add to NO_PROXY so they bypass the broker (repeatable, also comma-separated). Also read from "+noProxyEnv+". Defaults (localhost,127.0.0.1) are always preserved.")
 
 	c.Flags().String("image", "", "Container image override (requires --isolation=container)")
 	c.Flags().StringArray("mount", nil, "Extra bind mount src:dst[:ro] (repeatable; requires --isolation=container)")
@@ -382,16 +387,11 @@ func stripEnvKeys(env []string, keys map[string]struct{}) []string {
 	return out
 }
 
-// resolveExtraNoProxy collects additional NO_PROXY hosts from the
-// --no-proxy flag and the AGENT_VAULT_NO_PROXY env var. Order: flag
-// values first (already comma-split by pflag's StringSlice), env-var
-// values appended (split here since env vars arrive as a single string).
-// Trim, empty-drop, and dedup happen downstream in buildNoProxy — this
-// function deliberately stays a pass-through so there's a single source
-// of truth for sanitization.
+// resolveExtraNoProxy is a raw collector; sanitization lives in
+// buildNoProxy so there's one source of truth.
 func resolveExtraNoProxy(cmd *cobra.Command) []string {
-	hosts, _ := cmd.Flags().GetStringSlice("no-proxy")
-	if env := os.Getenv("AGENT_VAULT_NO_PROXY"); env != "" {
+	hosts, _ := cmd.Flags().GetStringSlice(noProxyFlag)
+	if env := os.Getenv(noProxyEnv); env != "" {
 		hosts = append(hosts, strings.Split(env, ",")...)
 	}
 	return hosts
@@ -406,10 +406,6 @@ func resolveExtraNoProxy(cmd *cobra.Command) []string {
 // Only HTTPS_PROXY is injected — not HTTP_PROXY. The MITM proxy handles
 // HTTP CONNECT only and returns 405 for every other method, so setting
 // HTTP_PROXY would route plain http:// requests into a dead end.
-//
-// extraNoProxy is appended to the NO_PROXY default (loopback) so callers
-// can carve specific hosts (e.g. tailnet sidecars on plain http://) out
-// of the broker path.
 func augmentEnvWithMITM(env []string, addr, token, vault, caPath string, extraNoProxy []string) ([]string, int, bool, error) {
 	pem, port, enabled, mitmTLS, err := fetchMITMCA(addr)
 	if err != nil {

--- a/cmd/run_container.go
+++ b/cmd/run_container.go
@@ -23,17 +23,11 @@ import (
 // containerOnlyFlags are no-ops in host mode. hostOnlyFlags are
 // no-ops in container mode (where MITM is always on, enforced by the
 // iptables lockdown). Either direction is a foot-gun if accepted
-// silently — reject in both.
-//
-// --no-proxy is host-only because container mode's iptables egress lock
-// blocks anything except the broker — so even if the bypass list told
-// the in-container client to skip the proxy for a given host, the
-// firewall would still drop the direct connection. Letting the flag
-// through silently would produce a connection error with no obvious
-// link back to the cause.
+// silently — reject in both. --no-proxy is host-only because the
+// container's iptables lock would drop any bypassed traffic anyway.
 var (
 	containerOnlyFlags = []string{"image", "mount", "keep", "no-firewall", "home-volume-shared", "share-agent-dir"}
-	hostOnlyFlags      = []string{"no-mitm", "no-proxy"}
+	hostOnlyFlags      = []string{"no-mitm", noProxyFlag}
 )
 
 // validateContainerFlagCombos enforces mutual-exclusion between container-mode
@@ -66,13 +60,9 @@ func validateIsolationFlagConflicts(cmd *cobra.Command, mode IsolationMode) erro
 		}
 		return fmt.Errorf("--%s requires --isolation=%s", name, otherMode)
 	}
-	// AGENT_VAULT_NO_PROXY is the env-var twin of --no-proxy; same rule
-	// applies. Catching it here (rather than silently ignoring it in
-	// container mode) makes the constraint discoverable instead of
-	// surfacing as an opaque connection error after the iptables lock
-	// drops the bypassed traffic.
-	if mode == IsolationContainer && os.Getenv("AGENT_VAULT_NO_PROXY") != "" {
-		return errors.New("AGENT_VAULT_NO_PROXY is not supported with --isolation=container: the iptables egress lock allows traffic only to the broker, so any NO_PROXY bypass would still be dropped by the firewall")
+	// Env-var twin of --no-proxy; same rule.
+	if mode == IsolationContainer && os.Getenv(noProxyEnv) != "" {
+		return fmt.Errorf("%s is not supported with --isolation=container: the iptables egress lock would drop any NO_PROXY bypass", noProxyEnv)
 	}
 	return nil
 }

--- a/cmd/run_container.go
+++ b/cmd/run_container.go
@@ -24,9 +24,16 @@ import (
 // no-ops in container mode (where MITM is always on, enforced by the
 // iptables lockdown). Either direction is a foot-gun if accepted
 // silently — reject in both.
+//
+// --no-proxy is host-only because container mode's iptables egress lock
+// blocks anything except the broker — so even if the bypass list told
+// the in-container client to skip the proxy for a given host, the
+// firewall would still drop the direct connection. Letting the flag
+// through silently would produce a connection error with no obvious
+// link back to the cause.
 var (
 	containerOnlyFlags = []string{"image", "mount", "keep", "no-firewall", "home-volume-shared", "share-agent-dir"}
-	hostOnlyFlags      = []string{"no-mitm"}
+	hostOnlyFlags      = []string{"no-mitm", "no-proxy"}
 )
 
 // validateContainerFlagCombos enforces mutual-exclusion between container-mode
@@ -58,6 +65,14 @@ func validateIsolationFlagConflicts(cmd *cobra.Command, mode IsolationMode) erro
 			continue
 		}
 		return fmt.Errorf("--%s requires --isolation=%s", name, otherMode)
+	}
+	// AGENT_VAULT_NO_PROXY is the env-var twin of --no-proxy; same rule
+	// applies. Catching it here (rather than silently ignoring it in
+	// container mode) makes the constraint discoverable instead of
+	// surfacing as an opaque connection error after the iptables lock
+	// drops the bypassed traffic.
+	if mode == IsolationContainer && os.Getenv("AGENT_VAULT_NO_PROXY") != "" {
+		return errors.New("AGENT_VAULT_NO_PROXY is not supported with --isolation=container: the iptables egress lock allows traffic only to the broker, so any NO_PROXY bypass would still be dropped by the firewall")
 	}
 	return nil
 }
@@ -208,7 +223,7 @@ func runContainer(cmd *cobra.Command, args []string, scopedToken, addr, vault st
 		return fmt.Errorf("getwd: %w", err)
 	}
 
-	env := isolation.BuildContainerEnv(scopedToken, vault, fwd.HTTPPort, fwd.MITMPort, mitmTLS)
+	env := isolation.BuildContainerEnv(scopedToken, vault, fwd.HTTPPort, fwd.MITMPort, mitmTLS, resolveExtraNoProxy(cmd))
 
 	mounts, _ := cmd.Flags().GetStringArray("mount")
 	keep, _ := cmd.Flags().GetBool("keep")

--- a/cmd/run_container_test.go
+++ b/cmd/run_container_test.go
@@ -130,12 +130,9 @@ func TestValidateContainerFlagCombos(t *testing.T) {
 	}
 }
 
-// TestValidateIsolationFlagConflicts_NoProxyEnvVarBlocked covers the
-// env-var twin of --no-proxy. Without this guard, AGENT_VAULT_NO_PROXY
-// would silently slip past the flag walk in container mode, the in-
-// container client would dial the bypassed host directly, and the
-// iptables egress lock would drop the connection — leaving the
-// operator to chase an opaque connection error.
+// AGENT_VAULT_NO_PROXY must be rejected in container mode: the flag
+// walk doesn't see env vars, so without an explicit check it would
+// slip through and surface as an opaque firewall-drop downstream.
 func TestValidateIsolationFlagConflicts_NoProxyEnvVarBlocked(t *testing.T) {
 	t.Setenv("AGENT_VAULT_NO_PROXY", "ai")
 	cmd := newRunCommandForTest()
@@ -148,9 +145,6 @@ func TestValidateIsolationFlagConflicts_NoProxyEnvVarBlocked(t *testing.T) {
 	}
 }
 
-// TestValidateIsolationFlagConflicts_NoProxyEnvVarAllowedInHost guards
-// the inverse: in host mode, AGENT_VAULT_NO_PROXY is the intended
-// extension mechanism and must not trigger the rejection.
 func TestValidateIsolationFlagConflicts_NoProxyEnvVarAllowedInHost(t *testing.T) {
 	t.Setenv("AGENT_VAULT_NO_PROXY", "ai")
 	cmd := newRunCommandForTest()

--- a/cmd/run_container_test.go
+++ b/cmd/run_container_test.go
@@ -169,6 +169,6 @@ func newRunCommandForTest() *cobra.Command {
 	c.Flags().Bool("home-volume-shared", false, "")
 	c.Flags().Bool("share-agent-dir", false, "")
 	c.Flags().Bool("no-mitm", false, "")
-	c.Flags().StringSlice("no-proxy", nil, "")
+	c.Flags().StringSlice(noProxyFlag, nil, "")
 	return c
 }

--- a/cmd/run_container_test.go
+++ b/cmd/run_container_test.go
@@ -73,6 +73,8 @@ func TestValidateIsolationFlagConflicts(t *testing.T) {
 		{"host mode rejects --share-agent-dir", IsolationHost, []string{"--share-agent-dir"}, "--share-agent-dir requires --isolation=container"},
 		{"container mode accepts --share-agent-dir alone", IsolationContainer, []string{"--share-agent-dir"}, ""},
 		{"container mode rejects --no-mitm", IsolationContainer, []string{"--no-mitm"}, "--no-mitm requires --isolation=host"},
+		{"container mode rejects --no-proxy", IsolationContainer, []string{"--no-proxy=ai"}, "--no-proxy requires --isolation=host"},
+		{"host mode accepts --no-proxy", IsolationHost, []string{"--no-proxy=ai"}, ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -128,6 +130,38 @@ func TestValidateContainerFlagCombos(t *testing.T) {
 	}
 }
 
+// TestValidateIsolationFlagConflicts_NoProxyEnvVarBlocked covers the
+// env-var twin of --no-proxy. Without this guard, AGENT_VAULT_NO_PROXY
+// would silently slip past the flag walk in container mode, the in-
+// container client would dial the bypassed host directly, and the
+// iptables egress lock would drop the connection — leaving the
+// operator to chase an opaque connection error.
+func TestValidateIsolationFlagConflicts_NoProxyEnvVarBlocked(t *testing.T) {
+	t.Setenv("AGENT_VAULT_NO_PROXY", "ai")
+	cmd := newRunCommandForTest()
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	err := validateIsolationFlagConflicts(cmd, IsolationContainer)
+	if err == nil || !strings.Contains(err.Error(), "AGENT_VAULT_NO_PROXY") {
+		t.Errorf("err = %v, want substring AGENT_VAULT_NO_PROXY", err)
+	}
+}
+
+// TestValidateIsolationFlagConflicts_NoProxyEnvVarAllowedInHost guards
+// the inverse: in host mode, AGENT_VAULT_NO_PROXY is the intended
+// extension mechanism and must not trigger the rejection.
+func TestValidateIsolationFlagConflicts_NoProxyEnvVarAllowedInHost(t *testing.T) {
+	t.Setenv("AGENT_VAULT_NO_PROXY", "ai")
+	cmd := newRunCommandForTest()
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if err := validateIsolationFlagConflicts(cmd, IsolationHost); err != nil {
+		t.Errorf("expected nil err in host mode, got %v", err)
+	}
+}
+
 // newRunCommandForTest isolates flag `Changed` state per subtest; runCmd
 // itself would leak pflag state across ParseFlags calls.
 func newRunCommandForTest() *cobra.Command {
@@ -141,5 +175,6 @@ func newRunCommandForTest() *cobra.Command {
 	c.Flags().Bool("home-volume-shared", false, "")
 	c.Flags().Bool("share-agent-dir", false, "")
 	c.Flags().Bool("no-mitm", false, "")
+	c.Flags().StringSlice("no-proxy", nil, "")
 	return c
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -363,12 +363,9 @@ func TestResolveExtraNoProxy_FlagAndEnvCombine(t *testing.T) {
 	}
 }
 
-// TestResolveExtraNoProxy_PassesThroughWhitespace locks the contract
-// that resolveExtraNoProxy is intentionally a pass-through and the
-// downstream buildNoProxy is the single source of truth for cleaning.
-// Lifting trim/empty-drop into this function would create two places
-// to keep in sync — exactly the kind of duplication the simplified
-// resolver exists to avoid.
+// TestResolveExtraNoProxy_PassesThroughWhitespace locks the
+// pass-through contract: cleaning is buildNoProxy's job, not this
+// function's.
 func TestResolveExtraNoProxy_PassesThroughWhitespace(t *testing.T) {
 	t.Setenv("AGENT_VAULT_NO_PROXY", " ai , , bar ")
 	c := runCmdForFlagTest()

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // expectedRunFlags is the single source of truth for flags both `vault run`
@@ -16,7 +18,7 @@ import (
 // the other is a bug. `vault` is inherited from vaultCmd's persistent flags
 // on `vault run` and registered locally on the top-level `run`.
 var expectedRunFlags = []string{
-	"address", "role", "ttl", "no-mitm", "vault",
+	"address", "role", "ttl", "no-mitm", "no-proxy", "vault",
 	"isolation", "image", "mount", "keep", "no-firewall",
 	"home-volume-shared", "share-agent-dir",
 }
@@ -71,7 +73,7 @@ func TestAugmentEnvWithMITM_Disabled(t *testing.T) {
 	caPath := filepath.Join(t.TempDir(), "mitm-ca.pem")
 	baseEnv := []string{"FOO=bar"}
 
-	env, port, ok, err := augmentEnvWithMITM(baseEnv, srv.URL, "av_sess_abc", "default", caPath)
+	env, port, ok, err := augmentEnvWithMITM(baseEnv, srv.URL, "av_sess_abc", "default", caPath, nil)
 	if err != nil {
 		t.Fatalf("expected nil err on 404, got %v", err)
 	}
@@ -113,7 +115,7 @@ func TestAugmentEnvWithMITM_Enabled(t *testing.T) {
 	defer srv.Close()
 
 	caPath := filepath.Join(t.TempDir(), "mitm-ca.pem")
-	env, port, ok, err := augmentEnvWithMITM(nil, srv.URL, "av_sess_abc", "default", caPath)
+	env, port, ok, err := augmentEnvWithMITM(nil, srv.URL, "av_sess_abc", "default", caPath, nil)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -201,7 +203,7 @@ func TestAugmentEnvWithMITM_PortFallback(t *testing.T) {
 	defer srv.Close()
 
 	caPath := filepath.Join(t.TempDir(), "mitm-ca.pem")
-	_, port, ok, err := augmentEnvWithMITM(nil, srv.URL, "tok", "v", caPath)
+	_, port, ok, err := augmentEnvWithMITM(nil, srv.URL, "tok", "v", caPath, nil)
 	if err != nil || !ok {
 		t.Fatalf("augmentEnvWithMITM: ok=%v err=%v", ok, err)
 	}
@@ -234,7 +236,7 @@ func TestAugmentEnvWithMITM_DedupesParentEnv(t *testing.T) {
 		"DENO_CERT=/etc/ssl/corp-ca.pem",
 		"UNRELATED=keep-me",
 	}
-	env, _, ok, err := augmentEnvWithMITM(parentEnv, srv.URL, "tok", "v", caPath)
+	env, _, ok, err := augmentEnvWithMITM(parentEnv, srv.URL, "tok", "v", caPath, nil)
 	if err != nil || !ok {
 		t.Fatalf("augmentEnvWithMITM: ok=%v err=%v", ok, err)
 	}
@@ -280,7 +282,7 @@ func TestAugmentEnvWithMITM_OldServerNoTLS(t *testing.T) {
 	defer srv.Close()
 
 	caPath := filepath.Join(t.TempDir(), "mitm-ca.pem")
-	env, _, ok, err := augmentEnvWithMITM(nil, srv.URL, "tok", "v", caPath)
+	env, _, ok, err := augmentEnvWithMITM(nil, srv.URL, "tok", "v", caPath, nil)
 	if err != nil || !ok {
 		t.Fatalf("augmentEnvWithMITM: ok=%v err=%v", ok, err)
 	}
@@ -303,4 +305,108 @@ func envMap(env []string) map[string]string {
 		}
 	}
 	return m
+}
+
+// runCmdForFlagTest returns a fresh `run` command with no-op RunE so we
+// can drive flag parsing in isolation without firing any of the actual
+// session-mint / exec logic.
+func runCmdForFlagTest() *cobra.Command {
+	c := newRunCmd("agent-vault vault run")
+	c.RunE = func(_ *cobra.Command, _ []string) error { return nil }
+	return c
+}
+
+// TestResolveExtraNoProxy_FlagSplits covers pflag's StringSlice
+// comma-handling: a single comma-separated --no-proxy value gets split,
+// repeated --no-proxy entries combine. resolveExtraNoProxy itself does
+// no trimming or empty-dropping — that's downstream in buildNoProxy —
+// so values arrive here exactly as pflag emitted them.
+func TestResolveExtraNoProxy_FlagSplits(t *testing.T) {
+	t.Setenv("AGENT_VAULT_NO_PROXY", "")
+	c := runCmdForFlagTest()
+	if err := c.ParseFlags([]string{"--no-proxy", "ai,*.ts.net", "--no-proxy", "foo.example.com"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	got := resolveExtraNoProxy(c)
+	want := []string{"ai", "*.ts.net", "foo.example.com"}
+	if !sliceEq(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestResolveExtraNoProxy_EnvVarOnly: with no flag, the env var alone
+// drives the result. The env-var path comma-splits the single string
+// (pflag doesn't see env vars). Trim/empty-drop is downstream.
+func TestResolveExtraNoProxy_EnvVarOnly(t *testing.T) {
+	t.Setenv("AGENT_VAULT_NO_PROXY", "ai,bar.example.com")
+	c := runCmdForFlagTest()
+	got := resolveExtraNoProxy(c)
+	want := []string{"ai", "bar.example.com"}
+	if !sliceEq(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestResolveExtraNoProxy_FlagAndEnvCombine: flag values come first
+// (in flag order), env-var values follow. Duplicates are fine — they
+// collapse downstream in buildNoProxy.
+func TestResolveExtraNoProxy_FlagAndEnvCombine(t *testing.T) {
+	t.Setenv("AGENT_VAULT_NO_PROXY", "env-host,ai")
+	c := runCmdForFlagTest()
+	if err := c.ParseFlags([]string{"--no-proxy", "ai,flag-host"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	got := resolveExtraNoProxy(c)
+	want := []string{"ai", "flag-host", "env-host", "ai"}
+	if !sliceEq(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestResolveExtraNoProxy_PassesThroughWhitespace locks the contract
+// that resolveExtraNoProxy is intentionally a pass-through and the
+// downstream buildNoProxy is the single source of truth for cleaning.
+// Lifting trim/empty-drop into this function would create two places
+// to keep in sync — exactly the kind of duplication the simplified
+// resolver exists to avoid.
+func TestResolveExtraNoProxy_PassesThroughWhitespace(t *testing.T) {
+	t.Setenv("AGENT_VAULT_NO_PROXY", " ai , , bar ")
+	c := runCmdForFlagTest()
+	got := resolveExtraNoProxy(c)
+	want := []string{" ai ", " ", " bar "}
+	if !sliceEq(got, want) {
+		t.Errorf("got %v, want %v (resolver should be raw; cleaning happens in buildNoProxy)", got, want)
+	}
+}
+
+// TestAugmentEnvWithMITM_ExtraNoProxyAppears: end-to-end from the
+// public-facing seam (caller provides extras) all the way to the env
+// vars emitted onto the child. Locks the contract that the chain
+// (resolveExtraNoProxy → augmentEnvWithMITM → BuildProxyEnv) doesn't
+// silently drop extras at any link.
+func TestAugmentEnvWithMITM_ExtraNoProxyAppears(t *testing.T) {
+	const fakePEM = "-----BEGIN CERTIFICATE-----\nMIIFAKE\n-----END CERTIFICATE-----\n"
+	srv := fakeMITMServer(t, fakePEM, 14322, true)
+	defer srv.Close()
+
+	caPath := filepath.Join(t.TempDir(), "mitm-ca.pem")
+	env, _, ok, err := augmentEnvWithMITM(nil, srv.URL, "tok", "v", caPath, []string{"ai", "*.ts.net"})
+	if err != nil || !ok {
+		t.Fatalf("augmentEnvWithMITM: ok=%v err=%v", ok, err)
+	}
+	if got := envMap(env)["NO_PROXY"]; got != "localhost,127.0.0.1,ai,*.ts.net" {
+		t.Errorf("NO_PROXY = %q, want localhost,127.0.0.1,ai,*.ts.net", got)
+	}
+}
+
+func sliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -41,6 +41,8 @@ You have access to Agent Vault, a transparent HTTPS proxy that injects credentia
 
 `agent-vault run` also pre-configures `HTTPS_PROXY`, `NO_PROXY`, `NODE_USE_ENV_PROXY`, and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) so HTTPS calls from your process route through the broker transparently. You don't manage these yourself.
 
+`NO_PROXY` defaults to `localhost,127.0.0.1`. The operator who launched you may have extended it (via `--no-proxy` or `AGENT_VAULT_NO_PROXY`) so specific hosts bypass the broker — typically a sidecar like a Tailscale-mediated AI gateway reachable over plain `http://`. If you hit a `405 method ... not supported on transparent proxy` from `127.0.0.1:14322` (the broker's MITM listener) for a plain-`http://` destination, the response body explains the cause and the operator-side fix; surface it verbatim to the human, you cannot resolve it from inside this process.
+
 Under `--isolation=container`, the same env shape is injected inside a Docker container, but the proxy URL host is `host.docker.internal` instead of `127.0.0.1` and egress to any other destination is blocked by iptables. From your perspective nothing changes — standard HTTP clients pick up the envvars as normal.
 
 ## Discover Available Services (Start Here)

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -40,6 +40,8 @@ You have access to Agent Vault, a transparent HTTPS proxy that injects credentia
 
 `vault run` also pre-configures `HTTPS_PROXY`, `NO_PROXY`, `NODE_USE_ENV_PROXY`, and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) so HTTPS calls from your process route through the broker transparently. You don't manage these yourself.
 
+`NO_PROXY` defaults to `localhost,127.0.0.1`. The operator who launched you may have extended it (via `--no-proxy` or `AGENT_VAULT_NO_PROXY`) so specific hosts bypass the broker — typically a sidecar like a Tailscale-mediated AI gateway reachable over plain `http://`. If you hit a `405 method ... not supported on transparent proxy` from `127.0.0.1:14322` (the broker's MITM listener) for a plain-`http://` destination, the response body explains the cause and the operator-side fix; surface it verbatim to the human, you cannot resolve it from inside this process.
+
 Under `--isolation=container`, the same env shape is injected inside a Docker container, but the proxy URL host is `host.docker.internal` instead of `127.0.0.1` and egress to any other destination is blocked by iptables. From your perspective nothing changes — standard HTTP clients pick up the envvars as normal.
 
 ## Discover Available Services (Start Here)

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -272,6 +272,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `--role` | `proxy` | Vault role for the session: `proxy`, `member`, or `admin` |
     | `--ttl` | `0` | Session TTL in seconds (300–604800). Default: server default (24h). |
     | `--no-mitm` | `false` | Skip HTTPS_PROXY/CA env injection; rely solely on the explicit `/proxy/{host}/{path}` endpoint. |
+    | `--no-proxy` | `[]` | Hosts to add to `NO_PROXY` so they bypass the broker entirely. Repeatable; values are also comma-split. Also read from `AGENT_VAULT_NO_PROXY`. The defaults (`localhost,127.0.0.1`) are always preserved. Use this for tailnet sidecars (e.g. Aperture's `ai`) reachable over plain http:// — those would otherwise hit the broker as forward-proxy POSTs and 405. |
     | `--isolation` | `host` | Isolation mode for the child: `host` (default, cooperative — runs on the host with HTTPS_PROXY) or `container` (non-cooperative Docker container; see [Container isolation](/guides/container-isolation)). Also read from `AGENT_VAULT_ISOLATION`. |
     | `--image` | | Override the bundled container image (`--isolation=container` only). |
     | `--mount` | | Extra bind mount `src:dst[:ro]`; repeatable (`--isolation=container` only). Host paths are EvalSymlinks-resolved; reserved paths rejected. |

--- a/docs/self-hosting/environment-variables.mdx
+++ b/docs/self-hosting/environment-variables.mdx
@@ -22,6 +22,7 @@ description: "All environment variables used to configure Agent Vault"
 | `AGENT_VAULT_LOGS_MAX_ROWS_PER_VAULT` | `10000` | Per-vault row cap for the request log. Whichever limit (age or rows) hits first wins, so heavy-traffic vaults retain a shorter window than the time-based TTL alone would suggest. Set to `0` to disable the row cap. |
 | `AGENT_VAULT_LOGS_RETENTION_LOCK` | `false` | When `true`, any owner-UI overrides for log retention are ignored and env values (or defaults) are pinned. Use when you want retention limits controlled only by the operator. |
 | `AGENT_VAULT_ISOLATION` | `host` | Default isolation mode for `agent-vault vault run`. `host` forks the child on the host with `HTTPS_PROXY` envvars (cooperative). `container` launches it inside a Docker container with iptables-locked egress (non-cooperative; see [Container isolation](/guides/container-isolation)). The `--isolation` flag overrides this. |
+| `AGENT_VAULT_NO_PROXY` | (unset) | Comma-separated hosts to add to the child's `NO_PROXY` (e.g. `ai,*.ts.net`) so they bypass the broker. Used by `agent-vault vault run` alongside its built-in `localhost,127.0.0.1` defaults — defaults are always preserved. Use this for tailnet sidecars (e.g. Tailscale Aperture) reachable over plain http:// that would otherwise hit the broker as forward-proxy POSTs and 405. The `--no-proxy` flag adds to whatever this env var contributes. |
 
 Master password resolution order:
 

--- a/internal/isolation/env.go
+++ b/internal/isolation/env.go
@@ -26,14 +26,7 @@ type ProxyEnvParams struct {
 	CAPath  string // path the child reads the CA PEM from
 	MITMTLS bool   // true → HTTPS_PROXY uses https://, false → http://
 
-	// ExtraNoProxy is appended to the NO_PROXY default
-	// ("localhost,127.0.0.1") so callers can carve specific hosts out
-	// of the broker's path — e.g. a Tailscale Aperture node reachable
-	// over plain http:// that should bypass the MITM listener entirely.
-	// Entries are trimmed of whitespace; empties and duplicates are
-	// dropped. The defaults are always preserved; this list never
-	// replaces them.
-	ExtraNoProxy []string
+	ExtraNoProxy []string // appended to NO_PROXY defaults; see buildNoProxy
 }
 
 // buildNoProxy merges the default bypass list (loopback) with the

--- a/internal/isolation/env.go
+++ b/internal/isolation/env.go
@@ -5,6 +5,7 @@ package isolation
 import (
 	"fmt"
 	"net/url"
+	"strings"
 )
 
 const (
@@ -24,6 +25,36 @@ type ProxyEnvParams struct {
 	Vault   string
 	CAPath  string // path the child reads the CA PEM from
 	MITMTLS bool   // true → HTTPS_PROXY uses https://, false → http://
+
+	// ExtraNoProxy is appended to the NO_PROXY default
+	// ("localhost,127.0.0.1") so callers can carve specific hosts out
+	// of the broker's path — e.g. a Tailscale Aperture node reachable
+	// over plain http:// that should bypass the MITM listener entirely.
+	// Entries are trimmed of whitespace; empties and duplicates are
+	// dropped. The defaults are always preserved; this list never
+	// replaces them.
+	ExtraNoProxy []string
+}
+
+// buildNoProxy merges the default bypass list (loopback) with the
+// caller's extras, trimming whitespace and dropping empties + dupes
+// while preserving order. The defaults always come first so the
+// localhost protections cannot be reordered or overridden.
+func buildNoProxy(extras []string) string {
+	hosts := []string{"localhost", "127.0.0.1"}
+	seen := map[string]struct{}{"localhost": {}, "127.0.0.1": {}}
+	for _, h := range extras {
+		h = strings.TrimSpace(h)
+		if h == "" {
+			continue
+		}
+		if _, dup := seen[h]; dup {
+			continue
+		}
+		seen[h] = struct{}{}
+		hosts = append(hosts, h)
+	}
+	return strings.Join(hosts, ",")
 }
 
 // BuildProxyEnv returns the nine env vars that point an HTTPS client at
@@ -45,7 +76,7 @@ func BuildProxyEnv(p ProxyEnvParams) []string {
 	}).String()
 	return []string{
 		"HTTPS_PROXY=" + proxyURL,
-		"NO_PROXY=localhost,127.0.0.1",
+		"NO_PROXY=" + buildNoProxy(p.ExtraNoProxy),
 		"NODE_USE_ENV_PROXY=1",
 		"SSL_CERT_FILE=" + p.CAPath,
 		"NODE_EXTRA_CA_CERTS=" + p.CAPath,
@@ -74,14 +105,18 @@ var ProxyEnvKeys = []string{
 // BuildContainerEnv returns the KEY=VALUE entries to pass to `docker
 // run` via -e flags. Produces a fresh list rather than augmenting
 // os.Environ() — the container should not inherit the host's env.
-func BuildContainerEnv(token, vault string, httpPort, mitmPort int, mitmTLS bool) []string {
+//
+// extraNoProxy is appended to NO_PROXY's default loopback entries; see
+// ProxyEnvParams.ExtraNoProxy for semantics.
+func BuildContainerEnv(token, vault string, httpPort, mitmPort int, mitmTLS bool, extraNoProxy []string) []string {
 	env := BuildProxyEnv(ProxyEnvParams{
-		Host:    ContainerProxyHost,
-		Port:    mitmPort,
-		Token:   token,
-		Vault:   vault,
-		CAPath:  ContainerCAPath,
-		MITMTLS: mitmTLS,
+		Host:         ContainerProxyHost,
+		Port:         mitmPort,
+		Token:        token,
+		Vault:        vault,
+		CAPath:       ContainerCAPath,
+		MITMTLS:      mitmTLS,
+		ExtraNoProxy: extraNoProxy,
 	})
 	return append(env,
 		"AGENT_VAULT_SESSION_TOKEN="+token,

--- a/internal/isolation/env_test.go
+++ b/internal/isolation/env_test.go
@@ -17,7 +17,7 @@ func envMap(env []string) map[string]string {
 }
 
 func TestBuildContainerEnv_ProxyURL(t *testing.T) {
-	env := BuildContainerEnv("av_sess_abc", "myvault", 14321, 14322, true)
+	env := BuildContainerEnv("av_sess_abc", "myvault", 14321, 14322, true, nil)
 	vars := envMap(env)
 
 	u, err := url.Parse(vars["HTTPS_PROXY"])
@@ -42,7 +42,7 @@ func TestBuildContainerEnv_ProxyURL(t *testing.T) {
 }
 
 func TestBuildContainerEnv_OldServerScheme(t *testing.T) {
-	env := BuildContainerEnv("tok", "v", 14321, 14322, false)
+	env := BuildContainerEnv("tok", "v", 14321, 14322, false, nil)
 	vars := envMap(env)
 	u, _ := url.Parse(vars["HTTPS_PROXY"])
 	if u.Scheme != "http" {
@@ -51,7 +51,7 @@ func TestBuildContainerEnv_OldServerScheme(t *testing.T) {
 }
 
 func TestBuildContainerEnv_CAPathsAllPointAtBindMount(t *testing.T) {
-	env := BuildContainerEnv("tok", "v", 14321, 14322, true)
+	env := BuildContainerEnv("tok", "v", 14321, 14322, true, nil)
 	vars := envMap(env)
 	for _, k := range []string{
 		"SSL_CERT_FILE",
@@ -68,7 +68,7 @@ func TestBuildContainerEnv_CAPathsAllPointAtBindMount(t *testing.T) {
 }
 
 func TestBuildContainerEnv_AgentVaultAddrUsesContainerHost(t *testing.T) {
-	env := BuildContainerEnv("tok", "v", 14321, 14322, true)
+	env := BuildContainerEnv("tok", "v", 14321, 14322, true, nil)
 	vars := envMap(env)
 	want := "http://" + ContainerProxyHost + ":14321"
 	if vars["AGENT_VAULT_ADDR"] != want {
@@ -85,7 +85,7 @@ func TestBuildContainerEnv_AgentVaultAddrUsesContainerHost(t *testing.T) {
 // Internal helpers for init-firewall.sh — stripped from claude's env by
 // entrypoint.sh, but we emit them so the init script sees them.
 func TestBuildContainerEnv_FirewallPortsEmitted(t *testing.T) {
-	env := BuildContainerEnv("tok", "v", 14321, 14322, true)
+	env := BuildContainerEnv("tok", "v", 14321, 14322, true, nil)
 	vars := envMap(env)
 	if vars["VAULT_HTTP_PORT"] != "14321" {
 		t.Errorf("VAULT_HTTP_PORT = %q", vars["VAULT_HTTP_PORT"])
@@ -98,9 +98,61 @@ func TestBuildContainerEnv_FirewallPortsEmitted(t *testing.T) {
 // HTTP_PROXY must not be set — the MITM proxy is HTTPS-only and would
 // 405 any plain http:// request routed through it.
 func TestBuildContainerEnv_NoHTTPProxy(t *testing.T) {
-	env := BuildContainerEnv("tok", "v", 14321, 14322, true)
+	env := BuildContainerEnv("tok", "v", 14321, 14322, true, nil)
 	vars := envMap(env)
 	if v, ok := vars["HTTP_PROXY"]; ok {
 		t.Errorf("HTTP_PROXY must not be set, got %q", v)
+	}
+}
+
+// TestBuildProxyEnv_NoProxyDefault confirms the loopback defaults are
+// emitted verbatim when no extras are supplied. This is the contract
+// every existing caller relied on before ExtraNoProxy existed.
+func TestBuildProxyEnv_NoProxyDefault(t *testing.T) {
+	env := BuildProxyEnv(ProxyEnvParams{
+		Host: "127.0.0.1", Port: 14322, Token: "tok", Vault: "v",
+		CAPath: "/tmp/ca.pem", MITMTLS: true,
+	})
+	if got := envMap(env)["NO_PROXY"]; got != "localhost,127.0.0.1" {
+		t.Errorf("NO_PROXY = %q, want localhost,127.0.0.1", got)
+	}
+}
+
+// TestBuildProxyEnv_NoProxyExtras_Append covers the happy path: an
+// operator passes a tailnet sidecar host (e.g. Aperture's "ai") and it
+// shows up after the loopback defaults.
+func TestBuildProxyEnv_NoProxyExtras_Append(t *testing.T) {
+	env := BuildProxyEnv(ProxyEnvParams{
+		Host: "127.0.0.1", Port: 14322, Token: "tok", Vault: "v",
+		CAPath: "/tmp/ca.pem", MITMTLS: true,
+		ExtraNoProxy: []string{"ai", "*.ts.net"},
+	})
+	if got := envMap(env)["NO_PROXY"]; got != "localhost,127.0.0.1,ai,*.ts.net" {
+		t.Errorf("NO_PROXY = %q, want localhost,127.0.0.1,ai,*.ts.net", got)
+	}
+}
+
+// TestBuildProxyEnv_NoProxyExtras_TrimAndDedup verifies the input
+// sanitization: leading/trailing whitespace gets trimmed, empties are
+// dropped, duplicates collapse, and the loopback defaults can't be
+// re-injected to reorder them.
+func TestBuildProxyEnv_NoProxyExtras_TrimAndDedup(t *testing.T) {
+	env := BuildProxyEnv(ProxyEnvParams{
+		Host: "127.0.0.1", Port: 14322, Token: "tok", Vault: "v",
+		CAPath: "/tmp/ca.pem", MITMTLS: true,
+		ExtraNoProxy: []string{"  ai  ", "", "ai", "localhost", "127.0.0.1", "foo.example.com"},
+	})
+	if got := envMap(env)["NO_PROXY"]; got != "localhost,127.0.0.1,ai,foo.example.com" {
+		t.Errorf("NO_PROXY = %q, want localhost,127.0.0.1,ai,foo.example.com", got)
+	}
+}
+
+// TestBuildContainerEnv_NoProxyExtras_PassThrough guards that container
+// mode honors the extras the same way host mode does — both call paths
+// share BuildProxyEnv but it's a thin wrapper, easy to drop the param.
+func TestBuildContainerEnv_NoProxyExtras_PassThrough(t *testing.T) {
+	env := BuildContainerEnv("tok", "v", 14321, 14322, true, []string{"ai"})
+	if got := envMap(env)["NO_PROXY"]; got != "localhost,127.0.0.1,ai" {
+		t.Errorf("NO_PROXY = %q, want localhost,127.0.0.1,ai", got)
 	}
 }

--- a/internal/mitm/proxy.go
+++ b/internal/mitm/proxy.go
@@ -168,5 +168,34 @@ func (p *Proxy) dispatch(w http.ResponseWriter, r *http.Request) {
 		p.handleConnect(w, r)
 		return
 	}
+	// Forward-proxy requests arrive here with an absolute URL in the
+	// request line (e.g. "POST http://ai/v1/messages HTTP/1.1"). The
+	// MITM listener only speaks the CONNECT half of the proxy protocol
+	// — we have no path for forwarding a plain HTTP request on the
+	// client's behalf. Surface the cause and every available lever
+	// instead of bare "method not supported", because the lever is
+	// non-obvious from the wire-level error alone.
+	if r.URL != nil && r.URL.IsAbs() {
+		host := r.URL.Hostname()
+		scheme := r.URL.Scheme
+		msg := fmt.Sprintf(
+			"Agent Vault broker received a forward-proxy %s request for %s://%s, but only handles HTTPS CONNECT tunnels.\n"+
+				"\n"+
+				"Cause: an HTTP client in your process picked up the broker's HTTPS_PROXY for a %s:// destination. The broker has no path to forward such a request — it can only tunnel TLS via CONNECT.\n"+
+				"\n"+
+				"Fix options (pick whichever fits):\n"+
+				"  1. If %q should bypass the broker entirely (e.g. a sidecar reachable over %s:// from this machine, like a Tailscale-mediated AI gateway), add it to NO_PROXY:\n"+
+				"       agent-vault vault run --no-proxy %s -- <agent>\n"+
+				"     or via env var:\n"+
+				"       AGENT_VAULT_NO_PROXY=%s agent-vault vault run -- <agent>\n"+
+				"  2. If the destination should go through the broker, change your client to call it over https:// — the broker will then receive a CONNECT and proceed normally.\n",
+			r.Method, scheme, host,
+			scheme,
+			host, scheme,
+			host, host,
+		)
+		http.Error(w, msg, http.StatusMethodNotAllowed)
+		return
+	}
 	http.Error(w, fmt.Sprintf("method %s not supported on transparent proxy", r.Method), http.StatusMethodNotAllowed)
 }

--- a/internal/mitm/proxy.go
+++ b/internal/mitm/proxy.go
@@ -168,33 +168,12 @@ func (p *Proxy) dispatch(w http.ResponseWriter, r *http.Request) {
 		p.handleConnect(w, r)
 		return
 	}
-	// Forward-proxy requests arrive here with an absolute URL in the
-	// request line (e.g. "POST http://ai/v1/messages HTTP/1.1"). The
-	// MITM listener only speaks the CONNECT half of the proxy protocol
-	// — we have no path for forwarding a plain HTTP request on the
-	// client's behalf. Surface the cause and every available lever
-	// instead of bare "method not supported", because the lever is
-	// non-obvious from the wire-level error alone.
+	// Absolute-URL request line = forward-proxy attempt; we only tunnel CONNECT.
 	if r.URL != nil && r.URL.IsAbs() {
-		host := r.URL.Hostname()
-		scheme := r.URL.Scheme
-		msg := fmt.Sprintf(
-			"Agent Vault broker received a forward-proxy %s request for %s://%s, but only handles HTTPS CONNECT tunnels.\n"+
-				"\n"+
-				"Cause: an HTTP client in your process picked up the broker's HTTPS_PROXY for a %s:// destination. The broker has no path to forward such a request — it can only tunnel TLS via CONNECT.\n"+
-				"\n"+
-				"Fix options (pick whichever fits):\n"+
-				"  1. If %q should bypass the broker entirely (e.g. a sidecar reachable over %s:// from this machine, like a Tailscale-mediated AI gateway), add it to NO_PROXY:\n"+
-				"       agent-vault vault run --no-proxy %s -- <agent>\n"+
-				"     or via env var:\n"+
-				"       AGENT_VAULT_NO_PROXY=%s agent-vault vault run -- <agent>\n"+
-				"  2. If the destination should go through the broker, change your client to call it over https:// — the broker will then receive a CONNECT and proceed normally.\n",
-			r.Method, scheme, host,
-			scheme,
-			host, scheme,
-			host, host,
-		)
-		http.Error(w, msg, http.StatusMethodNotAllowed)
+		http.Error(w, fmt.Sprintf(
+			"forward-proxy %s for %s://%s not supported; broker only tunnels HTTPS CONNECT. To bypass: --no-proxy %s (or AGENT_VAULT_NO_PROXY=%s), or use https:// instead",
+			r.Method, r.URL.Scheme, r.URL.Hostname(), r.URL.Hostname(), r.URL.Hostname(),
+		), http.StatusMethodNotAllowed)
 		return
 	}
 	http.Error(w, fmt.Sprintf("method %s not supported on transparent proxy", r.Method), http.StatusMethodNotAllowed)

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -512,6 +512,51 @@ func TestMITMRejectsNonConnectRequests(t *testing.T) {
 	}
 }
 
+// TestMITMForwardProxyHTTPGivesActionableHint verifies that a plain
+// http:// forward-proxy request — the shape sent when a client pulls
+// http://<host>/... through HTTPS_PROXY — receives a 405 whose body
+// names the offending host and tells the operator how to bypass the
+// broker for it via NO_PROXY / --no-proxy. This is the exact
+// foot-gun a Tailscale Aperture user trips: hermes' python client
+// routes http://ai/v1/... through HTTPS_PROXY, hits this handler, and
+// without the hint the only signal is "method POST not supported."
+func TestMITMForwardProxyHTTPGivesActionableHint(t *testing.T) {
+	proxyURL, clientRoots, _ := setupProxy(t, errResolver(brokercore.ErrInvalidSession), &fakeCredProvider{})
+
+	// Build a forward-proxy request manually: absolute-URL request line,
+	// http scheme, arbitrary destination. Standard HTTP libraries don't
+	// expose this form directly, so we open the socket ourselves and
+	// write the wire format hermes' httpx layer would produce.
+	conn, err := tls.Dial("tcp", proxyURL.Host, &tls.Config{RootCAs: clientRoots})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte("POST http://ai/v1/messages HTTP/1.1\r\nHost: ai\r\nContent-Length: 0\r\n\r\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	// Body must name the offending host, the scheme, both fix levers
+	// (--no-proxy flag and AGENT_VAULT_NO_PROXY env var), and call out
+	// the alternative (switching the destination to https://). Each is
+	// load-bearing for an operator who has never seen this error before.
+	for _, want := range []string{"ai", "http://", "NO_PROXY", "--no-proxy", "AGENT_VAULT_NO_PROXY", "https://"} {
+		if !strings.Contains(bodyStr, want) {
+			t.Errorf("405 body missing %q. Body:\n%s", want, bodyStr)
+		}
+	}
+}
+
 func TestMITMSubstitutionRewritesPath(t *testing.T) {
 	var sawPath, sawQuery, sawAuth string
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -512,21 +512,13 @@ func TestMITMRejectsNonConnectRequests(t *testing.T) {
 	}
 }
 
-// TestMITMForwardProxyHTTPGivesActionableHint verifies that a plain
-// http:// forward-proxy request — the shape sent when a client pulls
-// http://<host>/... through HTTPS_PROXY — receives a 405 whose body
-// names the offending host and tells the operator how to bypass the
-// broker for it via NO_PROXY / --no-proxy. This is the exact
-// foot-gun a Tailscale Aperture user trips: hermes' python client
-// routes http://ai/v1/... through HTTPS_PROXY, hits this handler, and
-// without the hint the only signal is "method POST not supported."
+// TestMITMForwardProxyHTTPGivesActionableHint: a forward-proxy
+// http:// request must surface the host + bypass levers in the 405
+// body. Standard HTTP libraries won't emit the absolute-URL request
+// line, so the test writes the wire format directly.
 func TestMITMForwardProxyHTTPGivesActionableHint(t *testing.T) {
 	proxyURL, clientRoots, _ := setupProxy(t, errResolver(brokercore.ErrInvalidSession), &fakeCredProvider{})
 
-	// Build a forward-proxy request manually: absolute-URL request line,
-	// http scheme, arbitrary destination. Standard HTTP libraries don't
-	// expose this form directly, so we open the socket ourselves and
-	// write the wire format hermes' httpx layer would produce.
 	conn, err := tls.Dial("tcp", proxyURL.Host, &tls.Config{RootCAs: clientRoots})
 	if err != nil {
 		t.Fatalf("dial: %v", err)
@@ -546,10 +538,6 @@ func TestMITMForwardProxyHTTPGivesActionableHint(t *testing.T) {
 	}
 	body, _ := io.ReadAll(resp.Body)
 	bodyStr := string(body)
-	// Body must name the offending host, the scheme, both fix levers
-	// (--no-proxy flag and AGENT_VAULT_NO_PROXY env var), and call out
-	// the alternative (switching the destination to https://). Each is
-	// load-bearing for an operator who has never seen this error before.
 	for _, want := range []string{"ai", "http://", "NO_PROXY", "--no-proxy", "AGENT_VAULT_NO_PROXY", "https://"} {
 		if !strings.Contains(bodyStr, want) {
 			t.Errorf("405 body missing %q. Body:\n%s", want, bodyStr)


### PR DESCRIPTION
## Summary

Adds a --no-proxy flag (and AGENT_VAULT_NO_PROXY env var) to vault run that extends the child process's NO_PROXY list, plus a clearer 405 error from the MITM proxy when an agent tries to forward-proxy plain HTTP through it.

  Surface changes
- cmd/run.go: new repeatable/comma-separated --no-proxy flag, also reads AGENT_VAULT_NO_PROXY.
- internal/isolation/env.go: new buildNoProxy merges defaults (localhost,127.0.0.1) with extras — defaults always come first, dupes/whitespace dropped. Threaded through BuildProxyEnv and BuildContainerEnv via ProxyEnvParams.ExtraNoProxy.
- internal/mitm/proxy.go: when a request lands on the MITM port with an absolute URL (i.e. someone set HTTP_PROXY and sent plain http://), return a 405 that names the actual host and tells the user how to bypass.
- Docs/skills/env-example updated per the CLAUDE.md convention.

Why
 
The transparent MITM is HTTPS-CONNECT-only. If an agent needs to talk to a plain-http service that lives outside the broker (the example in the help text is a Tailscale Aperture node, called out as hermes), there was no escape hatch — the request would either dead-end at the MITM or never reach the right place. --no-proxy lets the operator carve specific hosts out of proxying without disabling MITM globally, while keeping the loopback defaults locked in so they can't be accidentally overridden.

## Type of change

- [x ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ x] Documentation
- [ ] CI / build

## Test plan

internal/isolation/env_test.go — the data layer
cmd/run_test.go — the flag-collection layer
cmd/run_container_test.go — the isolation-mode guard 
internal/mitm/proxy_test.go — the actionable error

- [ x] Existing tests pass (`make test`)
- [ x] Added/updated tests for new behavior
- [ x] Manual testing (describe below)

## Security checklist

- [ x] No secrets or credentials in code
- [x ] No new unauthenticated endpoints
- [ x] Input validation on new API surfaces
- [ x] Checked for OWASP top 10 (injection, XSS, etc.)
