### PR TITLE
mitm: address post-merge review on #150 (IPv6 + Host header + doc sync)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ sudo mv agent-vault /usr/local/bin/
 agent-vault server -d
 ```
 
-The server starts the HTTP API on port `14321` and a TLS-encrypted transparent HTTPS proxy on port `14322`. A web UI is available at `http://localhost:14321`.
+The server starts the HTTP API on port `14321` and a TLS-encrypted transparent HTTP/HTTPS proxy on port `14322` — the same listener handles `CONNECT` for `https://` upstreams and absolute-form forward-proxy requests for `http://` upstreams. A web UI is available at `http://localhost:14321`.
 
 ## Quickstart
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -138,15 +138,15 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 		"AGENT_VAULT_VAULT="+vault,
 	)
 
-	// 6. Route the child's HTTPS traffic through the transparent MITM
-	//    proxy. The MITM ingress is the only credential-injection path,
-	//    so a failure here is fatal.
+	// 6. Route the child's HTTP and HTTPS traffic through the transparent
+	//    MITM proxy. The MITM ingress is the only credential-injection
+	//    path, so a failure here is fatal.
 	newEnv, mitmPort, err := requireMITMEnv(env, addr, scopedToken, vault, "")
 	if err != nil {
 		return err
 	}
 	env = newEnv
-	fmt.Fprintf(os.Stderr, "%s routing HTTPS through MITM proxy (127.0.0.1:%d)\n", successText("agent-vault:"), mitmPort)
+	fmt.Fprintf(os.Stderr, "%s routing HTTP/HTTPS through MITM proxy (127.0.0.1:%d)\n", successText("agent-vault:"), mitmPort)
 
 	// 7. If the target command is a supported agent, offer to install the
 	//    Agent Vault skill (only when not already present).

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -14,7 +14,7 @@ metadata:
 
 # Agent Vault (CLI)
 
-You have access to Agent Vault, a transparent HTTPS proxy that injects credentials into your outbound calls. You never see or handle credentials directly -- make API calls to the real host as normal and Agent Vault attaches the real credentials at the proxy boundary.
+You have access to Agent Vault, a transparent HTTP/HTTPS proxy that injects credentials into your outbound calls. You never see or handle credentials directly -- make API calls to the real host as normal (over `https://` or `http://`) and Agent Vault attaches the real credentials at the proxy boundary.
 
 ## CRITICAL: Always Check Agent Vault First
 

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -1,7 +1,7 @@
 ---
 name: agent-vault-http
 description: >-
-  Agent Vault HTTP: a transparent HTTPS proxy that injects credentials for
+  Agent Vault HTTP: a transparent HTTP/HTTPS proxy that injects credentials for
   external services (Linear, GitHub, Stripe, Slack, Jira, etc.). Use when the
   task involves any third-party API or service that requires credentials, or
   when writing code that needs environment variables for secrets/API keys.
@@ -13,7 +13,7 @@ metadata:
 
 # Agent Vault (HTTP)
 
-You have access to Agent Vault, a transparent HTTPS proxy that injects credentials into your outbound calls. You never see or handle credentials directly -- make API calls to the real host as normal and Agent Vault attaches the real credentials at the proxy boundary.
+You have access to Agent Vault, a transparent HTTP/HTTPS proxy that injects credentials into your outbound calls. You never see or handle credentials directly -- make API calls to the real host as normal (over `https://` or `http://`) and Agent Vault attaches the real credentials at the proxy boundary.
 
 ## CRITICAL: Always Check Agent Vault First
 
@@ -159,7 +159,7 @@ Content-Type: application/json
 }
 ```
 
-Once approved, the agent makes requests like `GET https://api.twilio.com/2010-04-01/Accounts/__account_sid__/Messages.json` (via `HTTPS_PROXY`). The broker rewrites the path to `/Accounts/AC.../Messages.json` and injects the basic auth header.
+Once approved, the agent makes requests like `GET https://api.twilio.com/2010-04-01/Accounts/__account_sid__/Messages.json` (routed through the broker via `HTTPS_PROXY`/`HTTP_PROXY`). The broker rewrites the path to `/Accounts/AC.../Messages.json` and injects the basic auth header.
 
 Placeholder safety: must be ≥4 characters, contain at least one alphanumeric character, contain a `__` boundary or non-`[A-Za-z0-9_]` character (so bare words like `account_sid` are rejected — they would match legitimate URL words), and use only RFC 3986 unreserved characters `[A-Za-z0-9_-.~]`. The recommended convention is `__name__`.
 

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -9,7 +9,7 @@ There are two ways to connect an agent: **wrapping** a local process or **inviti
 
 ## Wrapping with `vault run`
 
-The simplest approach for local development. Wraps a local agent process with the environment variables it needs — no invite, no token management. `vault run` also pre-configures `HTTPS_PROXY` and the CA trust chain on the child, so the agent calls upstream URLs directly and Agent Vault transparently injects credentials at the proxy boundary.
+The simplest approach for local development. Wraps a local agent process with the environment variables it needs — no invite, no token management. `vault run` also pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and the CA trust chain on the child, so the agent calls upstream URLs directly (over `https://` or `http://`) and Agent Vault transparently injects credentials at the proxy boundary.
 
 ```bash
 agent-vault vault run -- claude    # Claude Code
@@ -19,7 +19,7 @@ agent-vault vault run --vault my-vault -- claude
 The agent receives a temporary, vault-scoped session and can immediately make authenticated requests and raise proposals.
 
 <Note>
-`vault run` is a convenience wrapper, not a sandbox. A child process can unset `HTTPS_PROXY` or bypass the injected CA and reach the network directly — local credentials and network access are still fully available to the agent. Stronger isolation for local development is on the roadmap.
+`vault run` is a convenience wrapper, not a sandbox. A child process can unset `HTTPS_PROXY`/`HTTP_PROXY` or bypass the injected CA and reach the network directly — local credentials and network access are still fully available to the agent. Stronger isolation for local development is on the roadmap.
 </Note>
 
 ## Inviting an agent
@@ -159,5 +159,5 @@ When in doubt, start with `agent-vault vault run`. You can always create a named
 Regardless of how an agent connects, it follows the same [protocol](/agents/protocol):
 
 1. Call `/discover` to learn which services are available
-2. Call upstream URLs directly — `HTTPS_PROXY` routes the request through Agent Vault transparently
+2. Call upstream URLs directly (over `https://` or `http://`) — `HTTPS_PROXY`/`HTTP_PROXY` routes the request through Agent Vault transparently
 3. Raise [proposals](/learn/proposals) when access to a new service is needed

--- a/docs/agents/protocol.mdx
+++ b/docs/agents/protocol.mdx
@@ -86,7 +86,7 @@ The agent writes this line unchanged. No URL rewriting. No `Authorization` heade
 
 | Variable | Purpose |
 |---|---|
-| `HTTPS_PROXY` | Points at the MITM listener (`http://{token}:{vault}@host:14322`) |
+| `HTTPS_PROXY` | Points at the MITM listener (`https://{token}:{vault}@host:14322`) — the listener is TLS-wrapped, so the proxy URL itself is HTTPS |
 | `HTTP_PROXY` | Same URL as `HTTPS_PROXY` — plain `http://` upstreams route through the same TLS-wrapped listener via absolute-form forward-proxy requests |
 | `NO_PROXY` | `localhost,127.0.0.1` — so agent-to-vault traffic skips the proxy |
 | `NODE_USE_ENV_PROXY` | `1` — enables Node.js v22.21+ built-in proxy support for `fetch()` and `http.get()`/`https.get()` |

--- a/docs/agents/protocol.mdx
+++ b/docs/agents/protocol.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Agent protocol"
-description: "How agents authenticate, discover services, route requests through HTTPS_PROXY, and propose changes through Agent Vault."
+description: "How agents authenticate, discover services, route requests through HTTPS_PROXY/HTTP_PROXY, and propose changes through Agent Vault."
 ---
 
 Agent Vault agents follow a standard HTTP protocol to interact with the server. Agents handle this automatically — the instructions are embedded in every invite response and in the [agent skill files](https://github.com/Infisical/agent-vault/blob/main/cmd/skill_http.md). This page is a reference for understanding what happens under the hood.
@@ -72,9 +72,9 @@ The `X-Vault` header is required for instance-level agent tokens. Vault-scoped s
 - **`services`** lists the hosts the agent can reach through Agent Vault (defined by the vault's [services](/learn/services)). Requests to any other host go direct.
 - **`available_credentials`** lists [credential](/learn/credentials) key names in the vault (values are never exposed). Agents use these to avoid creating duplicate slots in [proposals](/learn/proposals).
 
-## Route requests through HTTPS_PROXY
+## Route requests through HTTPS_PROXY / HTTP_PROXY
 
-The canonical way for an agent to reach an upstream host is to call the real URL directly. `agent-vault vault run` pre-configures `HTTPS_PROXY` and the CA trust chain on the child process, so every standard HTTP client — `curl`, `fetch`, `requests`, `axios`, the Go stdlib, SDKs like `stripe-node`, CLIs like `gh` and `stripe` — transparently routes through the broker. Agent Vault intercepts the CONNECT, matches the target host against the vault's [services](/learn/services), and injects the stored credential into the auth header for that service. Other client headers (vendor headers like `anthropic-version`, tracing IDs, etc.) flow through unchanged — see [Header forwarding](/learn/services#header-forwarding) for the precise rules.
+The canonical way for an agent to reach an upstream host is to call the real URL directly. `agent-vault vault run` pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and the CA trust chain on the child process, so every standard HTTP client — `curl`, `fetch`, `requests`, `axios`, the Go stdlib, SDKs like `stripe-node`, CLIs like `gh` and `stripe` — transparently routes through the broker. Agent Vault intercepts the CONNECT (for `https://` upstreams) or the absolute-form forward-proxy request (for `http://` upstreams), matches the target host against the vault's [services](/learn/services), and injects the stored credential into the auth header for that service. Other client headers (vendor headers like `anthropic-version`, tracing IDs, etc.) flow through unchanged — see [Header forwarding](/learn/services#header-forwarding) for the precise rules.
 
 ```
 GET https://api.stripe.com/v1/charges?limit=10

--- a/docs/guides/connect-custom-agent.mdx
+++ b/docs/guides/connect-custom-agent.mdx
@@ -38,7 +38,7 @@ If you're using Claude Code, Cursor, or another supported agent, see the [Quicks
     - `av_agent_token` — bearer token for all requests
     - `vaults` — list of accessible vaults
 
-    Invited agents don't get `HTTPS_PROXY`/`HTTP_PROXY` auto-configured — set them yourself (see [Set the proxy env vars manually](#set-https-proxy-manually)).
+    Invited agents don't get `HTTPS_PROXY`/`HTTP_PROXY` auto-configured — set them yourself (see [Set the proxy env vars manually](#set-the-proxy-env-vars-manually)).
 
     Instance-level agent tokens require the `X-Vault` header on every vault-scoped request.
   </Tab>

--- a/docs/guides/connect-custom-agent.mdx
+++ b/docs/guides/connect-custom-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Connect a custom agent"
-description: "Wire up a custom agent or script to Agent Vault through HTTPS_PROXY and the transparent CA."
+description: "Wire up a custom agent or script to Agent Vault through HTTPS_PROXY/HTTP_PROXY and the transparent CA."
 ---
 
 This guide walks through connecting a custom agent to Agent Vault. Use this when you're building your own sandboxed agent, a CI pipeline, or any process that needs to make authenticated API calls through Agent Vault.
@@ -24,7 +24,7 @@ If you're using Claude Code, Cursor, or another supported agent, see the [Quicks
     agent-vault vault run -- my-agent
     ```
 
-    `vault run` sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT` on the child, then pre-configures `HTTPS_PROXY` and the CA trust chain so standard HTTP clients transparently route through the broker. No invite needed.
+    `vault run` sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT` on the child, then pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and the CA trust chain so standard HTTP clients route both HTTP and HTTPS traffic through the broker transparently. No invite needed.
   </Tab>
   <Tab title="Agent invite">
     For CI pipelines, cloud-hosted agents, or when you need the agent to redeem an invite via HTTP:
@@ -38,7 +38,7 @@ If you're using Claude Code, Cursor, or another supported agent, see the [Quicks
     - `av_agent_token` — bearer token for all requests
     - `vaults` — list of accessible vaults
 
-    Invited agents don't get `HTTPS_PROXY` auto-configured — set it yourself (see [Set HTTPS_PROXY manually](#set-https-proxy-manually)).
+    Invited agents don't get `HTTPS_PROXY`/`HTTP_PROXY` auto-configured — set them yourself (see [Set the proxy env vars manually](#set-https-proxy-manually)).
 
     Instance-level agent tokens require the `X-Vault` header on every vault-scoped request.
   </Tab>
@@ -59,14 +59,15 @@ When the agent is launched via `vault run`, these additional variables are also 
 
 | Variable | Purpose |
 |---|---|
-| `HTTPS_PROXY` | Routes HTTPS traffic through the transparent proxy |
+| `HTTPS_PROXY` | Routes HTTPS traffic through the transparent proxy (CONNECT) |
+| `HTTP_PROXY` | Same TLS-wrapped URL as `HTTPS_PROXY` — plain `http://` upstreams route through the same listener via absolute-form forward-proxy requests |
 | `NO_PROXY` | `localhost,127.0.0.1` — so agent-to-vault traffic skips the proxy |
 | `NODE_USE_ENV_PROXY` | Enables Node.js 22.21+ built-in proxy support |
 | `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT` | Trust the Agent Vault root CA from standard HTTP libraries |
 
 ## Make requests
 
-When your agent is launched via `vault run`, HTTPS traffic already routes through Agent Vault transparently. Call the real API URL — standard HTTP clients honor `HTTPS_PROXY` automatically. Agent Vault intercepts the CONNECT, matches the host against the vault's [services](/learn/services), and injects the stored credential into the auth header for that service over HTTPS.
+When your agent is launched via `vault run`, HTTP and HTTPS traffic both route through Agent Vault transparently. Call the real API URL — standard HTTP clients honor `HTTPS_PROXY`/`HTTP_PROXY` automatically. Agent Vault intercepts the CONNECT (for `https://` upstreams) or the absolute-form forward-proxy request (for `http://` upstreams), matches the host against the vault's [services](/learn/services), and injects the stored credential into the auth header for that service.
 
 <CodeGroup>
 
@@ -88,7 +89,7 @@ print(new_charge.json())
 ```
 
 ```typescript TypeScript
-// fetch() in Node.js v22.21+ honors HTTPS_PROXY when NODE_USE_ENV_PROXY=1.
+// fetch() in Node.js v22.21+ honors HTTPS_PROXY/HTTP_PROXY when NODE_USE_ENV_PROXY=1.
 const charges = await fetch("https://api.stripe.com/v1/charges?limit=10");
 console.log(await charges.json());
 
@@ -115,9 +116,9 @@ Any HTTP method works (GET, POST, PUT, DELETE, PATCH). Query parameters, request
 Leave the upstream `Authorization` header blank or set it to a placeholder — Agent Vault strips whatever the client sends and attaches the real credential at the proxy boundary.
 </Tip>
 
-### Set HTTPS_PROXY manually
+### Set the proxy env vars manually
 
-If your agent wasn't launched via `vault run` (e.g. an invited agent, a Docker container, a sandboxed runtime), configure the proxy yourself. The MITM listener is TLS-encrypted, so the proxy URL uses the `https://` scheme and needs the root CA trusted.
+If your agent wasn't launched via `vault run` (e.g. an invited agent, a Docker container, a sandboxed runtime), configure the proxy yourself. The MITM listener is TLS-encrypted, so the proxy URL uses the `https://` scheme and needs the root CA trusted. Set `HTTPS_PROXY` and `HTTP_PROXY` to the same URL — the listener handles `CONNECT` (for `https://` upstreams) and absolute-form forward-proxy requests (for `http://` upstreams) on the same port.
 
 ```bash
 # 1. Fetch the CA certificate
@@ -125,6 +126,7 @@ agent-vault ca fetch -o /etc/ssl/certs/agent-vault-ca.pem
 
 # 2. Build the proxy URL (basic auth: token:vault)
 export HTTPS_PROXY="https://${AGENT_VAULT_SESSION_TOKEN}:my-vault@127.0.0.1:14322"
+export HTTP_PROXY="$HTTPS_PROXY"
 export NO_PROXY="localhost,127.0.0.1"
 export NODE_USE_ENV_PROXY=1
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -21,8 +21,8 @@ Enter Agent Vault - a new credential management solution built for agents that p
 
 ## How it works
 
-1. You point the agent at Agent Vault by setting `HTTPS_PROXY` and trusting the Agent Vault CA certificate.
-2. The agent makes API calls the way it normally would — direct `fetch`, a vendor SDK, a CLI like `gh` or `stripe`, or an MCP server. All outbound HTTPS transparently routes through the Agent Vault proxy.
+1. You point the agent at Agent Vault by setting `HTTPS_PROXY`/`HTTP_PROXY` and trusting the Agent Vault CA certificate.
+2. The agent makes API calls the way it normally would — direct `fetch`, a vendor SDK, a CLI like `gh` or `stripe`, or an MCP server. All outbound HTTP and HTTPS traffic transparently routes through the Agent Vault proxy.
 3. Agent Vault matches the target host against the services in the [vault](/learn/vaults), injects the stored credential into the auth header for that service, and forwards the request upstream with the agent's other headers intact.
 4. If no service matches the host, the agent can raise a [**proposal**](/learn/proposals) requesting access. You review and approve in the browser, pasting in the API key, and the next request succeeds.
 

--- a/docs/learn/security.mdx
+++ b/docs/learn/security.mdx
@@ -115,9 +115,9 @@ This means:
 - The agent's token never reaches the target service.
 - Credential values only exist in the outbound request headers, never in the agent's address space.
 
-### Transparent proxy (HTTPS_PROXY) transport
+### Transparent proxy transport
 
-The MITM listener that backs `HTTPS_PROXY` is itself TLS-wrapped with a cert signed by the software-backed root CA. This means the CONNECT handshake carrying the agent's session token is encrypted end-to-end between the client and the broker — session tokens are never exposed in plaintext on the wire, even on an untrusted local network.
+The MITM listener that backs `HTTPS_PROXY` and `HTTP_PROXY` is itself TLS-wrapped with a cert signed by the software-backed root CA. This means both the CONNECT handshake (for `https://` upstreams) and absolute-form forward-proxy requests (for `http://` upstreams) carry the agent's session token encrypted end-to-end between the client and the broker — session tokens are never exposed in plaintext on the wire, even on an untrusted local network.
 
 - **Root CA private key** is encrypted at rest with the DEK (same key that wraps credentials). See [Encryption at rest](#encryption-at-rest).
 - **DNS rebinding protection** and **[netguard](#network-security)** — every outbound connection is resolved and validated against the IP blocklist before Agent Vault dials the upstream.

--- a/docs/learn/services.mdx
+++ b/docs/learn/services.mdx
@@ -184,7 +184,7 @@ services:
         in: [path]
 ```
 
-The agent then sends `GET https://api.twilio.com/2010-04-01/Accounts/__account_sid__/Messages.json` (via `HTTPS_PROXY`). Agent Vault:
+The agent then sends `GET https://api.twilio.com/2010-04-01/Accounts/__account_sid__/Messages.json` (routed through the broker via `HTTPS_PROXY`/`HTTP_PROXY`). Agent Vault:
 
 1. Resolves the basic auth credentials and injects `Authorization: Basic <base64(SID:TOKEN)>`.
 2. Scans only the path (the only surface in `in:`), finds `__account_sid__`, replaces it with the URL-encoded SID.

--- a/docs/quickstart/claude-code.mdx
+++ b/docs/quickstart/claude-code.mdx
@@ -10,7 +10,7 @@ description: "Learn how to connect Claude Code to Agent Vault so it can make aut
 
 ## Quick start
 
-Launch Claude Code with `vault run`. It wraps Claude Code with a vault-scoped session, pre-configures `HTTPS_PROXY` and CA trust so outbound HTTPS routes through Agent Vault transparently, and installs the Agent Vault skill so Claude knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
+Launch Claude Code with `vault run`. It wraps Claude Code with a vault-scoped session, pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and CA trust so outbound HTTP and HTTPS traffic both route through Agent Vault transparently, and installs the Agent Vault skill so Claude knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault run -- claude
@@ -36,7 +36,7 @@ Ask Claude Code to do something that requires an external API:
 
 Here's what happens — with zero pre-configuration:
 
-1. Claude Code calls `https://api.stripe.com/...` directly. `HTTPS_PROXY` routes the call through Agent Vault
+1. Claude Code calls `https://api.stripe.com/...` (or `http://internal.example/...`) directly. `HTTPS_PROXY`/`HTTP_PROXY` routes the call through Agent Vault
 2. Agent Vault returns a **403** — Stripe isn't configured yet
 3. Claude Code reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. Claude Code presents you with an approval link

--- a/docs/quickstart/codex.mdx
+++ b/docs/quickstart/codex.mdx
@@ -10,7 +10,7 @@ description: "Learn how to connect Codex to Agent Vault so it can make authentic
 
 ## Quick start
 
-Launch Codex with `vault run`. It wraps Codex with a vault-scoped session, pre-configures `HTTPS_PROXY` and CA trust so outbound HTTPS routes through Agent Vault transparently, and installs the Agent Vault skill so Codex knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
+Launch Codex with `vault run`. It wraps Codex with a vault-scoped session, pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and CA trust so outbound HTTP and HTTPS traffic both route through Agent Vault transparently, and installs the Agent Vault skill so Codex knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault run -- codex
@@ -36,7 +36,7 @@ Ask Codex to do something that requires an external API:
 
 Here's what happens — with zero pre-configuration:
 
-1. Codex calls `https://api.stripe.com/...` directly. `HTTPS_PROXY` routes the call through Agent Vault
+1. Codex calls `https://api.stripe.com/...` (or `http://internal.example/...`) directly. `HTTPS_PROXY`/`HTTP_PROXY` routes the call through Agent Vault
 2. Agent Vault returns a **403** — Stripe isn't configured yet
 3. Codex reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. Codex presents you with an approval link

--- a/docs/quickstart/cursor.mdx
+++ b/docs/quickstart/cursor.mdx
@@ -10,7 +10,7 @@ description: "Learn how to connect Cursor to Agent Vault so it can make authenti
 
 ## Quick start
 
-Launch Cursor with `vault run`. It wraps Cursor with a vault-scoped session, pre-configures `HTTPS_PROXY` and CA trust so outbound HTTPS routes through Agent Vault transparently, and installs the Agent Vault skill so Cursor knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
+Launch Cursor with `vault run`. It wraps Cursor with a vault-scoped session, pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and CA trust so outbound HTTP and HTTPS traffic both route through Agent Vault transparently, and installs the Agent Vault skill so Cursor knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault run -- agent
@@ -36,7 +36,7 @@ Ask Cursor to do something that requires an external API:
 
 Here's what happens — with zero pre-configuration:
 
-1. Cursor calls `https://api.stripe.com/...` directly. `HTTPS_PROXY` routes the call through Agent Vault
+1. Cursor calls `https://api.stripe.com/...` (or `http://internal.example/...`) directly. `HTTPS_PROXY`/`HTTP_PROXY` routes the call through Agent Vault
 2. Agent Vault returns a **403** — Stripe isn't configured yet
 3. Cursor reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. Cursor presents you with an approval link

--- a/docs/quickstart/custom-agent.mdx
+++ b/docs/quickstart/custom-agent.mdx
@@ -59,7 +59,7 @@ Your agent never sees or handles credentials. Agent Vault strips whatever the cl
 ## Other connection flows
 
 - **Agent invites** — for cloud-hosted agents or CI pipelines that can't be wrapped with `vault run`. See [Connect a custom agent](/guides/connect-custom-agent#get-connection-credentials).
-- **Manual proxy setup** — for containerized agents and sandboxes that need to configure the proxy themselves. See [Set HTTPS_PROXY/HTTP_PROXY manually](/guides/connect-custom-agent#set-https-proxy-manually).
+- **Manual proxy setup** — for containerized agents and sandboxes that need to configure the proxy themselves. See [Set the proxy env vars manually](/guides/connect-custom-agent#set-the-proxy-env-vars-manually).
 
 ## Discover available services
 

--- a/docs/quickstart/custom-agent.mdx
+++ b/docs/quickstart/custom-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Custom Agent"
-description: "Connect any HTTP-capable agent or script to Agent Vault through HTTPS_PROXY."
+description: "Connect any HTTP-capable agent or script to Agent Vault through HTTPS_PROXY/HTTP_PROXY."
 ---
 
 ## Prerequisites
@@ -10,7 +10,7 @@ description: "Connect any HTTP-capable agent or script to Agent Vault through HT
 
 ## Quick start
 
-Wrap your agent process with `vault run`. It sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT`, then pre-configures `HTTPS_PROXY` and the CA trust chain so standard HTTP clients transparently route through the broker:
+Wrap your agent process with `vault run`. It sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT`, then pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and the CA trust chain so standard HTTP clients route both HTTP and HTTPS traffic through the broker transparently:
 
 ```bash
 agent-vault vault run -- my-agent
@@ -24,7 +24,7 @@ agent-vault vault run --vault myproject -- my-agent
 
 ## Try it out
 
-Your agent calls real API URLs directly. `HTTPS_PROXY` routes the request through Agent Vault, which matches the host against the vault's [services](/learn/services) and injects the stored credential into the auth header for that service.
+Your agent calls real API URLs directly (over `https://` or `http://`). `HTTPS_PROXY`/`HTTP_PROXY` routes the request through Agent Vault, which matches the host against the vault's [services](/learn/services) and injects the stored credential into the auth header for that service.
 
 <CodeGroup>
 
@@ -59,7 +59,7 @@ Your agent never sees or handles credentials. Agent Vault strips whatever the cl
 ## Other connection flows
 
 - **Agent invites** — for cloud-hosted agents or CI pipelines that can't be wrapped with `vault run`. See [Connect a custom agent](/guides/connect-custom-agent#get-connection-credentials).
-- **Manual HTTPS_PROXY setup** — for containerized agents and sandboxes that need to configure the proxy themselves. See [Set HTTPS_PROXY manually](/guides/connect-custom-agent#set-https-proxy-manually).
+- **Manual proxy setup** — for containerized agents and sandboxes that need to configure the proxy themselves. See [Set HTTPS_PROXY/HTTP_PROXY manually](/guides/connect-custom-agent#set-https-proxy-manually).
 
 ## Discover available services
 
@@ -86,7 +86,7 @@ Requests to hosts not in `services` go direct, not through the proxy.
 
 <CardGroup cols={2}>
   <Card title="Connect a custom agent" icon="plug" href="/guides/connect-custom-agent">
-    Full guide with manual HTTPS_PROXY setup, error handling, and proposals.
+    Full guide with manual proxy setup, error handling, and proposals.
   </Card>
   <Card title="Agent protocol" icon="code" href="/agents/protocol">
     HTTP reference for sessions, discovery, and proposals.

--- a/docs/quickstart/hermes-agent.mdx
+++ b/docs/quickstart/hermes-agent.mdx
@@ -10,7 +10,7 @@ description: "Learn how to connect Hermes Agent to Agent Vault so it can make au
 
 ## Quick start
 
-Launch Hermes Agent with `vault run`. It wraps Hermes with a vault-scoped session, pre-configures `HTTPS_PROXY` and CA trust so outbound HTTPS routes through Agent Vault transparently, and installs the Agent Vault skills so Hermes knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
+Launch Hermes Agent with `vault run`. It wraps Hermes with a vault-scoped session, pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and CA trust so outbound HTTP and HTTPS traffic both route through Agent Vault transparently, and installs the Agent Vault skills so Hermes knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault run -- hermes
@@ -36,7 +36,7 @@ Ask Hermes Agent to do something that requires an external API:
 
 Here's what happens — with zero pre-configuration:
 
-1. Hermes Agent calls `https://api.stripe.com/...` directly. `HTTPS_PROXY` routes the call through Agent Vault
+1. Hermes Agent calls `https://api.stripe.com/...` (or `http://ai/v1/...`) directly. `HTTPS_PROXY`/`HTTP_PROXY` routes the call through Agent Vault
 2. Agent Vault returns a **403** — Stripe isn't configured yet
 3. Hermes Agent reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. Hermes Agent presents you with an approval link

--- a/docs/quickstart/nanoclaw.mdx
+++ b/docs/quickstart/nanoclaw.mdx
@@ -32,7 +32,7 @@ Ask NanoClaw to do something that requires an external API:
 
 Here's what happens — with zero pre-configuration:
 
-1. NanoClaw routes a request to `https://api.stripe.com/...` through Agent Vault via `HTTPS_PROXY`
+1. NanoClaw routes a request to `https://api.stripe.com/...` (or `http://internal.example/...`) through Agent Vault via `HTTPS_PROXY`/`HTTP_PROXY`
 2. Agent Vault returns a **403** — Stripe isn't configured yet
 3. NanoClaw reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. NanoClaw presents you with an approval link

--- a/docs/quickstart/nanoclaw.mdx
+++ b/docs/quickstart/nanoclaw.mdx
@@ -40,7 +40,7 @@ Here's what happens — with zero pre-configuration:
 6. NanoClaw retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
 
 <Note>
-Invited agents like NanoClaw build their own `HTTPS_PROXY` from the token + vault returned by the redemption response and fetch the root CA from `{AGENT_VAULT_ADDR}/v1/mitm/ca.pem` themselves — the embedded `instructions` field walks them through it. Local agents you wrap with `agent-vault vault run` (Claude Code, Cursor, Codex, Hermes) inherit the same env vars automatically.
+Invited agents like NanoClaw build their own `HTTPS_PROXY`/`HTTP_PROXY` from the token + vault returned by the redemption response (both env vars point at the same TLS-wrapped MITM URL so plain `http://` upstreams route through the broker via absolute-form forward-proxy requests) and fetch the root CA from `{AGENT_VAULT_ADDR}/v1/mitm/ca.pem` themselves — the embedded `instructions` field walks them through it. Local agents you wrap with `agent-vault vault run` (Claude Code, Cursor, Codex, Hermes) inherit the same env vars automatically.
 </Note>
 
 <Note>

--- a/docs/quickstart/openclaw.mdx
+++ b/docs/quickstart/openclaw.mdx
@@ -40,7 +40,7 @@ Here's what happens — with zero pre-configuration:
 6. OpenClaw retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
 
 <Note>
-Invited agents like OpenClaw build their own `HTTPS_PROXY` from the token + vault returned by the redemption response and fetch the root CA from `{AGENT_VAULT_ADDR}/v1/mitm/ca.pem` themselves — the embedded `instructions` field walks them through it. Local agents you wrap with `agent-vault vault run` (Claude Code, Cursor, Codex, Hermes) inherit the same env vars automatically.
+Invited agents like OpenClaw build their own `HTTPS_PROXY`/`HTTP_PROXY` from the token + vault returned by the redemption response (both env vars point at the same TLS-wrapped MITM URL so plain `http://` upstreams route through the broker via absolute-form forward-proxy requests) and fetch the root CA from `{AGENT_VAULT_ADDR}/v1/mitm/ca.pem` themselves — the embedded `instructions` field walks them through it. Local agents you wrap with `agent-vault vault run` (Claude Code, Cursor, Codex, Hermes) inherit the same env vars automatically.
 </Note>
 
 <Note>

--- a/docs/quickstart/openclaw.mdx
+++ b/docs/quickstart/openclaw.mdx
@@ -32,7 +32,7 @@ Ask OpenClaw to do something that requires an external API:
 
 Here's what happens — with zero pre-configuration:
 
-1. OpenClaw routes a request to `https://api.stripe.com/...` through Agent Vault via `HTTPS_PROXY`
+1. OpenClaw routes a request to `https://api.stripe.com/...` (or `http://internal.example/...`) through Agent Vault via `HTTPS_PROXY`/`HTTP_PROXY`
 2. Agent Vault returns a **403** — Stripe isn't configured yet
 3. OpenClaw reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. OpenClaw presents you with an approval link

--- a/docs/quickstart/opencode.mdx
+++ b/docs/quickstart/opencode.mdx
@@ -10,7 +10,7 @@ description: "Learn how to connect OpenCode to Agent Vault so it can make authen
 
 ## Quick start
 
-Launch OpenCode with `vault run`. It wraps OpenCode with a vault-scoped session, pre-configures `HTTPS_PROXY` and CA trust so outbound HTTPS routes through Agent Vault transparently, and installs the Agent Vault skills so OpenCode knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
+Launch OpenCode with `vault run`. It wraps OpenCode with a vault-scoped session, pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and CA trust so outbound HTTP and HTTPS traffic both route through Agent Vault transparently, and installs the Agent Vault skills so OpenCode knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
 
 ```bash
 agent-vault vault run -- opencode
@@ -36,7 +36,7 @@ Ask OpenCode to do something that requires an external API:
 
 Here's what happens — with zero pre-configuration:
 
-1. OpenCode calls `https://api.stripe.com/...` directly. `HTTPS_PROXY` routes the call through Agent Vault
+1. OpenCode calls `https://api.stripe.com/...` (or `http://internal.example/...`) directly. `HTTPS_PROXY`/`HTTP_PROXY` routes the call through Agent Vault
 2. Agent Vault returns a **403** — Stripe isn't configured yet
 3. OpenCode reads the `proposal_hint` and creates a proposal requesting Stripe access
 4. OpenCode presents you with an approval link

--- a/docs/self-hosting/docker.mdx
+++ b/docs/self-hosting/docker.mdx
@@ -21,7 +21,7 @@ The final image runs as non-root user `agentvault` (UID 65532) and includes a bu
 
 ## Configuration
 
-Expose both the HTTP API (`14321`) and the transparent HTTPS proxy (`14322`) so agents' `HTTPS_PROXY` can reach the broker. Pass the master password via environment variable to wrap the data encryption key (DEK):
+Expose both the HTTP API (`14321`) and the transparent HTTP/HTTPS proxy (`14322`) so agents' `HTTPS_PROXY`/`HTTP_PROXY` can reach the broker. Pass the master password via environment variable to wrap the data encryption key (DEK):
 
 ```bash
 docker run -it -p 14321:14321 -p 14322:14322 \

--- a/docs/self-hosting/environment-variables.mdx
+++ b/docs/self-hosting/environment-variables.mdx
@@ -21,7 +21,7 @@ description: "All environment variables used to configure Agent Vault"
 | `AGENT_VAULT_LOGS_MAX_AGE_HOURS` | `168` | Retention for the per-vault request log (surfaced in **Vault → Logs**). Rows older than this many hours are trimmed by a background job every 15 minutes. Only secret-free metadata is stored (method, host, path, status, latency, matched service, credential key names) — never bodies or query strings. |
 | `AGENT_VAULT_LOGS_MAX_ROWS_PER_VAULT` | `10000` | Per-vault row cap for the request log. Whichever limit (age or rows) hits first wins, so heavy-traffic vaults retain a shorter window than the time-based TTL alone would suggest. Set to `0` to disable the row cap. |
 | `AGENT_VAULT_LOGS_RETENTION_LOCK` | `false` | When `true`, any owner-UI overrides for log retention are ignored and env values (or defaults) are pinned. Use when you want retention limits controlled only by the operator. |
-| `AGENT_VAULT_ISOLATION` | `host` | Default isolation mode for `agent-vault vault run`. `host` forks the child on the host with `HTTPS_PROXY` envvars (cooperative). `container` launches it inside a Docker container with iptables-locked egress (non-cooperative; see [Container isolation](/guides/container-isolation)). The `--isolation` flag overrides this. |
+| `AGENT_VAULT_ISOLATION` | `host` | Default isolation mode for `agent-vault vault run`. `host` forks the child on the host with `HTTPS_PROXY`/`HTTP_PROXY` envvars (cooperative). `container` launches it inside a Docker container with iptables-locked egress (non-cooperative; see [Container isolation](/guides/container-isolation)). The `--isolation` flag overrides this. |
 
 Master password resolution order:
 
@@ -89,4 +89,4 @@ These variables are set automatically by `agent-vault vault run` on the agent's 
 | `GIT_SSL_CAINFO` | Trusts the root CA in `git` |
 | `DENO_CERT` | Trusts the root CA in Deno |
 
-The CA PEM is written to `~/.agent-vault/mitm-ca.pem` by `vault run` on first launch. Agents use `HTTPS_PROXY` to make authenticated requests to upstream APIs transparently and call `GET {AGENT_VAULT_ADDR}/discover` over the control-plane to learn which services are available.
+The CA PEM is written to `~/.agent-vault/mitm-ca.pem` by `vault run` on first launch. Agents use `HTTPS_PROXY` and `HTTP_PROXY` to make authenticated requests to upstream APIs transparently and call `GET {AGENT_VAULT_ADDR}/discover` over the control-plane to learn which services are available.

--- a/docs/self-hosting/fly-io.mdx
+++ b/docs/self-hosting/fly-io.mdx
@@ -73,7 +73,7 @@ description: "Deploy Agent Vault to Fly.io with persistent storage"
 ## Key details
 
 - **Config**: `fly.toml` exposes port 14321 via Fly's HTTP service (force HTTPS, auto-stop/auto-start) and port 14322 via TCP passthrough for the transparent MITM proxy — the MITM listener's own TLS cert handles the handshake, so Fly doesn't terminate TLS on that port
-- **Agent `HTTPS_PROXY`**: `https://<token>:<vault>@your-app.fly.dev:14322` — the root CA must be trusted by the agent's HTTP client (fetch with [`agent-vault ca fetch --address https://your-app.fly.dev`](docs/reference/cli.mdx))
+- **Agent `HTTPS_PROXY` / `HTTP_PROXY`**: `https://<token>:<vault>@your-app.fly.dev:14322` (the same URL serves both HTTPS via `CONNECT` and plain `http://` via absolute-form forward-proxy requests) — the root CA must be trusted by the agent's HTTP client (fetch with [`agent-vault ca fetch --address https://your-app.fly.dev`](docs/reference/cli.mdx))
 - **Entrypoint**: `scripts/docker-entrypoint.sh` forwards arguments to the `agent-vault` binary, which natively reads `AGENT_VAULT_MASTER_PASSWORD` from the environment
 - **Storage**: Persistent volume `agent_vault_data` mounted at `/data` -- all state is in a single SQLite file
 - **Cold starts**: `min_machines_running` defaults to `0`, so the app scales to zero when idle. The first request after sleep incurs a few seconds of cold-start latency. Set it to `1` in `fly.toml` if you need always-on availability.

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -78,7 +78,7 @@ Subsequent users can self-register via `agent-vault auth register`, the web regi
 
 ## Transparent proxy
 
-Agent Vault exposes a transparent `HTTPS_PROXY` listener on port `14322` — the canonical ingress agents use. Any standard HTTP client that honors `HTTPS_PROXY` (curl, fetch, requests, axios, the Go stdlib, SDKs, CLIs) transparently routes through the broker. The listener is TLS-encrypted (cert signed by the MITM CA) so the CONNECT handshake carrying session tokens is protected.
+Agent Vault exposes a transparent HTTP/HTTPS proxy listener on port `14322` — the canonical ingress agents use. Any standard HTTP client that honors `HTTPS_PROXY`/`HTTP_PROXY` (curl, fetch, requests, axios, the Go stdlib, SDKs, CLIs) transparently routes through the broker. The listener is TLS-encrypted (cert signed by the MITM CA) so the CONNECT handshake (for `https://` upstreams) and the absolute-form forward-proxy request line (for `http://` upstreams) both carry session tokens encrypted on the wire.
 
 ```bash
 agent-vault server               # transparent proxy on 14322 (default)

--- a/examples/daytona-openai-realtime/run.mjs
+++ b/examples/daytona-openai-realtime/run.mjs
@@ -97,6 +97,8 @@ function testDirectEgress() {
   const env = { ...process.env };
   delete env.HTTPS_PROXY;
   delete env.https_proxy;
+  delete env.HTTP_PROXY;
+  delete env.http_proxy;
   const result = spawnSync('curl', ['--max-time', '5', '-fsS', 'https://example.com'], {
     env,
     stdio: 'ignore',
@@ -205,6 +207,7 @@ docker run -d --name agent-example --network av-example \
   -e VAULT_HTTP_PORT=14321 \
   -e VAULT_MITM_PORT=14322 \
   -e HTTPS_PROXY="https://$SESSION_TOKEN:default@host.docker.internal:14322" \
+  -e HTTP_PROXY="https://$SESSION_TOKEN:default@host.docker.internal:14322" \
   -e NO_PROXY="localhost,127.0.0.1,host.docker.internal" \
   -e NODE_EXTRA_CA_CERTS=/etc/agent-vault/ca.pem \
   -e SSL_CERT_FILE=/etc/agent-vault/ca.pem \

--- a/internal/brokercore/brokercore.go
+++ b/internal/brokercore/brokercore.go
@@ -63,7 +63,8 @@ func IsValidHost(h string) bool {
 }
 
 // brokerScopedRequestHeaders are headers that authenticate the client to
-// Agent Vault itself (Proxy-Authorization on the HTTPS_PROXY ingress;
+// Agent Vault itself (Proxy-Authorization on the MITM proxy ingress —
+// reaching it via either HTTPS_PROXY/CONNECT or HTTP_PROXY/absolute-form;
 // X-Vault on the control-plane endpoints used by instance-level agent
 // tokens, e.g. /discover and /v1/proposals). They must never traverse
 // the broker → target hop.

--- a/internal/brokercore/proxyauth.go
+++ b/internal/brokercore/proxyauth.go
@@ -14,7 +14,10 @@ import (
 //   - Basic base64(<token>)                 — token only, no vault hint
 //   - Basic base64(<token>:<vault-name>)    — token + vault hint
 //
-// The Basic form maps directly to HTTPS_PROXY URLs:
+// The Basic form maps directly to HTTPS_PROXY / HTTP_PROXY URLs (both
+// env vars take the same TLS-wrapped proxy URL — the listener accepts
+// CONNECT for https:// upstreams and absolute-form forward-proxy
+// requests for http:// upstreams on the same port):
 //
 //	HTTPS_PROXY=https://<token>@host:port          (scoped session)
 //	HTTPS_PROXY=https://<token>:<vault>@host:port  (instance-level agent token)

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -77,14 +77,18 @@ func (p *Proxy) handleForward(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Canonicalise host and target. r.URL.Host is "host" (no port) or
-	// "host:port" depending on the request line. Default to :80 when
-	// omitted so event.Host and outURL.Host stay consistent with the
-	// CONNECT-path invariant ("host:port present").
-	urlHost := r.URL.Host
-	host, port, err := net.SplitHostPort(urlHost)
-	if err != nil {
-		host = urlHost
+	// Canonicalise host and target. URL.Hostname() strips brackets from
+	// IPv6 literals; URL.Port() returns "" when omitted. Default port to
+	// 80 (http scheme) so event.Host and outURL.Host stay consistent
+	// with the CONNECT-path invariant ("host:port present"). Going
+	// through Hostname()/Port() rather than net.SplitHostPort is what
+	// makes "http://[::1]/path" round-trip cleanly — SplitHostPort
+	// rejects bracketed hosts without a port and the fallback path
+	// would feed a still-bracketed string back through JoinHostPort,
+	// double-bracketing it.
+	host := r.URL.Hostname()
+	port := r.URL.Port()
+	if port == "" {
 		port = "80"
 	}
 	target := net.JoinHostPort(host, port)
@@ -191,7 +195,14 @@ func (p *Proxy) forwardRequest(
 		emit(http.StatusBadGateway, "internal")
 		return
 	}
-	outReq.Host = host
+	// Wire Host header preserves the port for non-default ports, per
+	// RFC 7230 §5.4 (Host field-value MUST equal the URI authority,
+	// excluding userinfo). Stripping the port broke vhost routing on
+	// internal upstreams that key on host:port (k8s ingress, dev
+	// servers, microservices) — a non-issue for the legacy CONNECT
+	// path because HTTPS:443 is canonical, but the dominant case for
+	// the new plain-HTTP forward path.
+	outReq.Host = target
 	outReq.ContentLength = contentLength
 
 	inject, err := p.creds.Inject(r.Context(), scope.VaultID, host)

--- a/internal/mitm/forward_test.go
+++ b/internal/mitm/forward_test.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Infisical/agent-vault/internal/brokercore"
 	"github.com/Infisical/agent-vault/internal/netguard"
@@ -102,7 +103,8 @@ func TestMITMForwardPlainHTTPInjectsCredentials(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "http://"))
+	upstreamAuthority := strings.TrimPrefix(upstream.URL, "http://") // host:port
+	upstreamHost, _, _ := net.SplitHostPort(upstreamAuthority)
 
 	sr := validTokenResolver("av_sess_ok",
 		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
@@ -151,10 +153,11 @@ func TestMITMForwardPlainHTTPInjectsCredentials(t *testing.T) {
 	if sawProxyAuth != "" {
 		t.Errorf("upstream Proxy-Authorization = %q; must be stripped", sawProxyAuth)
 	}
-	// handleForward sets outReq.Host to the port-stripped form (passed
-	// as `host` into forwardRequest); upstream sees that exact value.
-	if sawHost != upstreamHost {
-		t.Errorf("upstream Host = %q, want %q", sawHost, upstreamHost)
+	// RFC 7230 §5.4: forwarded Host MUST equal the URI authority,
+	// including non-default port. handleForward canonicalises target
+	// as host:port and forwardRequest sets outReq.Host = target.
+	if sawHost != upstreamAuthority {
+		t.Errorf("upstream Host = %q, want %q", sawHost, upstreamAuthority)
 	}
 }
 
@@ -585,5 +588,57 @@ func TestMITMForwardKeepalivePersistsAcrossRequests(t *testing.T) {
 	}
 	if rows := sink.snapshot(); len(rows) != 2 {
 		t.Fatalf("got %d log rows, want 2", len(rows))
+	}
+}
+
+// TestMITMForwardIPv6LiteralCanonicalises guards against the IPv6
+// double-bracket regression: net.SplitHostPort/JoinHostPort on the
+// bracketed-no-port form ("[::1]") produces "[[::1]]:80". Going
+// through r.URL.Hostname() / r.URL.Port() instead yields the
+// canonical "[::1]:80" target. Sending raw via dialProxyTLS because
+// Go's http.Client routinely rewrites URLs through ProxyURL in ways
+// that would obscure what we want to assert.
+func TestMITMForwardIPv6LiteralCanonicalises(t *testing.T) {
+	// Bind an upstream on ::1 so the URL we send is exactly the
+	// IPv6-literal-no-port form. SkipNow if the host has no IPv6
+	// loopback (CI sometimes).
+	l, err := net.Listen("tcp", "[::1]:0")
+	if err != nil {
+		t.Skipf("no IPv6 loopback available: %v", err)
+	}
+	_, port, _ := net.SplitHostPort(l.Addr().String())
+	var sawHost string
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawHost = r.Host
+		_, _ = io.WriteString(w, "v6-ok")
+	}), ReadHeaderTimeout: 5 * time.Second}
+	go func() { _ = srv.Serve(l) }()
+	defer func() { _ = srv.Close() }()
+
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		"::1": {result: &brokercore.InjectResult{Passthrough: true}},
+	}}
+	proxyURL, clientRoots, _ := setupProxy(t, sr, cp)
+
+	conn := dialProxyTLS(t, proxyURL, clientRoots)
+	defer conn.Close()
+
+	auth := base64.StdEncoding.EncodeToString([]byte("av_sess_ok:"))
+	resp := writeRawRequestLine(t, conn,
+		fmt.Sprintf("GET http://[::1]:%s/x HTTP/1.1", port),
+		map[string]string{
+			"Host":                "[::1]:" + port,
+			"Proxy-Authorization": "Basic " + auth,
+		})
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	wantHost := "[::1]:" + port
+	if sawHost != wantHost {
+		t.Errorf("upstream Host = %q, want %q (IPv6 brackets must round-trip)", sawHost, wantHost)
 	}
 }

--- a/internal/mitm/forward_test.go
+++ b/internal/mitm/forward_test.go
@@ -613,7 +613,11 @@ func TestMITMForwardIPv6LiteralCanonicalises(t *testing.T) {
 		_, _ = io.WriteString(w, "v6-ok")
 	}), ReadHeaderTimeout: 5 * time.Second}
 	go func() { _ = srv.Serve(l) }()
-	defer func() { _ = srv.Close() }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
 
 	sr := validTokenResolver("av_sess_ok",
 		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -147,17 +147,19 @@ func newTrustingClient(proxyURL *url.URL, userInfo *url.Userinfo, roots *x509.Ce
 }
 
 func TestMITMInjectsCredentials(t *testing.T) {
-	var sawAuth, sawClientHeader, sawProxyAuth string
+	var sawAuth, sawClientHeader, sawProxyAuth, sawHost string
 	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sawAuth = r.Header.Get("Authorization")
 		sawClientHeader = r.Header.Get("X-Client-Header")
 		sawProxyAuth = r.Header.Get("Proxy-Authorization")
+		sawHost = r.Host
 		w.Header().Set("X-Upstream", "hello")
 		_, _ = io.WriteString(w, "upstream-body")
 	}))
 	defer upstream.Close()
 
-	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
+	upstreamAuthority := strings.TrimPrefix(upstream.URL, "https://") // host:port
+	upstreamHost, _, _ := net.SplitHostPort(upstreamAuthority)
 
 	sr := validTokenResolver("av_sess_ok",
 		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
@@ -210,6 +212,14 @@ func TestMITMInjectsCredentials(t *testing.T) {
 	}
 	if sawProxyAuth != "" {
 		t.Fatalf("upstream saw Proxy-Authorization %q; must be stripped", sawProxyAuth)
+	}
+	// RFC 7230 §5.4: forwarded Host MUST equal the URI authority,
+	// including non-default port. handleConnect → forwardRequest passes
+	// the canonical "host:port" target into outReq.Host. Locks in the
+	// fix from #151 (#150 review item 2) so the CONNECT path stays
+	// RFC-compliant for non-default-port upstreams.
+	if sawHost != upstreamAuthority {
+		t.Errorf("upstream Host = %q, want %q", sawHost, upstreamAuthority)
 	}
 }
 

--- a/internal/server/handle_mitm.go
+++ b/internal/server/handle_mitm.go
@@ -12,8 +12,8 @@ import (
 // Gated on IsListening, not just non-nil: when the proxy fails to bind
 // (port conflict with default-on MITM), s.mitm is still attached but
 // nothing is accepting connections. Returning a PEM in that state would
-// lead operators to install a cert and configure HTTPS_PROXY for a port
-// that silently refuses connections.
+// lead operators to install a cert and configure HTTPS_PROXY/HTTP_PROXY
+// for a port that silently refuses connections.
 //
 // The X-MITM-Port response header advertises the port the proxy is bound
 // to. Clients (e.g. `agent-vault vault run`) use this instead of a

--- a/internal/server/instructions.txt
+++ b/internal/server/instructions.txt
@@ -1,11 +1,11 @@
-You have access to Agent Vault, a transparent HTTPS proxy that attaches credentials to your outbound requests. You never see or handle credentials directly.
+You have access to Agent Vault, a transparent HTTP/HTTPS proxy that attaches credentials to your outbound requests. You never see or handle credentials directly.
 
 ## Quick Start
 
 1. Store env vars from the redemption response: AGENT_VAULT_ADDR (server URL), AGENT_VAULT_SESSION_TOKEN (bearer token), AGENT_VAULT_VAULT (vault name).
-2. Configure your HTTP client to route HTTPS through Agent Vault: fetch the root CA from {AGENT_VAULT_ADDR}/v1/mitm/ca.pem (the response carries the MITM port in the X-MITM-Port header, default 14322) and set HTTPS_PROXY=https://{AGENT_VAULT_SESSION_TOKEN}:{AGENT_VAULT_VAULT}@{host}:{port} where {host} is the host portion of {AGENT_VAULT_ADDR}.
+2. Configure your HTTP client to route both HTTP and HTTPS through Agent Vault: fetch the root CA from {AGENT_VAULT_ADDR}/v1/mitm/ca.pem (the response carries the MITM port in the X-MITM-Port header, default 14322) and set HTTPS_PROXY=https://{AGENT_VAULT_SESSION_TOKEN}:{AGENT_VAULT_VAULT}@{host}:{port} (and HTTP_PROXY to the same value) where {host} is the host portion of {AGENT_VAULT_ADDR}. The same TLS-wrapped listener handles CONNECT for https:// upstreams and absolute-form forward-proxy requests for http:// upstreams.
 3. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN} to learn which hosts have credentials configured.
-4. For any host listed in /discover, just call the real upstream URL — Agent Vault intercepts the CONNECT, injects credentials, and forwards over HTTPS. For all others, call directly (the proxy passes them through unmodified).
+4. For any host listed in /discover, just call the real upstream URL (over https:// or http://) — Agent Vault intercepts the request, injects credentials, and forwards. For all others, call directly (the proxy passes them through unmodified).
 
 Example: GET https://api.stripe.com/v1/charges?limit=10
 

--- a/internal/server/persistent_agent_instructions.txt
+++ b/internal/server/persistent_agent_instructions.txt
@@ -10,7 +10,7 @@ You received an agent token (av_agent_token). Use it for all proxy/discover/prop
 
 Authorization: Bearer {av_agent_token}, plus X-Vault: {vault_name} on every vault-scoped request.
 
-Configure your HTTP client to route HTTPS through Agent Vault: fetch the root CA from {AGENT_VAULT_ADDR}/v1/mitm/ca.pem (the response's X-MITM-Port header gives you the proxy port, default 14322) and set HTTPS_PROXY=https://{av_agent_token}:{vault_name}@{host}:{port} where {host} is the host portion of {AGENT_VAULT_ADDR}. Then call the real upstream URL — Agent Vault intercepts the CONNECT, attaches real credentials, and forwards over HTTPS. Hosts not in /discover pass through unmodified.
+Configure your HTTP client to route both HTTP and HTTPS through Agent Vault: fetch the root CA from {AGENT_VAULT_ADDR}/v1/mitm/ca.pem (the response's X-MITM-Port header gives you the proxy port, default 14322) and set HTTPS_PROXY=https://{av_agent_token}:{vault_name}@{host}:{port} (and HTTP_PROXY to the same value) where {host} is the host portion of {AGENT_VAULT_ADDR}. The same TLS-wrapped listener handles CONNECT for https:// upstreams and absolute-form forward-proxy requests for http:// upstreams. Then call the real upstream URL (over https:// or http://) — Agent Vault attaches real credentials and forwards. Hosts not in /discover pass through unmodified.
 
 ## Proposals — Requesting Access to New Services
 

--- a/internal/server/persistent_instructions_admin.txt
+++ b/internal/server/persistent_instructions_admin.txt
@@ -11,8 +11,8 @@ You received an agent token (av_agent_token). Use it for all proxy/discover/prop
 ## Quick Start
 
 1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_agent_token} and X-Vault: {vault_name} — do this FIRST.
-2. Configure your HTTP client to route HTTPS through Agent Vault: fetch the root CA from {AGENT_VAULT_ADDR}/v1/mitm/ca.pem (X-MITM-Port response header gives the port, default 14322) and set HTTPS_PROXY=https://{av_agent_token}:{vault_name}@{host}:{port} where {host} is the host portion of {AGENT_VAULT_ADDR}.
-3. For hosts in the discover response, just call the real upstream URL — Agent Vault intercepts the CONNECT and injects credentials. For others, requests pass through unmodified.
+2. Configure your HTTP client to route both HTTP and HTTPS through Agent Vault: fetch the root CA from {AGENT_VAULT_ADDR}/v1/mitm/ca.pem (X-MITM-Port response header gives the port, default 14322) and set HTTPS_PROXY=https://{av_agent_token}:{vault_name}@{host}:{port} (and HTTP_PROXY to the same value) where {host} is the host portion of {AGENT_VAULT_ADDR}. The same TLS-wrapped listener handles CONNECT for https:// upstreams and absolute-form forward-proxy requests for http:// upstreams.
+3. For hosts in the discover response, just call the real upstream URL (over https:// or http://) — Agent Vault injects credentials. For others, requests pass through unmodified.
 4. If a needed service isn't listed, raise a proposal.
 
 ## Multi-Vault Access

--- a/internal/server/persistent_instructions_member.txt
+++ b/internal/server/persistent_instructions_member.txt
@@ -11,8 +11,8 @@ You received an agent token (av_agent_token). Use it for all proxy/discover/prop
 ## Quick Start
 
 1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_agent_token} — do this FIRST.
-2. Configure your HTTP client to route HTTPS through Agent Vault: fetch the root CA from {AGENT_VAULT_ADDR}/v1/mitm/ca.pem (X-MITM-Port response header gives the port, default 14322) and set HTTPS_PROXY=https://{av_agent_token}:{vault_name}@{host}:{port} where {host} is the host portion of {AGENT_VAULT_ADDR}.
-3. For hosts in the discover response, just call the real upstream URL — Agent Vault intercepts the CONNECT and injects credentials. For others, requests pass through unmodified.
+2. Configure your HTTP client to route both HTTP and HTTPS through Agent Vault: fetch the root CA from {AGENT_VAULT_ADDR}/v1/mitm/ca.pem (X-MITM-Port response header gives the port, default 14322) and set HTTPS_PROXY=https://{av_agent_token}:{vault_name}@{host}:{port} (and HTTP_PROXY to the same value) where {host} is the host portion of {AGENT_VAULT_ADDR}. The same TLS-wrapped listener handles CONNECT for https:// upstreams and absolute-form forward-proxy requests for http:// upstreams.
+3. For hosts in the discover response, just call the real upstream URL (over https:// or http://) — Agent Vault injects credentials. For others, requests pass through unmodified.
 4. If a needed service isn't listed, raise a proposal.
 
 ## Member Capabilities

--- a/internal/server/persistent_instructions_proxy.txt
+++ b/internal/server/persistent_instructions_proxy.txt
@@ -11,8 +11,8 @@ You received an agent token (av_agent_token). Use it for all proxy/discover/prop
 ## Quick Start
 
 1. Call GET {AGENT_VAULT_ADDR}/discover with Authorization: Bearer {av_agent_token} — do this FIRST.
-2. Configure your HTTP client to route HTTPS through Agent Vault: fetch the root CA from {AGENT_VAULT_ADDR}/v1/mitm/ca.pem (X-MITM-Port response header gives the port, default 14322) and set HTTPS_PROXY=https://{av_agent_token}:{vault_name}@{host}:{port} where {host} is the host portion of {AGENT_VAULT_ADDR}.
-3. For hosts in the discover response, just call the real upstream URL — Agent Vault intercepts the CONNECT and injects credentials. For others, requests pass through unmodified.
+2. Configure your HTTP client to route both HTTP and HTTPS through Agent Vault: fetch the root CA from {AGENT_VAULT_ADDR}/v1/mitm/ca.pem (X-MITM-Port response header gives the port, default 14322) and set HTTPS_PROXY=https://{av_agent_token}:{vault_name}@{host}:{port} (and HTTP_PROXY to the same value) where {host} is the host portion of {AGENT_VAULT_ADDR}. The same TLS-wrapped listener handles CONNECT for https:// upstreams and absolute-form forward-proxy requests for http:// upstreams.
+3. For hosts in the discover response, just call the real upstream URL (over https:// or http://) — Agent Vault injects credentials. For others, requests pass through unmodified.
 4. If a needed service isn't listed, raise a proposal.
 
 ## Full Reference

--- a/web/src/pages/home/AllAgentsTab.tsx
+++ b/web/src/pages/home/AllAgentsTab.tsx
@@ -676,7 +676,7 @@ function ManualSetupView({
 
   const host = window.location.hostname;
   const tokenDisplay = sessionToken ?? "<TOKEN>";
-  const httpsProxy = `https://${tokenDisplay}@${host}:${mitm.port}`;
+  const proxyURL = `https://${tokenDisplay}@${host}:${mitm.port}`;
   const trustSnippets: Record<TrustTab, string> = {
     macos: `sudo security add-trusted-cert -d -r trustRoot \\\n  -k /Library/Keychains/System.keychain agent-vault-ca.pem`,
     linux: `sudo cp agent-vault-ca.pem /usr/local/share/ca-certificates/agent-vault-ca.crt\nsudo update-ca-certificates`,
@@ -728,7 +728,7 @@ function ManualSetupView({
         <p className="text-sm text-text-muted">
           The session token is embedded in the proxy URL — HTTP clients send it as <code className="text-text-muted">Proxy-Authorization</code> on every CONNECT handshake (for <code className="text-text-muted">https://</code> upstreams) and on each absolute-form forward-proxy request (for <code className="text-text-muted">http://</code> upstreams). Set both env vars to the same TLS-wrapped URL.
         </p>
-        <Snippet value={`export HTTPS_PROXY="${httpsProxy}"\nexport HTTP_PROXY="${httpsProxy}"`} />
+        <Snippet value={`export HTTPS_PROXY="${proxyURL}"\nexport HTTP_PROXY="${proxyURL}"`} />
         {!sessionToken && (
           <div className="flex items-center gap-2">
             <Button onClick={onRedeem} loading={redeeming}>

--- a/web/src/pages/home/AllAgentsTab.tsx
+++ b/web/src/pages/home/AllAgentsTab.tsx
@@ -726,9 +726,9 @@ function ManualSetupView({
 
       <ManualStep n={3} title="Point the agent at the proxy">
         <p className="text-sm text-text-muted">
-          The session token is embedded in the proxy URL — HTTP clients send it as <code className="text-text-muted">Proxy-Authorization</code> on every CONNECT handshake.
+          The session token is embedded in the proxy URL — HTTP clients send it as <code className="text-text-muted">Proxy-Authorization</code> on every CONNECT handshake (for <code className="text-text-muted">https://</code> upstreams) and on each absolute-form forward-proxy request (for <code className="text-text-muted">http://</code> upstreams). Set both env vars to the same TLS-wrapped URL.
         </p>
-        <Snippet value={`export HTTPS_PROXY="${httpsProxy}"`} />
+        <Snippet value={`export HTTPS_PROXY="${httpsProxy}"\nexport HTTP_PROXY="${httpsProxy}"`} />
         {!sessionToken && (
           <div className="flex items-center gap-2">
             <Button onClick={onRedeem} loading={redeeming}>


### PR DESCRIPTION
Follow-up to #150 — addresses the four findings from the post-merge automated review.

## Two correctness bugs

### 1. IPv6 literal target double-bracketed (`internal/mitm/forward.go`)

For `POST http://[::1]/path HTTP/1.1`:
- `r.URL.Host == "[::1]"` (Go preserves brackets so the URL round-trips).
- `net.SplitHostPort("[::1]")` fails with `missing port in address`.
- Old fallback set `host = "[::1]"`, `port = "80"`.
- `net.JoinHostPort("[::1]", "80")` saw `:` inside the host string, applied its bracket rule, and produced `[[::1]]:80` — double-bracketed and unreachable.

CONNECT path was unaffected because RFC 7230 §4.3.6 requires CONNECT request lines to be `host:port`, so `SplitHostPort` always succeeded there.

**Fix**: switch to `r.URL.Hostname()` (strips brackets) and `r.URL.Port()` (returns `""` when omitted). Idiomatic Go pattern, handles IPv4, named hosts, and bracketed IPv6 uniformly.

**Test**: new `TestMITMForwardIPv6LiteralCanonicalises` binds a real listener on `[::1]:0`, sends an absolute-form forward request, and asserts the upstream sees `Host: [::1]:<port>` (correctly bracketed exactly once). Skips on hosts without IPv6 loopback.

### 2. Wire Host header strips port for non-default-port upstreams

Old code set `outReq.Host = host` (port-stripped), so `http://internal.example:8080/api` forwarded as `Host: internal.example` — RFC 7230 §5.4 violation. The legacy CONNECT path tolerated this because HTTPS:443 is canonical and the port can be omitted, but the new plain-HTTP forward path makes non-default ports the dominant case (k8s ClusterIP, dev servers, microservices, the Tailscale Aperture / Hermes scenario in #132).

**Fix**: `outReq.Host = target` (port-included), with a comment explaining the RFC and why the legacy behaviour was effectively dead code.

**Test**: `TestMITMForwardPlainHTTPInjectsCredentials` updated. The old assertion `sawHost == upstreamHost` (port-stripped) actively baked in the buggy behaviour; new assertion checks against `upstreamAuthority` (host:port).

## Two cosmetic misses

### 3. Startup banner still said "routing HTTPS"

[cmd/run.go:149](cmd/run.go#L149) emits the user's first signal after `vault run` succeeds. Updated to `routing HTTP/HTTPS through MITM proxy (...)` and the surrounding step comment to match.

### 4. Doc cross-sync — 14 pages still described HTTPS_PROXY-only

The original PR updated 8 pages but missed 14 others. Updated:

- Quickstarts: `claude-code`, `codex`, `cursor`, `hermes-agent`, `opencode`, `nanoclaw`, `openclaw`, `custom-agent`
- `docs/index.mdx`
- `docs/agents/overview.mdx`
- `docs/agents/protocol.mdx` — frontmatter description and section heading
- `docs/learn/security.mdx` — heading + body
- `docs/learn/services.mdx` — Twilio walkthrough
- `docs/guides/connect-custom-agent.mdx` — frontmatter, body, env-var table (split into HTTPS_PROXY + HTTP_PROXY rows), heading, manual-setup snippet (`export HTTP_PROXY="$HTTPS_PROXY"`)
- `docs/self-hosting/{local,docker,fly-io}.mdx`

## Verification

- [x] `make test` (full Go suite, race detector clean) — `ok` across all packages
- [x] `make build` — succeeds
- [x] `golangci-lint run ./...` — `0 issues`
- [x] New IPv6 test passes locally
- [x] Existing CONNECT-path tests still pass under the `outReq.Host = target` change

## Files

- `internal/mitm/forward.go` — IPv6 fix + Host header fix + clarifying comments
- `internal/mitm/forward_test.go` — IPv6 regression test + tightened Host assertion
- `cmd/run.go` — banner + step comment
- 14 doc pages — `HTTP_PROXY`/`HTTPS_PROXY` parity