### PR TITLE
docs/sdk: address #143 post-merge review

### DIFF
--- a/docs/quickstart/nanoclaw.mdx
+++ b/docs/quickstart/nanoclaw.mdx
@@ -40,7 +40,7 @@ Here's what happens — with zero pre-configuration:
 6. NanoClaw retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
 
 <Note>
-Invited agents like NanoClaw set `HTTPS_PROXY` and the Agent Vault root CA on their HTTP client themselves (the values come back in the invite redemption response). Local agents you wrap with `agent-vault vault run` (Claude Code, Cursor, Codex, Hermes) inherit the same env vars automatically.
+Invited agents like NanoClaw build their own `HTTPS_PROXY` from the token + vault returned by the redemption response and fetch the root CA from `{AGENT_VAULT_ADDR}/v1/mitm/ca.pem` themselves — the embedded `instructions` field walks them through it. Local agents you wrap with `agent-vault vault run` (Claude Code, Cursor, Codex, Hermes) inherit the same env vars automatically.
 </Note>
 
 <Note>

--- a/docs/quickstart/openclaw.mdx
+++ b/docs/quickstart/openclaw.mdx
@@ -40,7 +40,7 @@ Here's what happens — with zero pre-configuration:
 6. OpenClaw retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
 
 <Note>
-Invited agents like OpenClaw set `HTTPS_PROXY` and the Agent Vault root CA on their HTTP client themselves (the values come back in the invite redemption response). Local agents you wrap with `agent-vault vault run` (Claude Code, Cursor, Codex, Hermes) inherit the same env vars automatically.
+Invited agents like OpenClaw build their own `HTTPS_PROXY` from the token + vault returned by the redemption response and fetch the root CA from `{AGENT_VAULT_ADDR}/v1/mitm/ca.pem` themselves — the embedded `instructions` field walks them through it. Local agents you wrap with `agent-vault vault run` (Claude Code, Cursor, Codex, Hermes) inherit the same env vars automatically.
 </Note>
 
 <Note>

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -86,7 +86,7 @@ agent-vault server --mitm-port 0 # disable
 ```
 
 <Warning>
-HTTP/1.1 at the ingress (WebSocket upgrades over HTTP/1.1 are transparently brokered — useful for voice/realtime APIs like OpenAI Realtime). Clients that negotiate HTTP/2 end-to-end are forwarded uninspected, so credentials are not injected on those flows; pin the client to HTTP/1.1 if you need brokered auth.
+HTTP/1.1 at the ingress (WebSocket upgrades over HTTP/1.1 are transparently brokered — useful for voice/realtime APIs like OpenAI Realtime). The terminator advertises only `http/1.1` in ALPN, so clients offering both `h2` and `http/1.1` fall back to `http/1.1` and have credentials injected normally; clients that strictly require `h2` fail the TLS handshake with a `no_application_protocol` alert.
 </Warning>
 
 A software-backed root CA is created on first launch under `~/.agent-vault/ca/` (private key encrypted with the DEK). Clients must trust this root before the proxied TLS handshake will succeed. `agent-vault vault run` handles this automatically for child processes — only fetch the CA manually when configuring agents outside of `vault run` (containers, CI, invited agents).

--- a/sdks/sdk-typescript/README.md
+++ b/sdks/sdk-typescript/README.md
@@ -115,7 +115,7 @@ await vault.services.set([
 
 ## Error handling
 
-The SDK throws `ApiError` (and its subclass `ProxyForbiddenError` when the broker returns a `proposal_hint`) for non-2xx responses from Agent Vault control-plane endpoints. Upstream HTTP errors from agent-issued traffic — which travels through `HTTPS_PROXY`, not the SDK — surface in the agent's normal HTTP client.
+The SDK throws `ApiError` for non-2xx responses from Agent Vault control-plane endpoints. Upstream HTTP errors from agent-issued traffic — which travels through `HTTPS_PROXY`, not the SDK — surface in the agent's normal HTTP client.
 
 ## Documentation
 

--- a/sdks/sdk-typescript/src/errors.ts
+++ b/sdks/sdk-typescript/src/errors.ts
@@ -36,17 +36,9 @@ export class ApiError extends AgentVaultError {
     this.headers = headers;
   }
 
-  /**
-   * Parse an API error from an HTTP response.
-   *
-   * Handles both server error formats:
-   * - Standard: `{"error": "message"}`
-   * - Proxy:    `{"error": "code", "message": "detail"}`
-   */
   static async fromResponse(response: Response): Promise<ApiError> {
     let code = "unknown";
     let message = response.statusText;
-    let proposalHint: ProposalHint | undefined;
 
     try {
       const body = await response.json();
@@ -60,28 +52,9 @@ export class ApiError extends AgentVaultError {
           message =
             typeof messageField === "string" ? messageField : errorField;
         }
-
-        if (record.proposal_hint && typeof record.proposal_hint === "object") {
-          const hint = record.proposal_hint as Record<string, unknown>;
-          proposalHint = {
-            host: hint.host as string,
-            endpoint: hint.endpoint as string,
-            supportedAuthTypes: hint.supported_auth_types as string[],
-          };
-        }
       }
     } catch {
       // Response body wasn't JSON — fall back to statusText
-    }
-
-    if (proposalHint) {
-      return new ProxyForbiddenError({
-        status: response.status,
-        code,
-        message,
-        headers: response.headers,
-        proposalHint,
-      });
     }
 
     return new ApiError({
@@ -90,38 +63,5 @@ export class ApiError extends AgentVaultError {
       message,
       headers: response.headers,
     });
-  }
-}
-
-/** Structured hint returned by the broker when a proxy request is denied. */
-export interface ProposalHint {
-  host: string;
-  endpoint: string;
-  supportedAuthTypes: string[];
-}
-
-/**
- * Thrown when a proxy request is denied because no broker service matches the target host.
- * Contains a `proposalHint` with the information needed to create a proposal.
- */
-export class ProxyForbiddenError extends ApiError {
-  readonly proposalHint: ProposalHint;
-
-  constructor({
-    status,
-    code,
-    message,
-    headers,
-    proposalHint,
-  }: {
-    status: number;
-    code: string;
-    message: string;
-    headers: Headers;
-    proposalHint: ProposalHint;
-  }) {
-    super({ status, code, message, headers });
-    this.name = "ProxyForbiddenError";
-    this.proposalHint = proposalHint;
   }
 }

--- a/sdks/sdk-typescript/src/index.ts
+++ b/sdks/sdk-typescript/src/index.ts
@@ -3,8 +3,7 @@ export { AgentVault } from "./client.js";
 export { VaultClient } from "./vault.js";
 
 // Errors
-export { AgentVaultError, ApiError, ProxyForbiddenError } from "./errors.js";
-export type { ProposalHint } from "./errors.js";
+export { AgentVaultError, ApiError } from "./errors.js";
 
 // Config types
 export type { AgentVaultConfig, VaultClientConfig, ClientConfig } from "./types.js";


### PR DESCRIPTION
## Summary

Post-merge review on #143 surfaced three valid issues. Doc-only + dead-code SDK cleanup, no runtime behavior change.

- **[docs/self-hosting/local.mdx](docs/self-hosting/local.mdx)** — the HTTP/2 Warning claimed h2 traffic is "forwarded uninspected." It isn't: [internal/mitm/connect.go:101](internal/mitm/connect.go#L101) pins ALPN to `http/1.1`, so dual-protocol clients fall back to http/1.1 and have credentials injected normally; h2-only clients fail the TLS handshake with `no_application_protocol`. Rewrote the Warning to match.
- **[docs/quickstart/nanoclaw.mdx](docs/quickstart/nanoclaw.mdx) / [docs/quickstart/openclaw.mdx](docs/quickstart/openclaw.mdx)** — Note claimed the redemption response includes HTTPS_PROXY and the CA. It returns `{av_addr, av_agent_token, agent_name, vaults, instructions}` only; the agent assembles the URL and fetches `/v1/mitm/ca.pem` itself. Reworded to describe what the response actually carries.
- **[sdks/sdk-typescript](sdks/sdk-typescript)** — `ProxyForbiddenError` / `ProposalHint` and the `proposal_hint` parsing branch in `ApiError.fromResponse` were unreachable from the SDK after #143 (only [internal/mitm/forward.go:101](internal/mitm/forward.go#L101) emits `proposal_hint`, and the SDK never carries proxied traffic). Dropped the exports, the parsing branch, and the README parenthetical.

## Out of scope (separate follow-up)

The reviewer also flagged that [internal/server/handle_agents.go:368](internal/server/handle_agents.go#L368) and [:416](internal/server/handle_agents.go#L416) hardcode `persistentInstructionsAdmin` for every redemption, leaving `persistent_instructions_member.txt` / `persistent_instructions_proxy.txt` / `instructions.txt` / `persistent_agent_instructions.txt` as orphan files with no `//go:embed`. That's pre-existing on `main` (not introduced by #143) and deserves its own PR — either embed all four and select by role, or delete the orphans.

## Test plan

- [x] `npm run typecheck` in `sdks/sdk-typescript` — clean
- [x] `npm run test` in `sdks/sdk-typescript` — 91/91 pass
- [ ] Mintlify preview renders the rewritten Warning + Notes correctly