### PR TITLE
roles: collapse vault roles into a single instance-role tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ const av = new AgentVault({
 });
 const session = await av
   .vault("default")
-  .sessions.create({ vaultRole: "proxy" });
+  .sessions.create();
 
 // certPath is where you'll mount the CA certificate inside the sandbox.
 const certPath = "/etc/ssl/agent-vault-ca.pem";

--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -29,7 +29,6 @@ var agentListCmd = &cobra.Command{
 				CreatedAt string `json:"created_at"`
 				Vaults    []struct {
 					VaultName string `json:"vault_name"`
-					VaultRole string `json:"vault_role"`
 				} `json:"vaults"`
 			} `json:"agents"`
 		}
@@ -48,7 +47,7 @@ var agentListCmd = &cobra.Command{
 		for _, ag := range result.Agents {
 			var vaultParts []string
 			for _, v := range ag.Vaults {
-				vaultParts = append(vaultParts, fmt.Sprintf("%s:%s", v.VaultName, v.VaultRole))
+				vaultParts = append(vaultParts, v.VaultName)
 			}
 			vaults := strings.Join(vaultParts, ", ")
 			if vaults == "" {
@@ -79,17 +78,16 @@ var agentInfoCmd = &cobra.Command{
 		}
 
 		var info struct {
-			Name           string `json:"name"`
-			Role           string `json:"role"`
-			Status         string `json:"status"`
-			CreatedBy      string `json:"created_by"`
-			CreatedAt      string `json:"created_at"`
-			UpdatedAt      string `json:"updated_at"`
-			RevokedAt      *string `json:"revoked_at,omitempty"`
+			Name         string  `json:"name"`
+			Role         string  `json:"role"`
+			Status       string  `json:"status"`
+			CreatedBy    string  `json:"created_by"`
+			CreatedAt    string  `json:"created_at"`
+			UpdatedAt    string  `json:"updated_at"`
+			RevokedAt    *string `json:"revoked_at,omitempty"`
 			ActiveTokens int     `json:"active_tokens"`
-			Vaults         []struct {
+			Vaults       []struct {
 				VaultName string `json:"vault_name"`
-				VaultRole string `json:"vault_role"`
 			} `json:"vaults"`
 		}
 		if err := json.Unmarshal(respBody, &info); err != nil {
@@ -109,7 +107,7 @@ var agentInfoCmd = &cobra.Command{
 		if len(info.Vaults) > 0 {
 			_, _ = fmt.Fprintf(w, "%s\n", fieldLabel("Vaults:"))
 			for _, v := range info.Vaults {
-				_, _ = fmt.Fprintf(w, "  - %s (%s)\n", v.VaultName, v.VaultRole)
+				_, _ = fmt.Fprintf(w, "  - %s\n", v.VaultName)
 			}
 		} else {
 			_, _ = fmt.Fprintf(w, "%s none\n", fieldLabel("Vaults:"))
@@ -208,12 +206,12 @@ var agentRenameCmd = &cobra.Command{
 
 var vaultAgentCmd = &cobra.Command{
 	Use:   "agent",
-	Short: "Manage vault agent access",
+	Short: "Manage which agents have access to this vault",
 }
 
 var vaultAgentListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List agents in a vault",
+	Short: "List agents with access to a vault",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vault := resolveVault(cmd)
@@ -230,9 +228,9 @@ var vaultAgentListCmd = &cobra.Command{
 
 		var result struct {
 			Agents []struct {
-				Name      string `json:"name"`
-				VaultRole string `json:"vault_role"`
-				Status    string `json:"status"`
+				Name   string `json:"name"`
+				Role   string `json:"role"`
+				Status string `json:"status"`
 			} `json:"agents"`
 		}
 		if err := json.Unmarshal(respBody, &result); err != nil {
@@ -247,7 +245,7 @@ var vaultAgentListCmd = &cobra.Command{
 		t := newTable(cmd.OutOrStdout())
 		t.AppendHeader(table.Row{"NAME", "ROLE", "STATUS"})
 		for _, ag := range result.Agents {
-			t.AppendRow(table.Row{ag.Name, ag.VaultRole, statusBadge(ag.Status)})
+			t.AppendRow(table.Row{ag.Name, ag.Role, statusBadge(ag.Status)})
 		}
 		t.Render()
 		return nil
@@ -256,22 +254,18 @@ var vaultAgentListCmd = &cobra.Command{
 
 var vaultAgentAddCmd = &cobra.Command{
 	Use:   "add <name>",
-	Short: "Add an existing agent to this vault",
+	Short: "Grant an existing agent access to this vault",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		agentName := args[0]
 		vault := resolveVault(cmd)
-		role, _ := cmd.Flags().GetString("role")
-		if role == "" {
-			role = "proxy"
-		}
 
 		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
 
-		body, err := json.Marshal(map[string]string{"name": agentName, "role": role})
+		body, err := json.Marshal(map[string]string{"name": agentName})
 		if err != nil {
 			return err
 		}
@@ -281,14 +275,14 @@ var vaultAgentAddCmd = &cobra.Command{
 			return err
 		}
 
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Agent %q added to vault %q with role %q.\n", successText("✓"), agentName, vault, role)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Agent %q added to vault %q.\n", successText("✓"), agentName, vault)
 		return nil
 	},
 }
 
 var vaultAgentRemoveCmd = &cobra.Command{
 	Use:   "remove <name>",
-	Short: "Remove an agent from this vault",
+	Short: "Remove an agent's access from this vault",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		agentName := args[0]
@@ -309,41 +303,6 @@ var vaultAgentRemoveCmd = &cobra.Command{
 	},
 }
 
-var vaultAgentSetRoleCmd = &cobra.Command{
-	Use:   "set-role <name>",
-	Short: "Set an agent's vault role",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		agentName := args[0]
-		vault := resolveVault(cmd)
-		role, _ := cmd.Flags().GetString("role")
-		if role == "" {
-			return fmt.Errorf("--role is required (proxy, member, admin)")
-		}
-		if role != "proxy" && role != "member" && role != "admin" {
-			return fmt.Errorf("--role must be one of: proxy, member, admin")
-		}
-
-		sess, err := ensureSession()
-		if err != nil {
-			return err
-		}
-
-		body, err := json.Marshal(map[string]string{"role": role})
-		if err != nil {
-			return err
-		}
-
-		reqURL := sess.Address + "/v1/vaults/" + url.PathEscape(vault) + "/agents/" + url.PathEscape(agentName) + "/role"
-		if err := doAdminRequest("POST", reqURL, sess.Token, body); err != nil {
-			return err
-		}
-
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Agent %q role in vault %q set to %q.\n", successText("✓"), agentName, vault, role)
-		return nil
-	},
-}
-
 var agentSetRoleCmd = &cobra.Command{
 	Use:   "set-role <name>",
 	Short: "Set an agent's instance role",
@@ -352,10 +311,10 @@ var agentSetRoleCmd = &cobra.Command{
 		name := args[0]
 		role, _ := cmd.Flags().GetString("role")
 		if role == "" {
-			return fmt.Errorf("--role is required (owner or admin)")
+			return fmt.Errorf("--role is required (owner, admin, or agent)")
 		}
-		if role != "owner" && role != "admin" {
-			return fmt.Errorf("role must be 'owner' or 'admin'")
+		if role != "owner" && role != "admin" && role != "agent" {
+			return fmt.Errorf("role must be 'owner', 'admin', or 'agent'")
 		}
 
 		sess, err := ensureSession()
@@ -375,10 +334,7 @@ var agentSetRoleCmd = &cobra.Command{
 }
 
 func init() {
-	vaultAgentAddCmd.Flags().String("role", "proxy", "vault role (proxy, member, admin)")
-	vaultAgentSetRoleCmd.Flags().String("role", "", "vault role (proxy, member, admin)")
-
-	agentSetRoleCmd.Flags().String("role", "", "instance-level role (owner or admin)")
+	agentSetRoleCmd.Flags().String("role", "", "instance-level role (owner, admin, or agent)")
 
 	// Instance-level agent commands: agent-vault agent [list|info|revoke|rotate|rename|set-role]
 	topAgentCmd.AddCommand(agentListCmd)
@@ -389,10 +345,9 @@ func init() {
 	topAgentCmd.AddCommand(agentSetRoleCmd)
 	rootCmd.AddCommand(topAgentCmd)
 
-	// Vault-level agent commands: agent-vault vault agent [list|add|remove|set-role]
+	// Vault-level agent commands: agent-vault vault agent [list|add|remove]
 	vaultAgentCmd.AddCommand(vaultAgentListCmd)
 	vaultAgentCmd.AddCommand(vaultAgentAddCmd)
 	vaultAgentCmd.AddCommand(vaultAgentRemoveCmd)
-	vaultAgentCmd.AddCommand(vaultAgentSetRoleCmd)
 	vaultCmd.AddCommand(vaultAgentCmd)
 }

--- a/cmd/agent_invite.go
+++ b/cmd/agent_invite.go
@@ -33,16 +33,13 @@ var agentInviteCmd = &cobra.Command{
 
 		type vaultEntry struct {
 			VaultName string `json:"vault_name"`
-			VaultRole string `json:"vault_role"`
 		}
 
 		var vaults []vaultEntry
 		for _, v := range vaultFlags {
-			name, role, _ := strings.Cut(v, ":")
-			if role == "" {
-				role = "proxy"
-			}
-			vaults = append(vaults, vaultEntry{VaultName: name, VaultRole: role})
+			// Tolerate legacy "name:role" syntax — strip anything after ":".
+			name, _, _ := strings.Cut(v, ":")
+			vaults = append(vaults, vaultEntry{VaultName: name})
 		}
 
 		payload := map[string]any{
@@ -116,13 +113,13 @@ var agentInviteListCmd = &cobra.Command{
 		var resp struct {
 			Invites []struct {
 				AgentName string `json:"agent_name"`
+				AgentRole string `json:"agent_role"`
 				Status    string `json:"status"`
 				CreatedBy string `json:"created_by"`
 				CreatedAt string `json:"created_at"`
 				ExpiresAt string `json:"expires_at"`
 				Vaults    []struct {
 					VaultName string `json:"vault_name"`
-					VaultRole string `json:"vault_role"`
 				} `json:"vaults"`
 			} `json:"invites"`
 		}
@@ -136,11 +133,11 @@ var agentInviteListCmd = &cobra.Command{
 		}
 
 		t := newTable(cmd.OutOrStdout())
-		t.AppendHeader(table.Row{"NAME", "STATUS", "VAULTS", "INVITED BY", "CREATED", "EXPIRES"})
+		t.AppendHeader(table.Row{"NAME", "ROLE", "STATUS", "VAULTS", "INVITED BY", "CREATED", "EXPIRES"})
 		for _, inv := range resp.Invites {
 			var vaultParts []string
 			for _, v := range inv.Vaults {
-				vaultParts = append(vaultParts, fmt.Sprintf("%s:%s", v.VaultName, v.VaultRole))
+				vaultParts = append(vaultParts, v.VaultName)
 			}
 			vaults := strings.Join(vaultParts, ", ")
 			if vaults == "" {
@@ -154,7 +151,7 @@ var agentInviteListCmd = &cobra.Command{
 			if parsed, err := time.Parse(time.RFC3339, inv.ExpiresAt); err == nil {
 				expires = parsed.Format("2006-01-02 15:04")
 			}
-			t.AppendRow(table.Row{inv.AgentName, inv.Status, vaults, inv.CreatedBy, created, expires})
+			t.AppendRow(table.Row{inv.AgentName, inv.AgentRole, inv.Status, vaults, inv.CreatedBy, created, expires})
 		}
 		t.Render()
 		return nil
@@ -185,10 +182,10 @@ var agentInviteRevokeCmd = &cobra.Command{
 
 func init() {
 	agentInviteCmd.Flags().Duration("invite-ttl", 15*time.Minute, "invite link expiration time")
-	agentInviteCmd.Flags().StringArray("vault", nil, "vault pre-assignment (format: name:role, role defaults to proxy)")
+	agentInviteCmd.Flags().StringArray("vault", nil, "vault to grant access to (repeatable)")
 	agentInviteCmd.Flags().String("address", "", "Agent Vault server address (default: from session)")
 	agentInviteCmd.Flags().Bool("token-only", false, "output only the raw invite token (for programmatic use)")
-	agentInviteCmd.Flags().String("role", "admin", "instance-level role for the agent (owner or admin)")
+	agentInviteCmd.Flags().String("role", "agent", "instance-level role for the agent (owner, admin, or agent)")
 	agentInviteListCmd.Flags().String("status", "", "filter by status (pending, redeemed, expired, revoked)")
 
 	agentInviteCmd.AddCommand(agentInviteListCmd, agentInviteRevokeCmd)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -438,7 +438,8 @@ func TestProposalSubcommandsRegistered(t *testing.T) {
 }
 
 func TestAgentSubcommandsRegistered(t *testing.T) {
-	// Vault-level agent commands: list, add, remove, set-role
+	// Vault-level agent commands: list, add, remove. Per-vault role is
+	// gone under the unified instance-role model, so set-role is too.
 	vCmd := findSubcommand(rootCmd, "vault")
 	if vCmd == nil {
 		t.Fatal("vault command not found")
@@ -453,7 +454,7 @@ func TestAgentSubcommandsRegistered(t *testing.T) {
 		registered[c.Name()] = true
 	}
 
-	expected := []string{"list", "add", "remove", "set-role"}
+	expected := []string{"list", "add", "remove"}
 	for _, name := range expected {
 		if !registered[name] {
 			t.Errorf("expected vault agent subcommand %q to be registered, but it was not", name)

--- a/cmd/owner_vault.go
+++ b/cmd/owner_vault.go
@@ -82,29 +82,7 @@ var ownerVaultRemoveCmd = &cobra.Command{
 	},
 }
 
-var ownerVaultJoinCmd = &cobra.Command{
-	Use:   "join <name>",
-	Short: "Join a vault as admin (owner only)",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name := args[0]
-
-		sess, err := ensureSession()
-		if err != nil {
-			return err
-		}
-
-		url := fmt.Sprintf("%s/v1/vaults/%s/join", sess.Address, name)
-		if err := doAdminRequest("POST", url, sess.Token, nil); err != nil {
-			return err
-		}
-
-		fmt.Fprintf(cmd.OutOrStdout(), "%s Joined vault %q as admin\n", successText("✓"), name)
-		return nil
-	},
-}
-
 func init() {
-	ownerVaultCmd.AddCommand(ownerVaultListCmd, ownerVaultRemoveCmd, ownerVaultJoinCmd)
+	ownerVaultCmd.AddCommand(ownerVaultListCmd, ownerVaultRemoveCmd)
 	ownerCmd.AddCommand(ownerVaultCmd)
 }

--- a/cmd/reauth_test.go
+++ b/cmd/reauth_test.go
@@ -63,7 +63,7 @@ func TestRequestScopedSession_401MessagePreservesPrefix(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := requestScopedSession(srv.URL, "tok", "default", "", 0)
+	_, err := requestScopedSession(srv.URL, "tok", "default", 0)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -96,7 +96,7 @@ func TestRequestScopedSession_401WrapsErrSessionExpired(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := requestScopedSession(srv.URL, "stale-token", "default", "", 0)
+	_, err := requestScopedSession(srv.URL, "stale-token", "default", 0)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -189,7 +189,7 @@ func TestMintScopedSession_VaultResolutionMemoized(t *testing.T) {
 	cmd.Flags().String("vault", "", "")
 
 	sess := &session.ClientSession{Token: "stale", Address: srv.URL}
-	vault, token, err := mintScopedSession(cmd, sess, srv.URL, "", 0)
+	vault, token, err := mintScopedSession(cmd, sess, srv.URL, 0)
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -67,7 +67,6 @@ Example:
 	c.Flags().Var(&iso, "isolation", "Isolation mode: host (default) or container")
 
 	c.Flags().String("address", "", "Agent Vault server address (defaults to session address)")
-	c.Flags().String("role", "", "Vault role for the agent session (proxy, member, admin; default: proxy)")
 	c.Flags().Int("ttl", 0, "Session TTL in seconds (300–604800; default: server default 24h)")
 
 	c.Flags().String("image", "", "Container image override (requires --isolation=container)")
@@ -115,9 +114,8 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 
 	// 2-3. Resolve the vault and mint a vault-scoped session token,
 	//      retrying on session expiry. Shared with `vault token`.
-	role, _ := cmd.Flags().GetString("role")
 	ttl, _ := cmd.Flags().GetInt("ttl")
-	vault, scopedToken, err := mintScopedSession(cmd, sess, addr, role, ttl)
+	vault, scopedToken, err := mintScopedSession(cmd, sess, addr, ttl)
 	if err != nil {
 		return err
 	}
@@ -457,7 +455,7 @@ func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]stri
 // re-auth would be a UX regression, and the user's earlier choice is
 // still valid because vault membership is rechecked server-side when
 // requestScopedSession fires.
-func mintScopedSession(cmd *cobra.Command, sess *session.ClientSession, addr, role string, ttl int) (vault, scopedToken string, err error) {
+func mintScopedSession(cmd *cobra.Command, sess *session.ClientSession, addr string, ttl int) (vault, scopedToken string, err error) {
 	err = withReauthRetry(sess, addr, func(s *session.ClientSession) error {
 		if vault == "" {
 			v, verr := resolveVaultForRun(cmd, addr, s.Token)
@@ -466,7 +464,7 @@ func mintScopedSession(cmd *cobra.Command, sess *session.ClientSession, addr, ro
 			}
 			vault = v
 		}
-		token, terr := requestScopedSession(addr, s.Token, vault, role, ttl)
+		token, terr := requestScopedSession(addr, s.Token, vault, ttl)
 		if terr != nil {
 			return terr
 		}
@@ -478,11 +476,8 @@ func mintScopedSession(cmd *cobra.Command, sess *session.ClientSession, addr, ro
 
 // requestScopedSession calls the server to create a vault-scoped session
 // and returns the scoped token.
-func requestScopedSession(addr, adminToken, vault, role string, ttlSeconds int) (string, error) {
+func requestScopedSession(addr, adminToken, vault string, ttlSeconds int) (string, error) {
 	body := map[string]any{"vault": vault}
-	if role != "" {
-		body["vault_role"] = role
-	}
 	if ttlSeconds > 0 {
 		body["ttl_seconds"] = ttlSeconds
 	}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -16,7 +16,7 @@ import (
 // the other is a bug. `vault` is inherited from vaultCmd's persistent flags
 // on `vault run` and registered locally on the top-level `run`.
 var expectedRunFlags = []string{
-	"address", "role", "ttl", "vault",
+	"address", "ttl", "vault",
 	"isolation", "image", "mount", "keep", "no-firewall",
 	"home-volume-shared", "share-agent-dir",
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -244,13 +244,7 @@ func promptOwnerSetup(cmd *cobra.Command, db *store.SQLiteStore, masterPassword 
 		return fmt.Errorf("hashing password: %w", err)
 	}
 
-	// Get the default vault so the owner is granted admin access on it.
-	vault, err := db.GetVault(context.Background(), "default")
-	if err != nil {
-		return fmt.Errorf("looking up default vault: %w", err)
-	}
-
-	if _, err := db.RegisterFirstUser(context.Background(), email, hash, salt, vault.ID, kdfP.Time, kdfP.Memory, kdfP.Threads); err != nil {
+	if _, err := db.RegisterFirstUser(context.Background(), email, hash, salt, kdfP.Time, kdfP.Memory, kdfP.Threads); err != nil {
 		return fmt.Errorf("creating owner account: %w", err)
 	}
 

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -207,7 +207,7 @@ Key fields (JSON mode):
 
 ## Request Logs
 
-Agent Vault keeps a per-vault audit log of proxied requests (method, host, path, status, latency -- never bodies or query strings). The CLI does not wrap this yet; fetch via the HTTP API: `GET {AGENT_VAULT_ADDR}/v1/vaults/{vault}/logs` with `Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}`. Requires vault `member` or `admin` role. See `skill_http.md` for query params.
+Agent Vault keeps a per-vault audit log of proxied requests (method, host, path, status, latency -- never bodies or query strings). The CLI does not wrap this yet; fetch via the HTTP API: `GET {AGENT_VAULT_ADDR}/v1/vaults/{vault}/logs` with `Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}`. Requires the instance `admin` or `owner` role with access to the vault. See `skill_http.md` for query params.
 
 ## Building Code That Needs Credentials
 
@@ -246,7 +246,7 @@ agent-vault vault proposal create \
 
 ## Reading Credentials
 
-To read the decrypted value of a credential (requires member+ vault role):
+To read the decrypted value of a credential (requires the instance `admin` or `owner` role with access to the vault — instance `agent` actors are blocked):
 
 ```bash
 agent-vault vault credential get <key>

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -199,7 +199,7 @@ Key fields:
 
 ## Request Logs
 
-Agent Vault persists a per-request audit log for each vault (method, host, path, status, latency, matched service, credential key names -- **never** bodies or query strings). Useful for debugging "did the request go through?" and inspecting traffic patterns. Requires vault `member` or `admin` role.
+Agent Vault persists a per-request audit log for each vault (method, host, path, status, latency, matched service, credential key names -- **never** bodies or query strings). Useful for debugging "did the request go through?" and inspecting traffic patterns. Requires the instance `admin` or `owner` role with access to the vault.
 
 ```
 GET {AGENT_VAULT_ADDR}/v1/vaults/{vault}/logs

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -31,9 +31,8 @@ Example:
 			addr = sess.Address
 		}
 
-		role, _ := cmd.Flags().GetString("role")
 		ttl, _ := cmd.Flags().GetInt("ttl")
-		_, token, err := mintScopedSession(cmd, sess, addr, role, ttl)
+		_, token, err := mintScopedSession(cmd, sess, addr, ttl)
 		if err != nil {
 			return err
 		}
@@ -45,7 +44,6 @@ Example:
 
 func init() {
 	tokenCmd.Flags().String("address", "", "Agent Vault server address (defaults to session address)")
-	tokenCmd.Flags().String("role", "", "Vault role for the session (proxy, member, admin; default: proxy)")
 	tokenCmd.Flags().Int("ttl", 0, "Session TTL in seconds (300–604800; default: server default 24h)")
 
 	vaultCmd.AddCommand(tokenCmd)

--- a/cmd/user.go
+++ b/cmd/user.go
@@ -32,15 +32,11 @@ var userInfoCmd = &cobra.Command{
 			return err
 		}
 
-		type vaultGrant struct {
-			VaultName string `json:"vault_name"`
-			VaultRole string `json:"vault_role"`
-		}
 		var result struct {
-			Email     string       `json:"email"`
-			Role      string       `json:"role"`
-			Vaults    []vaultGrant `json:"vaults"`
-			CreatedAt string       `json:"created_at"`
+			Email     string   `json:"email"`
+			Role      string   `json:"role"`
+			Vaults    []string `json:"vaults"`
+			CreatedAt string   `json:"created_at"`
 		}
 		if err := json.Unmarshal(respBody, &result); err != nil {
 			return fmt.Errorf("parsing response: %w", err)
@@ -48,11 +44,7 @@ var userInfoCmd = &cobra.Command{
 
 		fmt.Fprintf(cmd.OutOrStdout(), "Email:      %s\n", result.Email)
 		fmt.Fprintf(cmd.OutOrStdout(), "Role:       %s\n", result.Role)
-		var parts []string
-		for _, v := range result.Vaults {
-			parts = append(parts, v.VaultName+"("+v.VaultRole+")")
-		}
-		ns := strings.Join(parts, ", ")
+		ns := strings.Join(result.Vaults, ", ")
 		if ns == "" {
 			ns = "(none)"
 		}

--- a/cmd/user_invite.go
+++ b/cmd/user_invite.go
@@ -23,7 +23,6 @@ var topUserListCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		type vaultGrant struct {
 			VaultName string `json:"vault_name"`
-			VaultRole string `json:"vault_role"`
 		}
 		type usersListResult struct {
 			Users []struct {
@@ -43,7 +42,6 @@ var topUserListCmd = &cobra.Command{
 			return nil
 		}
 
-		// Check if the response includes vault data (owner view).
 		hasVaults := false
 		for _, u := range result.Users {
 			if len(u.Vaults) > 0 {
@@ -58,7 +56,7 @@ var topUserListCmd = &cobra.Command{
 			for _, u := range result.Users {
 				var parts []string
 				for _, v := range u.Vaults {
-					parts = append(parts, v.VaultName+"("+v.VaultRole+")")
+					parts = append(parts, v.VaultName)
 				}
 				ns := strings.Join(parts, ", ")
 				if ns == "" {
@@ -93,16 +91,13 @@ var userInviteCmd = &cobra.Command{
 
 		type vaultEntry struct {
 			VaultName string `json:"vault_name"`
-			VaultRole string `json:"vault_role"`
 		}
 
 		var vaults []vaultEntry
 		for _, v := range vaultFlags {
-			name, role, _ := strings.Cut(v, ":")
-			if role == "" {
-				role = "member"
-			}
-			vaults = append(vaults, vaultEntry{VaultName: name, VaultRole: role})
+			// Tolerate legacy "name:role" syntax — strip anything after ":".
+			name, _, _ := strings.Cut(v, ":")
+			vaults = append(vaults, vaultEntry{VaultName: name})
 		}
 
 		role, _ := cmd.Flags().GetString("role")
@@ -179,7 +174,6 @@ var userInviteListCmd = &cobra.Command{
 				ExpiresAt string `json:"expires_at"`
 				Vaults    []struct {
 					VaultName string `json:"vault_name"`
-					VaultRole string `json:"vault_role"`
 				} `json:"vaults"`
 			} `json:"invites"`
 		}
@@ -197,7 +191,7 @@ var userInviteListCmd = &cobra.Command{
 		for _, inv := range resp.Invites {
 			var vaultParts []string
 			for _, v := range inv.Vaults {
-				vaultParts = append(vaultParts, fmt.Sprintf("%s:%s", v.VaultName, v.VaultRole))
+				vaultParts = append(vaultParts, v.VaultName)
 			}
 			vaults := strings.Join(vaultParts, ", ")
 			if vaults == "" {
@@ -241,8 +235,8 @@ var userInviteRevokeCmd = &cobra.Command{
 }
 
 func init() {
-	userInviteCmd.Flags().String("role", "", "instance role for the invited user (owner or admin, default admin)")
-	userInviteCmd.Flags().StringArray("vault", nil, "vault pre-assignment (format: name:role, role defaults to member)")
+	userInviteCmd.Flags().String("role", "", "instance role for the invited user (owner or admin; default admin)")
+	userInviteCmd.Flags().StringArray("vault", nil, "vault to grant access to (repeatable; effective power comes from the user's instance role)")
 	userInviteListCmd.Flags().String("status", "", "filter by status (pending, accepted, expired, revoked)")
 
 	userInviteCmd.AddCommand(userInviteListCmd, userInviteRevokeCmd)

--- a/cmd/vaults.go
+++ b/cmd/vaults.go
@@ -142,22 +142,18 @@ var vaultUserCmd = &cobra.Command{
 
 var vaultUserAddCmd = &cobra.Command{
 	Use:   "add <email>",
-	Short: "Add an existing instance user to this vault",
+	Short: "Grant an existing instance user access to this vault",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		email := args[0]
 		vaultName := resolveVault(cmd)
-		role, _ := cmd.Flags().GetString("role")
 
 		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
 
-		body, err := json.Marshal(map[string]string{
-			"email": email,
-			"role":  role,
-		})
+		body, err := json.Marshal(map[string]string{"email": email})
 		if err != nil {
 			return err
 		}
@@ -167,7 +163,7 @@ var vaultUserAddCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Fprintf(cmd.OutOrStdout(), "%s Added %s to vault %s (role: %s)\n", successText("✓"), email, vaultName, role)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s Added %s to vault %s\n", successText("✓"), email, vaultName)
 		return nil
 	},
 }
@@ -235,33 +231,6 @@ var vaultUserRemoveCmd = &cobra.Command{
 		}
 
 		fmt.Fprintf(cmd.OutOrStdout(), "%s Removed %s from vault %s\n", successText("✓"), email, vaultName)
-		return nil
-	},
-}
-
-var vaultUserSetRoleCmd = &cobra.Command{
-	Use:   "set-role <email>",
-	Short: "Set a user's vault role",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		email := args[0]
-		vaultName := resolveVault(cmd)
-		role, _ := cmd.Flags().GetString("role")
-		if role == "" {
-			return fmt.Errorf("--role is required (admin or member)")
-		}
-
-		sess, err := ensureSession()
-		if err != nil {
-			return err
-		}
-
-		body, _ := json.Marshal(map[string]string{"role": role})
-		reqURL := fmt.Sprintf("%s/v1/vaults/%s/users/%s/role", sess.Address, vaultName, url.PathEscape(email))
-		if err := doAdminRequest("POST", reqURL, sess.Token, body); err != nil {
-			return err
-		}
-		fmt.Fprintf(cmd.OutOrStdout(), "%s Set role %s for %s in vault %s\n", successText("✓"), role, email, vaultName)
 		return nil
 	},
 }
@@ -348,10 +317,7 @@ func init() {
 	vaultCmd.AddCommand(vaultUseCmd)
 	vaultCmd.AddCommand(vaultCurrentCmd)
 
-	vaultUserAddCmd.Flags().String("role", "member", "role to grant (admin or member)")
-	vaultUserSetRoleCmd.Flags().String("role", "", "role to set (admin or member)")
-
-	vaultUserCmd.AddCommand(vaultUserAddCmd, vaultUserListCmd, vaultUserRemoveCmd, vaultUserSetRoleCmd)
+	vaultUserCmd.AddCommand(vaultUserAddCmd, vaultUserListCmd, vaultUserRemoveCmd)
 	vaultCmd.AddCommand(vaultUserCmd)
 
 	rootCmd.AddCommand(vaultCmd)

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -3,7 +3,7 @@ title: "Agents"
 description: "Understand how agents connect to Agent Vault and how to manage them."
 ---
 
-An `Agent` is any AI-powered process that connects to Agent Vault to proxy requests and raise [proposals](/learn/proposals). Agents are **instance-level entities** (like users) with an instance-level role (`owner` or `admin`) and can be granted access to multiple [vaults](/learn/vaults) with independent roles per vault.
+An `Agent` is any AI-powered process that connects to Agent Vault to proxy requests and raise [proposals](/learn/proposals). Agents are **instance-level entities** (like users). Each holds a single instance role — `owner`, `admin`, or `agent` — and is granted scope on the [vaults](/learn/vaults) it can touch. Effective power inside each vault comes from the agent's instance role, not a per-vault role. See [Permissions](/learn/permissions) for the full model.
 
 There are two ways to connect an agent: **wrapping** a local process or **inviting** any agent via a prompt.
 
@@ -34,26 +34,27 @@ Outputs a prompt with the invite URL. Paste it into the agent's chat. The agent 
 
 ### Instance role
 
-By default, invited agents are created with the `admin` instance role. Use `--role` to set a different instance-level role:
+By default, invited agents are created with the `agent` instance role (proxy-only on scoped vaults). Use `--role` to pick a different role; only owners can mint owner-tier invites, and admins cannot grant a role higher than their own.
 
 ```bash
-# Invite an agent as an instance owner
+# Proxy-only: can use the proxy and raise proposals.
+agent-vault agent invite my-agent --role agent
+
+# Scoped admin: full vault management on the listed vaults.
+agent-vault agent invite my-agent --role admin --vault default
+
+# Owner: god mode. Owner-only.
 agent-vault agent invite my-agent --role owner
 ```
 
 ### Vault pre-assignments
 
-Optionally pre-assign vault access at invite time using the `--vault` flag (repeatable):
+Optionally attach vault scope at invite time using the `--vault` flag (repeatable). The agent's instance role decides what it can do inside each vault.
 
 ```bash
-# Invite with proxy access to the default vault
-agent-vault agent invite my-agent --vault default:proxy
-
-# Invite with access to multiple vaults
-agent-vault agent invite my-agent --vault default:member --vault payments:proxy
+# Scope an agent-role bot to two vaults.
+agent-vault agent invite my-agent --vault default --vault payments
 ```
-
-The format is `vault_name:role` where role is `proxy`, `member`, or `admin` (defaults to `proxy` if omitted).
 
 <Note>
 Agent names must be 3-64 characters, lowercase alphanumeric and hyphens only, and globally unique across the instance.
@@ -64,8 +65,8 @@ Agent names must be 3-64 characters, lowercase alphanumeric and hyphens only, an
 You can also grant vault access after the agent has been created:
 
 ```bash
-agent-vault vault agent add my-agent --role proxy
-agent-vault vault agent add my-agent --vault payments --role member
+agent-vault vault agent add my-agent --vault default
+agent-vault vault agent add my-agent --vault payments
 ```
 
 ## Managing agents
@@ -81,8 +82,8 @@ agent-vault agent list
 # View agent details (vaults, status, active sessions)
 agent-vault agent info my-agent
 
-# Change an agent's instance-level role
-agent-vault agent set-role my-agent --role owner
+# Change an agent's instance-level role (owner | admin | agent)
+agent-vault agent set-role my-agent --role admin
 
 # Delete an agent and all its sessions
 agent-vault agent delete my-agent
@@ -94,17 +95,14 @@ agent-vault agent rename my-agent new-name
 ### Vault-level commands
 
 ```bash
-# List agents in a specific vault
+# List agents with access to a specific vault
 agent-vault vault agent list --vault my-vault
 
-# Add an existing agent to a vault
-agent-vault vault agent add my-agent --role proxy
+# Grant an existing agent access to a vault
+agent-vault vault agent add my-agent --vault my-vault
 
-# Change an agent's vault role
-agent-vault vault agent set-role my-agent --role member
-
-# Remove an agent from a vault
-agent-vault vault agent remove my-agent
+# Remove an agent's access from a vault
+agent-vault vault agent remove my-agent --vault my-vault
 ```
 
 ### Rotating an agent token

--- a/docs/learn/permissions.mdx
+++ b/docs/learn/permissions.mdx
@@ -1,123 +1,93 @@
 ---
 title: "Permissions"
-description: "Understand how instance roles and vault roles control access across Agent Vault."
+description: "Understand how the unified instance role system controls access across Agent Vault."
 ---
 
-Agent Vault separates permissions into two independent axes: **instance roles** and **vault roles**. Instance roles control who can manage the Agent Vault server itself (users, agents, global settings, resets). Vault roles control who can operate within a specific [vault](/learn/vaults), approving [proposals](/learn/proposals), managing members, and configuring [credentials](/learn/credentials). The two axes are fully independent, so having one does not imply the other.
+Agent Vault has a single permission tier: **instance roles**. Each user or agent holds exactly one role — `owner`, `admin`, or `agent` — and that role, together with the actor's set of scoped vaults, determines everything they can do. There is no separate per-vault role to keep in sync.
 
-## Instance roles
+## The three roles
 
-Instance-level roles govern administrative operations across the entire Agent Vault instance. Both **users** and **agents** have instance-level roles. There are two roles: `owner` and `admin`.
+| Role  | Who can hold it       | Effective power |
+| ----- | --------------------- | --------------- |
+| `owner` | Users and agents     | God mode. Auto-accesses every vault. Can manage instance settings, users, agents, and every vault. |
+| `admin` | Users and agents     | Manages scoped vaults end-to-end (services, credentials, proposal approval). Can create new vaults. Can invite other admins or agents — but cannot grant a role higher than their own and cannot pre-assign vaults outside their own scope. |
+| `agent` | **Programmatic agents only** | Proxy-only on scoped vaults. Can use the proxy and raise proposals; **cannot** reveal credentials, approve/reject proposals, or mutate services. Humans cannot hold this role. |
 
-| Capability                            | Owner           | Admin           |
-| ------------------------------------- | --------------- | --------------- |
-| [Instance settings](/guides/instance-settings) (invite-only, domains) | Yes | No |
-| Manage users (list, remove, set-role) | Yes             | No              |
-| Manage agents (invite, list, revoke, rotate, rename, set-role) | Yes | Yes |
-| List / delete all vaults              | Yes             | No              |
-| See all vaults & join as admin        | Yes             | No              |
-| Send test emails                      | Yes             | No              |
-| Reset instance                        | Yes             | No              |
-| Access vault contents                 | Only if member  | Only if member  |
+## Vault scope
 
-<Info>
-  Owners can **see** every vault and **join** any vault as admin, but they are
-  not automatic members. Until an owner explicitly joins a vault (via
-  `agent-vault owner vault join` or the web UI), they cannot view its
-  [credentials](/learn/credentials) or approve [proposals](/learn/proposals).
-  This lets owners recover orphaned vaults while keeping vault contents
-  access-controlled.
-</Info>
+Owners auto-access every vault — there is no "join" step. Admin and agent actors carry an explicit list of vaults they can touch (their **scope**). Adding a user or agent to a vault simply attaches that vault to their scope; effective power inside the vault still comes from their instance role.
 
-## Vault roles
+| Operation | Owner | Admin (in scope) | Agent (in scope) |
+| --- | --- | --- | --- |
+| Use the proxy | Yes | Yes | Yes |
+| Discover services | Yes | Yes | Yes |
+| Raise proposals | Yes | Yes | Yes |
+| List credential names | Yes | Yes | Yes |
+| Reveal credential values | Yes | Yes | No |
+| Set / delete credentials | Yes | Yes | No |
+| Approve / reject proposals | Yes | Yes | No |
+| Manage vault services | Yes | Yes | No |
+| Add or remove vault scope (users / agents) | Yes | Yes | No |
+| Delete vault | Yes | Yes | No |
+| Manage instance settings, users, agents, all vaults | Yes | Limited (see below) | No |
 
-Vault-level roles govern what users and [agents](/agents/overview) can do inside a [vault](/learn/vaults) they belong to. There are three roles: `admin`, `member`, and `proxy`.
+An admin with **zero** scoped vaults is still useful: they can create a new vault, which auto-grants them scope on it.
 
-| Capability                                     | Admin | Member   | Proxy    |
-| ---------------------------------------------- | ----- | -------- | -------- |
-| Use proxy                                      | Yes   | Yes      | Yes      |
-| Discover services                              | Yes   | Yes      | Yes      |
-| Raise [proposals](/learn/proposals)            | Yes   | Yes      | Yes      |
-| View credential names                          | Yes   | Yes      | Yes      |
-| Set / delete credentials directly               | Yes   | Yes      | No       |
-| Approve / reject [proposals](/learn/proposals) | Yes   | Yes      | No       |
-| Manage vault [services](/learn/services)       | Yes   | Yes      | No       |
-| Add agents to vault (proxy only)               | Yes   | Yes      | No       |
-| Add agents to vault (any role)                 | Yes   | No       | No       |
-| Invite users to vault                          | Yes   | No       | No       |
-| Manage vault users (remove, set-role)          | Yes   | No       | No       |
-| Manage vault agents (remove, set-role)         | Yes   | No       | No       |
-| Delete vault                                   | Yes   | No       | No       |
+## Inviting other actors
 
-The **proxy** role is the most restricted, ideal for agents that only need to proxy requests and raise proposals for human review. The **member** role adds the ability to manage credentials, approve proposals, and configure vault services. The **admin** role has full control, including inviting users and agents with any role.
+Admins can invite users and agents, with two safety rails:
 
-Vault admins and members can both review agent [proposals](/learn/proposals). When an agent raises a proposal, vault members receive the approval link (via email if SMTP is configured) and can approve or reject from the browser or CLI.
+- **Cannot escalate.** An admin can only create invites for `admin` or `agent`. Only owners can mint owner-tier invites.
+- **Cannot widen scope.** Pre-assigned vaults on an admin's invite must be a subset of the inviter's own scope. Owners are unrestricted.
 
-## How the two axes interact
+Owners have no such restrictions.
 
-The two permission axes are fully independent. An instance owner who has not joined a vault cannot see its credentials or approve proposals. A vault admin who is not an instance owner cannot manage users or reset the instance.
+## How proposals stay safe
 
-**Example**: Alice is an instance owner but has not joined the `payments` vault. She can see it in her vault list and join it at any time, but she cannot approve proposals or proxy requests through `payments` until she does. Meanwhile, Bob is a vault admin on `payments` but only an instance admin (not an instance owner). He can approve proposals and manage agents within `payments`, but he cannot create new users or reset the instance.
+Agents can raise proposals but cannot approve them. Approval requires the instance `admin` (with vault scope) or `owner` role. This is the same self-approval block the previous "proxy" tier provided, now structural — agents simply lack the verb.
 
 ## The first user
 
 <Steps>
   <Step title="Start the server">```bash agent-vault server ```</Step>
   <Step title="Register">
-    The first user to register becomes the instance **owner** and is
-    automatically granted **vault admin** on the default vault. ```bash agent-vault
-    register ```
+    The first user to register becomes the instance **owner** and auto-accesses every vault, including the default vault that the server seeds at startup. ```bash agent-vault register ```
   </Step>
   <Step title="Start working">
-    The owner can immediately invite agents, set
-    [credentials](/learn/credentials), and configure [services](/learn/services)
-    on the default vault. No further setup is needed.
+    The owner can immediately invite admins or agents, set [credentials](/learn/credentials), and configure [services](/learn/services). No further setup is needed.
   </Step>
 </Steps>
 
-<Tip>
-  A **default** vault is created automatically at startup. The first user is
-  granted admin on this vault as part of registration.
-</Tip>
+## Changing roles
 
-## Change roles
-
-### Instance role
-
-Only instance owners can change instance-level roles. Both users and agents can be promoted or demoted.
+Only instance owners can change roles, and the last owner cannot be demoted. Both users and agents accept the role flag.
 
 ```bash
-# Change a user's instance role
+# Promote a user to owner.
 agent-vault owner user set-role alice@example.com --role owner
 
-# Change an agent's instance role
-agent-vault agent set-role my-agent --role owner
-```
-
-### Vault role
-
-Vault admins (and instance owners for any vault) can change vault-level roles.
-
-```bash
-agent-vault vault user set-role alice@example.com --role proxy --vault my-vault
-agent-vault vault agent set-role my-agent --role member --vault my-vault
+# Set an agent's role.
+agent-vault agent set-role my-agent --role agent   # owner | admin | agent
 ```
 
 <Warning>
-  The last instance owner cannot be demoted. Agent Vault blocks `set-role` if it would
-  leave the instance with zero owners. This applies across both users and agents.
+  The last instance owner cannot be demoted. Agent Vault blocks `set-role` if it would leave the instance with zero owners. This applies across both users and agents.
 </Warning>
 
-<AccordionGroup>
-  <Accordion title="Owner-level vault operations">
-    Instance owners have a set of cross-vault operations that do not require vault membership:
+## Adding or removing vault scope
 
-    - **See all vaults**: Owners see every vault in their vault list, including vaults they have not joined.
-    - **Join any vault**: `agent-vault owner vault join <name>` grants the owner admin access to a vault. Useful for recovering orphaned vaults.
-    - **Delete any vault**: `agent-vault owner vault delete <name>` deletes a vault regardless of membership.
-    - **Manage agents**: `agent-vault agent list`, `info`, `delete`, `rotate`, `rename`, and `set-role` are instance-level operations. Any authenticated user can invite agents; vault admins control per-vault agent access.
+Adding scope replaces the old "vault role" assignment — there is no role to pick.
 
-    These operations affect vault existence and agent lifecycle. To access vault contents (credentials, proposals, proxy), the owner must first join the vault.
+```bash
+# Grant an existing user access to a vault.
+agent-vault vault user add alice@example.com --vault payments
 
-  </Accordion>
-</AccordionGroup>
+# Grant an existing agent access to a vault.
+agent-vault vault agent add my-agent --vault payments
+
+# Remove access.
+agent-vault vault user remove alice@example.com --vault payments
+agent-vault vault agent remove my-agent --vault payments
+```
+
+Owners auto-access every vault and do not appear in scope lists.

--- a/docs/learn/vaults.mdx
+++ b/docs/learn/vaults.mdx
@@ -89,15 +89,17 @@ Vault resolution priority: `--vault` flag > `AGENT_VAULT_VAULT` env var > `agent
 
 ## Manage members and agents
 
+Vault scope (who can touch this vault) is managed here. Effective power inside the vault comes from each actor's instance role — see [Permissions](/learn/permissions). To change someone's role, use `agent-vault owner user set-role` or `agent-vault agent set-role` instead.
+
 ```bash
 # List vault members
 agent-vault vault user list --vault my-vault
 
+# Grant a user access to the vault
+agent-vault vault user add alice@example.com --vault my-vault
+
 # Remove a member
 agent-vault vault user remove alice@example.com --vault my-vault
-
-# Change vault role
-agent-vault vault user set-role alice@example.com --role member --vault my-vault
 
 # List agents in a vault
 agent-vault vault agent list --vault my-vault

--- a/docs/learn/vaults.mdx
+++ b/docs/learn/vaults.mdx
@@ -135,24 +135,18 @@ The default vault cannot be deleted. Use `--yes` to skip the confirmation prompt
 
 ## Owner-level vault management
 
-Instance [owners](/learn/permissions#instance-roles) can see and manage all vaults across the instance, regardless of vault membership.
+Instance [owners](/learn/permissions#instance-roles) auto-access every vault on the instance — they can manage credentials, approve proposals, and configure services in any vault without an explicit grant.
 
 ```bash
 # List ALL vaults (owner only)
 agent-vault owner vault list
 
-# Join a vault as admin (owner only)
-agent-vault owner vault join my-vault
-
 # Delete a vault (owner only)
 agent-vault owner vault delete my-vault
 ```
 
-Owners see every vault in their vault list. Vaults they have not joined appear in a separate "Other Vaults" section with a **Join** button. Joining grants the owner admin access, letting them manage credentials, approve proposals, and configure services.
-
 <Tip>
   If a user is deleted and their vaults become orphaned (no remaining members),
-  an instance owner can always join those vaults to recover access. User deletion
-  only removes the user and their vault grants — vaults and their data stay
-  intact.
+  an instance owner still has full access. User deletion only removes the user
+  and their vault grants — vaults and their data stay intact.
 </Tip>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -852,14 +852,6 @@ description: "Complete reference for all Agent Vault CLI commands."
     List all vaults on the instance. Owner only.
   </Accordion>
 
-  <Accordion title="agent-vault owner vault join">
-    ```bash
-    agent-vault owner vault join <name>
-    ```
-
-    No-op compatibility shim — owners now auto-access every vault, so explicit joining is unnecessary. Returns 200 for any vault that exists.
-  </Accordion>
-
   <Accordion title="agent-vault owner vault delete">
     ```bash
     agent-vault owner vault delete <name>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -267,7 +267,6 @@ description: "Complete reference for all Agent Vault CLI commands."
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--address` | | Server address override |
-    | `--role` | `proxy` | Vault role for the session: `proxy`, `member`, or `admin` |
     | `--ttl` | `0` | Session TTL in seconds (300–604800). Default: server default (24h). |
     | `--isolation` | `host` | Isolation mode for the child: `host` (default, cooperative — runs on the host with `HTTPS_PROXY`/`HTTP_PROXY`) or `container` (non-cooperative Docker container; see [Container isolation](/guides/container-isolation)). Also read from `AGENT_VAULT_ISOLATION`. |
     | `--image` | | Override the bundled container image (`--isolation=container` only). |
@@ -283,12 +282,11 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault token [flags]
     ```
 
-    Mint a vault-scoped session token and print it to stdout. Useful when you need a scoped token without wrapping a child process via `agent-vault run`.
+    Mint a vault-scoped session token and print it to stdout. Useful when you need a scoped token without wrapping a child process via `agent-vault run`. Effective power inside the scoped session is the calling actor's instance role; there is no per-session role to choose.
 
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--address` | | Server address override |
-    | `--role` | `proxy` | Vault role for the session: `proxy`, `member`, or `admin` |
     | `--ttl` | `0` | Session TTL in seconds (300–604800). Default: server default (24h). |
 
     ```bash
@@ -297,8 +295,8 @@ description: "Complete reference for all Agent Vault CLI commands."
     export AGENT_VAULT_ADDR=http://localhost:14321
     export AGENT_VAULT_VAULT=default
 
-    # Mint a short-lived token with member role
-    agent-vault vault token --vault myproject --role member --ttl 3600
+    # Mint a short-lived scoped token.
+    agent-vault vault token --vault myproject --ttl 3600
     ```
   </Accordion>
 </AccordionGroup>
@@ -311,12 +309,11 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault user add <email> [flags]
     ```
 
-    Add an existing instance user to a vault (direct grant, no invite needed).
+    Add an existing instance user to a vault (direct scope grant, no invite needed). Effective power in the vault comes from the user's instance role.
 
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--vault` | `default` | Target vault |
-    | `--role` | `member` | Vault role: `admin` or `member` |
   </Accordion>
 
   <Accordion title="agent-vault vault user list">
@@ -343,18 +340,6 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `--vault` | `default` | Target vault |
   </Accordion>
 
-  <Accordion title="agent-vault vault user set-role">
-    ```bash
-    agent-vault vault user set-role <email> [flags]
-    ```
-
-    Change a user's vault-level role.
-
-    | Flag | Default | Description |
-    |------|---------|-------------|
-    | `--vault` | `default` | Target vault |
-    | `--role` | | Vault role: `admin` or `member` (required) |
-  </Accordion>
 </AccordionGroup>
 
 ## Users
@@ -373,16 +358,16 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault user invite <email> [flags]
     ```
 
-    Invite a user to the Agent Vault instance. Sends an HTML email with an acceptance link if SMTP is configured; always returns the `invite_link` in the response. Any authenticated user can create invites. Invites optionally pre-assign vault access.
+    Invite a user to the Agent Vault instance. Sends an HTML email with an acceptance link if SMTP is configured; always returns the `invite_link` in the response. Owners and admins can create invites — admins cannot grant a role above their own and cannot pre-assign vaults outside their own scope. Invites optionally pre-assign vault scope.
 
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--role` | `admin` | Instance role for the invited user: `owner` or `admin` |
-    | `--vault` | | Vault pre-assignment in `name:role` format (repeatable). Role defaults to `member`. |
+    | `--vault` | | Vault to grant access to (repeatable). Effective power inside the vault comes from the user's instance role. |
 
     ```bash
-    # Invite with vault pre-assignments
-    agent-vault user invite alice@example.com --vault default:admin --vault payments:member
+    # Invite with vault scope pre-assignments
+    agent-vault user invite alice@example.com --vault default --vault payments
     ```
   </Accordion>
 
@@ -528,7 +513,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--vault` | `default` | Target vault |
-    | `--reveal` | `false` | Show decrypted credential values (requires member+ role) |
+    | `--reveal` | `false` | Show decrypted credential values (requires the instance `admin` or `owner` role with access to the vault — instance `agent` actors are blocked) |
   </Accordion>
 
   <Accordion title="agent-vault vault credential get">
@@ -536,7 +521,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault credential get <KEY> [flags]
     ```
 
-    Print the decrypted value of a single credential to stdout. Pipe-friendly. Requires member+ role. Alias: `agent-vault vault creds get`.
+    Print the decrypted value of a single credential to stdout. Pipe-friendly. Requires the instance `admin` or `owner` role with access to the vault — instance `agent` actors are blocked. Alias: `agent-vault vault creds get`.
 
     | Flag | Default | Description |
     |------|---------|-------------|
@@ -684,22 +669,22 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault agent invite <name> [flags]
     ```
 
-    Create an agent invite and print the onboarding prompt (copies to clipboard). The agent redeems the invite via HTTP and receives an instance-level agent token.
+    Create an agent invite and print the onboarding prompt (copies to clipboard). The agent redeems the invite via HTTP and receives an instance-level agent token. Owners and admins can create invites — admins cannot grant a role above their own and cannot pre-assign vaults outside their own scope.
 
     | Flag | Default | Description |
     |------|---------|-------------|
-    | `--role` | `admin` | Instance-level role: `owner` or `admin` |
-    | `--vault` | | Vault pre-assignment in `name:role` format (repeatable). Role defaults to `proxy`. |
+    | `--role` | `agent` | Instance-level role for the agent: `owner`, `admin`, or `agent` |
+    | `--vault` | | Vault to grant access to (repeatable). Effective power inside the vault comes from the agent's instance role. |
     | `--invite-ttl` | `15m` | Invite link expiration time (Go duration format) |
     | `--address` | | Agent Vault server address (default: from session) |
     | `--token-only` | `false` | Output only the raw invite token (for programmatic use) |
 
     ```bash
-    # Invite with vault pre-assignments
-    agent-vault agent invite my-agent --vault default:proxy --vault payments:member
+    # Proxy-only agent scoped to two vaults.
+    agent-vault agent invite my-agent --vault default --vault payments
 
-    # Invite as an instance owner
-    agent-vault agent invite my-agent --role owner --vault default:admin
+    # Scoped admin agent — full vault management on the listed vaults.
+    agent-vault agent invite my-agent --role admin --vault default
     ```
   </Accordion>
 
@@ -772,7 +757,7 @@ description: "Complete reference for all Agent Vault CLI commands."
 
     | Flag | Default | Description |
     |------|---------|-------------|
-    | `--role` | | Instance role: `owner` or `admin` (required) |
+    | `--role` | | Instance role: `owner`, `admin`, or `agent` (required) |
   </Accordion>
 </AccordionGroup>
 
@@ -796,12 +781,11 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault agent add <name> [flags]
     ```
 
-    Add an existing instance agent to a vault.
+    Grant an existing instance agent access to this vault. Effective power in the vault comes from the agent's instance role.
 
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--vault` | `default` | Target vault |
-    | `--role` | `proxy` | Vault role: `proxy`, `member`, or `admin` |
   </Accordion>
 
   <Accordion title="agent-vault vault agent remove">
@@ -809,24 +793,11 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault agent remove <name> [flags]
     ```
 
-    Remove an agent from a vault.
+    Remove an agent's access from a vault.
 
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--vault` | `default` | Target vault |
-  </Accordion>
-
-  <Accordion title="agent-vault vault agent set-role">
-    ```bash
-    agent-vault vault agent set-role <name> [flags]
-    ```
-
-    Change an agent's vault role.
-
-    | Flag | Default | Description |
-    |------|---------|-------------|
-    | `--vault` | `default` | Target vault |
-    | `--role` | | Vault role: `proxy`, `member`, or `admin` (required) |
   </Accordion>
 </AccordionGroup>
 
@@ -886,7 +857,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault owner vault join <name>
     ```
 
-    Join a vault as admin. Useful for recovering orphaned vaults. Owner only. Returns 409 if already a member.
+    No-op compatibility shim — owners now auto-access every vault, so explicit joining is unnecessary. Returns 200 for any vault that exists.
   </Accordion>
 
   <Accordion title="agent-vault owner vault delete">

--- a/internal/brokercore/session.go
+++ b/internal/brokercore/session.go
@@ -16,13 +16,13 @@ const MaxProxyBodyBytes = 64 << 20
 
 // ProxyScope is the resolved identity + vault context for a proxy request.
 // It is produced once per CONNECT on the MITM ingress and carried through
-// to credential injection.
+// to credential injection. Effective permissions in the vault come from
+// the actor's instance role and are not part of the scope.
 type ProxyScope struct {
 	AgentID   string // non-empty for agent tokens
 	UserID    string // non-empty for user sessions
 	VaultID   string
 	VaultName string
-	VaultRole string
 }
 
 // ActorID returns the non-empty principal ID — UserID for user
@@ -48,7 +48,8 @@ type SessionStore interface {
 	GetSession(ctx context.Context, rawToken string) (*store.Session, error)
 	GetVault(ctx context.Context, name string) (*store.Vault, error)
 	GetVaultByID(ctx context.Context, id string) (*store.Vault, error)
-	GetVaultRole(ctx context.Context, actorID, vaultID string) (string, error)
+	GetAgentByID(ctx context.Context, id string) (*store.Agent, error)
+	HasVaultAccess(ctx context.Context, actorID, vaultID string) (bool, error)
 	ListActorGrants(ctx context.Context, actorID string) ([]store.VaultGrant, error)
 }
 
@@ -99,33 +100,43 @@ func (r *StoreSessionResolver) ResolveForProxy(ctx context.Context, token, vault
 			AgentID:   sess.AgentID,
 			VaultID:   v.ID,
 			VaultName: v.Name,
-			VaultRole: sess.VaultRole,
 		}, nil
 	}
 
 	// Instance-level agent token: resolve vault from hint, or from the
-	// agent's unique grant if any.
+	// agent's unique grant if any. Owners auto-access every vault and
+	// therefore must always supply a hint (no unique-grant inference).
 	if sess.AgentID == "" {
 		return nil, ErrNoVaultContext
 	}
+
+	agent, err := r.Store.GetAgentByID(ctx, sess.AgentID)
+	if err != nil || agent == nil {
+		return nil, ErrInvalidSession
+	}
+	isOwner := agent.Role == "owner"
 
 	if vaultHint != "" {
 		v, err := r.Store.GetVault(ctx, vaultHint)
 		if err != nil || v == nil {
 			return nil, ErrVaultNotFound
 		}
-		role, err := r.Store.GetVaultRole(ctx, sess.AgentID, v.ID)
-		if err != nil || role == "" {
-			return nil, ErrVaultAccessDenied
+		if !isOwner {
+			ok, err := r.Store.HasVaultAccess(ctx, sess.AgentID, v.ID)
+			if err != nil || !ok {
+				return nil, ErrVaultAccessDenied
+			}
 		}
 		return &ProxyScope{
 			AgentID:   sess.AgentID,
 			VaultID:   v.ID,
 			VaultName: v.Name,
-			VaultRole: role,
 		}, nil
 	}
 
+	if isOwner {
+		return nil, ErrNoVaultContext
+	}
 	grants, err := r.Store.ListActorGrants(ctx, sess.AgentID)
 	if err != nil {
 		return nil, ErrNoVaultContext
@@ -139,7 +150,6 @@ func (r *StoreSessionResolver) ResolveForProxy(ctx context.Context, token, vault
 			AgentID:   sess.AgentID,
 			VaultID:   g.VaultID,
 			VaultName: g.VaultName,
-			VaultRole: g.Role,
 		}, nil
 	default:
 		return nil, ErrAgentVaultAmbiguous

--- a/internal/brokercore/session_test.go
+++ b/internal/brokercore/session_test.go
@@ -14,7 +14,8 @@ type fakeSessionStore struct {
 	sessions map[string]*store.Session
 	vaults   map[string]*store.Vault // keyed by name
 	byID     map[string]*store.Vault
-	roles    map[string]string // key = actorID+"|"+vaultID → role
+	access   map[string]bool // key = actorID+"|"+vaultID
+	agents   map[string]*store.Agent
 	grants   map[string][]store.VaultGrant
 }
 
@@ -23,7 +24,8 @@ func newFakeSessionStore() *fakeSessionStore {
 		sessions: map[string]*store.Session{},
 		vaults:   map[string]*store.Vault{},
 		byID:     map[string]*store.Vault{},
-		roles:    map[string]string{},
+		access:   map[string]bool{},
+		agents:   map[string]*store.Agent{},
 		grants:   map[string][]store.VaultGrant{},
 	}
 }
@@ -49,12 +51,15 @@ func (f *fakeSessionStore) GetVaultByID(_ context.Context, id string) (*store.Va
 	}
 	return v, nil
 }
-func (f *fakeSessionStore) GetVaultRole(_ context.Context, actorID, vaultID string) (string, error) {
-	r, ok := f.roles[actorID+"|"+vaultID]
+func (f *fakeSessionStore) GetAgentByID(_ context.Context, id string) (*store.Agent, error) {
+	a, ok := f.agents[id]
 	if !ok {
-		return "", errors.New("no role")
+		return nil, errors.New("not found")
 	}
-	return r, nil
+	return a, nil
+}
+func (f *fakeSessionStore) HasVaultAccess(_ context.Context, actorID, vaultID string) (bool, error) {
+	return f.access[actorID+"|"+vaultID], nil
 }
 func (f *fakeSessionStore) ListActorGrants(_ context.Context, actorID string) ([]store.VaultGrant, error) {
 	return f.grants[actorID], nil
@@ -66,17 +71,21 @@ func (f *fakeSessionStore) putVault(id, name string) {
 	f.byID[id] = v
 }
 
+func (f *fakeSessionStore) putAgent(id, role string) {
+	f.agents[id] = &store.Agent{ID: id, Role: role, Status: "active"}
+}
+
 func TestResolveForProxy_ScopedSession_NoHint(t *testing.T) {
 	f := newFakeSessionStore()
 	f.putVault("v1", "default")
-	f.sessions["tok"] = &store.Session{ID: "tok", UserID: "u1", VaultID: "v1", VaultRole: "admin"}
+	f.sessions["tok"] = &store.Session{ID: "tok", UserID: "u1", VaultID: "v1"}
 
 	r := NewStoreSessionResolver(f)
 	scope, err := r.ResolveForProxy(context.Background(), "tok", "")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if scope.VaultID != "v1" || scope.VaultName != "default" || scope.VaultRole != "admin" || scope.UserID != "u1" {
+	if scope.VaultID != "v1" || scope.VaultName != "default" || scope.UserID != "u1" {
 		t.Fatalf("scope = %+v", scope)
 	}
 }
@@ -84,7 +93,7 @@ func TestResolveForProxy_ScopedSession_NoHint(t *testing.T) {
 func TestResolveForProxy_ScopedSession_MatchingHint(t *testing.T) {
 	f := newFakeSessionStore()
 	f.putVault("v1", "default")
-	f.sessions["tok"] = &store.Session{UserID: "u1", VaultID: "v1", VaultRole: "member"}
+	f.sessions["tok"] = &store.Session{UserID: "u1", VaultID: "v1"}
 
 	r := NewStoreSessionResolver(f)
 	scope, err := r.ResolveForProxy(context.Background(), "tok", "default")
@@ -100,7 +109,7 @@ func TestResolveForProxy_ScopedSession_MismatchedHint(t *testing.T) {
 	f := newFakeSessionStore()
 	f.putVault("v1", "default")
 	f.putVault("v2", "prod")
-	f.sessions["tok"] = &store.Session{UserID: "u1", VaultID: "v1", VaultRole: "member"}
+	f.sessions["tok"] = &store.Session{UserID: "u1", VaultID: "v1"}
 
 	r := NewStoreSessionResolver(f)
 	_, err := r.ResolveForProxy(context.Background(), "tok", "prod")
@@ -112,15 +121,16 @@ func TestResolveForProxy_ScopedSession_MismatchedHint(t *testing.T) {
 func TestResolveForProxy_AgentSingleGrant_NoHint(t *testing.T) {
 	f := newFakeSessionStore()
 	f.putVault("v1", "default")
+	f.putAgent("a1", "agent")
 	f.sessions["tok"] = &store.Session{AgentID: "a1"}
-	f.grants["a1"] = []store.VaultGrant{{ActorID: "a1", VaultID: "v1", VaultName: "default", Role: "proxy"}}
+	f.grants["a1"] = []store.VaultGrant{{ActorID: "a1", VaultID: "v1", VaultName: "default"}}
 
 	r := NewStoreSessionResolver(f)
 	scope, err := r.ResolveForProxy(context.Background(), "tok", "")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if scope.VaultID != "v1" || scope.VaultName != "default" || scope.VaultRole != "proxy" {
+	if scope.VaultID != "v1" || scope.VaultName != "default" {
 		t.Fatalf("scope = %+v", scope)
 	}
 }
@@ -129,21 +139,53 @@ func TestResolveForProxy_AgentWithHint(t *testing.T) {
 	f := newFakeSessionStore()
 	f.putVault("v1", "default")
 	f.putVault("v2", "prod")
+	f.putAgent("a1", "admin")
 	f.sessions["tok"] = &store.Session{AgentID: "a1"}
-	f.roles["a1|v2"] = "member"
+	f.access["a1|v2"] = true
 
 	r := NewStoreSessionResolver(f)
 	scope, err := r.ResolveForProxy(context.Background(), "tok", "prod")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if scope.VaultID != "v2" || scope.VaultRole != "member" {
+	if scope.VaultID != "v2" {
 		t.Fatalf("scope = %+v", scope)
+	}
+}
+
+func TestResolveForProxy_OwnerAgentAutoAccess(t *testing.T) {
+	// Owner agents auto-access every vault — no scope grant needed.
+	f := newFakeSessionStore()
+	f.putVault("v1", "default")
+	f.putAgent("a1", "owner")
+	f.sessions["tok"] = &store.Session{AgentID: "a1"}
+
+	r := NewStoreSessionResolver(f)
+	scope, err := r.ResolveForProxy(context.Background(), "tok", "default")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if scope.VaultID != "v1" {
+		t.Fatalf("scope = %+v", scope)
+	}
+}
+
+func TestResolveForProxy_OwnerAgentNoHint(t *testing.T) {
+	// Owner agents with no hint can't infer a unique vault — error.
+	f := newFakeSessionStore()
+	f.putAgent("a1", "owner")
+	f.sessions["tok"] = &store.Session{AgentID: "a1"}
+
+	r := NewStoreSessionResolver(f)
+	_, err := r.ResolveForProxy(context.Background(), "tok", "")
+	if !errors.Is(err, ErrNoVaultContext) {
+		t.Fatalf("expected ErrNoVaultContext, got %v", err)
 	}
 }
 
 func TestResolveForProxy_AgentZeroGrants(t *testing.T) {
 	f := newFakeSessionStore()
+	f.putAgent("a1", "agent")
 	f.sessions["tok"] = &store.Session{AgentID: "a1"}
 
 	r := NewStoreSessionResolver(f)
@@ -155,10 +197,11 @@ func TestResolveForProxy_AgentZeroGrants(t *testing.T) {
 
 func TestResolveForProxy_AgentMultipleGrantsAmbiguous(t *testing.T) {
 	f := newFakeSessionStore()
+	f.putAgent("a1", "agent")
 	f.sessions["tok"] = &store.Session{AgentID: "a1"}
 	f.grants["a1"] = []store.VaultGrant{
-		{ActorID: "a1", VaultID: "v1", VaultName: "a", Role: "proxy"},
-		{ActorID: "a1", VaultID: "v2", VaultName: "b", Role: "proxy"},
+		{ActorID: "a1", VaultID: "v1", VaultName: "a"},
+		{ActorID: "a1", VaultID: "v2", VaultName: "b"},
 	}
 
 	r := NewStoreSessionResolver(f)
@@ -170,6 +213,7 @@ func TestResolveForProxy_AgentMultipleGrantsAmbiguous(t *testing.T) {
 
 func TestResolveForProxy_AgentHintUnknownVault(t *testing.T) {
 	f := newFakeSessionStore()
+	f.putAgent("a1", "agent")
 	f.sessions["tok"] = &store.Session{AgentID: "a1"}
 
 	r := NewStoreSessionResolver(f)
@@ -182,6 +226,7 @@ func TestResolveForProxy_AgentHintUnknownVault(t *testing.T) {
 func TestResolveForProxy_AgentHintNoAccess(t *testing.T) {
 	f := newFakeSessionStore()
 	f.putVault("v1", "default")
+	f.putAgent("a1", "agent")
 	f.sessions["tok"] = &store.Session{AgentID: "a1"}
 
 	r := NewStoreSessionResolver(f)
@@ -212,7 +257,7 @@ func TestResolveForProxy_ExpiredSession(t *testing.T) {
 	f := newFakeSessionStore()
 	past := time.Now().Add(-1 * time.Hour)
 	f.putVault("v1", "default")
-	f.sessions["tok"] = &store.Session{UserID: "u1", VaultID: "v1", VaultRole: "admin", ExpiresAt: &past}
+	f.sessions["tok"] = &store.Session{UserID: "u1", VaultID: "v1", ExpiresAt: &past}
 
 	r := &StoreSessionResolver{Store: f, Now: time.Now}
 	_, err := r.ResolveForProxy(context.Background(), "tok", "")

--- a/internal/mitm/forward_test.go
+++ b/internal/mitm/forward_test.go
@@ -107,7 +107,7 @@ func TestMITMForwardPlainHTTPInjectsCredentials(t *testing.T) {
 	upstreamHost, _, _ := net.SplitHostPort(upstreamAuthority)
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			Headers: map[string]string{"Authorization": "Bearer injected-secret"},
@@ -167,7 +167,7 @@ func TestMITMForwardPlainHTTPInjectsCredentials(t *testing.T) {
 // nudges the client toward CONNECT for HTTPS upstreams.
 func TestMITMForwardRejectsHTTPSScheme(t *testing.T) {
 	proxyURL, clientRoots, _ := setupProxy(t,
-		validTokenResolver("av_sess_ok", &brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"}),
+		validTokenResolver("av_sess_ok", &brokercore.ProxyScope{VaultID: "v1", VaultName: "default"}),
 		&fakeCredProvider{})
 
 	conn := dialProxyTLS(t, proxyURL, clientRoots)
@@ -196,7 +196,7 @@ func TestMITMForwardRejectsHTTPSScheme(t *testing.T) {
 // malformed forward-proxy requests.
 func TestMITMForwardRejectsNonHTTPSchemes(t *testing.T) {
 	proxyURL, clientRoots, _ := setupProxy(t,
-		validTokenResolver("av_sess_ok", &brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"}),
+		validTokenResolver("av_sess_ok", &brokercore.ProxyScope{VaultID: "v1", VaultName: "default"}),
 		&fakeCredProvider{})
 
 	auth := base64.StdEncoding.EncodeToString([]byte("av_sess_ok:"))
@@ -222,7 +222,7 @@ func TestMITMForwardRejectsNonHTTPSchemes(t *testing.T) {
 // Proxy-Authorization gets a 407 challenge with Proxy-Authenticate.
 func TestMITMForwardRequiresProxyAuthorization(t *testing.T) {
 	proxyURL, clientRoots, _ := setupProxy(t,
-		validTokenResolver("av_sess_ok", &brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"}),
+		validTokenResolver("av_sess_ok", &brokercore.ProxyScope{VaultID: "v1", VaultName: "default"}),
 		&fakeCredProvider{})
 
 	conn := dialProxyTLS(t, proxyURL, clientRoots)
@@ -304,7 +304,7 @@ func TestMITMForwardStripsHopByHopHeaders(t *testing.T) {
 
 	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "http://"))
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{Passthrough: true}},
 	}}
@@ -388,7 +388,7 @@ func TestMITMForwardWebSocketPlainHTTP(t *testing.T) {
 
 	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "http://"))
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{Passthrough: true}},
 	}}
@@ -451,7 +451,7 @@ func TestMITMForwardSSRFLoopbackBlocked(t *testing.T) {
 
 	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "http://"))
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{Passthrough: true}},
 	}}
@@ -488,7 +488,6 @@ func TestMITMForwardEmitsRequestLogRow(t *testing.T) {
 			AgentID:   "agent-42",
 			VaultID:   "v1",
 			VaultName: "default",
-			VaultRole: "proxy",
 		})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
@@ -562,7 +561,7 @@ func TestMITMForwardKeepalivePersistsAcrossRequests(t *testing.T) {
 
 	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "http://"))
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{Passthrough: true}},
 	}}
@@ -622,7 +621,7 @@ func TestMITMForwardIPv6PreservesHostHeader(t *testing.T) {
 	})
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		"::1": {result: &brokercore.InjectResult{Passthrough: true}},
 	}}

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -162,7 +162,7 @@ func TestMITMInjectsCredentials(t *testing.T) {
 	upstreamHost, _, _ := net.SplitHostPort(upstreamAuthority)
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			Headers: map[string]string{"Authorization": "Bearer injected-secret"},
@@ -238,7 +238,7 @@ func TestMITMForwardsBoundedBodiesWithContentLength(t *testing.T) {
 
 	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			Headers: map[string]string{"Authorization": "Bearer injected-secret"},
@@ -330,7 +330,7 @@ func TestMITMWebSocketInjectsCredentialsAndPipesFrames(t *testing.T) {
 	upstreamTarget := strings.TrimPrefix(upstream.URL, "https://")
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			Headers: map[string]string{"Authorization": "Bearer injected-ws-secret"},
@@ -436,7 +436,7 @@ func TestMITMWebSocketXAITTSIntegration(t *testing.T) {
 	}
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		"api.x.ai": {result: &brokercore.InjectResult{
 			Headers: map[string]string{"Authorization": "Bearer " + xaiKey},
@@ -526,7 +526,7 @@ func TestMITMWebSocketOpenAIRealtimeIntegration(t *testing.T) {
 	}
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		"api.openai.com": {result: &brokercore.InjectResult{
 			Headers: map[string]string{"Authorization": "Bearer " + openAIKey},
@@ -638,7 +638,7 @@ func TestMITMWebSocketSanitizesSwitchingResponseAndInjectedHeadersWin(t *testing
 	upstreamTarget := strings.TrimPrefix(upstream.URL, "https://")
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{AgentID: "agent1", VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{AgentID: "agent1", VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			Headers: map[string]string{"Sec-WebSocket-Protocol": "injected-proto"},
@@ -739,7 +739,7 @@ func TestMITMWebSocketHoldsProxyConcurrencyUntilTunnelCloses(t *testing.T) {
 	upstreamTarget := strings.TrimPrefix(upstream.URL, "https://")
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{AgentID: "agent1", VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{AgentID: "agent1", VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			Headers: map[string]string{"Authorization": "Bearer injected-secret"},
@@ -856,7 +856,7 @@ func TestMITMWebSocketUpstreamHandshakeTimeout(t *testing.T) {
 	upstreamTarget := strings.TrimPrefix(upstream.URL, "https://")
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{AgentID: "agent1", VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{AgentID: "agent1", VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			Headers: map[string]string{"Authorization": "Bearer injected-secret"},
@@ -927,7 +927,7 @@ func TestMITMPassthroughForwardsClientAuthorization(t *testing.T) {
 	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			MatchedHost: upstreamHost,
@@ -1001,7 +1001,7 @@ func TestMITMBearerForwardsArbitraryClientHeaders(t *testing.T) {
 	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			MatchedHost: upstreamHost,
@@ -1237,7 +1237,7 @@ func TestMITMUnknownHostInTunnel(t *testing.T) {
 	defer upstream.Close()
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	// byHost empty → every Inject returns ErrServiceNotFound.
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{}}
 
@@ -1287,7 +1287,7 @@ func TestMITMUnknownHostPassthrough(t *testing.T) {
 	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{Passthrough: true}},
 	}}
@@ -1325,7 +1325,7 @@ func TestMITMUpstreamCertUntrusted(t *testing.T) {
 	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			Headers: map[string]string{"Authorization": "Bearer whatever"},
@@ -1381,7 +1381,7 @@ func TestMITMSubstitutionRewritesPath(t *testing.T) {
 	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			Headers: map[string]string{"Authorization": "Basic " + base64.StdEncoding.EncodeToString([]byte("AC12345:tok-shh"))},
@@ -1437,7 +1437,7 @@ func TestMITMSubstitutionCaseSensitive(t *testing.T) {
 	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			Substitutions: []brokercore.ResolvedSubstitution{{
@@ -1478,7 +1478,7 @@ func TestMITMSubstitutionRewritesQueryAndHeader(t *testing.T) {
 	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
 
 	sr := validTokenResolver("av_sess_ok",
-		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default"})
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{
 			Substitutions: []brokercore.ResolvedSubstitution{

--- a/internal/server/handle_agents.go
+++ b/internal/server/handle_agents.go
@@ -72,27 +72,22 @@ func (s *Server) handleAgentInviteList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Filter: owners see all; others see invites they created or with pre-assignments to vaults they admin.
-	var actorAdminVaults map[string]bool
-	if !actor.IsOwner() {
-		actorAdminVaults = make(map[string]bool)
-		if grants, err := s.store.ListActorGrants(ctx, actor.ID); err == nil {
-			for _, g := range grants {
-				if g.Role == "admin" {
-					actorAdminVaults[g.VaultID] = true
-				}
-			}
-		}
-	}
-
+	// Filter: owners see all; admins see invites they created or with
+	// pre-assignments to a vault they have scope on. Agents only see
+	// invites they themselves created (agents normally shouldn't reach
+	// this endpoint, but be defensive).
+	scope := s.actorVaultScope(ctx, actor)
 	var filtered []store.Invite
 	for _, inv := range invites {
 		if actor.IsOwner() || inv.CreatedBy == actor.ID {
 			filtered = append(filtered, inv)
 			continue
 		}
+		if !actor.IsAdmin() {
+			continue
+		}
 		for _, v := range inv.Vaults {
-			if actorAdminVaults[v.VaultID] {
+			if scopeContains(scope, v.VaultID) {
 				filtered = append(filtered, inv)
 				break
 			}
@@ -114,16 +109,12 @@ func (s *Server) handleAgentInviteList(w http.ResponseWriter, r *http.Request) {
 
 	items := make([]inviteItem, len(filtered))
 	for i, inv := range filtered {
-		var vaults []agentVaultJSON
-		for _, v := range inv.Vaults {
-			vaults = append(vaults, agentVaultJSON{VaultName: v.VaultName, VaultRole: v.VaultRole})
-		}
 		items[i] = inviteItem{
 			ID:        inv.ID,
 			AgentName: inv.AgentName,
 			AgentRole: inv.AgentRole,
 			Status:    inv.Status,
-			Vaults:    vaults,
+			Vaults:    inviteVaultsToJSON(inv.Vaults),
 			CreatedAt: inv.CreatedAt.Format(time.RFC3339),
 			ExpiresAt: inv.ExpiresAt.Format(time.RFC3339),
 		}
@@ -157,7 +148,7 @@ func (s *Server) handleAgentInviteRevoke(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if !s.canRevokeAgentInvite(ctx, actor, inv) {
+	if !s.canManageInvite(ctx, actor, inv.CreatedBy, agentInviteVaultIDs(inv)) {
 		jsonError(w, http.StatusForbidden, "You do not have permission to revoke this invite")
 		return
 	}
@@ -196,7 +187,7 @@ func (s *Server) handleAgentInviteRevokeByID(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if !s.canRevokeAgentInvite(ctx, actor, inv) {
+	if !s.canManageInvite(ctx, actor, inv.CreatedBy, agentInviteVaultIDs(inv)) {
 		jsonError(w, http.StatusForbidden, "You do not have permission to revoke this invite")
 		return
 	}
@@ -214,17 +205,57 @@ func (s *Server) handleAgentInviteRevokeByID(w http.ResponseWriter, r *http.Requ
 	jsonOK(w, map[string]string{"status": "revoked"})
 }
 
-// canRevokeAgentInvite checks if the user is the invite creator, an owner, or admin of a pre-assigned vault.
-func (s *Server) canRevokeAgentInvite(ctx context.Context, actor *Actor, inv *store.Invite) bool {
-	if actor.IsOwner() || inv.CreatedBy == actor.ID {
+// canManageInvite reports whether actor can revoke or reinvite the
+// invite identified by createdBy + the set of pre-assigned vault IDs.
+// The rule is: invite creator OR instance owner OR instance admin
+// scoped to at least one of the pre-assigned vaults. Agents may only
+// manage invites they themselves created.
+func (s *Server) canManageInvite(ctx context.Context, actor *Actor, createdBy string, vaultIDs []string) bool {
+	if actor.IsOwner() || createdBy == actor.ID {
 		return true
 	}
-	for _, v := range inv.Vaults {
-		if role, err := s.store.GetVaultRole(ctx, actor.ID, v.VaultID); err == nil && role == "admin" {
+	if !actor.IsAdmin() {
+		return false
+	}
+	scope := s.actorVaultScope(ctx, actor)
+	for _, vaultID := range vaultIDs {
+		if scopeContains(scope, vaultID) {
 			return true
 		}
 	}
 	return false
+}
+
+func agentInviteVaultIDs(inv *store.Invite) []string {
+	ids := make([]string, len(inv.Vaults))
+	for i, v := range inv.Vaults {
+		ids[i] = v.VaultID
+	}
+	return ids
+}
+
+func userInviteVaultIDs(inv *store.UserInvite) []string {
+	ids := make([]string, len(inv.Vaults))
+	for i, v := range inv.Vaults {
+		ids[i] = v.VaultID
+	}
+	return ids
+}
+
+func vaultGrantsToJSON(grants []store.VaultGrant) []agentVaultJSON {
+	out := make([]agentVaultJSON, len(grants))
+	for i, v := range grants {
+		out[i] = agentVaultJSON{VaultName: v.VaultName}
+	}
+	return out
+}
+
+func inviteVaultsToJSON(vaults []store.AgentInviteVault) []agentVaultJSON {
+	out := make([]agentVaultJSON, len(vaults))
+	for i, v := range vaults {
+		out[i] = agentVaultJSON{VaultName: v.VaultName}
+	}
+	return out
 }
 
 //go:embed persistent_instructions_admin.txt
@@ -334,15 +365,17 @@ func (s *Server) handlePersistentInviteRedeem(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Apply vault pre-assignments from the invite.
-	var vaultInfos []agentVaultJSON
-	for _, v := range inv.Vaults {
-		if err := s.store.GrantVaultRole(ctx, agent.ID, "agent", v.VaultID, v.VaultRole); err != nil {
-			jsonError(w, http.StatusInternalServerError, "Failed to grant vault access")
-			return
+	// Apply vault pre-assignments from the invite. Owners auto-access
+	// every vault, so we skip writing scope rows for owner invites.
+	if inv.AgentRole != "owner" {
+		for _, v := range inv.Vaults {
+			if err := s.store.GrantVaultAccess(ctx, agent.ID, "agent", v.VaultID); err != nil {
+				jsonError(w, http.StatusInternalServerError, "Failed to grant vault access")
+				return
+			}
 		}
-		vaultInfos = append(vaultInfos, agentVaultJSON{VaultName: v.VaultName, VaultRole: v.VaultRole})
 	}
+	vaultInfos := inviteVaultsToJSON(inv.Vaults)
 
 	// Create instance-level agent token (no vault_id).
 	var tokenExpiry *time.Time
@@ -401,10 +434,7 @@ func (s *Server) handleRotationRedeem(w http.ResponseWriter, r *http.Request, in
 	// Link token back to invite so invite list can show token expiry.
 	_ = s.store.UpdateInviteSessionID(ctx, inv.ID, sess.ID)
 
-	var vaultInfos []agentVaultJSON
-	for _, v := range agent.Vaults {
-		vaultInfos = append(vaultInfos, agentVaultJSON{VaultName: v.VaultName, VaultRole: v.Role})
-	}
+	vaultInfos := vaultGrantsToJSON(agent.Vaults)
 
 	baseURL := s.baseURL
 
@@ -436,18 +466,16 @@ func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 
 	// For non-owner actors, filter to agents sharing at least one vault.
 	actor, _ := s.actorFromSession(ctx, sess)
-	isOwner := actor != nil && actor.IsOwner()
-	var accessibleVaults map[string]bool
-	if !isOwner && actor != nil {
-		grants, _ := s.store.ListActorGrants(ctx, actor.ID)
-		accessibleVaults = make(map[string]bool, len(grants))
-		for _, g := range grants {
-			accessibleVaults[g.VaultID] = true
-		}
+	if actor == nil {
+		jsonError(w, http.StatusForbidden, "Authentication required")
+		return
+	}
+	scope := s.actorVaultScope(ctx, actor)
+	if scope != nil {
 		var filtered []store.Agent
 		for _, ag := range agents {
 			for _, v := range ag.Vaults {
-				if accessibleVaults[v.VaultID] {
+				if scope[v.VaultID] {
 					filtered = append(filtered, ag)
 					break
 				}
@@ -469,15 +497,11 @@ func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 	items := make([]agentItem, 0, len(agents))
 	seen := make(map[string]bool)
 	for _, ag := range agents {
-		vaults := make([]agentVaultJSON, 0, len(ag.Vaults))
-		for _, v := range ag.Vaults {
-			vaults = append(vaults, agentVaultJSON{VaultName: v.VaultName, VaultRole: v.Role})
-		}
 		item := agentItem{
 			Name:      ag.Name,
 			Role:      ag.Role,
 			Status:    ag.Status,
-			Vaults:    vaults,
+			Vaults:    vaultGrantsToJSON(ag.Vaults),
 			CreatedAt: ag.CreatedAt.Format(time.RFC3339),
 		}
 		if ag.RevokedAt != nil {
@@ -501,10 +525,10 @@ func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 		if seen[inv.AgentName] {
 			continue
 		}
-		if !isOwner && accessibleVaults != nil {
+		if scope != nil {
 			hasOverlap := false
 			for _, v := range inv.Vaults {
-				if accessibleVaults[v.VaultID] {
+				if scope[v.VaultID] {
 					hasOverlap = true
 					break
 				}
@@ -513,15 +537,11 @@ func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 		}
-		vaults := make([]agentVaultJSON, 0, len(inv.Vaults))
-		for _, v := range inv.Vaults {
-			vaults = append(vaults, agentVaultJSON{VaultName: v.VaultName, VaultRole: v.VaultRole})
-		}
 		items = append(items, agentItem{
 			Name:      inv.AgentName,
 			Role:      inv.AgentRole,
 			Status:    "pending",
-			Vaults:    vaults,
+			Vaults:    inviteVaultsToJSON(inv.Vaults),
 			CreatedAt: inv.CreatedAt.Format(time.RFC3339),
 		})
 		seen[inv.AgentName] = true
@@ -547,16 +567,11 @@ func (s *Server) handleAgentGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	vaults := make([]agentVaultJSON, 0, len(agent.Vaults))
-	for _, v := range agent.Vaults {
-		vaults = append(vaults, agentVaultJSON{VaultName: v.VaultName, VaultRole: v.Role})
-	}
-
 	resp := map[string]interface{}{
 		"name":       agent.Name,
 		"role":       agent.Role,
 		"status":     agent.Status,
-		"vaults":     vaults,
+		"vaults":     vaultGrantsToJSON(agent.Vaults),
 		"created_by": agent.CreatedBy,
 		"created_at": agent.CreatedAt.Format(time.RFC3339),
 		"updated_at": agent.UpdatedAt.Format(time.RFC3339),
@@ -601,7 +616,7 @@ func (s *Server) handleAgentRevoke(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Safety: cannot revoke the last owner.
-	if agent.Role == "owner" && s.guardLastOwner(ctx, w, "revoke") {
+	if agent.IsOwner() && s.guardLastOwner(ctx, w, "revoke") {
 		return
 	}
 
@@ -739,27 +754,19 @@ func (s *Server) handleVaultAgentList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type item struct {
-		Name      string `json:"name"`
-		AgentID   string `json:"agent_id"`
-		VaultRole string `json:"vault_role"`
-		Status    string `json:"status"`
+		Name    string `json:"name"`
+		AgentID string `json:"agent_id"`
+		Role    string `json:"role"`
+		Status  string `json:"status"`
 	}
 	items := make([]item, 0, len(agents))
 	seen := make(map[string]bool)
 	for _, ag := range agents {
-		// Find this vault's role from the agent's grants.
-		var role string
-		for _, v := range ag.Vaults {
-			if v.VaultID == ns.ID {
-				role = v.Role
-				break
-			}
-		}
 		items = append(items, item{
-			Name:      ag.Name,
-			AgentID:   ag.ID,
-			VaultRole: role,
-			Status:    ag.Status,
+			Name:    ag.Name,
+			AgentID: ag.ID,
+			Role:    ag.Role,
+			Status:  ag.Status,
 		})
 		seen[ag.Name] = true
 	}
@@ -773,9 +780,9 @@ func (s *Server) handleVaultAgentList(w http.ResponseWriter, r *http.Request) {
 		for _, v := range inv.Vaults {
 			if v.VaultID == ns.ID {
 				items = append(items, item{
-					Name:      inv.AgentName,
-					VaultRole: v.VaultRole,
-					Status:    "pending",
+					Name:   inv.AgentName,
+					Role:   inv.AgentRole,
+					Status: "pending",
 				})
 				seen[inv.AgentName] = true
 				break
@@ -803,41 +810,33 @@ func (s *Server) handleVaultAgentAdd(w http.ResponseWriter, r *http.Request) {
 
 	var body struct {
 		Name string `json:"name"`
-		Role string `json:"role"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Name == "" {
 		jsonError(w, http.StatusBadRequest, `Request body must include {"name": "agent-name"}`)
 		return
 	}
-	if body.Role == "" {
-		body.Role = "proxy"
-	}
-	if body.Role != "proxy" && body.Role != "member" && body.Role != "admin" {
-		jsonError(w, http.StatusBadRequest, "Role must be one of: proxy, member, admin")
-		return
-	}
 
 	agent, err := s.store.GetAgentByName(ctx, body.Name)
 	if err != nil || agent == nil {
-		// Agent doesn't exist yet — check for a pending invite and add a vault pre-assignment.
+		// Agent doesn't exist yet — check for a pending invite and add
+		// a vault scope pre-assignment.
 		inv, invErr := s.store.GetPendingInviteByAgentName(ctx, body.Name)
 		if invErr != nil || inv == nil {
 			jsonError(w, http.StatusNotFound, fmt.Sprintf("Agent %q not found", body.Name))
 			return
 		}
-		// Check not already pre-assigned to this vault.
 		for _, v := range inv.Vaults {
 			if v.VaultID == ns.ID {
 				jsonError(w, http.StatusConflict, fmt.Sprintf("Agent %q is already pre-assigned to vault %q", body.Name, nsName))
 				return
 			}
 		}
-		if err := s.store.AddAgentInviteVault(ctx, inv.ID, ns.ID, body.Role); err != nil {
+		if err := s.store.AddAgentInviteVault(ctx, inv.ID, ns.ID); err != nil {
 			jsonError(w, http.StatusInternalServerError, "Failed to add vault pre-assignment to agent invite")
 			return
 		}
 		jsonCreated(w, map[string]string{
-			"message": fmt.Sprintf("agent %q pre-assigned to vault %q with role %q (pending invite acceptance)", body.Name, nsName, body.Role),
+			"message": fmt.Sprintf("agent %q pre-assigned to vault %q (pending invite acceptance)", body.Name, nsName),
 		})
 		return
 	}
@@ -845,20 +844,23 @@ func (s *Server) handleVaultAgentAdd(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusConflict, "Agent is revoked")
 		return
 	}
+	if agent.IsOwner() {
+		jsonError(w, http.StatusConflict, "Owner agents auto-access every vault")
+		return
+	}
 
-	// Check not already granted.
 	if has, _ := s.store.HasVaultAccess(ctx, agent.ID, ns.ID); has {
 		jsonError(w, http.StatusConflict, fmt.Sprintf("Agent %q already has access to vault %q", body.Name, nsName))
 		return
 	}
 
-	if err := s.store.GrantVaultRole(ctx, agent.ID, "agent", ns.ID, body.Role); err != nil {
+	if err := s.store.GrantVaultAccess(ctx, agent.ID, "agent", ns.ID); err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to add agent to vault")
 		return
 	}
 
 	jsonCreated(w, map[string]string{
-		"message": fmt.Sprintf("agent %q added to vault %q with role %q", body.Name, nsName, body.Role),
+		"message": fmt.Sprintf("agent %q added to vault %q", body.Name, nsName),
 	})
 }
 
@@ -906,93 +908,15 @@ func (s *Server) handleVaultAgentRemove(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
-func (s *Server) handleVaultAgentSetRole(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	nsName := r.PathValue("name")
-	agentName := r.PathValue("agentName")
-
-	ns, err := s.store.GetVault(ctx, nsName)
-	if err != nil || ns == nil {
-		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", nsName))
-		return
-	}
-
-	// Vault admin required.
-	if _, err := s.requireVaultAdmin(w, r, ns.ID); err != nil {
-		return
-	}
-
-	var body struct {
-		Role string `json:"role"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Role == "" {
-		jsonError(w, http.StatusBadRequest, `Request body must include {"role": "proxy|member|admin"}`)
-		return
-	}
-	if body.Role != "proxy" && body.Role != "member" && body.Role != "admin" {
-		jsonError(w, http.StatusBadRequest, "Role must be one of: proxy, member, admin")
-		return
-	}
-
-	agent, err := s.store.GetAgentByName(ctx, agentName)
-	if err != nil || agent == nil {
-		// Agent doesn't exist yet — check for a pending invite pre-assignment.
-		inv, invErr := s.store.GetPendingInviteByAgentName(ctx, agentName)
-		if invErr != nil || inv == nil {
-			jsonError(w, http.StatusNotFound, fmt.Sprintf("Agent %q not found", agentName))
-			return
-		}
-		// Verify pre-assignment exists for this vault.
-		found := false
-		for _, v := range inv.Vaults {
-			if v.VaultID == ns.ID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			jsonError(w, http.StatusNotFound, fmt.Sprintf("Agent %q does not have access to vault %q", agentName, nsName))
-			return
-		}
-		if err := s.store.UpdateAgentInviteVaultRole(ctx, inv.ID, ns.ID, body.Role); err != nil {
-			jsonError(w, http.StatusInternalServerError, "Failed to update agent role")
-			return
-		}
-		jsonOK(w, map[string]string{
-			"message": fmt.Sprintf("agent %q vault %q pre-assignment role updated to %q", agentName, nsName, body.Role),
-		})
-		return
-	}
-
-	// Verify agent has access to this vault.
-	oldRole, err := s.store.GetVaultRole(ctx, agent.ID, ns.ID)
-	if err != nil {
-		jsonError(w, http.StatusNotFound, fmt.Sprintf("Agent %q does not have access to vault %q", agentName, nsName))
-		return
-	}
-
-	if err := s.store.GrantVaultRole(ctx, agent.ID, "agent", ns.ID, body.Role); err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to update agent role")
-		return
-	}
-
-	jsonOK(w, map[string]string{
-		"message":  fmt.Sprintf("agent %q role in vault %q updated to %q", agentName, nsName, body.Role),
-		"old_role": oldRole,
-		"new_role": body.Role,
-	})
-}
-
 func (s *Server) handleAgentInviteCreate(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	type vaultReq struct {
 		VaultName string `json:"vault_name"`
-		VaultRole string `json:"vault_role"`
 	}
 	var req struct {
 		Name              string     `json:"name"`
-		Role              string     `json:"role"` // instance-level role: "owner" or "admin" (default: "admin")
+		Role              string     `json:"role"` // instance role: "owner", "admin", or "agent" (default: "agent")
 		TTLSeconds        int        `json:"ttl_seconds"`
 		SessionTTLSeconds *int       `json:"session_ttl_seconds,omitempty"`
 		Vaults            []vaultReq `json:"vaults"`
@@ -1034,9 +958,13 @@ func (s *Server) handleAgentInviteCreate(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	// Any authenticated actor can create agent invites.
+	// Owners and admins can create agent invites; agents cannot invite.
 	actor, err := s.requireActor(w, r)
 	if err != nil {
+		return
+	}
+	if actor.IsAgent() {
+		jsonError(w, http.StatusForbidden, "Agents cannot create agent invites")
 		return
 	}
 
@@ -1062,46 +990,38 @@ func (s *Server) handleAgentInviteCreate(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Validate and resolve vault pre-assignments.
+	// Validate and resolve vault pre-assignments. Each entry is a pure
+	// scope grant; effective power inside the vault comes from the
+	// invite's instance role. Admin inviters cannot pre-assign vaults
+	// outside their own scope.
+	scope := s.actorVaultScope(ctx, actor)
 	var inviteVaults []store.AgentInviteVault
 	for _, v := range req.Vaults {
-		if v.VaultRole == "" {
-			v.VaultRole = "proxy"
-		}
-		if v.VaultRole != "proxy" && v.VaultRole != "member" && v.VaultRole != "admin" {
-			jsonError(w, http.StatusBadRequest, fmt.Sprintf("Invalid vault role %q for vault %q", v.VaultRole, v.VaultName))
-			return
-		}
 		ns, err := s.store.GetVault(ctx, v.VaultName)
 		if err != nil || ns == nil {
 			jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", v.VaultName))
 			return
 		}
-		// Inviter must be admin of the vault (or instance owner).
-		if !actor.IsOwner() {
-			role, err := s.store.GetVaultRole(ctx, actor.ID, ns.ID)
-			if err != nil || role != "admin" {
-				jsonError(w, http.StatusForbidden, fmt.Sprintf("You must be an admin of vault %q to pre-assign it", v.VaultName))
-				return
-			}
+		if !scopeContains(scope, ns.ID) {
+			jsonError(w, http.StatusForbidden, fmt.Sprintf("You must have access to vault %q to pre-assign it", v.VaultName))
+			return
 		}
 		inviteVaults = append(inviteVaults, store.AgentInviteVault{
 			VaultID:   ns.ID,
 			VaultName: v.VaultName,
-			VaultRole: v.VaultRole,
 		})
 	}
 
 	// Validate and default agent instance role.
 	agentRole := req.Role
 	if agentRole == "" {
-		agentRole = "admin"
+		agentRole = "agent"
 	}
-	if agentRole != "owner" && agentRole != "admin" {
-		jsonError(w, http.StatusBadRequest, "Role must be one of: owner, admin")
+	if agentRole != "owner" && agentRole != "admin" && agentRole != "agent" {
+		jsonError(w, http.StatusBadRequest, "Role must be one of: owner, admin, agent")
 		return
 	}
-	// Only owner actors can create owner-role agent invites.
+	// An inviter cannot grant a role higher than their own.
 	if agentRole == "owner" && !actor.IsOwner() {
 		jsonError(w, http.StatusForbidden, "Only owners can create owner-role agent invites")
 		return
@@ -1123,11 +1043,10 @@ func (s *Server) handleAgentInviteCreate(w http.ResponseWriter, r *http.Request)
 
 	type vaultResp struct {
 		VaultName string `json:"vault_name"`
-		VaultRole string `json:"vault_role"`
 	}
 	vaults := make([]vaultResp, 0, len(inviteVaults))
 	for _, v := range inviteVaults {
-		vaults = append(vaults, vaultResp{VaultName: v.VaultName, VaultRole: v.VaultRole})
+		vaults = append(vaults, vaultResp{VaultName: v.VaultName})
 	}
 
 	jsonCreated(w, map[string]interface{}{
@@ -1153,11 +1072,11 @@ func (s *Server) handleAgentSetRole(w http.ResponseWriter, r *http.Request) {
 		Role string `json:"role"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Role == "" {
-		jsonError(w, http.StatusBadRequest, `Request body must include {"role": "owner|admin"}`)
+		jsonError(w, http.StatusBadRequest, `Request body must include {"role": "owner|admin|agent"}`)
 		return
 	}
-	if body.Role != "owner" && body.Role != "admin" {
-		jsonError(w, http.StatusBadRequest, "Role must be one of: owner, admin")
+	if body.Role != "owner" && body.Role != "admin" && body.Role != "agent" {
+		jsonError(w, http.StatusBadRequest, "Role must be one of: owner, admin, agent")
 		return
 	}
 
@@ -1172,7 +1091,7 @@ func (s *Server) handleAgentSetRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Safety: cannot demote the last owner (user or agent).
-	if agent.Role == "owner" && body.Role == "admin" && s.guardLastOwner(ctx, w, "demote") {
+	if agent.IsOwner() && body.Role != "owner" && s.guardLastOwner(ctx, w, "demote") {
 		return
 	}
 

--- a/internal/server/handle_agents.go
+++ b/internal/server/handle_agents.go
@@ -472,8 +472,15 @@ func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 	}
 	scope := s.actorVaultScope(ctx, actor)
 	if scope != nil {
+		// Owner agents auto-access every vault and have no vault_grants
+		// rows, so include them unconditionally — otherwise scoped admins
+		// can't see which owner agents may be hitting their vault.
 		var filtered []store.Agent
 		for _, ag := range agents {
+			if ag.IsOwner() {
+				filtered = append(filtered, ag)
+				continue
+			}
 			for _, v := range ag.Vaults {
 				if scope[v.VaultID] {
 					filtered = append(filtered, ag)
@@ -519,13 +526,15 @@ func (s *Server) handleAgentList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Include agents with pending invites (not yet redeemed).
-	// Non-owners only see invites targeting vaults they can access.
+	// Non-owners only see invites targeting vaults they can access, plus
+	// any owner-role invites (those have no per-vault scope and the
+	// resulting agent will auto-access every vault once redeemed).
 	pendingInvites, _ := s.store.ListInvites(ctx, "pending")
 	for _, inv := range pendingInvites {
 		if seen[inv.AgentName] {
 			continue
 		}
-		if scope != nil {
+		if scope != nil && inv.AgentRole != "owner" {
 			hasOverlap := false
 			for _, v := range inv.Vaults {
 				if scope[v.VaultID] {
@@ -771,7 +780,28 @@ func (s *Server) handleVaultAgentList(w http.ResponseWriter, r *http.Request) {
 		seen[ag.Name] = true
 	}
 
-	// Include pending invite pre-assignments for this vault.
+	// Owner agents auto-access every vault and have no vault_grants rows,
+	// so ListAgents (which inner-joins on vault_grants) excludes them.
+	// Union them in here so vault members can see owner agents that may be
+	// hitting their vault through the proxy.
+	if allAgents, err := s.store.ListAllAgents(ctx); err == nil {
+		for _, ag := range allAgents {
+			if !ag.IsOwner() || seen[ag.Name] {
+				continue
+			}
+			items = append(items, item{
+				Name:    ag.Name,
+				AgentID: ag.ID,
+				Role:    ag.Role,
+				Status:  ag.Status,
+			})
+			seen[ag.Name] = true
+		}
+	}
+
+	// Include pending invite pre-assignments for this vault, plus any
+	// pending owner-role invites (they don't carry per-vault scope but the
+	// resulting agent will auto-access this vault once redeemed).
 	pendingInvites, _ := s.store.ListInvitesByVault(ctx, ns.ID, "pending")
 	for _, inv := range pendingInvites {
 		if seen[inv.AgentName] {
@@ -787,6 +817,19 @@ func (s *Server) handleVaultAgentList(w http.ResponseWriter, r *http.Request) {
 				seen[inv.AgentName] = true
 				break
 			}
+		}
+	}
+	if ownerInvites, err := s.store.ListInvites(ctx, "pending"); err == nil {
+		for _, inv := range ownerInvites {
+			if inv.AgentRole != "owner" || seen[inv.AgentName] {
+				continue
+			}
+			items = append(items, item{
+				Name:   inv.AgentName,
+				Role:   inv.AgentRole,
+				Status: "pending",
+			})
+			seen[inv.AgentName] = true
 		}
 	}
 

--- a/internal/server/handle_auth.go
+++ b/internal/server/handle_auth.go
@@ -147,13 +147,9 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Try to register as the first user (atomic: count + create + activate + grant).
-	defaultVault, _ := s.store.GetVault(ctx, store.DefaultVault)
-	var defaultVaultID string
-	if defaultVault != nil {
-		defaultVaultID = defaultVault.ID
-	}
-	user, err := s.store.RegisterFirstUser(ctx, req.Email, hash, salt, defaultVaultID, kdfParams.Time, kdfParams.Memory, kdfParams.Threads)
+	// Try to register as the first user (atomic: count + create + activate).
+	// Owners auto-access every vault, so no per-vault grant is needed.
+	user, err := s.store.RegisterFirstUser(ctx, req.Email, hash, salt, kdfParams.Time, kdfParams.Memory, kdfParams.Threads)
 	if err == nil {
 		// First user: owner created successfully.
 		s.initialized = true

--- a/internal/server/handle_credentials.go
+++ b/internal/server/handle_credentials.go
@@ -42,8 +42,7 @@ func (s *Server) handleCredentialsSet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Setting credentials requires member+ role.
-	if _, err := s.requireVaultMember(w, r, ns.ID); err != nil {
+	if _, err := s.requireVaultAdmin(w, r, ns.ID); err != nil {
 		return
 	}
 
@@ -98,12 +97,10 @@ func (s *Server) handleCredentialsList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if reveal {
-		// Revealing values requires member+ role (blocks proxy-role agents).
-		if _, err := s.requireVaultMember(w, r, ns.ID); err != nil {
+		if _, err := s.requireVaultAdmin(w, r, ns.ID); err != nil {
 			return
 		}
 	} else {
-		// Listing keys only requires any vault access.
 		if _, err := s.requireVaultAccess(w, r, ns.ID); err != nil {
 			return
 		}
@@ -189,8 +186,7 @@ func (s *Server) handleCredentialsDelete(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Deleting credentials requires member+ role.
-	if _, err := s.requireVaultMember(w, r, ns.ID); err != nil {
+	if _, err := s.requireVaultAdmin(w, r, ns.ID); err != nil {
 		return
 	}
 

--- a/internal/server/handle_discovery.go
+++ b/internal/server/handle_discovery.go
@@ -28,7 +28,7 @@ func (s *Server) handleDiscover(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ns, _, err := s.resolveVaultForSession(w, r, sess)
+	ns, err := s.resolveVaultForSession(w, r, sess)
 	if err != nil {
 		return
 	}

--- a/internal/server/handle_logs.go
+++ b/internal/server/handle_logs.go
@@ -40,9 +40,7 @@ func (s *Server) handleVaultLogsList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Logs live alongside Proposals: member+ can read, proxy-only (agents)
-	// cannot. Owner-scoped instance-wide logs will be a separate handler.
-	if _, err := s.requireVaultMember(w, r, ns.ID); err != nil {
+	if _, err := s.requireVaultAdmin(w, r, ns.ID); err != nil {
 		return
 	}
 

--- a/internal/server/handle_proposals.go
+++ b/internal/server/handle_proposals.go
@@ -121,7 +121,7 @@ func (s *Server) handleProposalCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resolvedVault, _, err := s.resolveVaultForSession(w, r, sess)
+	resolvedVault, err := s.resolveVaultForSession(w, r, sess)
 	if err != nil {
 		return
 	}
@@ -212,24 +212,39 @@ func (s *Server) handleProposalCreate(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// notifyProposalCreated sends an email notification to all vault members
-// when a new proposal is created. Intended to be called in a goroutine.
+// notifyProposalCreated sends an email notification to every human who
+// can approve the proposal: instance admins with explicit vault scope,
+// plus all instance owners (owners auto-access every vault under the
+// unified instance-role model). Intended to be called in a goroutine.
 func (s *Server) notifyProposalCreated(vaultID, vaultName string, proposalID int, message, approvalURL, agentName string) {
 	ctx := context.Background()
 
-	grants, err := s.store.ListVaultMembersByType(ctx, vaultID, "user")
-	if err != nil || len(grants) == 0 {
-		return
-	}
+	emailSet := make(map[string]struct{})
 
-	var emails []string
-	for _, g := range grants {
-		if u, err := s.store.GetUserByID(ctx, g.ActorID); err == nil && u != nil {
-			emails = append(emails, u.Email)
+	// Scoped users (admins with explicit grant on this vault).
+	if grants, err := s.store.ListVaultMembersByType(ctx, vaultID, "user"); err == nil {
+		for _, g := range grants {
+			if u, err := s.store.GetUserByID(ctx, g.ActorID); err == nil && u != nil && u.IsActive {
+				emailSet[u.Email] = struct{}{}
+			}
 		}
 	}
-	if len(emails) == 0 {
+
+	// All instance owners — they auto-access every vault.
+	if users, err := s.store.ListUsers(ctx); err == nil {
+		for _, u := range users {
+			if u.Role == "owner" && u.IsActive {
+				emailSet[u.Email] = struct{}{}
+			}
+		}
+	}
+
+	if len(emailSet) == 0 {
 		return
+	}
+	emails := make([]string, 0, len(emailSet))
+	for email := range emailSet {
+		emails = append(emails, email)
 	}
 
 	// Truncate message for the email body.
@@ -260,7 +275,7 @@ func (s *Server) handleProposalGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resolvedVault, _, err := s.resolveVaultForSession(w, r, sess)
+	resolvedVault, err := s.resolveVaultForSession(w, r, sess)
 	if err != nil {
 		return
 	}
@@ -299,7 +314,7 @@ func (s *Server) handleProposalList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resolvedVault, _, err := s.resolveVaultForSession(w, r, sess)
+	resolvedVault, err := s.resolveVaultForSession(w, r, sess)
 	if err != nil {
 		return
 	}
@@ -362,8 +377,7 @@ func (s *Server) handleAdminProposalApprove(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Approving proposals requires member+ role (blocks proxy-role agents from self-approving).
-	if _, err := s.requireProposalReview(w, r, ns.ID); err != nil {
+	if _, err := s.requireVaultAdmin(w, r, ns.ID); err != nil {
 		return
 	}
 
@@ -504,8 +518,7 @@ func (s *Server) handleAdminProposalReject(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Rejecting proposals requires member+ role (blocks proxy-role agents from self-rejecting).
-	if _, err := s.requireProposalReview(w, r, ns.ID); err != nil {
+	if _, err := s.requireVaultAdmin(w, r, ns.ID); err != nil {
 		return
 	}
 
@@ -544,28 +557,18 @@ func (s *Server) handleAdminProposalList(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if _, err := s.requireVaultAccess(w, r, ns.ID); err != nil {
+	actor, err := s.requireVaultAccess(w, r, ns.ID)
+	if err != nil {
 		return
-	}
-
-	// Proxy-role sessions can only view pending proposals (to avoid duplicates).
-	sess := sessionFromContext(r.Context())
-	isProxy := false
-	if sess != nil {
-		if sess.VaultID != "" {
-			isProxy = sess.VaultRole == "proxy"
-		} else if sess.AgentID != "" {
-			if role, err := s.store.GetVaultRole(ctx, sess.AgentID, ns.ID); err == nil {
-				isProxy = role == "proxy"
-			}
-		}
 	}
 
 	// Lazy expiration.
 	_, _ = s.store.ExpirePendingProposals(ctx, time.Now().Add(-7*24*time.Hour))
 
 	status := r.URL.Query().Get("status")
-	if isProxy {
+	// Agents can only see pending proposals — clamp the filter so they
+	// don't see their own proposals after approval/rejection.
+	if actor.IsAgent() {
 		status = "pending"
 	}
 	list, err := s.store.ListProposals(ctx, ns.ID, status)
@@ -620,7 +623,8 @@ func (s *Server) handleAdminProposalGet(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if _, err := s.requireVaultAccess(w, r, ns.ID); err != nil {
+	actor, err := s.requireVaultAccess(w, r, ns.ID)
+	if err != nil {
 		return
 	}
 
@@ -637,10 +641,8 @@ func (s *Server) handleAdminProposalGet(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Proxy-role agents can only view pending proposals.
-	sess := sessionFromContext(r.Context())
-	if sess != nil && sess.VaultID != "" && sess.VaultRole == "proxy" && cs.Status != "pending" {
-		jsonError(w, http.StatusForbidden, "Proxy-role agents can only view pending proposals")
+	if actor.IsAgent() && cs.Status != "pending" {
+		jsonError(w, http.StatusForbidden, "Agents can only view pending proposals")
 		return
 	}
 

--- a/internal/server/handle_sessions.go
+++ b/internal/server/handle_sessions.go
@@ -1,18 +1,14 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
-
-	"github.com/Infisical/agent-vault/internal/store"
 )
 
 type scopedSessionRequest struct {
 	Vault      string `json:"vault"`
-	VaultRole  string `json:"vault_role"`
 	TTLSeconds *int   `json:"ttl_seconds,omitempty"`
 }
 
@@ -29,13 +25,6 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate role if provided.
-	if req.VaultRole != "" && req.VaultRole != "proxy" && req.VaultRole != "member" && req.VaultRole != "admin" {
-		jsonError(w, http.StatusBadRequest, "vault_role must be one of: proxy, member, admin")
-		return
-	}
-
-	// Validate TTL bounds if provided.
 	if req.TTLSeconds != nil {
 		ttl := time.Duration(*req.TTLSeconds) * time.Second
 		if ttl < scopedSessionMinTTL || ttl > scopedSessionMaxTTL {
@@ -55,24 +44,13 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check that the caller has access to this vault.
-	if _, err := s.requireVaultAccess(w, r, ns.ID); err != nil {
+	// requireVaultAccess returns the resolved actor; effective power inside
+	// the scoped session derives from the actor's instance role.
+	actor, err := s.requireVaultAccess(w, r, ns.ID)
+	if err != nil {
 		return
 	}
 
-	// Default to "proxy" if no role specified; cap to caller's own role.
-	requestedRole := req.VaultRole
-	if requestedRole == "" {
-		requestedRole = "proxy"
-	}
-	parentSess := sessionFromContext(ctx)
-	cappedRole, errMsg := s.capRequestedRole(ctx, parentSess, ns.ID, requestedRole)
-	if errMsg != "" {
-		jsonError(w, http.StatusForbidden, errMsg)
-		return
-	}
-
-	// Compute expiry: use ttl_seconds if provided, otherwise default 24h.
 	var expiresAt *time.Time
 	if req.TTLSeconds != nil {
 		t := time.Now().Add(time.Duration(*req.TTLSeconds) * time.Second)
@@ -82,7 +60,13 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 		expiresAt = &t
 	}
 
-	sess, err := s.store.CreateScopedSession(ctx, ns.ID, cappedRole, expiresAt)
+	var userID, agentID string
+	if actor.Type == "user" {
+		userID = actor.ID
+	} else {
+		agentID = actor.ID
+	}
+	sess, err := s.store.CreateScopedSession(ctx, ns.ID, userID, agentID, expiresAt)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create scoped session")
 		return
@@ -94,42 +78,3 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 		AVAddr:    s.baseURL,
 	})
 }
-
-// capRequestedRole enforces role-capping rules: the requested role cannot
-// exceed the caller's own vault role. Proxy-role agents cannot mint sessions at all.
-// Returns the validated role, or an error string if the caller lacks permission.
-func (s *Server) capRequestedRole(ctx context.Context, sess *store.Session, vaultID, requestedRole string) (string, string) {
-	if requestedRole == "" {
-		requestedRole = "proxy"
-	}
-
-	var callerRole string
-
-	if sess.VaultID != "" {
-		// Scoped session (agent or temp invite).
-		if sess.VaultID != vaultID {
-			return "", "Session not authorized for this vault"
-		}
-		if !roleSatisfies(sess.VaultRole, "member") {
-			return "", "Member role required"
-		}
-		callerRole = sess.VaultRole
-	} else {
-		// Instance-level session: resolve actor and check vault access.
-		actor, err := s.actorFromSession(ctx, sess)
-		if err != nil || actor == nil {
-			return "", "Invalid session"
-		}
-		role, err2 := s.store.GetVaultRole(ctx, actor.ID, vaultID)
-		if err2 != nil {
-			return "", "No access to this vault"
-		}
-		callerRole = role
-	}
-
-	if !roleSatisfies(callerRole, requestedRole) {
-		return "", fmt.Sprintf("Your vault role (%s) cannot mint sessions with role %s", callerRole, requestedRole)
-	}
-	return requestedRole, ""
-}
-

--- a/internal/server/handle_users.go
+++ b/internal/server/handle_users.go
@@ -76,7 +76,6 @@ func (s *Server) buildOwnerUserList(ctx context.Context, users []store.User) []m
 
 	type vaultEntry struct {
 		VaultName string `json:"vault_name"`
-		VaultRole string `json:"vault_role"`
 	}
 	items := make([]map[string]interface{}, len(users))
 	for i, u := range users {
@@ -84,7 +83,7 @@ func (s *Server) buildOwnerUserList(ctx context.Context, users []store.User) []m
 		vaults := make([]vaultEntry, 0, len(grants))
 		for _, g := range grants {
 			if name, ok := vaultNameByID[g.VaultID]; ok {
-				vaults = append(vaults, vaultEntry{VaultName: name, VaultRole: g.Role})
+				vaults = append(vaults, vaultEntry{VaultName: name})
 			}
 		}
 		items[i] = map[string]interface{}{
@@ -192,7 +191,7 @@ func (s *Server) handleUserDelete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Prevent deleting the last owner.
-	if user.Role == "owner" && s.guardLastOwner(ctx, w, "remove") {
+	if user.IsOwner() && s.guardLastOwner(ctx, w, "remove") {
 		return
 	}
 
@@ -235,7 +234,7 @@ func (s *Server) handleUserSetRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Prevent demoting the last owner.
-	if user.Role == "owner" && req.Role == "admin" && s.guardLastOwner(ctx, w, "demote") {
+	if user.IsOwner() && req.Role == "admin" && s.guardLastOwner(ctx, w, "demote") {
 		return
 	}
 
@@ -254,13 +253,12 @@ const maxPendingUserInvites = 50
 // userInviteVaultJSON is the JSON response shape for vault pre-assignments on invites.
 type userInviteVaultJSON struct {
 	VaultName string `json:"vault_name"`
-	VaultRole string `json:"vault_role"`
 }
 
 func vaultsToJSON(vaults []store.UserInviteVault) []userInviteVaultJSON {
 	items := make([]userInviteVaultJSON, len(vaults))
 	for i, v := range vaults {
-		items[i] = userInviteVaultJSON{VaultName: v.VaultName, VaultRole: v.VaultRole}
+		items[i] = userInviteVaultJSON{VaultName: v.VaultName}
 	}
 	return items
 }
@@ -305,13 +303,17 @@ func (s *Server) handleUserInviteCreate(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		return
 	}
+	// Agents are proxy-only and cannot invite other actors.
+	if actor.IsAgent() {
+		jsonError(w, http.StatusForbidden, "Agents cannot create user invites")
+		return
+	}
 
 	var req struct {
 		Email  string `json:"email"`
 		Role   string `json:"role"`
 		Vaults []struct {
 			VaultName string `json:"vault_name"`
-			VaultRole string `json:"vault_role"`
 		} `json:"vaults"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -366,30 +368,23 @@ func (s *Server) handleUserInviteCreate(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Resolve and validate vault pre-assignments.
+	// Resolve and validate vault pre-assignments. Each entry is a pure
+	// scope grant; effective power inside the vault comes from the
+	// invite's instance role. Admin inviters cannot pre-assign vaults
+	// outside their own scope.
+	scope := s.actorVaultScope(ctx, actor)
 	var vaults []store.UserInviteVault
 	for _, v := range req.Vaults {
-		if v.VaultRole == "" {
-			v.VaultRole = "member"
-		}
-		if v.VaultRole != "admin" && v.VaultRole != "member" {
-			jsonError(w, http.StatusBadRequest, fmt.Sprintf("Vault role must be 'admin' or 'member', got %q", v.VaultRole))
-			return
-		}
 		vault, err := s.store.GetVault(ctx, v.VaultName)
 		if err != nil || vault == nil {
 			jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", v.VaultName))
 			return
 		}
-		// Non-owners must be admin of each pre-assigned vault.
-		if !actor.IsOwner() {
-			role, _ := s.store.GetVaultRole(ctx, actor.ID, vault.ID)
-			if role != "admin" {
-				jsonError(w, http.StatusForbidden, fmt.Sprintf("You must be an admin of vault %q to pre-assign it", v.VaultName))
-				return
-			}
+		if !scopeContains(scope, vault.ID) {
+			jsonError(w, http.StatusForbidden, fmt.Sprintf("You must have access to vault %q to pre-assign it", v.VaultName))
+			return
 		}
-		vaults = append(vaults, store.UserInviteVault{VaultID: vault.ID, VaultName: vault.Name, VaultRole: v.VaultRole})
+		vaults = append(vaults, store.UserInviteVault{VaultID: vault.ID, VaultName: vault.Name})
 	}
 
 	inv, err := s.store.CreateUserInvite(ctx, req.Email, actor.ID, role, time.Now().Add(userInviteTTL), vaults)
@@ -497,11 +492,14 @@ func (s *Server) handleUserInviteAccept(w http.ResponseWriter, r *http.Request) 
 		user = newUser
 	}
 
-	// Grant pre-assigned vault access.
-	for _, v := range inv.Vaults {
-		if err := s.store.GrantVaultRole(ctx, user.ID, "user", v.VaultID, v.VaultRole); err != nil {
-			jsonError(w, http.StatusInternalServerError, "Failed to grant vault access")
-			return
+	// Grant pre-assigned vault scope. Owners auto-access every vault, so
+	// we skip the writes for owner invites.
+	if inv.Role != "owner" {
+		for _, v := range inv.Vaults {
+			if err := s.store.GrantVaultAccess(ctx, user.ID, "user", v.VaultID); err != nil {
+				jsonError(w, http.StatusInternalServerError, "Failed to grant vault access")
+				return
+			}
 		}
 	}
 
@@ -534,24 +532,20 @@ func (s *Server) handleUserInviteList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Non-owners only see invites they created or invites with pre-assignments to vaults they admin.
-	if !actor.IsOwner() {
-		actorGrants, _ := s.store.ListActorGrants(ctx, actor.ID)
-		adminVaultIDs := map[string]bool{}
-		for _, g := range actorGrants {
-			if g.Role == "admin" {
-				adminVaultIDs[g.VaultID] = true
-			}
-		}
-
+	// Non-owners only see invites they created or invites with
+	// pre-assignments overlapping their own scope.
+	if scope := s.actorVaultScope(ctx, actor); scope != nil {
 		var filtered []store.UserInvite
 		for _, inv := range invites {
 			if inv.CreatedBy == actor.ID {
 				filtered = append(filtered, inv)
 				continue
 			}
+			if !actor.IsAdmin() {
+				continue
+			}
 			for _, v := range inv.Vaults {
-				if adminVaultIDs[v.VaultID] {
+				if scope[v.VaultID] {
 					filtered = append(filtered, inv)
 					break
 				}
@@ -604,18 +598,7 @@ func (s *Server) handleUserInviteRevoke(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Authorization: creator, owner, or admin of a pre-assigned vault
-	allowed := inv.CreatedBy == actor.ID || actor.IsOwner()
-	if !allowed {
-		for _, v := range inv.Vaults {
-			role, _ := s.store.GetVaultRole(ctx, actor.ID, v.VaultID)
-			if role == "admin" {
-				allowed = true
-				break
-			}
-		}
-	}
-	if !allowed {
+	if !s.canManageInvite(ctx, actor, inv.CreatedBy, userInviteVaultIDs(inv)) {
 		jsonError(w, http.StatusForbidden, "You don't have permission to revoke this invite")
 		return
 	}
@@ -650,18 +633,7 @@ func (s *Server) handleUserInviteReinvite(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Authorization: creator, owner, or admin of a pre-assigned vault
-	allowed := existing.CreatedBy == actor.ID || actor.IsOwner()
-	if !allowed {
-		for _, v := range existing.Vaults {
-			role, _ := s.store.GetVaultRole(ctx, actor.ID, v.VaultID)
-			if role == "admin" {
-				allowed = true
-				break
-			}
-		}
-	}
-	if !allowed {
+	if !s.canManageInvite(ctx, actor, existing.CreatedBy, userInviteVaultIDs(existing)) {
 		jsonError(w, http.StatusForbidden, "You don't have permission to reinvite")
 		return
 	}

--- a/internal/server/handle_vaults.go
+++ b/internal/server/handle_vaults.go
@@ -16,9 +16,10 @@ import (
 )
 
 // resolveVaultForAdminOrOwner loads the vault and verifies the caller is
-// either a vault admin or the instance owner — the auth scope shared by
-// vault rename, delete, and settings handlers. On failure it writes the
-// error response and returns nil; callers should `return` immediately.
+// the instance owner or an instance admin scoped to it — the auth scope
+// shared by vault rename, delete, and settings handlers. On failure it
+// writes the error response and returns nil; callers should `return`
+// immediately.
 func (s *Server) resolveVaultForAdminOrOwner(w http.ResponseWriter, r *http.Request, name string) *store.Vault {
 	ctx := r.Context()
 	ns, err := s.store.GetVault(ctx, name)
@@ -26,13 +27,7 @@ func (s *Server) resolveVaultForAdminOrOwner(w http.ResponseWriter, r *http.Requ
 		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", name))
 		return nil
 	}
-	actor, err := s.requireActor(w, r)
-	if err != nil {
-		return nil
-	}
-	role, _ := s.store.GetVaultRole(ctx, actor.ID, ns.ID)
-	if role != "admin" && !actor.IsOwner() {
-		jsonError(w, http.StatusForbidden, "Vault admin or instance owner required")
+	if _, err := s.requireVaultAdmin(w, r, ns.ID); err != nil {
 		return nil
 	}
 	return ns
@@ -59,7 +54,10 @@ func readUnmatchedHostPolicy(ctx context.Context, st interface {
 	return policy, nil
 }
 
-// handleVaultContext returns the current user's membership context for a vault.
+// handleVaultContext returns the current actor's membership context for
+// a vault. Effective permissions come from the actor's instance role;
+// the response includes that role plus an explicit access flag so the
+// frontend can decide what to show.
 func (s *Server) handleVaultContext(w http.ResponseWriter, r *http.Request) {
 	vaultName := r.PathValue("name")
 	ctx := r.Context()
@@ -75,15 +73,23 @@ func (s *Server) handleVaultContext(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	vaultRole, err := s.store.GetVaultRole(ctx, actor.ID, vault.ID)
-	if err != nil {
+	hasAccess := actor.IsOwner()
+	if !hasAccess {
+		has, err := s.store.HasVaultAccess(ctx, actor.ID, vault.ID)
+		if err != nil {
+			jsonError(w, http.StatusInternalServerError, "Failed to check vault access")
+			return
+		}
+		hasAccess = has
+	}
+	if !hasAccess {
 		jsonError(w, http.StatusForbidden, "No vault access")
 		return
 	}
 
 	jsonOK(w, map[string]interface{}{
 		"vault_name": vault.Name,
-		"vault_role": vaultRole,
+		"role":       actor.Role,
 	})
 }
 
@@ -119,15 +125,16 @@ func (s *Server) handleVaultUserList(w http.ResponseWriter, r *http.Request) {
 		if err != nil || u == nil {
 			continue
 		}
-		users = append(users, userItem{Email: u.Email, Role: g.Role, Status: "active"})
+		users = append(users, userItem{Email: u.Email, Role: u.Role, Status: "active"})
 	}
 
-	// Include pending invite entries for this vault.
+	// Include pending invite entries for this vault. The instance role
+	// (from the invite) determines effective power once accepted.
 	pendingInvites, _ := s.store.ListUserInvitesByVault(ctx, vault.ID, "pending")
 	for _, inv := range pendingInvites {
 		for _, v := range inv.Vaults {
 			if v.VaultID == vault.ID {
-				users = append(users, userItem{Email: inv.Email, Role: v.VaultRole, Status: "pending"})
+				users = append(users, userItem{Email: inv.Email, Role: inv.Role, Status: "pending"})
 				break
 			}
 		}
@@ -136,7 +143,10 @@ func (s *Server) handleVaultUserList(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]interface{}{"users": users})
 }
 
-// handleVaultUserAdd adds an existing instance user to a vault directly.
+// handleVaultUserAdd attaches an existing instance user to a vault as a
+// pure scope grant. Effective power inside the vault comes from the
+// user's instance role (admin / agent — owners auto-access every vault
+// already).
 func (s *Server) handleVaultUserAdd(w http.ResponseWriter, r *http.Request) {
 	vaultName := r.PathValue("name")
 	ctx := r.Context()
@@ -153,7 +163,6 @@ func (s *Server) handleVaultUserAdd(w http.ResponseWriter, r *http.Request) {
 
 	var req struct {
 		Email string `json:"email"`
-		Role  string `json:"role"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, http.StatusBadRequest, "Invalid request body")
@@ -163,17 +172,14 @@ func (s *Server) handleVaultUserAdd(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if req.Role == "" {
-		req.Role = "member"
-	}
-	if req.Role != "admin" && req.Role != "member" {
-		jsonError(w, http.StatusBadRequest, "Role must be 'admin' or 'member'")
-		return
-	}
 
 	target, err := s.store.GetUserByEmail(ctx, req.Email)
 	if err != nil || target == nil {
 		jsonError(w, http.StatusNotFound, fmt.Sprintf("User %q not found in this instance", req.Email))
+		return
+	}
+	if target.IsOwner() {
+		jsonError(w, http.StatusConflict, "Owners auto-access every vault")
 		return
 	}
 
@@ -183,14 +189,14 @@ func (s *Server) handleVaultUserAdd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.store.GrantVaultRole(ctx, target.ID, "user", vault.ID, req.Role); err != nil {
+	if err := s.store.GrantVaultAccess(ctx, target.ID, "user", vault.ID); err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to grant vault access")
 		return
 	}
 
 	jsonCreated(w, map[string]interface{}{
 		"email": req.Email,
-		"role":  req.Role,
+		"role":  target.Role,
 	})
 }
 
@@ -215,81 +221,12 @@ func (s *Server) handleVaultUserRemove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Guard: can't remove last admin.
-	role, _ := s.store.GetVaultRole(ctx, user.ID, vault.ID)
-	if role == "admin" {
-		adminCount, _ := s.store.CountVaultAdmins(ctx, vault.ID)
-		if adminCount <= 1 {
-			jsonError(w, http.StatusConflict, "Cannot remove the last admin from this vault")
-			return
-		}
-	}
-
 	if err := s.store.RevokeVaultAccess(ctx, user.ID, vault.ID); err != nil {
 		jsonError(w, http.StatusNotFound, "User does not belong to this vault")
 		return
 	}
 
 	jsonOK(w, map[string]string{"message": fmt.Sprintf("removed %s from vault %s", email, vaultName)})
-}
-
-func (s *Server) handleVaultUserSetRole(w http.ResponseWriter, r *http.Request) {
-	vaultName := r.PathValue("name")
-	email := r.PathValue("email")
-	ctx := r.Context()
-
-	vault, err := s.store.GetVault(ctx, vaultName)
-	if err != nil || vault == nil {
-		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", vaultName))
-		return
-	}
-
-	if _, err := s.requireVaultAdmin(w, r, vault.ID); err != nil {
-		return
-	}
-
-	var req struct {
-		Role string `json:"role"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		jsonError(w, http.StatusBadRequest, "Invalid request body")
-		return
-	}
-	if req.Role != "admin" && req.Role != "member" {
-		jsonError(w, http.StatusBadRequest, "Role must be 'admin' or 'member'")
-		return
-	}
-
-	user, err := s.store.GetUserByEmail(ctx, email)
-	if err != nil || user == nil {
-		jsonError(w, http.StatusNotFound, fmt.Sprintf("User %q not found", email))
-		return
-	}
-
-	// Guard: can't demote last admin.
-	currentRole, _ := s.store.GetVaultRole(ctx, user.ID, vault.ID)
-	if currentRole == "" {
-		jsonError(w, http.StatusNotFound, "User does not belong to this vault")
-		return
-	}
-	if currentRole == "admin" && req.Role == "member" {
-		adminCount, _ := s.store.CountVaultAdmins(ctx, vault.ID)
-		if adminCount <= 1 {
-			jsonError(w, http.StatusConflict, "Cannot demote the last admin of this vault")
-			return
-		}
-	}
-
-	if err := s.store.GrantVaultRole(ctx, user.ID, "user", vault.ID, req.Role); err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to update role")
-		return
-	}
-
-	jsonOK(w, map[string]string{
-		"email":   email,
-		"role":    req.Role,
-		"message": fmt.Sprintf("updated %s's role to %s in vault %s", email, req.Role, vaultName),
-	})
 }
 
 func (s *Server) handleVaultCreate(w http.ResponseWriter, r *http.Request) {
@@ -330,8 +267,11 @@ func (s *Server) handleVaultCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Creator becomes vault admin.
-	_ = s.store.GrantVaultRole(ctx, actor.ID, actor.Type, ns.ID, "admin")
+	// Creator gets explicit scope on the new vault. Owners auto-access
+	// every vault, so we skip the write for them.
+	if !actor.IsOwner() {
+		_ = s.store.GrantVaultAccess(ctx, actor.ID, actor.Type, ns.ID)
+	}
 
 	jsonCreated(w, map[string]interface{}{
 		"id":         ns.ID,
@@ -361,8 +301,7 @@ func (s *Server) handleVaultList(w http.ResponseWriter, r *http.Request) {
 	var items []nsItem
 
 	if actor.IsOwner() {
-		// Owners see all vaults. Vaults they have explicit grants for are
-		// "explicit"; the rest are "implicit" (visible but not yet joined).
+		// Owners auto-access every vault.
 		vaults, err := s.store.ListVaults(ctx)
 		if err != nil {
 			jsonError(w, http.StatusInternalServerError, "Failed to list vaults")
@@ -370,22 +309,17 @@ func (s *Server) handleVaultList(w http.ResponseWriter, r *http.Request) {
 		}
 		for _, v := range vaults {
 			pending, _ := s.store.CountPendingProposals(ctx, v.ID)
-			role, _ := s.store.GetVaultRole(ctx, actor.ID, v.ID)
-			membership := "implicit"
-			if role != "" {
-				membership = "explicit"
-			}
 			items = append(items, nsItem{
 				ID:               v.ID,
 				Name:             v.Name,
-				Role:             role,
-				Membership:       membership,
+				Role:             actor.Role,
+				Membership:       "implicit",
 				CreatedAt:        v.CreatedAt.Format(time.RFC3339),
 				PendingProposals: pending,
 			})
 		}
 	} else {
-		// Non-owners see only vaults they have explicit grants for.
+		// Non-owners see only vaults they have explicit scope on.
 		grants, err := s.store.ListActorGrants(ctx, actor.ID)
 		if err != nil {
 			jsonError(w, http.StatusInternalServerError, "Failed to list vaults")
@@ -400,7 +334,7 @@ func (s *Server) handleVaultList(w http.ResponseWriter, r *http.Request) {
 			items = append(items, nsItem{
 				ID:               ns.ID,
 				Name:             ns.Name,
-				Role:             g.Role,
+				Role:             actor.Role,
 				Membership:       "explicit",
 				CreatedAt:        ns.CreatedAt.Format(time.RFC3339),
 				PendingProposals: pending,
@@ -581,12 +515,14 @@ func (s *Server) handleVaultSettingsPatch(w http.ResponseWriter, r *http.Request
 	jsonOK(w, map[string]interface{}{"unmatched_host_policy": string(policy)})
 }
 
+// handleVaultJoin is a no-op compatibility shim for owner-only callers.
+// Owners auto-access every vault under the unified instance-role model,
+// so explicit joining is obsolete. Returns 200 for any vault that exists
+// so older clients keep working unchanged.
 func (s *Server) handleVaultJoin(w http.ResponseWriter, r *http.Request) {
-	actor, err := s.requireOwnerActor(w, r)
-	if err != nil {
+	if _, err := s.requireOwnerActor(w, r); err != nil {
 		return
 	}
-
 	name := r.PathValue("name")
 	ctx := r.Context()
 	ns, err := s.store.GetVault(ctx, name)
@@ -594,25 +530,9 @@ func (s *Server) handleVaultJoin(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", name))
 		return
 	}
-
-	has, err := s.store.HasVaultAccess(ctx, actor.ID, ns.ID)
-	if err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to check vault access")
-		return
-	}
-	if has {
-		jsonError(w, http.StatusConflict, "Already a member of this vault")
-		return
-	}
-
-	if err := s.store.GrantVaultRole(ctx, actor.ID, actor.Type, ns.ID, "admin"); err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to join vault")
-		return
-	}
-
 	jsonOK(w, map[string]interface{}{
 		"vault":  name,
-		"role":   "admin",
+		"role":   "owner",
 		"joined": true,
 	})
 }

--- a/internal/server/handle_vaults.go
+++ b/internal/server/handle_vaults.go
@@ -293,30 +293,17 @@ func (s *Server) handleVaultList(w http.ResponseWriter, r *http.Request) {
 		ID               string `json:"id"`
 		Name             string `json:"name"`
 		Role             string `json:"role,omitempty"`
-		Membership       string `json:"membership"`
 		CreatedAt        string `json:"created_at"`
 		PendingProposals int    `json:"pending_proposals"`
 	}
 
-	var items []nsItem
-
+	var vaults []store.Vault
 	if actor.IsOwner() {
 		// Owners auto-access every vault.
-		vaults, err := s.store.ListVaults(ctx)
+		vaults, err = s.store.ListVaults(ctx)
 		if err != nil {
 			jsonError(w, http.StatusInternalServerError, "Failed to list vaults")
 			return
-		}
-		for _, v := range vaults {
-			pending, _ := s.store.CountPendingProposals(ctx, v.ID)
-			items = append(items, nsItem{
-				ID:               v.ID,
-				Name:             v.Name,
-				Role:             actor.Role,
-				Membership:       "implicit",
-				CreatedAt:        v.CreatedAt.Format(time.RFC3339),
-				PendingProposals: pending,
-			})
 		}
 	} else {
 		// Non-owners see only vaults they have explicit scope on.
@@ -330,19 +317,20 @@ func (s *Server) handleVaultList(w http.ResponseWriter, r *http.Request) {
 			if err != nil || ns == nil {
 				continue
 			}
-			pending, _ := s.store.CountPendingProposals(ctx, ns.ID)
-			items = append(items, nsItem{
-				ID:               ns.ID,
-				Name:             ns.Name,
-				Role:             actor.Role,
-				Membership:       "explicit",
-				CreatedAt:        ns.CreatedAt.Format(time.RFC3339),
-				PendingProposals: pending,
-			})
+			vaults = append(vaults, *ns)
 		}
 	}
-	if items == nil {
-		items = []nsItem{}
+
+	items := make([]nsItem, 0, len(vaults))
+	for _, v := range vaults {
+		pending, _ := s.store.CountPendingProposals(ctx, v.ID)
+		items = append(items, nsItem{
+			ID:               v.ID,
+			Name:             v.Name,
+			Role:             actor.Role,
+			CreatedAt:        v.CreatedAt.Format(time.RFC3339),
+			PendingProposals: pending,
+		})
 	}
 
 	jsonOK(w, map[string]interface{}{"vaults": items})
@@ -515,24 +503,3 @@ func (s *Server) handleVaultSettingsPatch(w http.ResponseWriter, r *http.Request
 	jsonOK(w, map[string]interface{}{"unmatched_host_policy": string(policy)})
 }
 
-// handleVaultJoin is a no-op compatibility shim for owner-only callers.
-// Owners auto-access every vault under the unified instance-role model,
-// so explicit joining is obsolete. Returns 200 for any vault that exists
-// so older clients keep working unchanged.
-func (s *Server) handleVaultJoin(w http.ResponseWriter, r *http.Request) {
-	if _, err := s.requireOwnerActor(w, r); err != nil {
-		return
-	}
-	name := r.PathValue("name")
-	ctx := r.Context()
-	ns, err := s.store.GetVault(ctx, name)
-	if err != nil || ns == nil {
-		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", name))
-		return
-	}
-	jsonOK(w, map[string]interface{}{
-		"vault":  name,
-		"role":   "owner",
-		"joined": true,
-	})
-}

--- a/internal/server/persistent_instructions_admin.txt
+++ b/internal/server/persistent_instructions_admin.txt
@@ -26,8 +26,8 @@ For vaults where you have admin role, you can also:
 - Delete credentials: DELETE {AGENT_VAULT_ADDR}/v1/credentials with X-Vault header and {"vault": "...", "keys": ["KEY"]}
 - Approve proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/approve with {"vault": "...", "credentials": {"KEY": "value"}}
 - Reject proposals: POST {AGENT_VAULT_ADDR}/v1/admin/proposals/{id}/reject with {"vault": "...", "reason": "..."}
-- Invite agents: POST {AGENT_VAULT_ADDR}/v1/agents/invites with {"name": "...", "vaults": [{"vault_name": "...", "vault_role": "proxy|member|admin"}]}
-- Invite users: POST {AGENT_VAULT_ADDR}/v1/users/invites with {"email": "...", "vaults": [{"vault_name": "...", "vault_role": "member|admin"}]}
+- Invite agents: POST {AGENT_VAULT_ADDR}/v1/agents/invites with {"name": "...", "role": "owner|admin|agent", "vaults": [{"vault_name": "..."}]}. Effective power inside each vault comes from the invite's instance role.
+- Invite users: POST {AGENT_VAULT_ADDR}/v1/users/invites with {"email": "...", "role": "owner|admin", "vaults": [{"vault_name": "..."}]}. Humans cannot hold the `agent` role.
 
 ## Full Reference
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -602,7 +602,6 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("GET /v1/vaults", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultList))))
 	mux.HandleFunc("DELETE /v1/vaults/{name}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultDelete))))
 	mux.HandleFunc("POST /v1/vaults/{name}/rename", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultRename)))))
-	mux.HandleFunc("POST /v1/vaults/{name}/join", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultJoin)))))
 	mux.HandleFunc("GET /v1/vaults/{name}/settings", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultSettingsGet))))
 	mux.HandleFunc("PATCH /v1/vaults/{name}/settings", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultSettingsPatch)))))
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -143,7 +143,7 @@ type Store interface {
 	UpdateUserPassword(ctx context.Context, userID string, passwordHash, passwordSalt []byte, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) error
 	DeleteUser(ctx context.Context, userID string) error
 	CountUsers(ctx context.Context) (int, error)
-	RegisterFirstUser(ctx context.Context, email string, passwordHash, passwordSalt []byte, defaultVaultID string, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) (*store.User, error)
+	RegisterFirstUser(ctx context.Context, email string, passwordHash, passwordSalt []byte, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) (*store.User, error)
 	CreateUserSession(ctx context.Context, p store.CreateUserSessionParams) (*store.Session, error)
 	CreateScopedSession(ctx context.Context, vaultID, userID, agentID string, expiresAt *time.Time) (*store.Session, error)
 	GetSession(ctx context.Context, id string) (*store.Session, error)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,10 +46,11 @@ var passwordResetEmailHTML string
 //go:embed test_email.html
 var testEmailHTML string
 
-// agentVaultJSON is the JSON representation of an agent's vault grant (reused across handlers).
+// agentVaultJSON is the JSON representation of an actor's vault scope grant.
+// Effective permissions in the vault come from the actor's instance role
+// (owner / admin / agent), so the grant is just a scope record.
 type agentVaultJSON struct {
 	VaultName string `json:"vault_name"`
-	VaultRole string `json:"vault_role"`
 }
 
 // Server is the Agent Vault HTTP server.
@@ -144,7 +145,7 @@ type Store interface {
 	CountUsers(ctx context.Context) (int, error)
 	RegisterFirstUser(ctx context.Context, email string, passwordHash, passwordSalt []byte, defaultVaultID string, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) (*store.User, error)
 	CreateUserSession(ctx context.Context, p store.CreateUserSessionParams) (*store.Session, error)
-	CreateScopedSession(ctx context.Context, vaultID, vaultRole string, expiresAt *time.Time) (*store.Session, error)
+	CreateScopedSession(ctx context.Context, vaultID, userID, agentID string, expiresAt *time.Time) (*store.Session, error)
 	GetSession(ctx context.Context, id string) (*store.Session, error)
 	DeleteSession(ctx context.Context, id string) error
 	DeleteUserSessions(ctx context.Context, userID string) error
@@ -160,13 +161,14 @@ type Store interface {
 	DeleteVault(ctx context.Context, name string) error
 	RenameVault(ctx context.Context, oldName string, newName string) error
 
-	// Vault grants (unified: actor_id + actor_type)
-	GrantVaultRole(ctx context.Context, actorID, actorType, vaultID, role string) error
+	// Vault scope grants (unified: actor_id + actor_type). Each row is a
+	// pure scope record — effective permissions come from the actor's
+	// instance role (owner / admin / agent). Owners are not stored here;
+	// they auto-access every vault.
+	GrantVaultAccess(ctx context.Context, actorID, actorType, vaultID string) error
 	RevokeVaultAccess(ctx context.Context, actorID, vaultID string) error
 	ListActorGrants(ctx context.Context, actorID string) ([]store.VaultGrant, error)
 	HasVaultAccess(ctx context.Context, actorID, vaultID string) (bool, error)
-	GetVaultRole(ctx context.Context, actorID, vaultID string) (string, error)
-	CountVaultAdmins(ctx context.Context, vaultID string) (int, error)
 	ListVaultMembers(ctx context.Context, vaultID string) ([]store.VaultGrant, error)
 	ListVaultMembersByType(ctx context.Context, vaultID, actorType string) ([]store.VaultGrant, error)
 
@@ -208,9 +210,8 @@ type Store interface {
 	CountPendingInvites(ctx context.Context) (int, error)
 	HasPendingInviteByAgentName(ctx context.Context, name string) (bool, error)
 	GetPendingInviteByAgentName(ctx context.Context, name string) (*store.Invite, error)
-	AddAgentInviteVault(ctx context.Context, inviteID int, vaultID, role string) error
+	AddAgentInviteVault(ctx context.Context, inviteID int, vaultID string) error
 	RemoveAgentInviteVault(ctx context.Context, inviteID int, vaultID string) error
-	UpdateAgentInviteVaultRole(ctx context.Context, inviteID int, vaultID, role string) error
 	ExpirePendingInvites(ctx context.Context, before time.Time) (int, error)
 
 	// User invites (instance-level)
@@ -288,13 +289,24 @@ func sessionFromContext(ctx context.Context) *store.Session {
 type Actor struct {
 	ID    string       // user.ID or agent.ID
 	Type  string       // "user" or "agent"
-	Role  string       // "owner" or "admin" (instance-level)
+	Role  string       // "owner", "admin", or "agent" (instance-level)
 	User  *store.User  // non-nil for user actors
 	Agent *store.Agent // non-nil for agent actors
 }
 
 // IsOwner returns true if the actor has the instance-level owner role.
+// Owners auto-access every vault and can perform any operation.
 func (a *Actor) IsOwner() bool { return a.Role == "owner" }
+
+// IsAdmin returns true if the actor has the instance-level admin role.
+// Admins can manage scoped vaults end-to-end (services, credentials,
+// proposal approval, scoped invites).
+func (a *Actor) IsAdmin() bool { return a.Role == "admin" }
+
+// IsAgent returns true if the actor has the instance-level agent role
+// (programmatic-only). Agents can use the proxy and raise proposals but
+// cannot reveal credentials or approve/reject proposals.
+func (a *Actor) IsAgent() bool { return a.Role == "agent" }
 
 // DisplayLabel returns a human-readable label for the actor (email for users, name for agents).
 func (a *Actor) DisplayLabel() string {
@@ -369,163 +381,90 @@ func (s *Server) guardLastOwner(ctx context.Context, w http.ResponseWriter, acti
 }
 
 
-// requireVaultAccess checks that the session has access to the given vault.
-// For scoped sessions (VaultID set): checks that the session's vault matches.
-// For instance-level sessions: resolves actor and checks the unified vault_grants table.
-// Returns the actor (nil for scoped sessions) or writes an error response.
+// requireVaultAccess checks that the session has access to the given
+// resolveVaultActor performs the vault-access check shared by
+// requireVaultAccess and requireVaultAdmin. requireAdmin=false admits
+// any actor with access (owner, or any actor with a scope grant);
+// requireAdmin=true additionally forbids the instance `agent` role.
+// Always returns a non-nil actor on success.
+func (s *Server) resolveVaultActor(w http.ResponseWriter, r *http.Request, vaultID string, requireAdmin bool) (*Actor, error) {
+	sess := sessionFromContext(r.Context())
+	if sess == nil {
+		jsonError(w, http.StatusForbidden, "Authentication required")
+		return nil, fmt.Errorf("no session")
+	}
+
+	if sess.VaultID != "" && sess.VaultID != vaultID {
+		jsonError(w, http.StatusForbidden, "Session not authorized for this vault")
+		return nil, fmt.Errorf("vault mismatch")
+	}
+
+	actor, err := s.actorFromSession(r.Context(), sess)
+	if err != nil {
+		jsonError(w, http.StatusForbidden, "Invalid session")
+		return nil, err
+	}
+
+	if requireAdmin && actor.IsAgent() {
+		jsonError(w, http.StatusForbidden, "Admin role required")
+		return nil, fmt.Errorf("agent forbidden")
+	}
+
+	if actor.IsOwner() {
+		return actor, nil
+	}
+
+	// Scoped sessions are pre-bound to a specific vault, so vault
+	// access is implicit once the vaultID match passes above.
+	if sess.VaultID == "" {
+		has, err := s.store.HasVaultAccess(r.Context(), actor.ID, vaultID)
+		if err != nil {
+			jsonError(w, http.StatusInternalServerError, "Failed to check vault access")
+			return nil, err
+		}
+		if !has {
+			jsonError(w, http.StatusForbidden, "No access to this vault")
+			return nil, fmt.Errorf("no grant")
+		}
+	}
+	return actor, nil
+}
+
+// actorVaultScope returns the set of vault IDs the actor is explicitly
+// scoped to. For owners (auto-access every vault) it returns nil — call
+// sites should treat a nil map as "all vaults granted." Errors fetching
+// the grants are non-fatal: a stale empty map fails closed at the caller.
+func (s *Server) actorVaultScope(ctx context.Context, actor *Actor) map[string]bool {
+	if actor.IsOwner() {
+		return nil
+	}
+	scope := make(map[string]bool)
+	if grants, err := s.store.ListActorGrants(ctx, actor.ID); err == nil {
+		for _, g := range grants {
+			scope[g.VaultID] = true
+		}
+	}
+	return scope
+}
+
+// scopeContains reports whether actor has scope on vaultID. Owners
+// (nil scope) match everything.
+func scopeContains(scope map[string]bool, vaultID string) bool {
+	return scope == nil || scope[vaultID]
+}
+
+// requireVaultAccess admits any actor with access to the vault: owner
+// (auto-access), or admin/agent with an explicit scope grant. Returns
+// the resolved actor.
 func (s *Server) requireVaultAccess(w http.ResponseWriter, r *http.Request, vaultID string) (*Actor, error) {
-	sess := sessionFromContext(r.Context())
-	if sess == nil {
-		jsonError(w, http.StatusForbidden, "Authentication required")
-		return nil, fmt.Errorf("no session")
-	}
-
-	// Scoped session: vault is baked into the session.
-	if sess.VaultID != "" {
-		if sess.VaultID != vaultID {
-			jsonError(w, http.StatusForbidden, "Session not authorized for this vault")
-			return nil, fmt.Errorf("vault mismatch")
-		}
-		return nil, nil // scoped session, no actor resolved
-	}
-
-	// Instance-level session: resolve actor, check unified vault_grants.
-	actor, err := s.actorFromSession(r.Context(), sess)
-	if err != nil {
-		jsonError(w, http.StatusForbidden, "Invalid session")
-		return nil, err
-	}
-
-	has, err := s.store.HasVaultAccess(r.Context(), actor.ID, vaultID)
-	if err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to check vault access")
-		return nil, err
-	}
-	if !has {
-		jsonError(w, http.StatusForbidden, "No access to this vault")
-		return nil, fmt.Errorf("no grant")
-	}
-
-	return actor, nil
+	return s.resolveVaultActor(w, r, vaultID, false)
 }
 
-// requireVaultAdmin checks that the actor has admin role in the given vault.
-// For scoped sessions: checks sess.VaultRole. For instance-level sessions: checks vault_grants.
+// requireVaultAdmin admits owners and instance admins with vault scope.
+// Agents are forbidden. Used for credential CRUD/reveal, services CRUD,
+// proposal approve/reject, and vault settings.
 func (s *Server) requireVaultAdmin(w http.ResponseWriter, r *http.Request, vaultID string) (*Actor, error) {
-	sess := sessionFromContext(r.Context())
-	if sess == nil {
-		jsonError(w, http.StatusForbidden, "Authentication required")
-		return nil, fmt.Errorf("no session")
-	}
-
-	// Scoped session: check role from session.
-	if sess.VaultID != "" {
-		if sess.VaultID != vaultID {
-			jsonError(w, http.StatusForbidden, "Session not authorized for this vault")
-			return nil, fmt.Errorf("vault mismatch")
-		}
-		if !roleSatisfies(sess.VaultRole, "admin") {
-			jsonError(w, http.StatusForbidden, "Vault admin role required")
-			return nil, fmt.Errorf("insufficient role: %s", sess.VaultRole)
-		}
-		return nil, nil
-	}
-
-	// Instance-level session: single GetVaultRole call (covers both existence and role check).
-	actor, err := s.actorFromSession(r.Context(), sess)
-	if err != nil {
-		jsonError(w, http.StatusForbidden, "Invalid session")
-		return nil, err
-	}
-	role, err := s.store.GetVaultRole(r.Context(), actor.ID, vaultID)
-	if err != nil {
-		jsonError(w, http.StatusForbidden, "No access to this vault")
-		return nil, fmt.Errorf("no vault grant")
-	}
-	if role != "admin" {
-		jsonError(w, http.StatusForbidden, "Vault admin role required")
-		return nil, fmt.Errorf("not vault admin")
-	}
-	return actor, nil
-}
-
-// roleSatisfies returns true if role is at least as privileged as requiredRole.
-// Hierarchy: proxy(0) < member(1) < admin(2).
-var roleRank = map[string]int{"proxy": 0, "member": 1, "admin": 2}
-
-func roleSatisfies(role, requiredRole string) bool {
-	return roleRank[role] >= roleRank[requiredRole]
-}
-
-// requireVaultMember checks that the session has member+ access to the vault.
-// For scoped sessions: requires sess.VaultRole is "member" or "admin".
-// For instance-level sessions: checks the unified vault_grants table.
-func (s *Server) requireVaultMember(w http.ResponseWriter, r *http.Request, vaultID string) (*Actor, error) {
-	sess := sessionFromContext(r.Context())
-	if sess == nil {
-		jsonError(w, http.StatusForbidden, "Authentication required")
-		return nil, fmt.Errorf("no session")
-	}
-
-	// Scoped session: check vault_role from session.
-	if sess.VaultID != "" {
-		if sess.VaultID != vaultID {
-			jsonError(w, http.StatusForbidden, "Session not authorized for this vault")
-			return nil, fmt.Errorf("vault mismatch")
-		}
-		if !roleSatisfies(sess.VaultRole, "member") {
-			jsonError(w, http.StatusForbidden, "Member role required")
-			return nil, fmt.Errorf("insufficient role: %s", sess.VaultRole)
-		}
-		return nil, nil
-	}
-
-	// Instance-level session: check vault grant and role.
-	actor, err := s.actorFromSession(r.Context(), sess)
-	if err != nil {
-		jsonError(w, http.StatusForbidden, "Invalid session")
-		return nil, err
-	}
-
-	role, err := s.store.GetVaultRole(r.Context(), actor.ID, vaultID)
-	if err != nil {
-		jsonError(w, http.StatusForbidden, "No access to this vault")
-		return nil, fmt.Errorf("no vault grant")
-	}
-	if !roleSatisfies(role, "member") {
-		jsonError(w, http.StatusForbidden, "Member role required")
-		return nil, fmt.Errorf("insufficient role: %s", role)
-	}
-	return actor, nil
-}
-
-// requireProposalReview checks proposal approve/reject access.
-// Scoped sessions require admin role (proxy-scoped sessions cannot self-approve).
-// Instance-level sessions require member+ — proxy-role actors are forbidden so
-// that a proxy cannot approve a proposal it raised and trick the broker into
-// injecting credentials toward an attacker-controlled host.
-func (s *Server) requireProposalReview(w http.ResponseWriter, r *http.Request, vaultID string) (*Actor, error) {
-	sess := sessionFromContext(r.Context())
-	if sess == nil {
-		jsonError(w, http.StatusForbidden, "Authentication required")
-		return nil, fmt.Errorf("no session")
-	}
-
-	// Scoped session: require admin role.
-	if sess.VaultID != "" {
-		if sess.VaultID != vaultID {
-			jsonError(w, http.StatusForbidden, "Session not authorized for this vault")
-			return nil, fmt.Errorf("vault mismatch")
-		}
-		if !roleSatisfies(sess.VaultRole, "admin") {
-			jsonError(w, http.StatusForbidden, "Admin role required")
-			return nil, fmt.Errorf("insufficient role: %s", sess.VaultRole)
-		}
-		return nil, nil
-	}
-
-	// Instance-level session: require member+ (proxy-role actors cannot self-approve).
-	return s.requireVaultMember(w, r, vaultID)
+	return s.resolveVaultActor(w, r, vaultID, true)
 }
 
 
@@ -643,7 +582,6 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("GET /v1/vaults/{name}/agents", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultAgentList))))
 	mux.HandleFunc("POST /v1/vaults/{name}/agents", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultAgentAdd)))))
 	mux.HandleFunc("DELETE /v1/vaults/{name}/agents/{agentName}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultAgentRemove))))
-	mux.HandleFunc("POST /v1/vaults/{name}/agents/{agentName}/role", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultAgentSetRole)))))
 
 	// Instance settings (owner-only)
 	mux.HandleFunc("GET /v1/admin/settings", s.requireInitialized(s.requireAuth(actorAuthed(s.handleGetSettings))))
@@ -701,7 +639,6 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("GET /v1/vaults/{name}/users", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultUserList))))
 	mux.HandleFunc("POST /v1/vaults/{name}/users", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultUserAdd)))))
 	mux.HandleFunc("DELETE /v1/vaults/{name}/users/{email}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultUserRemove))))
-	mux.HandleFunc("POST /v1/vaults/{name}/users/{email}/role", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultUserSetRole)))))
 
 	// Proposal approval details (token-based, no auth required)
 	mux.HandleFunc("GET /v1/proposals/approve-details", s.requireInitialized(ipApprovalToken(s.handleProposalApproveDetails)))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -175,11 +175,12 @@ func (m *mockStore) RevokeUserSession(_ context.Context, userID, publicID string
 	return sql.ErrNoRows
 }
 
-func (m *mockStore) CreateScopedSession(_ context.Context, vaultID, vaultRole string, expiresAt *time.Time) (*store.Session, error) {
+func (m *mockStore) CreateScopedSession(_ context.Context, vaultID, userID, agentID string, expiresAt *time.Time) (*store.Session, error) {
 	s := &store.Session{
 		ID:        "scoped-session-id",
 		VaultID:   vaultID,
-		VaultRole: vaultRole,
+		UserID:    userID,
+		AgentID:   agentID,
 		ExpiresAt: expiresAt,
 		CreatedAt: time.Now(),
 	}
@@ -468,13 +469,10 @@ func (m *mockStore) GetPendingInviteByAgentName(_ context.Context, name string) 
 	return nil, fmt.Errorf("not found")
 }
 
-func (m *mockStore) AddAgentInviteVault(_ context.Context, inviteID int, vaultID, role string) error {
+func (m *mockStore) AddAgentInviteVault(_ context.Context, inviteID int, vaultID string) error {
 	for _, inv := range m.invites {
 		if inv.ID == inviteID {
-			inv.Vaults = append(inv.Vaults, store.AgentInviteVault{
-				VaultID:   vaultID,
-				VaultRole: role,
-			})
+			inv.Vaults = append(inv.Vaults, store.AgentInviteVault{VaultID: vaultID})
 			return nil
 		}
 	}
@@ -492,21 +490,6 @@ func (m *mockStore) RemoveAgentInviteVault(_ context.Context, inviteID int, vaul
 			}
 			inv.Vaults = filtered
 			return nil
-		}
-	}
-	return fmt.Errorf("invite not found")
-}
-
-func (m *mockStore) UpdateAgentInviteVaultRole(_ context.Context, inviteID int, vaultID, role string) error {
-	for _, inv := range m.invites {
-		if inv.ID == inviteID {
-			for i, v := range inv.Vaults {
-				if v.VaultID == vaultID {
-					inv.Vaults[i].VaultRole = role
-					return nil
-				}
-			}
-			return fmt.Errorf("vault not found on invite")
 		}
 	}
 	return fmt.Errorf("invite not found")
@@ -659,10 +642,17 @@ func (m *mockStore) ExpirePendingInvites(_ context.Context, before time.Time) (i
 }
 
 
-func (m *mockStore) GrantVaultRole(_ context.Context, actorID, actorType, vaultID, role string) error {
+// mockStore models scope as a yes/no per-actor-per-vault grant. The
+// per-vault role is gone; the actor's instance role determines power.
+func (m *mockStore) GrantVaultAccess(_ context.Context, actorID, actorType, vaultID string) error {
 	if actorType == "agent" {
+		for _, g := range m.agentVaultGrants {
+			if g.ActorID == actorID && g.VaultID == vaultID {
+				return nil
+			}
+		}
 		m.agentVaultGrants = append(m.agentVaultGrants, store.VaultGrant{
-			ActorID: actorID, ActorType: "agent", VaultID: vaultID, Role: role, CreatedAt: time.Now(),
+			ActorID: actorID, ActorType: "agent", VaultID: vaultID, CreatedAt: time.Now(),
 		})
 		return nil
 	}
@@ -672,27 +662,33 @@ func (m *mockStore) GrantVaultRole(_ context.Context, actorID, actorType, vaultI
 	if m.grants[actorID] == nil {
 		m.grants[actorID] = make(map[string]string)
 	}
-	m.grants[actorID][vaultID] = role
+	m.grants[actorID][vaultID] = ""
 	return nil
 }
 
-func (m *mockStore) RevokeVaultAccess(_ context.Context, userID, vaultID string) error {
-	if m.grants != nil && m.grants[userID] != nil {
-		delete(m.grants[userID], vaultID)
-		return nil
+func (m *mockStore) RevokeVaultAccess(_ context.Context, actorID, vaultID string) error {
+	if m.grants != nil && m.grants[actorID] != nil {
+		if _, ok := m.grants[actorID][vaultID]; ok {
+			delete(m.grants[actorID], vaultID)
+			return nil
+		}
+	}
+	for i, g := range m.agentVaultGrants {
+		if g.ActorID == actorID && g.VaultID == vaultID {
+			m.agentVaultGrants = append(m.agentVaultGrants[:i], m.agentVaultGrants[i+1:]...)
+			return nil
+		}
 	}
 	return fmt.Errorf("grant not found")
 }
 
 func (m *mockStore) ListActorGrants(_ context.Context, actorID string) ([]store.VaultGrant, error) {
 	var grants []store.VaultGrant
-	// Check user grants
 	if m.grants != nil && m.grants[actorID] != nil {
-		for nsID, role := range m.grants[actorID] {
-			grants = append(grants, store.VaultGrant{ActorID: actorID, ActorType: "user", VaultID: nsID, Role: role})
+		for nsID := range m.grants[actorID] {
+			grants = append(grants, store.VaultGrant{ActorID: actorID, ActorType: "user", VaultID: nsID})
 		}
 	}
-	// Check agent vault grants
 	for _, g := range m.agentVaultGrants {
 		if g.ActorID == actorID {
 			grants = append(grants, g)
@@ -701,42 +697,27 @@ func (m *mockStore) ListActorGrants(_ context.Context, actorID string) ([]store.
 	return grants, nil
 }
 
-func (m *mockStore) HasVaultAccess(_ context.Context, userID, vaultID string) (bool, error) {
-	if m.grants != nil && m.grants[userID] != nil {
-		_, ok := m.grants[userID][vaultID]
-		return ok, nil
+func (m *mockStore) HasVaultAccess(_ context.Context, actorID, vaultID string) (bool, error) {
+	if m.grants != nil && m.grants[actorID] != nil {
+		if _, ok := m.grants[actorID][vaultID]; ok {
+			return true, nil
+		}
+	}
+	for _, g := range m.agentVaultGrants {
+		if g.ActorID == actorID && g.VaultID == vaultID {
+			return true, nil
+		}
 	}
 	return false, nil
 }
 
-func (m *mockStore) GetVaultRole(_ context.Context, userID, vaultID string) (string, error) {
-	if m.grants != nil && m.grants[userID] != nil {
-		if role, ok := m.grants[userID][vaultID]; ok {
-			return role, nil
-		}
-	}
-	return "", fmt.Errorf("no grant found")
-}
-
-func (m *mockStore) CountVaultAdmins(_ context.Context, vaultID string) (int, error) {
-	count := 0
-	for _, userGrants := range m.grants {
-		if role, ok := userGrants[vaultID]; ok && role == "admin" {
-			count++
-		}
-	}
-	return count, nil
-}
-
 func (m *mockStore) ListVaultMembers(_ context.Context, vaultID string) ([]store.VaultGrant, error) {
 	var result []store.VaultGrant
-	// User grants
 	for userID, userGrants := range m.grants {
-		if role, ok := userGrants[vaultID]; ok {
-			result = append(result, store.VaultGrant{ActorID: userID, ActorType: "user", VaultID: vaultID, Role: role})
+		if _, ok := userGrants[vaultID]; ok {
+			result = append(result, store.VaultGrant{ActorID: userID, ActorType: "user", VaultID: vaultID})
 		}
 	}
-	// Agent grants
 	for _, g := range m.agentVaultGrants {
 		if g.VaultID == vaultID {
 			result = append(result, g)
@@ -750,8 +731,8 @@ func (m *mockStore) ListVaultMembersByType(_ context.Context, vaultID, actorType
 	switch actorType {
 	case "user":
 		for userID, userGrants := range m.grants {
-			if role, ok := userGrants[vaultID]; ok {
-				result = append(result, store.VaultGrant{ActorID: userID, ActorType: "user", VaultID: vaultID, Role: role})
+			if _, ok := userGrants[vaultID]; ok {
+				result = append(result, store.VaultGrant{ActorID: userID, ActorType: "user", VaultID: vaultID})
 			}
 		}
 	case "agent":
@@ -1770,7 +1751,7 @@ func setupMockStoreWithSession(t *testing.T) (*mockStore, string) {
 		Role: "owner", IsActive: true,
 	}
 	// Grant owner access to the default vault.
-	ms.GrantVaultRole(context.Background(), "owner-user-id", "user", "root-ns-id", "admin")
+	ms.GrantVaultAccess(context.Background(), "owner-user-id", "user", "root-ns-id")
 	sess, err := ms.CreateSession(context.Background(), "owner-user-id", time.Now().Add(time.Hour))
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
@@ -1937,48 +1918,16 @@ func TestScopedSessionSuccess(t *testing.T) {
 	if scopedSess.VaultID != "root-ns-id" {
 		t.Fatalf("expected vault_id root-ns-id, got %q", scopedSess.VaultID)
 	}
-	if scopedSess.VaultRole != "proxy" {
-		t.Fatalf("expected vault_role proxy, got %q", scopedSess.VaultRole)
-	}
 }
 
-func TestScopedSessionExplicitRole(t *testing.T) {
-	ms, token := setupMockStoreWithSession(t)
-	srv := newTestServer(withStore(ms))
-
-	body := `{"vault":"default","vault_role":"admin"}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", strings.NewReader(body))
-	req.Header.Set("Authorization", "Bearer "+token)
-	rec := httptest.NewRecorder()
-
-	srv.httpServer.Handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	var resp scopedSessionResponse
-	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	scopedSess := ms.sessions[resp.Token]
-	if scopedSess == nil {
-		t.Fatal("scoped session not found in store")
-	}
-	if scopedSess.VaultRole != "admin" {
-		t.Fatalf("expected vault_role admin, got %q", scopedSess.VaultRole)
-	}
-}
-
-func TestScopedSessionRoleRejected(t *testing.T) {
-	// Create a non-owner user with vault role "member" (not vault admin) to verify
-	// scoped-session role escalation is rejected.
+func TestScopedSessionScopedAdminAllowed(t *testing.T) {
+	// An instance admin scoped to the vault can mint a scoped session.
 	ms := newMockStore()
 	ms.users["admin@test.com"] = &store.User{
 		ID: "admin-user-id", Email: "admin@test.com",
 		Role: "admin", IsActive: true,
 	}
-	ms.GrantVaultRole(context.Background(), "admin-user-id", "user", "root-ns-id", "member")
+	ms.GrantVaultAccess(context.Background(), "admin-user-id", "user", "root-ns-id")
 	sess, err := ms.CreateSession(context.Background(), "admin-user-id", time.Now().Add(time.Hour))
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
@@ -1986,35 +1935,7 @@ func TestScopedSessionRoleRejected(t *testing.T) {
 
 	srv := newTestServer(withStore(ms))
 
-	// Member requests admin — should be rejected.
-	body := `{"vault":"default","vault_role":"admin"}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", strings.NewReader(body))
-	req.Header.Set("Authorization", "Bearer "+sess.ID)
-	rec := httptest.NewRecorder()
-
-	srv.httpServer.Handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
-	}
-}
-
-func TestScopedSessionMemberGetsMember(t *testing.T) {
-	// A vault member requesting member role should succeed.
-	ms := newMockStore()
-	ms.users["admin@test.com"] = &store.User{
-		ID: "admin-user-id", Email: "admin@test.com",
-		Role: "admin", IsActive: true,
-	}
-	ms.GrantVaultRole(context.Background(), "admin-user-id", "user", "root-ns-id", "member")
-	sess, err := ms.CreateSession(context.Background(), "admin-user-id", time.Now().Add(time.Hour))
-	if err != nil {
-		t.Fatalf("CreateSession: %v", err)
-	}
-
-	srv := newTestServer(withStore(ms))
-
-	body := `{"vault":"default","vault_role":"member"}`
+	body := `{"vault":"default"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+sess.ID)
 	rec := httptest.NewRecorder()
@@ -2023,18 +1944,6 @@ func TestScopedSessionMemberGetsMember(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	var resp scopedSessionResponse
-	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	scopedSess := ms.sessions[resp.Token]
-	if scopedSess == nil {
-		t.Fatal("scoped session not found in store")
-	}
-	if scopedSess.VaultRole != "member" {
-		t.Fatalf("expected vault_role member, got %q", scopedSess.VaultRole)
 	}
 }
 
@@ -2075,15 +1984,21 @@ func setupMockStoreWithScopedSession(t *testing.T, vaultName, vaultID string) (*
 	return setupMockStoreWithScopedSessionRole(t, vaultName, vaultID, "proxy")
 }
 
-func setupMockStoreWithScopedSessionRole(t *testing.T, vaultName, vaultID, role string) (*mockStore, string) {
+func setupMockStoreWithScopedSessionRole(t *testing.T, vaultName, vaultID, _role string) (*mockStore, string) {
 	t.Helper()
 	ms := newMockStore()
-	// Add a second vault
 	if vaultName != "default" {
 		ms.vaults[vaultName] = &store.Vault{ID: vaultID, Name: vaultName}
 	}
-	// Create a scoped session locked to the given vault
-	sess, err := ms.CreateScopedSession(context.Background(), vaultID, role, tp(time.Now().Add(time.Hour)))
+	// Per-vault role is gone under the unified instance-role model; the
+	// role argument is retained for call-site compatibility but ignored.
+	// Bind the scoped session to a seeded owner so middleware can
+	// resolve an actor with admin-grade powers.
+	ms.users["owner@test.com"] = &store.User{
+		ID: "owner-user-id", Email: "owner@test.com",
+		Role: "owner", IsActive: true,
+	}
+	sess, err := ms.CreateScopedSession(context.Background(), vaultID, "owner-user-id", "", tp(time.Now().Add(time.Hour)))
 	if err != nil {
 		t.Fatalf("CreateScopedSession: %v", err)
 	}
@@ -2297,16 +2212,18 @@ func TestCredentialsRevealNotFoundKey(t *testing.T) {
 	}
 }
 
-func TestCredentialsRevealProxyBlocked(t *testing.T) {
-	// Scoped session with proxy role — should be blocked from reveal.
-	ms, token := setupMockStoreWithScopedSessionRole(t, "default", "root-ns-id", "proxy")
+func TestCredentialsRevealAgentRoleBlocked(t *testing.T) {
+	// Instance-`agent`-role actors are proxy-only and must not be able to
+	// reveal credentials, regardless of vault scope.
+	ms := newMockStore()
+	agentToken := setupAgentRoleSession(t, ms, "root-ns-id")
 	encKey := make([]byte, 32)
 	srv := newTestServer(withStore(ms), withEncKey(encKey))
 
 	seedEncryptedCredential(t, ms, encKey, "root-ns-id", "SECRET", "s3cr3t")
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/credentials?vault=default&reveal=true", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+agentToken)
 	rec := httptest.NewRecorder()
 
 	srv.httpServer.Handler.ServeHTTP(rec, req)
@@ -2420,7 +2337,11 @@ func setupVaultWithCredential(t *testing.T, servicesJSON string) (*mockStore, st
 	ms := newMockStore()
 	encKey := make([]byte, 32)
 
-	sess, err := ms.CreateScopedSession(context.Background(), "root-ns-id", "proxy", tp(time.Now().Add(time.Hour)))
+	ms.users["owner@test.com"] = &store.User{
+		ID: "owner-user-id", Email: "owner@test.com",
+		Role: "owner", IsActive: true,
+	}
+	sess, err := ms.CreateScopedSession(context.Background(), "root-ns-id", "owner-user-id", "", tp(time.Now().Add(time.Hour)))
 	if err != nil {
 		t.Fatalf("CreateScopedSession: %v", err)
 	}
@@ -2546,7 +2467,11 @@ func TestDiscoverEmptyRules(t *testing.T) {
 
 func TestDiscoverNoCredentials(t *testing.T) {
 	ms := newMockStore()
-	sess, err := ms.CreateScopedSession(context.Background(), "root-ns-id", "proxy", tp(time.Now().Add(time.Hour)))
+	ms.users["owner@test.com"] = &store.User{
+		ID: "owner-user-id", Email: "owner@test.com",
+		Role: "owner", IsActive: true,
+	}
+	sess, err := ms.CreateScopedSession(context.Background(), "root-ns-id", "owner-user-id", "", tp(time.Now().Add(time.Hour)))
 	if err != nil {
 		t.Fatalf("CreateScopedSession: %v", err)
 	}
@@ -2878,7 +2803,7 @@ func setupAdminProposalTest(t *testing.T) (*Server, *mockStore, string) {
 	ms.users["owner@test.com"] = &store.User{
 		ID: "owner-user-id", Email: "owner@test.com", Role: "owner", IsActive: true,
 	}
-	ms.GrantVaultRole(context.Background(), "owner-user-id", "user", "root-ns-id", "admin")
+	ms.GrantVaultAccess(context.Background(), "owner-user-id", "user", "root-ns-id")
 	adminSess := &store.Session{
 		ID:        "admin-session",
 		UserID:    "owner-user-id",
@@ -3199,9 +3124,138 @@ func setupAdminSession(t *testing.T, ms *mockStore, grantVaultIDs ...string) str
 	ms.sessions[adminSess.ID] = adminSess
 
 	for _, nsID := range grantVaultIDs {
-		ms.GrantVaultRole(context.Background(), "admin-user-id", "user", nsID, "member")
+		ms.GrantVaultAccess(context.Background(), "admin-user-id", "user", nsID)
 	}
 	return adminSess.ID
+}
+
+// --- Inviter constraint tests (unified instance-role model) ---
+//
+// An instance admin must not be able to invite an `owner`, and must not
+// be able to pre-assign vaults outside their own scope. The same applies
+// to agent invites. Owners are unrestricted; agents cannot invite at all.
+
+func TestUserInviteAdminCannotEscalateToOwner(t *testing.T) {
+	ms, _ := setupMockStoreWithSession(t)
+	adminToken := setupAdminSession(t, ms, "root-ns-id")
+	srv := newTestServer(withStore(ms))
+
+	body := `{"email":"new@test.com","role":"owner"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/invites", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUserInviteAdminCannotPreAssignOutOfScope(t *testing.T) {
+	ms, _ := setupMockStoreWithSession(t)
+	// Admin is scoped to root-ns-id only.
+	adminToken := setupAdminSession(t, ms, "root-ns-id")
+	// Create a second vault the admin has no scope on.
+	if _, err := ms.CreateVault(context.Background(), "secret"); err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	srv := newTestServer(withStore(ms))
+
+	body := `{"email":"new@test.com","role":"admin","vaults":[{"vault_name":"secret"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/invites", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUserInviteAdminCanInviteAdmin(t *testing.T) {
+	// An admin inviting another admin scoped to a vault they share is fine.
+	ms, _ := setupMockStoreWithSession(t)
+	adminToken := setupAdminSession(t, ms, "root-ns-id")
+	srv := newTestServer(withStore(ms))
+
+	body := `{"email":"new@test.com","role":"admin","vaults":[{"vault_name":"default"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/invites", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUserInviteAgentRoleBlocked(t *testing.T) {
+	// Agents are proxy-only and cannot invite users.
+	ms := newMockStore()
+	agentToken := setupAgentRoleSession(t, ms, "root-ns-id")
+	srv := newTestServer(withStore(ms))
+
+	body := `{"email":"new@test.com","role":"admin"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/invites", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+agentToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentInviteAdminCannotEscalateToOwner(t *testing.T) {
+	ms, _ := setupMockStoreWithSession(t)
+	adminToken := setupAdminSession(t, ms, "root-ns-id")
+	srv := newTestServer(withStore(ms))
+
+	body := `{"name":"my-bot","role":"owner"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/invites", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentInviteAdminCannotPreAssignOutOfScope(t *testing.T) {
+	ms, _ := setupMockStoreWithSession(t)
+	adminToken := setupAdminSession(t, ms, "root-ns-id")
+	if _, err := ms.CreateVault(context.Background(), "secret"); err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	srv := newTestServer(withStore(ms))
+
+	body := `{"name":"my-bot","role":"agent","vaults":[{"vault_name":"secret"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/invites", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentInviteAdminCanInviteAgentInOwnScope(t *testing.T) {
+	// Admins can mint agent-role invites scoped within their own vaults.
+	ms, _ := setupMockStoreWithSession(t)
+	adminToken := setupAdminSession(t, ms, "root-ns-id")
+	srv := newTestServer(withStore(ms))
+
+	body := `{"name":"my-bot","role":"agent","vaults":[{"vault_name":"default"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/invites", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
 }
 
 func TestAdminCanAccessGrantedVault(t *testing.T) {
@@ -3237,9 +3291,9 @@ func TestAdminCannotAccessNonGrantedVault(t *testing.T) {
 	}
 }
 
-func TestOwnerCannotAccessVaultWithoutGrant(t *testing.T) {
+func TestOwnerAutoAccessesAllVaults(t *testing.T) {
+	// Owners auto-access every vault; no explicit grant required.
 	ms, ownerToken := setupMockStoreWithSession(t)
-	// Add a second vault — owner should NOT access without explicit grant.
 	ms.vaults["prod"] = &store.Vault{ID: "prod-ns-id", Name: "prod"}
 	srv := newTestServer(withStore(ms))
 
@@ -3249,8 +3303,8 @@ func TestOwnerCannotAccessVaultWithoutGrant(t *testing.T) {
 
 	srv.httpServer.Handler.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -3316,29 +3370,33 @@ func TestAdminCanApproveProposalInAnyMemberVault(t *testing.T) {
 	}
 }
 
-// setupProxyRoleSession creates a proxy-role user with a login session and optional vault grants.
-func setupProxyRoleSession(t *testing.T, ms *mockStore, grantVaultIDs ...string) string {
+// setupAgentRoleSession creates an instance-`agent`-role agent with a
+// session and optional vault scope grants. Agents are programmatic-only
+// and cannot approve/reject proposals — the analogue of the previous
+// "instance-level proxy".
+func setupAgentRoleSession(t *testing.T, ms *mockStore, grantVaultIDs ...string) string {
 	t.Helper()
-	ms.users["proxybot@test.com"] = &store.User{
-		ID: "proxy-user-id", Email: "proxybot@test.com", Role: "admin", IsActive: true,
+	ms.agents["proxybot"] = &store.Agent{
+		ID: "proxy-agent-id", Name: "proxybot", Role: "agent", Status: "active",
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
 	}
 	proxySess := &store.Session{
 		ID:        "proxy-session",
-		UserID:    "proxy-user-id",
+		AgentID:   "proxy-agent-id",
 		ExpiresAt: tp(time.Now().Add(time.Hour)),
 		CreatedAt: time.Now(),
 	}
 	ms.sessions[proxySess.ID] = proxySess
 
 	for _, nsID := range grantVaultIDs {
-		ms.GrantVaultRole(context.Background(), "proxy-user-id", "user", nsID, "proxy")
+		ms.GrantVaultAccess(context.Background(), "proxy-agent-id", "agent", nsID)
 	}
 	return proxySess.ID
 }
 
-func TestInstanceLevelProxyCannotApproveProposal(t *testing.T) {
+func TestAgentRoleCannotApproveProposal(t *testing.T) {
 	ms := newMockStore()
-	proxyToken := setupProxyRoleSession(t, ms, "root-ns-id")
+	proxyToken := setupAgentRoleSession(t, ms, "root-ns-id")
 
 	encKey := make([]byte, 32)
 	srv := newTestServer(withStore(ms), withEncKey(encKey))
@@ -3369,9 +3427,9 @@ func TestInstanceLevelProxyCannotApproveProposal(t *testing.T) {
 	}
 }
 
-func TestInstanceLevelProxyCannotRejectProposal(t *testing.T) {
+func TestAgentRoleCannotRejectProposal(t *testing.T) {
 	ms := newMockStore()
-	proxyToken := setupProxyRoleSession(t, ms, "root-ns-id")
+	proxyToken := setupAgentRoleSession(t, ms, "root-ns-id")
 
 	encKey := make([]byte, 32)
 	srv := newTestServer(withStore(ms), withEncKey(encKey))
@@ -3434,11 +3492,14 @@ func TestLastOwnerCannotBeRemoved(t *testing.T) {
 
 
 func TestEmailTestRequiresOwner(t *testing.T) {
-	ms, agentToken := setupMockStoreWithScopedSession(t, "default", "root-ns-id")
+	// An instance admin without owner role must be rejected from the
+	// owner-only email-test endpoint.
+	ms := newMockStore()
+	adminToken := setupAdminSession(t, ms, "root-ns-id")
 	srv := newTestServer(withStore(ms))
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/admin/email/test", nil)
-	req.Header.Set("Authorization", "Bearer "+agentToken)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	rec := httptest.NewRecorder()
 
 	srv.httpServer.Handler.ServeHTTP(rec, req)
@@ -3517,7 +3578,7 @@ func setupAgentTest(t *testing.T) (*Server, *mockStore, string) {
 	ms.users["owner@test.com"] = &store.User{
 		ID: "owner-user-id", Email: "owner@test.com", Role: "owner", IsActive: true,
 	}
-	ms.GrantVaultRole(context.Background(), "owner-user-id", "user", "root-ns-id", "admin")
+	ms.GrantVaultAccess(context.Background(), "owner-user-id", "user", "root-ns-id")
 	adminSess := &store.Session{
 		ID: "admin-session", UserID: "owner-user-id",
 		ExpiresAt: tp(time.Now().Add(time.Hour)), CreatedAt: time.Now(),
@@ -3706,8 +3767,8 @@ func TestAgentList(t *testing.T) {
 
 	ms.agents["bot1"] = &store.Agent{ID: "a1", Name: "bot1", Status: "active", CreatedAt: time.Now(), UpdatedAt: time.Now()}
 	ms.agents["bot2"] = &store.Agent{ID: "a2", Name: "bot2", Status: "active", CreatedAt: time.Now(), UpdatedAt: time.Now()}
-	ms.agentVaultGrants = append(ms.agentVaultGrants, store.VaultGrant{ActorID: "a1", ActorType: "agent", VaultID: "root-ns-id", Role: "proxy"})
-	ms.agentVaultGrants = append(ms.agentVaultGrants, store.VaultGrant{ActorID: "a2", ActorType: "agent", VaultID: "root-ns-id", Role: "proxy"})
+	ms.agentVaultGrants = append(ms.agentVaultGrants, store.VaultGrant{ActorID: "a1", ActorType: "agent", VaultID: "root-ns-id"})
+	ms.agentVaultGrants = append(ms.agentVaultGrants, store.VaultGrant{ActorID: "a2", ActorType: "agent", VaultID: "root-ns-id"})
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/agents", nil)
 	req.Header.Set("Authorization", "Bearer "+sessID)
@@ -3803,7 +3864,7 @@ func TestVaultRename(t *testing.T) {
 
 	// Create a non-default vault to rename.
 	ms.vaults["oldvault"] = &store.Vault{ID: "old-vault-id", Name: "oldvault"}
-	ms.GrantVaultRole(context.Background(), "owner-user-id", "user", "old-vault-id", "admin")
+	ms.GrantVaultAccess(context.Background(), "owner-user-id", "user", "old-vault-id")
 
 	t.Run("success", func(t *testing.T) {
 		body := strings.NewReader(`{"name": "newvault"}`)
@@ -3930,35 +3991,33 @@ func TestVaultSettingsUnmatchedHostPolicy(t *testing.T) {
 		}
 	})
 
-	t.Run("non-admin member: GET reflects real policy, PATCH is forbidden", func(t *testing.T) {
-		// Persist deny so we can verify the non-admin GET sees the truth
-		// rather than the previous silent passthrough fallback.
+	t.Run("scoped admin: GET reflects real policy, PATCH succeeds", func(t *testing.T) {
+		// Under the unified instance-role model, an instance admin scoped
+		// to the vault has full vault-management power, including PATCH.
 		_ = ms.SetVaultSetting(context.Background(), "root-ns-id", settingUnmatchedHostPolicy, "deny")
 		adminToken := setupAdminSession(t, ms, "root-ns-id")
 
-		// GET should succeed and return the actual stored policy.
 		req := httptest.NewRequest(http.MethodGet, "/v1/vaults/default/settings", nil)
 		req.Header.Set("Authorization", "Bearer "+adminToken)
 		rec := httptest.NewRecorder()
 		srv.httpServer.Handler.ServeHTTP(rec, req)
 		if rec.Code != http.StatusOK {
-			t.Fatalf("expected GET 200 for member, got %d: %s", rec.Code, rec.Body.String())
+			t.Fatalf("expected GET 200 for scoped admin, got %d: %s", rec.Code, rec.Body.String())
 		}
 		var resp map[string]string
 		_ = json.Unmarshal(rec.Body.Bytes(), &resp)
 		if resp["unmatched_host_policy"] != "deny" {
-			t.Fatalf("member GET should see real deny policy, got %q", resp["unmatched_host_policy"])
+			t.Fatalf("scoped admin GET should see real deny policy, got %q", resp["unmatched_host_policy"])
 		}
 
-		// PATCH must still be admin/owner-only.
 		patchBody := strings.NewReader(`{"unmatched_host_policy": "passthrough"}`)
 		req = httptest.NewRequest(http.MethodPatch, "/v1/vaults/default/settings", patchBody)
 		req.Header.Set("Authorization", "Bearer "+adminToken)
 		req.Header.Set("Content-Type", "application/json")
 		rec = httptest.NewRecorder()
 		srv.httpServer.Handler.ServeHTTP(rec, req)
-		if rec.Code != http.StatusForbidden {
-			t.Fatalf("expected PATCH 403 for member, got %d: %s", rec.Code, rec.Body.String())
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected PATCH 200 for scoped admin, got %d: %s", rec.Code, rec.Body.String())
 		}
 	})
 }
@@ -4573,14 +4632,13 @@ func TestOwnerVaultListShowsAllVaultsWithMembership(t *testing.T) {
 		byName[v.Name] = struct{ Role, Membership string }{v.Role, v.Membership}
 	}
 
-	// default vault: owner has explicit admin grant
-	if v, ok := byName["default"]; !ok || v.Membership != "explicit" || v.Role != "admin" {
-		t.Errorf("default vault: expected explicit/admin, got %+v", byName["default"])
+	// Under the unified instance-role model, owners auto-access every
+	// vault — every vault is reported as implicit/owner.
+	if v, ok := byName["default"]; !ok || v.Membership != "implicit" || v.Role != "owner" {
+		t.Errorf("default vault: expected implicit/owner, got %+v", byName["default"])
 	}
-
-	// orphaned vault: owner has no grant, should be implicit
-	if v, ok := byName["orphaned"]; !ok || v.Membership != "implicit" || v.Role != "" {
-		t.Errorf("orphaned vault: expected implicit/empty role, got %+v", byName["orphaned"])
+	if v, ok := byName["orphaned"]; !ok || v.Membership != "implicit" || v.Role != "owner" {
+		t.Errorf("orphaned vault: expected implicit/owner, got %+v", byName["orphaned"])
 	}
 }
 
@@ -4619,11 +4677,12 @@ func TestAdminVaultListOnlyShowsGrantedVaults(t *testing.T) {
 	}
 }
 
-func TestOwnerVaultJoinSuccess(t *testing.T) {
+func TestOwnerVaultJoinNoOp(t *testing.T) {
+	// Owners auto-access every vault now; the legacy join endpoint is a
+	// no-op compatibility shim that returns 200 for owners.
 	ms, ownerToken := setupMockStoreWithSession(t)
 	srv := newTestServer(withStore(ms))
 
-	// Create a vault the owner has no grant for.
 	ms.CreateVault(context.Background(), "team-x")
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/vaults/team-x/join", nil)
@@ -4633,27 +4692,6 @@ func TestOwnerVaultJoinSuccess(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	// Verify grant was created as admin.
-	role, err := ms.GetVaultRole(context.Background(), "owner-user-id", "ns-team-x")
-	if err != nil || role != "admin" {
-		t.Fatalf("expected admin grant, got role=%q err=%v", role, err)
-	}
-}
-
-func TestOwnerVaultJoinAlreadyMember(t *testing.T) {
-	ms, ownerToken := setupMockStoreWithSession(t)
-	srv := newTestServer(withStore(ms))
-
-	// Owner already has a grant on the default vault.
-	req := httptest.NewRequest(http.MethodPost, "/v1/vaults/default/join", nil)
-	req.Header.Set("Authorization", "Bearer "+ownerToken)
-	rec := httptest.NewRecorder()
-	srv.httpServer.Handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusConflict {
-		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -4793,7 +4831,9 @@ func TestScopedSessionTTLBounds(t *testing.T) {
 	}
 }
 
-func TestScopedSessionInvalidRole(t *testing.T) {
+func TestScopedSessionIgnoresUnknownFields(t *testing.T) {
+	// Per-vault role is gone; legacy clients sending a `vault_role` field
+	// should not break — we simply ignore it and mint a normal session.
 	ms, token := setupMockStoreWithSession(t)
 	srv := newTestServer(withStore(ms))
 
@@ -4802,8 +4842,8 @@ func TestScopedSessionInvalidRole(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
 	srv.httpServer.Handler.ServeHTTP(rec, req)
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for invalid role, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -75,7 +75,7 @@ func (m *mockStore) CreateUser(_ context.Context, email string, passwordHash, pa
 	return u, nil
 }
 
-func (m *mockStore) RegisterFirstUser(_ context.Context, email string, passwordHash, passwordSalt []byte, defaultVaultID string, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) (*store.User, error) {
+func (m *mockStore) RegisterFirstUser(_ context.Context, email string, passwordHash, passwordSalt []byte, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) (*store.User, error) {
 	if len(m.users) > 0 {
 		return nil, store.ErrNotFirstUser
 	}
@@ -86,15 +86,6 @@ func (m *mockStore) RegisterFirstUser(_ context.Context, email string, passwordH
 		Role: "owner", IsActive: true, CreatedAt: time.Now(), UpdatedAt: time.Now(),
 	}
 	m.users[email] = u
-	if defaultVaultID != "" {
-		if m.grants == nil {
-			m.grants = make(map[string]map[string]string)
-		}
-		if m.grants[u.ID] == nil {
-			m.grants[u.ID] = make(map[string]string)
-		}
-		m.grants[u.ID][defaultVaultID] = "admin"
-	}
 	return u, nil
 }
 
@@ -3784,6 +3775,83 @@ func TestAgentList(t *testing.T) {
 	agents := resp["agents"].([]interface{})
 	if len(agents) != 2 {
 		t.Fatalf("expected 2 agents, got %d", len(agents))
+	}
+}
+
+// Owner agents auto-access every vault and have no vault_grants rows, so
+// scoped admins must still be able to see them in both the cross-vault
+// (/v1/agents) and per-vault (/v1/vaults/{name}/agents) listings.
+func TestAgentListOwnerAgentVisibleToScopedAdmin(t *testing.T) {
+	ms := newMockStore()
+
+	// Scoped admin with explicit grant on the default vault.
+	ms.users["admin@test.com"] = &store.User{
+		ID: "scoped-admin", Email: "admin@test.com", Role: "admin", IsActive: true,
+	}
+	ms.GrantVaultAccess(context.Background(), "scoped-admin", "user", "root-ns-id")
+	sess := &store.Session{
+		ID: "scoped-admin-session", UserID: "scoped-admin",
+		ExpiresAt: tp(time.Now().Add(time.Hour)), CreatedAt: time.Now(),
+	}
+	ms.sessions[sess.ID] = sess
+
+	// Owner agent: no vault_grants rows at all.
+	ms.agents["global-bot"] = &store.Agent{
+		ID: "owner-agent-id", Name: "global-bot", Role: "owner", Status: "active",
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	// Scoped admin agent: explicit grant on the default vault.
+	ms.agents["scoped-bot"] = &store.Agent{
+		ID: "scoped-agent-id", Name: "scoped-bot", Role: "admin", Status: "active",
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		Vaults: []store.VaultGrant{{ActorID: "scoped-agent-id", ActorType: "agent", VaultID: "root-ns-id"}},
+	}
+	ms.agentVaultGrants = append(ms.agentVaultGrants, store.VaultGrant{
+		ActorID: "scoped-agent-id", ActorType: "agent", VaultID: "root-ns-id",
+	})
+
+	srv := newTestServer(withStore(ms), withEncKey(make([]byte, 32)))
+
+	// Cross-vault listing: scoped admin should see both agents.
+	req := httptest.NewRequest(http.MethodGet, "/v1/agents", nil)
+	req.Header.Set("Authorization", "Bearer "+sess.ID)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+	names := map[string]bool{}
+	for _, a := range resp["agents"].([]interface{}) {
+		names[a.(map[string]interface{})["name"].(string)] = true
+	}
+	if !names["global-bot"] {
+		t.Fatalf("/v1/agents: expected owner agent global-bot to be listed for scoped admin, got %v", names)
+	}
+	if !names["scoped-bot"] {
+		t.Fatalf("/v1/agents: expected scoped-bot to be listed, got %v", names)
+	}
+
+	// Per-vault listing: scoped admin should see both agents on the default vault.
+	req = httptest.NewRequest(http.MethodGet, "/v1/vaults/default/agents", nil)
+	req.Header.Set("Authorization", "Bearer "+sess.ID)
+	rec = httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	resp = map[string]interface{}{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+	names = map[string]bool{}
+	for _, a := range resp["agents"].([]interface{}) {
+		names[a.(map[string]interface{})["name"].(string)] = true
+	}
+	if !names["global-bot"] {
+		t.Fatalf("/v1/vaults/default/agents: expected owner agent global-bot to be listed, got %v", names)
+	}
+	if !names["scoped-bot"] {
+		t.Fatalf("/v1/vaults/default/agents: expected scoped-bot to be listed, got %v", names)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4666,11 +4666,12 @@ func TestSettingsSetInviteOnly(t *testing.T) {
 	}
 }
 
-func TestOwnerVaultListShowsAllVaultsWithMembership(t *testing.T) {
+func TestOwnerVaultListShowsAllVaults(t *testing.T) {
 	ms, ownerToken := setupMockStoreWithSession(t)
 	srv := newTestServer(withStore(ms))
 
-	// Create a second vault that the owner has NO grant for.
+	// Create a second vault that the owner has NO grant for; owners
+	// should see it anyway since they auto-access every vault.
 	ms.CreateVault(context.Background(), "orphaned")
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/vaults", nil)
@@ -4684,29 +4685,21 @@ func TestOwnerVaultListShowsAllVaultsWithMembership(t *testing.T) {
 
 	var resp struct {
 		Vaults []struct {
-			Name       string `json:"name"`
-			Role       string `json:"role"`
-			Membership string `json:"membership"`
+			Name string `json:"name"`
+			Role string `json:"role"`
 		} `json:"vaults"`
 	}
 	json.NewDecoder(rec.Body).Decode(&resp)
 
-	if len(resp.Vaults) < 2 {
-		t.Fatalf("expected at least 2 vaults, got %d", len(resp.Vaults))
-	}
-
-	byName := map[string]struct{ Role, Membership string }{}
+	byName := map[string]string{}
 	for _, v := range resp.Vaults {
-		byName[v.Name] = struct{ Role, Membership string }{v.Role, v.Membership}
+		byName[v.Name] = v.Role
 	}
-
-	// Under the unified instance-role model, owners auto-access every
-	// vault — every vault is reported as implicit/owner.
-	if v, ok := byName["default"]; !ok || v.Membership != "implicit" || v.Role != "owner" {
-		t.Errorf("default vault: expected implicit/owner, got %+v", byName["default"])
+	if role, ok := byName["default"]; !ok || role != "owner" {
+		t.Errorf("default vault: expected role=owner, got %q (present=%v)", role, ok)
 	}
-	if v, ok := byName["orphaned"]; !ok || v.Membership != "implicit" || v.Role != "owner" {
-		t.Errorf("orphaned vault: expected implicit/owner, got %+v", byName["orphaned"])
+	if role, ok := byName["orphaned"]; !ok || role != "owner" {
+		t.Errorf("orphaned vault: expected role=owner, got %q (present=%v)", role, ok)
 	}
 }
 
@@ -4729,8 +4722,7 @@ func TestAdminVaultListOnlyShowsGrantedVaults(t *testing.T) {
 
 	var resp struct {
 		Vaults []struct {
-			Name       string `json:"name"`
-			Membership string `json:"membership"`
+			Name string `json:"name"`
 		} `json:"vaults"`
 	}
 	json.NewDecoder(rec.Body).Decode(&resp)
@@ -4739,58 +4731,6 @@ func TestAdminVaultListOnlyShowsGrantedVaults(t *testing.T) {
 		if v.Name == "secret" {
 			t.Fatalf("admin should not see vault %q", v.Name)
 		}
-		if v.Membership != "explicit" {
-			t.Errorf("admin vault %q: expected explicit membership, got %q", v.Name, v.Membership)
-		}
-	}
-}
-
-func TestOwnerVaultJoinNoOp(t *testing.T) {
-	// Owners auto-access every vault now; the legacy join endpoint is a
-	// no-op compatibility shim that returns 200 for owners.
-	ms, ownerToken := setupMockStoreWithSession(t)
-	srv := newTestServer(withStore(ms))
-
-	ms.CreateVault(context.Background(), "team-x")
-
-	req := httptest.NewRequest(http.MethodPost, "/v1/vaults/team-x/join", nil)
-	req.Header.Set("Authorization", "Bearer "+ownerToken)
-	rec := httptest.NewRecorder()
-	srv.httpServer.Handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-}
-
-func TestAdminCannotJoinVault(t *testing.T) {
-	ms, _ := setupMockStoreWithSession(t)
-	adminToken := setupAdminSession(t, ms, "root-ns-id")
-	srv := newTestServer(withStore(ms))
-
-	ms.CreateVault(context.Background(), "team-x")
-
-	req := httptest.NewRequest(http.MethodPost, "/v1/vaults/team-x/join", nil)
-	req.Header.Set("Authorization", "Bearer "+adminToken)
-	rec := httptest.NewRecorder()
-	srv.httpServer.Handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
-	}
-}
-
-func TestOwnerVaultJoinNotFound(t *testing.T) {
-	ms, ownerToken := setupMockStoreWithSession(t)
-	srv := newTestServer(withStore(ms))
-
-	req := httptest.NewRequest(http.MethodPost, "/v1/vaults/nonexistent/join", nil)
-	req.Header.Set("Authorization", "Bearer "+ownerToken)
-	rec := httptest.NewRecorder()
-	srv.httpServer.Handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/server/vault_resolve.go
+++ b/internal/server/vault_resolve.go
@@ -7,44 +7,51 @@ import (
 	"github.com/Infisical/agent-vault/internal/store"
 )
 
-// resolveVaultForSession resolves the vault and vault role for the current
-// session. User-scoped sessions carry the vault directly; instance-level
-// agent tokens select a vault via the X-Vault request header and the
-// agent's vault membership.
-func (s *Server) resolveVaultForSession(w http.ResponseWriter, r *http.Request, sess *store.Session) (*store.Vault, string, error) {
+// resolveVaultForSession resolves the vault for the current session.
+// User-scoped sessions carry the vault directly; instance-level agent
+// tokens select a vault via the X-Vault request header and must either
+// be owners (auto-access) or have a scope grant on the vault.
+func (s *Server) resolveVaultForSession(w http.ResponseWriter, r *http.Request, sess *store.Session) (*store.Vault, error) {
 	ctx := r.Context()
 
 	if sess.VaultID != "" {
 		ns, err := s.store.GetVaultByID(ctx, sess.VaultID)
 		if err != nil || ns == nil {
 			jsonError(w, http.StatusInternalServerError, "Failed to resolve vault")
-			return nil, "", fmt.Errorf("vault not found")
+			return nil, fmt.Errorf("vault not found")
 		}
-		return ns, sess.VaultRole, nil
+		return ns, nil
 	}
 
 	if sess.AgentID == "" {
 		jsonError(w, http.StatusForbidden, "Session requires vault scope")
-		return nil, "", fmt.Errorf("no vault context")
+		return nil, fmt.Errorf("no vault context")
 	}
 
 	vaultName := r.Header.Get("X-Vault")
 	if vaultName == "" {
 		jsonError(w, http.StatusBadRequest, "Agent tokens require X-Vault header to specify which vault to use")
-		return nil, "", fmt.Errorf("missing X-Vault header")
+		return nil, fmt.Errorf("missing X-Vault header")
 	}
 
 	ns, err := s.store.GetVault(ctx, vaultName)
 	if err != nil || ns == nil {
 		jsonError(w, http.StatusNotFound, "Vault not found: "+vaultName)
-		return nil, "", fmt.Errorf("vault not found")
+		return nil, fmt.Errorf("vault not found")
 	}
 
-	role, err := s.store.GetVaultRole(ctx, sess.AgentID, ns.ID)
-	if err != nil {
-		jsonError(w, http.StatusForbidden, "Agent does not have access to vault: "+vaultName)
-		return nil, "", fmt.Errorf("no vault access")
+	agent, err := s.store.GetAgentByID(ctx, sess.AgentID)
+	if err != nil || agent == nil {
+		jsonError(w, http.StatusForbidden, "Agent not found")
+		return nil, fmt.Errorf("agent not found")
+	}
+	if agent.Role != "owner" {
+		has, err := s.store.HasVaultAccess(ctx, sess.AgentID, ns.ID)
+		if err != nil || !has {
+			jsonError(w, http.StatusForbidden, "Agent does not have access to vault: "+vaultName)
+			return nil, fmt.Errorf("no vault access")
+		}
 	}
 
-	return ns, role, nil
+	return ns, nil
 }

--- a/internal/store/migration_verify_test.go
+++ b/internal/store/migration_verify_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 )
@@ -32,4 +33,42 @@ func TestMigrationOnDisk(t *testing.T) {
 		}
 	}
 	t.Log("OK: agents table schema is correct")
+}
+
+// TestRegisterFirstUserAfterMigrations exercises the full first-user
+// onboarding path against a freshly migrated DB. Regression for the bug
+// where RegisterFirstUser tried to insert into the dropped `role` column on
+// vault_grants after migration 045, which would 500 every fresh install.
+func TestRegisterFirstUserAfterMigrations(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer s.Close()
+
+	user, err := s.RegisterFirstUser(
+		context.Background(),
+		"first@example.com",
+		[]byte("hash"),
+		[]byte("salt"),
+		1, 64*1024, 1,
+	)
+	if err != nil {
+		t.Fatalf("RegisterFirstUser failed: %v", err)
+	}
+	if user.Role != "owner" {
+		t.Fatalf("expected role=owner, got %q", user.Role)
+	}
+
+	// Owners auto-access every vault — they should have no vault_grants row.
+	var grantCount int
+	if err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM vault_grants WHERE actor_id = ?", user.ID,
+	).Scan(&grantCount); err != nil {
+		t.Fatalf("counting grants: %v", err)
+	}
+	if grantCount != 0 {
+		t.Fatalf("expected owner to have no vault_grants rows, got %d", grantCount)
+	}
 }

--- a/internal/store/migration_verify_test.go
+++ b/internal/store/migration_verify_test.go
@@ -35,6 +35,74 @@ func TestMigrationOnDisk(t *testing.T) {
 	t.Log("OK: agents table schema is correct")
 }
 
+// TestUpdateRolePromotionToOwnerClearsGrants verifies that promoting a user
+// or agent to 'owner' atomically deletes their vault_grants rows so the
+// invariant from migration 045 (owners auto-access every vault, never
+// stored in vault_grants) is preserved across the actor's lifetime.
+func TestUpdateRolePromotionToOwnerClearsGrants(t *testing.T) {
+	dir := t.TempDir()
+	s, err := Open(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	nowStr := nowUTC()
+	if _, err := s.db.Exec(
+		"INSERT INTO vaults (id, name, created_at, updated_at) VALUES ('v1', 'v1', ?, ?), ('v2', 'v2', ?, ?)",
+		nowStr, nowStr, nowStr, nowStr,
+	); err != nil {
+		t.Fatalf("seeding vaults: %v", err)
+	}
+
+	// User: admin with grants on v1 and v2.
+	if _, err := s.CreateUser(ctx, "admin@example.com", []byte("h"), []byte("s"), "admin", 1, 64*1024, 1); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	u, _ := s.GetUserByEmail(ctx, "admin@example.com")
+	if err := s.GrantVaultAccess(ctx, u.ID, "user", "v1"); err != nil {
+		t.Fatalf("grant v1: %v", err)
+	}
+	if err := s.GrantVaultAccess(ctx, u.ID, "user", "v2"); err != nil {
+		t.Fatalf("grant v2: %v", err)
+	}
+
+	if err := s.UpdateUserRole(ctx, u.ID, "owner"); err != nil {
+		t.Fatalf("UpdateUserRole: %v", err)
+	}
+	var n int
+	if err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM vault_grants WHERE actor_id = ? AND actor_type = 'user'", u.ID,
+	).Scan(&n); err != nil {
+		t.Fatalf("counting user grants: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected owner promotion to clear user grants, got %d", n)
+	}
+
+	// Agent: admin with grants on v1.
+	a, err := s.CreateAgent(ctx, "bot1", u.ID, "admin")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	if err := s.GrantVaultAccess(ctx, a.ID, "agent", "v1"); err != nil {
+		t.Fatalf("grant agent v1: %v", err)
+	}
+
+	if err := s.UpdateAgentRole(ctx, a.ID, "owner"); err != nil {
+		t.Fatalf("UpdateAgentRole: %v", err)
+	}
+	if err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM vault_grants WHERE actor_id = ? AND actor_type = 'agent'", a.ID,
+	).Scan(&n); err != nil {
+		t.Fatalf("counting agent grants: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected owner promotion to clear agent grants, got %d", n)
+	}
+}
+
 // TestRegisterFirstUserAfterMigrations exercises the full first-user
 // onboarding path against a freshly migrated DB. Regression for the bug
 // where RegisterFirstUser tried to insert into the dropped `role` column on

--- a/internal/store/migrations/045_unified_instance_roles.sql
+++ b/internal/store/migrations/045_unified_instance_roles.sql
@@ -126,7 +126,7 @@ CREATE TABLE sessions_new (
     created_at       TEXT NOT NULL DEFAULT (datetime('now')),
     vault_id         TEXT REFERENCES vaults(id) ON DELETE CASCADE,
     user_id          TEXT REFERENCES users(id) ON DELETE CASCADE,
-    agent_id         TEXT REFERENCES agents(id),
+    agent_id         TEXT REFERENCES agents(id) ON DELETE CASCADE,
     label            TEXT,
     last_used_at     TEXT,
     idle_ttl_seconds INTEGER,

--- a/internal/store/migrations/045_unified_instance_roles.sql
+++ b/internal/store/migrations/045_unified_instance_roles.sql
@@ -14,27 +14,18 @@
 
 PRAGMA foreign_keys = OFF;
 
--- 1. Collapse agent instance roles using highest-wins mapping.
---    Done before relaxing the CHECK constraint so the staging values
---    (still 'owner' or 'admin') validate against the existing schema.
-UPDATE agents
-   SET role = 'agent'
- WHERE role = 'admin'
-   AND id NOT IN (
-       SELECT actor_id
-         FROM vault_grants
-        WHERE actor_type = 'agent'
-          AND role IN ('admin', 'member')
-   );
-
--- Owners auto-access every vault now -> drop their grants.
+-- 1. Owners auto-access every vault now -> drop their grants.
 DELETE FROM vault_grants WHERE actor_id IN (
     SELECT id FROM users  WHERE role = 'owner'
     UNION
     SELECT id FROM agents WHERE role = 'owner'
 );
 
--- 2. agents.role: relax CHECK to allow 'agent'.
+-- 2. agents.role: relax CHECK to allow 'agent', and collapse agent
+--    instance roles using highest-wins mapping in the same step. Doing
+--    the downgrade as part of the rebuild avoids violating the old
+--    CHECK(role IN ('owner','admin')) constraint that's still in force
+--    on the live `agents` table at this point.
 CREATE TABLE agents_new (
     id         TEXT PRIMARY KEY,
     name       TEXT NOT NULL UNIQUE,
@@ -46,7 +37,14 @@ CREATE TABLE agents_new (
     role       TEXT NOT NULL DEFAULT 'agent' CHECK(role IN ('owner', 'admin', 'agent'))
 );
 INSERT INTO agents_new (id, name, status, created_by, created_at, updated_at, revoked_at, role)
-SELECT id, name, status, created_by, created_at, updated_at, revoked_at, role
+SELECT id, name, status, created_by, created_at, updated_at, revoked_at,
+       CASE
+           WHEN role = 'admin' AND id NOT IN (
+               SELECT actor_id FROM vault_grants
+                WHERE actor_type = 'agent' AND role IN ('admin', 'member')
+           ) THEN 'agent'
+           ELSE role
+       END
 FROM agents;
 DROP TABLE agents;
 ALTER TABLE agents_new RENAME TO agents;

--- a/internal/store/migrations/045_unified_instance_roles.sql
+++ b/internal/store/migrations/045_unified_instance_roles.sql
@@ -1,0 +1,149 @@
+-- Collapse the two-tier role system (instance + vault) into a single
+-- instance-level role with three values: owner, admin, agent.
+--
+-- Existing-data mapping for agents (only place data changes role).
+--   * agents.role='owner' is unchanged.
+--   * agents.role='admin' stays admin if the agent has at least one
+--     vault_grants row with role IN (admin, member). Otherwise it
+--     downgrades to 'agent' (proxy-only or no grants).
+--
+-- Owners' vault_grants rows are dropped — owners now auto-access every
+-- vault. Users keep role='admin' or 'owner' as before. The vault_grants
+-- table loses its role column. Sessions and invite junction tables are
+-- rebuilt to drop their per-vault role columns.
+
+PRAGMA foreign_keys = OFF;
+
+-- 1. Collapse agent instance roles using highest-wins mapping.
+--    Done before relaxing the CHECK constraint so the staging values
+--    (still 'owner' or 'admin') validate against the existing schema.
+UPDATE agents
+   SET role = 'agent'
+ WHERE role = 'admin'
+   AND id NOT IN (
+       SELECT actor_id
+         FROM vault_grants
+        WHERE actor_type = 'agent'
+          AND role IN ('admin', 'member')
+   );
+
+-- Owners auto-access every vault now -> drop their grants.
+DELETE FROM vault_grants WHERE actor_id IN (
+    SELECT id FROM users  WHERE role = 'owner'
+    UNION
+    SELECT id FROM agents WHERE role = 'owner'
+);
+
+-- 2. agents.role: relax CHECK to allow 'agent'.
+CREATE TABLE agents_new (
+    id         TEXT PRIMARY KEY,
+    name       TEXT NOT NULL UNIQUE,
+    status     TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active','revoked')),
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    revoked_at TEXT,
+    role       TEXT NOT NULL DEFAULT 'agent' CHECK(role IN ('owner', 'admin', 'agent'))
+);
+INSERT INTO agents_new (id, name, status, created_by, created_at, updated_at, revoked_at, role)
+SELECT id, name, status, created_by, created_at, updated_at, revoked_at, role
+FROM agents;
+DROP TABLE agents;
+ALTER TABLE agents_new RENAME TO agents;
+CREATE UNIQUE INDEX idx_agents_name ON agents(name);
+
+-- 3. invites.agent_role: relax CHECK to allow 'agent'.
+CREATE TABLE invites_new (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    token               TEXT,
+    token_hash          TEXT,
+    agent_name          TEXT NOT NULL,
+    agent_id            TEXT REFERENCES agents(id),
+    session_ttl_seconds INTEGER,
+    session_label       TEXT,
+    status              TEXT NOT NULL DEFAULT 'pending'
+                        CHECK(status IN ('pending','redeemed','expired','revoked')),
+    session_id          TEXT,
+    created_by          TEXT NOT NULL,
+    created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+    expires_at          TEXT NOT NULL,
+    redeemed_at         TEXT,
+    revoked_at          TEXT,
+    agent_role          TEXT NOT NULL DEFAULT 'agent' CHECK(agent_role IN ('owner', 'admin', 'agent'))
+);
+INSERT INTO invites_new (id, token, token_hash, agent_name, agent_id, session_ttl_seconds, session_label, status, session_id, created_by, created_at, expires_at, redeemed_at, revoked_at, agent_role)
+SELECT id, token, token_hash, agent_name, agent_id, session_ttl_seconds, session_label, status, session_id, created_by, created_at, expires_at, redeemed_at, revoked_at, agent_role
+FROM invites;
+DROP TABLE invites;
+ALTER TABLE invites_new RENAME TO invites;
+CREATE INDEX idx_invites_token_hash ON invites(token_hash);
+CREATE INDEX idx_invites_status ON invites(status);
+
+-- 4. vault_grants: drop the role column.
+CREATE TABLE vault_grants_new (
+    actor_id   TEXT NOT NULL,
+    actor_type TEXT NOT NULL CHECK(actor_type IN ('user', 'agent')),
+    vault_id   TEXT NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (actor_id, vault_id)
+);
+INSERT INTO vault_grants_new (actor_id, actor_type, vault_id, created_at)
+SELECT actor_id, actor_type, vault_id, created_at FROM vault_grants;
+DROP TABLE vault_grants;
+ALTER TABLE vault_grants_new RENAME TO vault_grants;
+CREATE INDEX idx_vault_grants_vault ON vault_grants(vault_id);
+CREATE INDEX idx_vault_grants_actor ON vault_grants(actor_id);
+CREATE INDEX idx_vault_grants_type  ON vault_grants(actor_type);
+
+-- 5. user_invite_vaults: drop vault_role.
+CREATE TABLE user_invite_vaults_new (
+    user_invite_id  INTEGER NOT NULL REFERENCES user_invites(id) ON DELETE CASCADE,
+    vault_id        TEXT    NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+    PRIMARY KEY (user_invite_id, vault_id)
+);
+INSERT INTO user_invite_vaults_new (user_invite_id, vault_id)
+SELECT user_invite_id, vault_id FROM user_invite_vaults;
+DROP TABLE user_invite_vaults;
+ALTER TABLE user_invite_vaults_new RENAME TO user_invite_vaults;
+CREATE INDEX idx_user_invite_vaults_vault ON user_invite_vaults(vault_id);
+
+-- 6. agent_invite_vaults: drop vault_role.
+CREATE TABLE agent_invite_vaults_new (
+    invite_id  INTEGER NOT NULL REFERENCES invites(id) ON DELETE CASCADE,
+    vault_id   TEXT    NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+    PRIMARY KEY (invite_id, vault_id)
+);
+INSERT INTO agent_invite_vaults_new (invite_id, vault_id)
+SELECT invite_id, vault_id FROM agent_invite_vaults;
+DROP TABLE agent_invite_vaults;
+ALTER TABLE agent_invite_vaults_new RENAME TO agent_invite_vaults;
+CREATE INDEX idx_agent_invite_vaults_vault ON agent_invite_vaults(vault_id);
+
+-- 7. sessions: drop the vault_role column. Scoped sessions still bind to a
+--    single vault (vault_id) but no longer carry a role. Effective power
+--    is derived from the actor's instance role.
+CREATE TABLE sessions_new (
+    id               TEXT PRIMARY KEY,
+    expires_at       TEXT,
+    created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    vault_id         TEXT REFERENCES vaults(id) ON DELETE CASCADE,
+    user_id          TEXT REFERENCES users(id) ON DELETE CASCADE,
+    agent_id         TEXT REFERENCES agents(id),
+    label            TEXT,
+    last_used_at     TEXT,
+    idle_ttl_seconds INTEGER,
+    device_label     TEXT,
+    last_ip          TEXT,
+    last_user_agent  TEXT,
+    public_id        TEXT
+);
+INSERT INTO sessions_new (id, expires_at, created_at, vault_id, user_id, agent_id, label, last_used_at, idle_ttl_seconds, device_label, last_ip, last_user_agent, public_id)
+SELECT id, expires_at, created_at, vault_id, user_id, agent_id, label, last_used_at, idle_ttl_seconds, device_label, last_ip, last_user_agent, public_id
+FROM sessions;
+DROP TABLE sessions;
+ALTER TABLE sessions_new RENAME TO sessions;
+CREATE INDEX        idx_sessions_agent_id  ON sessions(agent_id);
+CREATE INDEX        idx_sessions_user_id   ON sessions(user_id);
+CREATE UNIQUE INDEX idx_sessions_public_id ON sessions(public_id);
+
+PRAGMA foreign_keys = ON;

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -570,15 +570,15 @@ func (s *SQLiteStore) CountOwners(ctx context.Context) (int, error) {
 
 // --- Vault Grants ---
 
-func (s *SQLiteStore) GrantVaultRole(ctx context.Context, actorID, actorType, vaultID, role string) error {
+func (s *SQLiteStore) GrantVaultAccess(ctx context.Context, actorID, actorType, vaultID string) error {
 	nowStr := nowUTC()
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO vault_grants (actor_id, actor_type, vault_id, role, created_at) VALUES (?, ?, ?, ?, ?)
-		 ON CONFLICT(actor_id, vault_id) DO UPDATE SET role = excluded.role`,
-		actorID, actorType, vaultID, role, nowStr,
+		`INSERT INTO vault_grants (actor_id, actor_type, vault_id, created_at) VALUES (?, ?, ?, ?)
+		 ON CONFLICT(actor_id, vault_id) DO NOTHING`,
+		actorID, actorType, vaultID, nowStr,
 	)
 	if err != nil {
-		return fmt.Errorf("granting vault role: %w", err)
+		return fmt.Errorf("granting vault access: %w", err)
 	}
 	return nil
 }
@@ -600,7 +600,7 @@ func (s *SQLiteStore) RevokeVaultAccess(ctx context.Context, actorID, vaultID st
 
 func (s *SQLiteStore) ListActorGrants(ctx context.Context, actorID string) ([]VaultGrant, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT vg.actor_id, vg.actor_type, vg.vault_id, v.name, vg.role, vg.created_at
+		`SELECT vg.actor_id, vg.actor_type, vg.vault_id, v.name, vg.created_at
 		 FROM vault_grants vg
 		 JOIN vaults v ON v.id = vg.vault_id
 		 WHERE vg.actor_id = ? ORDER BY vg.created_at`,
@@ -615,7 +615,7 @@ func (s *SQLiteStore) ListActorGrants(ctx context.Context, actorID string) ([]Va
 	for rows.Next() {
 		var g VaultGrant
 		var createdAt string
-		if err := rows.Scan(&g.ActorID, &g.ActorType, &g.VaultID, &g.VaultName, &g.Role, &createdAt); err != nil {
+		if err := rows.Scan(&g.ActorID, &g.ActorType, &g.VaultID, &g.VaultName, &createdAt); err != nil {
 			return nil, fmt.Errorf("scanning grant: %w", err)
 		}
 		g.CreatedAt, _ = time.Parse(time.DateTime, createdAt)
@@ -639,30 +639,9 @@ func (s *SQLiteStore) HasVaultAccess(ctx context.Context, actorID, vaultID strin
 	return true, nil
 }
 
-func (s *SQLiteStore) GetVaultRole(ctx context.Context, actorID, vaultID string) (string, error) {
-	var role string
-	err := s.db.QueryRowContext(ctx,
-		"SELECT role FROM vault_grants WHERE actor_id = ? AND vault_id = ?",
-		actorID, vaultID,
-	).Scan(&role)
-	if err != nil {
-		return "", err
-	}
-	return role, nil
-}
-
-func (s *SQLiteStore) CountVaultAdmins(ctx context.Context, vaultID string) (int, error) {
-	var count int
-	err := s.db.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM vault_grants WHERE vault_id = ? AND role = 'admin'",
-		vaultID,
-	).Scan(&count)
-	return count, err
-}
-
 func (s *SQLiteStore) ListVaultMembers(ctx context.Context, vaultID string) ([]VaultGrant, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT vg.actor_id, vg.actor_type, vg.vault_id, v.name, vg.role, vg.created_at
+		`SELECT vg.actor_id, vg.actor_type, vg.vault_id, v.name, vg.created_at
 		 FROM vault_grants vg
 		 JOIN vaults v ON v.id = vg.vault_id
 		 WHERE vg.vault_id = ? ORDER BY vg.created_at`,
@@ -677,7 +656,7 @@ func (s *SQLiteStore) ListVaultMembers(ctx context.Context, vaultID string) ([]V
 	for rows.Next() {
 		var g VaultGrant
 		var createdAt string
-		if err := rows.Scan(&g.ActorID, &g.ActorType, &g.VaultID, &g.VaultName, &g.Role, &createdAt); err != nil {
+		if err := rows.Scan(&g.ActorID, &g.ActorType, &g.VaultID, &g.VaultName, &createdAt); err != nil {
 			return nil, fmt.Errorf("scanning grant: %w", err)
 		}
 		g.CreatedAt, _ = time.Parse(time.DateTime, createdAt)
@@ -688,7 +667,7 @@ func (s *SQLiteStore) ListVaultMembers(ctx context.Context, vaultID string) ([]V
 
 func (s *SQLiteStore) ListVaultMembersByType(ctx context.Context, vaultID, actorType string) ([]VaultGrant, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT vg.actor_id, vg.actor_type, vg.vault_id, v.name, vg.role, vg.created_at
+		`SELECT vg.actor_id, vg.actor_type, vg.vault_id, v.name, vg.created_at
 		 FROM vault_grants vg
 		 JOIN vaults v ON v.id = vg.vault_id
 		 WHERE vg.vault_id = ? AND vg.actor_type = ? ORDER BY vg.created_at`,
@@ -703,7 +682,7 @@ func (s *SQLiteStore) ListVaultMembersByType(ctx context.Context, vaultID, actor
 	for rows.Next() {
 		var g VaultGrant
 		var createdAt string
-		if err := rows.Scan(&g.ActorID, &g.ActorType, &g.VaultID, &g.VaultName, &g.Role, &createdAt); err != nil {
+		if err := rows.Scan(&g.ActorID, &g.ActorType, &g.VaultID, &g.VaultName, &createdAt); err != nil {
 			return nil, fmt.Errorf("scanning grant: %w", err)
 		}
 		g.CreatedAt, _ = time.Parse(time.DateTime, createdAt)
@@ -789,7 +768,7 @@ func (s *SQLiteStore) CreateUserSession(ctx context.Context, p CreateUserSession
 	}, nil
 }
 
-func (s *SQLiteStore) CreateScopedSession(ctx context.Context, vaultID, vaultRole string, expiresAt *time.Time) (*Session, error) {
+func (s *SQLiteStore) CreateScopedSession(ctx context.Context, vaultID, userID, agentID string, expiresAt *time.Time) (*Session, error) {
 	rawToken := newSessionToken()
 	tokenHash := hashSessionToken(rawToken)
 	now := time.Now().UTC()
@@ -798,33 +777,40 @@ func (s *SQLiteStore) CreateScopedSession(ctx context.Context, vaultID, vaultRol
 	if expiresAt != nil {
 		expiresAtStr = sql.NullString{String: expiresAt.UTC().Format(time.DateTime), Valid: true}
 	}
+	var userIDArg, agentIDArg sql.NullString
+	if userID != "" {
+		userIDArg = sql.NullString{String: userID, Valid: true}
+	}
+	if agentID != "" {
+		agentIDArg = sql.NullString{String: agentID, Valid: true}
+	}
 
 	_, err := s.db.ExecContext(ctx,
-		"INSERT INTO sessions (id, vault_id, vault_role, expires_at, created_at) VALUES (?, ?, ?, ?, ?)",
-		tokenHash, vaultID, vaultRole, expiresAtStr, now.Format(time.DateTime),
+		"INSERT INTO sessions (id, vault_id, user_id, agent_id, expires_at, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+		tokenHash, vaultID, userIDArg, agentIDArg, expiresAtStr, now.Format(time.DateTime),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating scoped session: %w", err)
 	}
 
-	return &Session{ID: rawToken, VaultID: vaultID, VaultRole: vaultRole, ExpiresAt: utcTimePtr(expiresAt), CreatedAt: now}, nil
+	return &Session{ID: rawToken, VaultID: vaultID, UserID: userID, AgentID: agentID, ExpiresAt: utcTimePtr(expiresAt), CreatedAt: now}, nil
 }
 
 func (s *SQLiteStore) GetSession(ctx context.Context, rawToken string) (*Session, error) {
 	tokenHash := hashSessionToken(rawToken)
 	row := s.db.QueryRowContext(ctx,
-		`SELECT id, user_id, vault_id, agent_id, vault_role, expires_at, created_at,
+		`SELECT id, user_id, vault_id, agent_id, expires_at, created_at,
 		        last_used_at, idle_ttl_seconds, device_label, last_ip, last_user_agent, public_id
 		 FROM sessions WHERE id = ?`, tokenHash,
 	)
 
 	var sess Session
 	var storedID string
-	var userID, vaultID, agentID, vaultRole, expiresAt sql.NullString
+	var userID, vaultID, agentID, expiresAt sql.NullString
 	var lastUsedAt, deviceLabel, lastIP, lastUserAgent, publicID sql.NullString
 	var idleSecs sql.NullInt64
 	var createdAt string
-	if err := row.Scan(&storedID, &userID, &vaultID, &agentID, &vaultRole, &expiresAt, &createdAt,
+	if err := row.Scan(&storedID, &userID, &vaultID, &agentID, &expiresAt, &createdAt,
 		&lastUsedAt, &idleSecs, &deviceLabel, &lastIP, &lastUserAgent, &publicID); err != nil {
 		return nil, err
 	}
@@ -833,7 +819,6 @@ func (s *SQLiteStore) GetSession(ctx context.Context, rawToken string) (*Session
 	sess.UserID = userID.String
 	sess.VaultID = vaultID.String
 	sess.AgentID = agentID.String
-	sess.VaultRole = vaultRole.String
 	if expiresAt.Valid {
 		t, _ := time.Parse(time.DateTime, expiresAt.String)
 		sess.ExpiresAt = &t
@@ -1432,8 +1417,8 @@ func (s *SQLiteStore) CreateAgentInvite(ctx context.Context, agentName, createdB
 	// Insert vault pre-assignments.
 	for _, v := range vaults {
 		_, err := tx.ExecContext(ctx,
-			`INSERT INTO agent_invite_vaults (invite_id, vault_id, vault_role) VALUES (?, ?, ?)`,
-			inviteID, v.VaultID, v.VaultRole,
+			`INSERT INTO agent_invite_vaults (invite_id, vault_id) VALUES (?, ?)`,
+			inviteID, v.VaultID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("inserting invite vault: %w", err)
@@ -1709,10 +1694,11 @@ func (s *SQLiteStore) GetPendingInviteByAgentName(ctx context.Context, name stri
 	return inv, nil
 }
 
-func (s *SQLiteStore) AddAgentInviteVault(ctx context.Context, inviteID int, vaultID, role string) error {
+func (s *SQLiteStore) AddAgentInviteVault(ctx context.Context, inviteID int, vaultID string) error {
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO agent_invite_vaults (invite_id, vault_id, vault_role) VALUES (?, ?, ?)`,
-		inviteID, vaultID, role,
+		`INSERT INTO agent_invite_vaults (invite_id, vault_id) VALUES (?, ?)
+		 ON CONFLICT(invite_id, vault_id) DO NOTHING`,
+		inviteID, vaultID,
 	)
 	return err
 }
@@ -1721,14 +1707,6 @@ func (s *SQLiteStore) RemoveAgentInviteVault(ctx context.Context, inviteID int, 
 	_, err := s.db.ExecContext(ctx,
 		`DELETE FROM agent_invite_vaults WHERE invite_id = ? AND vault_id = ?`,
 		inviteID, vaultID,
-	)
-	return err
-}
-
-func (s *SQLiteStore) UpdateAgentInviteVaultRole(ctx context.Context, inviteID int, vaultID, role string) error {
-	_, err := s.db.ExecContext(ctx,
-		`UPDATE agent_invite_vaults SET vault_role = ? WHERE invite_id = ? AND vault_id = ?`,
-		role, inviteID, vaultID,
 	)
 	return err
 }
@@ -1807,7 +1785,7 @@ func scanInviteRow(rows *sql.Rows) (*Invite, error) {
 // loadAgentInviteVaults loads the vault pre-assignments for an invite.
 func (s *SQLiteStore) loadAgentInviteVaults(ctx context.Context, inviteID int) ([]AgentInviteVault, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT aiv.vault_id, v.name, aiv.vault_role
+		`SELECT aiv.vault_id, v.name
 		 FROM agent_invite_vaults aiv
 		 JOIN vaults v ON v.id = aiv.vault_id
 		 WHERE aiv.invite_id = ?`, inviteID,
@@ -1820,7 +1798,7 @@ func (s *SQLiteStore) loadAgentInviteVaults(ctx context.Context, inviteID int) (
 	var vaults []AgentInviteVault
 	for rows.Next() {
 		var v AgentInviteVault
-		if err := rows.Scan(&v.VaultID, &v.VaultName, &v.VaultRole); err != nil {
+		if err := rows.Scan(&v.VaultID, &v.VaultName); err != nil {
 			return nil, err
 		}
 		vaults = append(vaults, v)
@@ -1860,9 +1838,8 @@ func (s *SQLiteStore) CreateUserInvite(ctx context.Context, email, createdBy, ro
 
 	for _, v := range vaults {
 		_, err := tx.ExecContext(ctx,
-			`INSERT INTO user_invite_vaults (user_invite_id, vault_id, vault_role)
-			 VALUES (?, ?, ?)`,
-			inviteID, v.VaultID, v.VaultRole,
+			`INSERT INTO user_invite_vaults (user_invite_id, vault_id) VALUES (?, ?)`,
+			inviteID, v.VaultID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("inserting user invite vault: %w", err)
@@ -2053,8 +2030,8 @@ func (s *SQLiteStore) UpdateUserInviteVaults(ctx context.Context, token string, 
 
 	for _, v := range vaults {
 		_, err := tx.ExecContext(ctx,
-			`INSERT INTO user_invite_vaults (user_invite_id, vault_id, vault_role) VALUES (?, ?, ?)`,
-			inviteID, v.VaultID, v.VaultRole,
+			`INSERT INTO user_invite_vaults (user_invite_id, vault_id) VALUES (?, ?)`,
+			inviteID, v.VaultID,
 		)
 		if err != nil {
 			return fmt.Errorf("inserting user invite vault: %w", err)
@@ -2075,7 +2052,7 @@ func (s *SQLiteStore) CountPendingUserInvites(ctx context.Context) (int, error) 
 // loadUserInviteVaults fetches the vault pre-assignments for a user invite.
 func (s *SQLiteStore) loadUserInviteVaults(ctx context.Context, inviteID int) ([]UserInviteVault, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT uiv.vault_id, v.name, uiv.vault_role
+		`SELECT uiv.vault_id, v.name
 		 FROM user_invite_vaults uiv
 		 JOIN vaults v ON v.id = uiv.vault_id
 		 WHERE uiv.user_invite_id = ?`, inviteID,
@@ -2088,7 +2065,7 @@ func (s *SQLiteStore) loadUserInviteVaults(ctx context.Context, inviteID int) ([
 	var vaults []UserInviteVault
 	for rows.Next() {
 		var v UserInviteVault
-		if err := rows.Scan(&v.VaultID, &v.VaultName, &v.VaultRole); err != nil {
+		if err := rows.Scan(&v.VaultID, &v.VaultName); err != nil {
 			return nil, err
 		}
 		vaults = append(vaults, v)
@@ -2106,7 +2083,7 @@ func (s *SQLiteStore) loadUserInviteVaultsBatch(ctx context.Context, invites []U
 		ids[i] = inv.ID
 	}
 
-	query := "SELECT uiv.user_invite_id, uiv.vault_id, v.name, uiv.vault_role FROM user_invite_vaults uiv JOIN vaults v ON v.id = uiv.vault_id WHERE uiv.user_invite_id IN (" + strings.Repeat("?,", len(ids)-1) + "?)" //nolint:gosec // only '?' placeholders
+	query := "SELECT uiv.user_invite_id, uiv.vault_id, v.name FROM user_invite_vaults uiv JOIN vaults v ON v.id = uiv.vault_id WHERE uiv.user_invite_id IN (" + strings.Repeat("?,", len(ids)-1) + "?)" //nolint:gosec // only '?' placeholders
 	rows, err := s.db.QueryContext(ctx, query, ids...)
 	if err != nil {
 		return fmt.Errorf("loading user invite vaults batch: %w", err)
@@ -2117,7 +2094,7 @@ func (s *SQLiteStore) loadUserInviteVaultsBatch(ctx context.Context, invites []U
 	for rows.Next() {
 		var inviteID int
 		var v UserInviteVault
-		if err := rows.Scan(&inviteID, &v.VaultID, &v.VaultName, &v.VaultRole); err != nil {
+		if err := rows.Scan(&inviteID, &v.VaultID, &v.VaultName); err != nil {
 			return err
 		}
 		byID[inviteID] = append(byID[inviteID], v)
@@ -2649,7 +2626,7 @@ func (s *SQLiteStore) batchLoadAgentVaultGrants(ctx context.Context, agents []Ag
 		placeholders[i] = "?"
 	}
 
-	query := `SELECT vg.actor_id, vg.actor_type, vg.vault_id, v.name, vg.role, vg.created_at
+	query := `SELECT vg.actor_id, vg.actor_type, vg.vault_id, v.name, vg.created_at
 		 FROM vault_grants vg
 		 JOIN vaults v ON v.id = vg.vault_id
 		 WHERE vg.actor_id IN (` + strings.Join(placeholders, ",") + `)` // #nosec G202 -- placeholders are static "?" strings, not user input
@@ -2663,7 +2640,7 @@ func (s *SQLiteStore) batchLoadAgentVaultGrants(ctx context.Context, agents []Ag
 	for rows.Next() {
 		var g VaultGrant
 		var createdAt string
-		if err := rows.Scan(&g.ActorID, &g.ActorType, &g.VaultID, &g.VaultName, &g.Role, &createdAt); err != nil {
+		if err := rows.Scan(&g.ActorID, &g.ActorType, &g.VaultID, &g.VaultName, &createdAt); err != nil {
 			return err
 		}
 		g.CreatedAt, _ = time.Parse(time.DateTime, createdAt)

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -519,7 +519,13 @@ func (s *SQLiteStore) UpdateUserPassword(ctx context.Context, userID string, pas
 
 func (s *SQLiteStore) UpdateUserRole(ctx context.Context, userID, role string) error {
 	nowStr := nowUTC()
-	res, err := s.db.ExecContext(ctx,
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.ExecContext(ctx,
 		"UPDATE users SET role = ?, updated_at = ? WHERE id = ?",
 		role, nowStr, userID,
 	)
@@ -530,7 +536,18 @@ func (s *SQLiteStore) UpdateUserRole(ctx context.Context, userID, role string) e
 	if n == 0 {
 		return sql.ErrNoRows
 	}
-	return nil
+
+	// Owners auto-access every vault and must have no vault_grants rows
+	// (mirrors migration 045). Clean up any stale grants on promotion.
+	if role == "owner" {
+		if _, err := tx.ExecContext(ctx,
+			"DELETE FROM vault_grants WHERE actor_id = ? AND actor_type = 'user'", userID,
+		); err != nil {
+			return fmt.Errorf("clearing user grants on owner promotion: %w", err)
+		}
+	}
+
+	return tx.Commit()
 }
 
 func (s *SQLiteStore) DeleteUser(ctx context.Context, userID string) error {
@@ -2646,7 +2663,13 @@ func (s *SQLiteStore) batchLoadAgentVaultGrants(ctx context.Context, agents []Ag
 
 func (s *SQLiteStore) UpdateAgentRole(ctx context.Context, agentID, role string) error {
 	nowStr := nowUTC()
-	res, err := s.db.ExecContext(ctx,
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	res, err := tx.ExecContext(ctx,
 		"UPDATE agents SET role = ?, updated_at = ? WHERE id = ?",
 		role, nowStr, agentID,
 	)
@@ -2657,7 +2680,18 @@ func (s *SQLiteStore) UpdateAgentRole(ctx context.Context, agentID, role string)
 	if n == 0 {
 		return sql.ErrNoRows
 	}
-	return nil
+
+	// Owners auto-access every vault and must have no vault_grants rows
+	// (mirrors migration 045). Clean up any stale grants on promotion.
+	if role == "owner" {
+		if _, err := tx.ExecContext(ctx,
+			"DELETE FROM vault_grants WHERE actor_id = ? AND actor_type = 'agent'", agentID,
+		); err != nil {
+			return fmt.Errorf("clearing agent grants on owner promotion: %w", err)
+		}
+	}
+
+	return tx.Commit()
 }
 
 func (s *SQLiteStore) CountAllOwners(ctx context.Context) (int, error) {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -422,7 +422,7 @@ func (s *SQLiteStore) CountUsers(ctx context.Context) (int, error) {
 
 // RegisterFirstUser atomically checks that no users exist and creates the
 // first user as an active owner. Returns ErrNotFirstUser if users already exist.
-func (s *SQLiteStore) RegisterFirstUser(ctx context.Context, email string, passwordHash, passwordSalt []byte, defaultVaultID string, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) (*User, error) {
+func (s *SQLiteStore) RegisterFirstUser(ctx context.Context, email string, passwordHash, passwordSalt []byte, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) (*User, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("begin tx: %w", err)
@@ -449,15 +449,8 @@ func (s *SQLiteStore) RegisterFirstUser(ctx context.Context, email string, passw
 		return nil, fmt.Errorf("creating owner: %w", err)
 	}
 
-	if defaultVaultID != "" {
-		_, err = tx.ExecContext(ctx,
-			"INSERT INTO vault_grants (actor_id, actor_type, vault_id, role, created_at) VALUES (?, 'user', ?, 'admin', ?) ON CONFLICT(actor_id, vault_id) DO UPDATE SET role = excluded.role",
-			id, defaultVaultID, nowStr,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("granting vault admin: %w", err)
-		}
-	}
+	// Owners auto-access every vault under the unified instance-role
+	// model, so no vault_grants row is needed for the first user.
 
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit: %w", err)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -28,8 +28,8 @@ func TestOpenAndMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("querying schema_migrations: %v", err)
 	}
-	if version != 44 {
-		t.Fatalf("expected migration version 44, got %d", version)
+	if version != 45 {
+		t.Fatalf("expected migration version 45, got %d", version)
 	}
 }
 
@@ -338,7 +338,7 @@ func TestScopedSessionCRUD(t *testing.T) {
 
 	expires := time.Now().Add(1 * time.Hour).UTC().Truncate(time.Second)
 
-	sess, err := s.CreateScopedSession(ctx, ns.ID, "proxy", &expires)
+	sess, err := s.CreateScopedSession(ctx, ns.ID, "", "", &expires)
 	if err != nil {
 		t.Fatalf("CreateScopedSession: %v", err)
 	}
@@ -1370,8 +1370,8 @@ func TestInviteWithVaultPreAssignment(t *testing.T) {
 	ctx := context.Background()
 	ns, _ := s.GetVault(ctx, "default")
 
-	inv, err := s.CreateAgentInvite(ctx, "vaultbot", "admin", time.Now().Add(15*time.Minute), 0, "admin", []AgentInviteVault{
-		{VaultID: ns.ID, VaultRole: "proxy"},
+	inv, err := s.CreateAgentInvite(ctx, "vaultbot", "admin", time.Now().Add(15*time.Minute), 0, "agent", []AgentInviteVault{
+		{VaultID: ns.ID},
 	})
 	if err != nil {
 		t.Fatalf("CreateAgentInvite with vaults: %v", err)
@@ -1379,8 +1379,8 @@ func TestInviteWithVaultPreAssignment(t *testing.T) {
 	if len(inv.Vaults) != 1 {
 		t.Fatalf("expected 1 vault pre-assignment, got %d", len(inv.Vaults))
 	}
-	if inv.Vaults[0].VaultRole != "proxy" {
-		t.Fatalf("expected vault role proxy, got %s", inv.Vaults[0].VaultRole)
+	if inv.Vaults[0].VaultID != ns.ID {
+		t.Fatalf("expected vault id %s, got %s", ns.ID, inv.Vaults[0].VaultID)
 	}
 
 	// Fetch and verify vaults are loaded.
@@ -1533,8 +1533,8 @@ func TestVaultGrantsCRUD(t *testing.T) {
 	ns, _ := s.CreateVault(ctx, "dev")
 
 	// Grant
-	if err := s.GrantVaultRole(ctx, u.ID, "user", ns.ID, "member"); err != nil {
-		t.Fatalf("GrantVaultRole: %v", err)
+	if err := s.GrantVaultAccess(ctx, u.ID, "user", ns.ID); err != nil {
+		t.Fatalf("GrantVaultAccess: %v", err)
 	}
 
 	// HasAccess
@@ -1581,9 +1581,9 @@ func TestGrantVaultAccessIdempotent(t *testing.T) {
 	ns, _ := s.CreateVault(ctx, "dev")
 
 	// Granting twice should not error
-	s.GrantVaultRole(ctx, u.ID, "user", ns.ID, "member")
-	if err := s.GrantVaultRole(ctx, u.ID, "user", ns.ID, "member"); err != nil {
-		t.Fatalf("second GrantVaultRole should not error: %v", err)
+	s.GrantVaultAccess(ctx, u.ID, "user", ns.ID)
+	if err := s.GrantVaultAccess(ctx, u.ID, "user", ns.ID); err != nil {
+		t.Fatalf("second GrantVaultAccess should not error: %v", err)
 	}
 }
 
@@ -1624,7 +1624,7 @@ func TestDeleteUserCascadesGrants(t *testing.T) {
 
 	u, _ := s.CreateUser(ctx, "user@test.com", []byte("h"), []byte("s"), "admin", 3, 65536, 4)
 	ns, _ := s.CreateVault(ctx, "dev")
-	s.GrantVaultRole(ctx, u.ID, "user", ns.ID, "member")
+	s.GrantVaultAccess(ctx, u.ID, "user", ns.ID)
 
 	// Delete user — grants should cascade
 	s.DeleteUser(ctx, u.ID)
@@ -1684,9 +1684,9 @@ func TestListAgents(t *testing.T) {
 	a3, _ := s.CreateAgent(ctx, "a3", "c", "admin")
 
 	// Grant vault access.
-	s.GrantVaultRole(ctx, a1.ID, "agent", ns.ID, "proxy")
-	s.GrantVaultRole(ctx, a2.ID, "agent", ns.ID, "proxy")
-	s.GrantVaultRole(ctx, a3.ID, "agent", ns2.ID, "proxy")
+	s.GrantVaultAccess(ctx, a1.ID, "agent", ns.ID)
+	s.GrantVaultAccess(ctx, a2.ID, "agent", ns.ID)
+	s.GrantVaultAccess(ctx, a3.ID, "agent", ns2.ID)
 
 	// All agents (cross-vault)
 	all, err := s.ListAllAgents(ctx)
@@ -1834,7 +1834,7 @@ func TestGetSessionBackwardCompat(t *testing.T) {
 	ctx := context.Background()
 
 	ns, _ := s.GetVault(ctx, "default")
-	sess, _ := s.CreateScopedSession(ctx, ns.ID, "proxy", tp(time.Now().Add(24*time.Hour)))
+	sess, _ := s.CreateScopedSession(ctx, ns.ID, "", "", tp(time.Now().Add(24*time.Hour)))
 
 	fetched, err := s.GetSession(ctx, sess.ID)
 	if err != nil {
@@ -1850,8 +1850,8 @@ func TestCreateAgentInviteWithVaults(t *testing.T) {
 	ctx := context.Background()
 
 	ns, _ := s.GetVault(ctx, "default")
-	inv, err := s.CreateAgentInvite(ctx, "mybot", "creator1", time.Now().Add(15*time.Minute), 0, "admin", []AgentInviteVault{
-		{VaultID: ns.ID, VaultRole: "proxy"},
+	inv, err := s.CreateAgentInvite(ctx, "mybot", "creator1", time.Now().Add(15*time.Minute), 0, "agent", []AgentInviteVault{
+		{VaultID: ns.ID},
 	})
 	if err != nil {
 		t.Fatalf("CreateAgentInvite: %v", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -22,13 +22,14 @@ type Vault struct {
 	UpdatedAt time.Time
 }
 
-// VaultGrant represents an actor's (user or agent) access to a vault with a specific role.
+// VaultGrant represents an actor's (user or agent) access to a vault.
+// Effective permissions in the vault come from the actor's instance role
+// (owner / admin / agent) — the grant itself is a pure scope record.
 type VaultGrant struct {
 	ActorID   string
 	ActorType string // "user" or "agent"
 	VaultID   string
 	VaultName string // populated via JOIN on reads (optional)
-	Role      string // "proxy", "member", or "admin"
 	CreatedAt time.Time
 }
 
@@ -70,7 +71,6 @@ type Session struct {
 	UserID    string     // non-empty for user login sessions, empty for agent tokens
 	VaultID   string     // empty for global/agent tokens, non-empty for user scoped sessions
 	AgentID   string     // non-empty for agent tokens
-	VaultRole string     // set for user scoped sessions; empty for agent tokens (resolved per-request)
 	ExpiresAt *time.Time // nil = never expires
 	CreatedAt time.Time
 
@@ -109,6 +109,14 @@ type CreateUserSessionParams struct {
 	LastUserAgent string
 }
 
+// Instance role values. Users may hold owner or admin; programmatic
+// agents may additionally hold the proxy-only `agent` role.
+const (
+	RoleOwner = "owner"
+	RoleAdmin = "admin"
+	RoleAgent = "agent"
+)
+
 // User represents a human user account.
 type User struct {
 	ID           string
@@ -123,6 +131,9 @@ type User struct {
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 }
+
+// IsOwner reports whether the user holds the instance owner role.
+func (u *User) IsOwner() bool { return u.Role == RoleOwner }
 
 // BrokerConfig holds the brokering services for a vault.
 type BrokerConfig struct {
@@ -198,7 +209,7 @@ type Invite struct {
 	Token             string
 	AgentName         string             // required: agent name (3-64 chars, lowercase alphanumeric + hyphens)
 	AgentID           string             // set for rotation invites (references existing agent)
-	AgentRole         string             // "owner" or "admin" — instance role for the agent
+	AgentRole         string             // "owner", "admin", or "agent" — instance role for the agent
 	SessionTTLSeconds int                // desired session lifetime when redeemed (0 = no expiry)
 	Status            string             // pending, redeemed, expired, revoked
 	SessionID         string             // populated after redemption
@@ -211,10 +222,10 @@ type Invite struct {
 }
 
 // AgentInviteVault represents a pre-assigned vault grant on an agent invite.
+// Effective power inside the vault comes from the invite's AgentRole.
 type AgentInviteVault struct {
 	VaultID   string
 	VaultName string // populated via JOIN on reads
-	VaultRole string // "proxy", "member", or "admin"
 }
 
 // Agent represents a named, instance-level agent entity.
@@ -222,7 +233,7 @@ type AgentInviteVault struct {
 type Agent struct {
 	ID        string
 	Name      string
-	Role      string // "owner" or "admin" (instance-level role, like users)
+	Role      string // "owner", "admin", or "agent" (instance-level role)
 	Status    string // "active" or "revoked"
 	CreatedBy string // user ID of the creator
 	Vaults    []VaultGrant
@@ -230,6 +241,9 @@ type Agent struct {
 	UpdatedAt time.Time
 	RevokedAt *time.Time
 }
+
+// IsOwner reports whether the agent holds the instance owner role.
+func (a *Agent) IsOwner() bool { return a.Role == RoleOwner }
 
 // UserInvite represents an instance-level invitation for a new user.
 // Invites bring users into the instance, with optional vault pre-assignment.
@@ -247,10 +261,10 @@ type UserInvite struct {
 }
 
 // UserInviteVault represents a pre-assigned vault grant on a user invite.
+// Effective power inside the vault comes from the invite's Role.
 type UserInviteVault struct {
 	VaultID   string
 	VaultName string // populated via JOIN on reads
-	VaultRole string // "admin" or "member"
 }
 
 // EmailVerification holds a verification code for self-signup email confirmation.
@@ -302,13 +316,14 @@ type Store interface {
 	CountOwners(ctx context.Context) (int, error)
 	RegisterFirstUser(ctx context.Context, email string, passwordHash, passwordSalt []byte, defaultVaultID string, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) (*User, error)
 
-	// Vault grants (unified: actor_id + actor_type)
-	GrantVaultRole(ctx context.Context, actorID, actorType, vaultID, role string) error
+	// Vault scope grants (unified: actor_id + actor_type). Each row is a
+	// pure scope record — effective permissions come from the actor's
+	// instance role (owner / admin / agent). Owners are not stored here;
+	// they auto-access every vault.
+	GrantVaultAccess(ctx context.Context, actorID, actorType, vaultID string) error
 	RevokeVaultAccess(ctx context.Context, actorID, vaultID string) error
 	ListActorGrants(ctx context.Context, actorID string) ([]VaultGrant, error)
 	HasVaultAccess(ctx context.Context, actorID, vaultID string) (bool, error)
-	GetVaultRole(ctx context.Context, actorID, vaultID string) (string, error)
-	CountVaultAdmins(ctx context.Context, vaultID string) (int, error)
 	ListVaultMembers(ctx context.Context, vaultID string) ([]VaultGrant, error)
 	ListVaultMembersByType(ctx context.Context, vaultID, actorType string) ([]VaultGrant, error)
 
@@ -320,7 +335,7 @@ type Store interface {
 
 	// Sessions
 	CreateUserSession(ctx context.Context, p CreateUserSessionParams) (*Session, error)
-	CreateScopedSession(ctx context.Context, vaultID, vaultRole string, expiresAt *time.Time) (*Session, error)
+	CreateScopedSession(ctx context.Context, vaultID, userID, agentID string, expiresAt *time.Time) (*Session, error)
 	GetSession(ctx context.Context, id string) (*Session, error)
 	DeleteSession(ctx context.Context, id string) error
 	// TouchSession bumps last_used_at for the given raw token and
@@ -370,9 +385,8 @@ type Store interface {
 	CountPendingInvites(ctx context.Context) (int, error)
 	HasPendingInviteByAgentName(ctx context.Context, name string) (bool, error)
 	GetPendingInviteByAgentName(ctx context.Context, name string) (*Invite, error)
-	AddAgentInviteVault(ctx context.Context, inviteID int, vaultID, role string) error
+	AddAgentInviteVault(ctx context.Context, inviteID int, vaultID string) error
 	RemoveAgentInviteVault(ctx context.Context, inviteID int, vaultID string) error
-	UpdateAgentInviteVaultRole(ctx context.Context, inviteID int, vaultID, role string) error
 	ExpirePendingInvites(ctx context.Context, before time.Time) (int, error)
 
 	// User invites (instance-level)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -314,7 +314,7 @@ type Store interface {
 	DeleteUser(ctx context.Context, userID string) error
 	CountUsers(ctx context.Context) (int, error)
 	CountOwners(ctx context.Context) (int, error)
-	RegisterFirstUser(ctx context.Context, email string, passwordHash, passwordSalt []byte, defaultVaultID string, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) (*User, error)
+	RegisterFirstUser(ctx context.Context, email string, passwordHash, passwordSalt []byte, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) (*User, error)
 
 	// Vault scope grants (unified: actor_id + actor_type). Each row is a
 	// pure scope record — effective permissions come from the actor's

--- a/web/src/pages/UserInvite.tsx
+++ b/web/src/pages/UserInvite.tsx
@@ -6,9 +6,10 @@ import { ErrorBanner } from "../components/shared";
 import { DomainNotice } from "../components/DomainNotice";
 import { apiFetch } from "../lib/api";
 
+// Pre-assigned vault scope on the invite. Effective power inside the
+// vault comes from the invite's instance role.
 interface InviteVault {
   vault_name: string;
-  vault_role: string;
 }
 
 interface UserInviteData {
@@ -139,9 +140,6 @@ function InviteDetails({ role, vaults }: { role?: string; vaults: InviteVault[] 
         {vaults.map((v) => (
           <div key={v.vault_name} className="flex items-center justify-between">
             <span className="text-sm text-text font-medium">{v.vault_name}</span>
-            <span className="inline-block px-2.5 py-0.5 bg-primary/10 text-primary text-xs font-semibold rounded-full capitalize">
-              {v.vault_role}
-            </span>
           </div>
         ))}
       </div>

--- a/web/src/pages/home/AllAgentsTab.tsx
+++ b/web/src/pages/home/AllAgentsTab.tsx
@@ -15,10 +15,12 @@ import type { AuthContext } from "../../router";
 
 interface AgentRow {
   name: string;
-  role: string; // instance-level role: "owner" or "admin"
+  role: string; // instance-level role: "owner", "admin", or "agent"
   status: string;
   created_at: string;
-  vaults: { vault_name: string; vault_role: string }[];
+  // Vault scope only — effective power inside each vault comes from the
+  // agent's instance role.
+  vaults: { vault_name: string }[];
   // For pending invites shown inline
   invite_id?: number;
 }
@@ -66,13 +68,19 @@ function RowActions({
   const items: { label: string; onClick: () => void; variant?: "danger" }[] = [];
 
   if (isOwner) {
-    const targetRole = agent.role === "owner" ? "admin" : "owner";
+    // Single click always advances to a different role.
+    const nextRoleByCurrent: Record<string, string> = {
+      owner: "admin",
+      admin: "agent",
+      agent: "owner",
+    };
+    const nextRole = nextRoleByCurrent[agent.role] ?? "agent";
     items.push({
-      label: `Set role: ${targetRole}`,
+      label: `Set role: ${nextRole}`,
       onClick: async () => {
         await apiFetch(
           `/v1/agents/${encodeURIComponent(agent.name)}/role`,
-          { method: "POST", body: JSON.stringify({ role: targetRole }) }
+          { method: "POST", body: JSON.stringify({ role: nextRole }) }
         );
         onDone();
       },
@@ -111,9 +119,9 @@ export default function AllAgentsTab() {
 
       const agentsData = await agentsResp.json();
       const activeRows: AgentRow[] = (agentsData.agents ?? []).map(
-        (a: { name: string; role: string; status: string; created_at: string; vaults?: { vault_name: string; vault_role: string }[] }) => ({
+        (a: { name: string; role: string; status: string; created_at: string; vaults?: { vault_name: string }[] }) => ({
           name: a.name,
-          role: a.role || "admin",
+          role: a.role || "agent",
           status: a.status,
           created_at: a.created_at,
           vaults: a.vaults ?? [],
@@ -129,9 +137,9 @@ export default function AllAgentsTab() {
             inv.status === "pending" && !agentNames.has(inv.agent_name)
           )
           .map(
-            (inv: { id: number; agent_name: string; agent_role?: string; created_at: string; vaults?: { vault_name: string; vault_role: string }[] }) => ({
+            (inv: { id: number; agent_name: string; agent_role?: string; created_at: string; vaults?: { vault_name: string }[] }) => ({
               name: inv.agent_name,
-              role: inv.agent_role || "admin",
+              role: inv.agent_role || "agent",
               status: "pending",
               created_at: inv.created_at,
               vaults: inv.vaults ?? [],
@@ -179,6 +187,11 @@ export default function AllAgentsTab() {
         key: "vaults",
         header: "Vaults",
         render: (agent) => {
+          if (agent.role === "owner") {
+            return (
+              <span className="text-xs text-text-dim italic">All (owner)</span>
+            );
+          }
           if (agent.vaults.length === 0) return <span className="text-sm text-text-dim">{"\u2014"}</span>;
           return (
             <div className="flex flex-wrap gap-1">
@@ -187,7 +200,7 @@ export default function AllAgentsTab() {
                   key={v.vault_name}
                   className="inline-block px-2 py-0.5 bg-primary/10 text-primary text-xs font-medium rounded-full"
                 >
-                  {v.vault_name}:{v.vault_role}
+                  {v.vault_name}
                 </span>
               ))}
             </div>
@@ -267,10 +280,20 @@ export default function AllAgentsTab() {
   );
 }
 
+// Pre-assigned vault scope on an agent invite. No per-vault role under
+// the unified instance-role model — effective power inside each vault
+// comes from the invite's instance role.
 interface VaultAssignment {
   vault_name: string;
-  vault_role: "proxy" | "member" | "admin";
 }
+
+type AgentRole = "owner" | "admin" | "agent";
+
+const ROLE_HELPER_TEXT: Record<AgentRole, string> = {
+  owner: "Owners auto-access every vault and manage users, vaults, and instance settings.",
+  admin: "Admins manage credentials, services, and proposals on their scoped vaults.",
+  agent: "Agents are proxy-only on scoped vaults — they can use the proxy and raise proposals but cannot reveal credentials or approve proposals.",
+};
 
 function InviteAgentButton({
   onInvited,
@@ -281,7 +304,7 @@ function InviteAgentButton({
 }) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
-  const [agentRole, setAgentRole] = useState<"owner" | "admin">("admin");
+  const [agentRole, setAgentRole] = useState<AgentRole>("agent");
   const [vaultAssignments, setVaultAssignments] = useState<VaultAssignment[]>([]);
   const [availableVaults, setAvailableVaults] = useState<VaultOption[]>([]);
   const [submitting, setSubmitting] = useState(false);
@@ -290,13 +313,12 @@ function InviteAgentButton({
 
   useEffect(() => {
     if (!open) return;
+    // Owners can pre-assign any vault. Admins are constrained to vaults
+    // already in their own scope (server enforces this regardless).
     apiFetch("/v1/vaults")
       .then((r) => r.json())
       .then((data) => {
-        const vaults = (data.vaults ?? []).filter(
-          (v: VaultOption) => isOwner || v.role === "admin"
-        );
-        setAvailableVaults(vaults);
+        setAvailableVaults(data.vaults ?? []);
       })
       .catch(() => {});
   }, [open, isOwner]);
@@ -304,7 +326,7 @@ function InviteAgentButton({
   function close() {
     setOpen(false);
     setName("");
-    setAgentRole("admin");
+    setAgentRole("agent");
     setVaultAssignments([]);
     setError("");
     setInviteResult(null);
@@ -314,7 +336,7 @@ function InviteAgentButton({
     const assignedNames = new Set(vaultAssignments.map((a) => a.vault_name));
     const next = availableVaults.find((v) => !assignedNames.has(v.name));
     if (next) {
-      setVaultAssignments([...vaultAssignments, { vault_name: next.name, vault_role: "proxy" }]);
+      setVaultAssignments([...vaultAssignments, { vault_name: next.name }]);
     }
   }
 
@@ -322,9 +344,9 @@ function InviteAgentButton({
     setVaultAssignments(vaultAssignments.filter((_, i) => i !== idx));
   }
 
-  function updateVault(idx: number, field: "vault_name" | "vault_role", value: string) {
+  function updateVault(idx: number, value: string) {
     const updated = [...vaultAssignments];
-    updated[idx] = { ...updated[idx], [field]: value };
+    updated[idx] = { vault_name: value };
     setVaultAssignments(updated);
   }
 
@@ -333,10 +355,7 @@ function InviteAgentButton({
     setSubmitting(true);
     setError("");
     try {
-      const payload: Record<string, unknown> = { name: name.trim() };
-      if (isOwner && agentRole !== "admin") {
-        payload.role = agentRole;
-      }
+      const payload: Record<string, unknown> = { name: name.trim(), role: agentRole };
       if (vaultAssignments.length > 0) {
         payload.vaults = vaultAssignments;
       }
@@ -440,22 +459,19 @@ function InviteAgentButton({
               />
             </FormField>
 
-            {isOwner && (
-              <FormField
-                label="Instance role"
-                helperText={agentRole === "owner"
-                  ? "This agent will be able to manage users, vaults, and instance settings."
-                  : "This agent will have standard access, scoped to its assigned vaults."}
+            <FormField
+              label="Instance role"
+              helperText={ROLE_HELPER_TEXT[agentRole]}
+            >
+              <Select
+                value={agentRole}
+                onChange={(e) => setAgentRole(e.target.value as AgentRole)}
               >
-                <Select
-                  value={agentRole}
-                  onChange={(e) => setAgentRole(e.target.value as "owner" | "admin")}
-                >
-                  <option value="admin">Admin</option>
-                  <option value="owner">Owner</option>
-                </Select>
-              </FormField>
-            )}
+                <option value="agent">Agent (proxy-only)</option>
+                <option value="admin">Admin</option>
+                {isOwner && <option value="owner">Owner</option>}
+              </Select>
+            </FormField>
 
             <div>
               <div className="flex items-center justify-between mb-2">
@@ -474,7 +490,9 @@ function InviteAgentButton({
               </div>
               {vaultAssignments.length === 0 ? (
                 <p className="text-sm text-text-muted">
-                  No vaults pre-assigned. The agent will join the instance without vault access.
+                  {agentRole === "owner"
+                    ? "Owners auto-access every vault — no scope needed."
+                    : "No vaults pre-assigned. The agent will join the instance without vault access."}
                 </p>
               ) : (
                 <div className="space-y-2">
@@ -482,7 +500,7 @@ function InviteAgentButton({
                     <div key={idx} className="flex items-center gap-2">
                       <select
                         value={assignment.vault_name}
-                        onChange={(e) => updateVault(idx, "vault_name", e.target.value)}
+                        onChange={(e) => updateVault(idx, e.target.value)}
                         className="flex-1 px-3 py-2 bg-surface border border-border rounded-lg text-text text-sm outline-none"
                       >
                         {availableVaults.map((v) => (
@@ -495,15 +513,6 @@ function InviteAgentButton({
                           </option>
                         ))}
                       </select>
-                      <Select
-                        value={assignment.vault_role}
-                        onChange={(e) => updateVault(idx, "vault_role", e.target.value)}
-                        className="w-28"
-                      >
-                        <option value="proxy">Proxy</option>
-                        <option value="member">Member</option>
-                        <option value="admin">Admin</option>
-                      </Select>
                       <button
                         type="button"
                         onClick={() => removeVault(idx)}

--- a/web/src/pages/home/AllUsersTab.tsx
+++ b/web/src/pages/home/AllUsersTab.tsx
@@ -17,7 +17,9 @@ interface PublicUser {
   email: string;
   role: string;
   status: "active" | "pending";
-  vaults?: { vault_name: string; vault_role: string }[];
+  // Vault scope is just a list of vault names now; effective power
+  // inside a vault comes from the user's instance role.
+  vaults?: { vault_name: string }[];
   created_at: string;
   invite_token?: string;
 }
@@ -112,7 +114,7 @@ export default function AllUsersTab() {
       if (invResp.ok) {
         const invData = await invResp.json();
         pendingUsers = (invData.invites ?? []).map(
-          (inv: { email: string; role?: string; token: string; created_at: string; vaults?: { vault_name: string; vault_role: string }[] }) => ({
+          (inv: { email: string; role?: string; token: string; created_at: string; vaults?: { vault_name: string }[] }) => ({
             email: inv.email,
             role: inv.role || "admin",
             status: "pending" as const,
@@ -197,6 +199,11 @@ export default function AllUsersTab() {
         key: "vaults",
         header: "Vaults",
         render: (u) => {
+          if (u.role === "owner") {
+            return (
+              <span className="text-xs text-text-dim italic">All (owner)</span>
+            );
+          }
           if (!u.vaults || u.vaults.length === 0) return <span className="text-sm text-text-dim">{"\u2014"}</span>;
           return (
             <div className="flex flex-wrap gap-1">
@@ -205,7 +212,7 @@ export default function AllUsersTab() {
                   key={typeof v === "string" ? v : v.vault_name}
                   className="inline-block px-2 py-0.5 bg-primary/10 text-primary text-xs font-medium rounded-full"
                 >
-                  {typeof v === "string" ? v : `${v.vault_name}:${v.vault_role}`}
+                  {typeof v === "string" ? v : v.vault_name}
                 </span>
               ))}
             </div>
@@ -286,9 +293,11 @@ export default function AllUsersTab() {
   );
 }
 
+// Pre-assigned vault scope on a user invite. No per-vault role under
+// the unified instance-role model — effective power comes from the
+// invite's instance role.
 interface VaultAssignment {
   vault_name: string;
-  vault_role: "member" | "admin";
 }
 
 function InviteUserButton({
@@ -309,14 +318,12 @@ function InviteUserButton({
 
   useEffect(() => {
     if (!open) return;
-    // Fetch vaults the user can assign
+    // Owners can pre-assign any vault. Admins are constrained to vaults
+    // already in their own scope (server enforces this regardless).
     apiFetch("/v1/vaults")
       .then((r) => r.json())
       .then((data) => {
-        const vaults = (data.vaults ?? []).filter(
-          (v: VaultOption) => isOwner || v.role === "admin"
-        );
-        setAvailableVaults(vaults);
+        setAvailableVaults(data.vaults ?? []);
       })
       .catch(() => {});
   }, [open, isOwner]);
@@ -334,7 +341,7 @@ function InviteUserButton({
     const assignedNames = new Set(vaultAssignments.map((a) => a.vault_name));
     const next = availableVaults.find((v) => !assignedNames.has(v.name));
     if (next) {
-      setVaultAssignments([...vaultAssignments, { vault_name: next.name, vault_role: "member" }]);
+      setVaultAssignments([...vaultAssignments, { vault_name: next.name }]);
     }
   }
 
@@ -342,9 +349,9 @@ function InviteUserButton({
     setVaultAssignments(vaultAssignments.filter((_, i) => i !== idx));
   }
 
-  function updateVault(idx: number, field: "vault_name" | "vault_role", value: string) {
+  function updateVault(idx: number, value: string) {
     const updated = [...vaultAssignments];
-    updated[idx] = { ...updated[idx], [field]: value };
+    updated[idx] = { vault_name: value };
     setVaultAssignments(updated);
   }
 
@@ -493,7 +500,9 @@ function InviteUserButton({
               </div>
               {vaultAssignments.length === 0 ? (
                 <p className="text-sm text-text-muted">
-                  No vaults pre-assigned. User will join the instance without vault access.
+                  {role === "owner"
+                    ? "Owners auto-access every vault — no scope needed."
+                    : "No vaults pre-assigned. User will join the instance without vault access."}
                 </p>
               ) : (
                 <div className="space-y-2">
@@ -501,7 +510,7 @@ function InviteUserButton({
                     <div key={idx} className="flex items-center gap-2">
                       <select
                         value={assignment.vault_name}
-                        onChange={(e) => updateVault(idx, "vault_name", e.target.value)}
+                        onChange={(e) => updateVault(idx, e.target.value)}
                         className="flex-1 px-3 py-2 bg-surface border border-border rounded-lg text-text text-sm outline-none"
                       >
                         {availableVaults.map((v) => (
@@ -513,14 +522,6 @@ function InviteUserButton({
                             {v.name}
                           </option>
                         ))}
-                      </select>
-                      <select
-                        value={assignment.vault_role}
-                        onChange={(e) => updateVault(idx, "vault_role", e.target.value)}
-                        className="w-28 px-3 py-2 bg-surface border border-border rounded-lg text-text text-sm outline-none"
-                      >
-                        <option value="member">Member</option>
-                        <option value="admin">Admin</option>
                       </select>
                       <button
                         type="button"

--- a/web/src/pages/home/VaultsListTab.tsx
+++ b/web/src/pages/home/VaultsListTab.tsx
@@ -13,7 +13,6 @@ interface Vault {
   id: string;
   name: string;
   role: string;
-  membership: "explicit" | "implicit";
   is_default?: boolean;
   created_at: string;
   pending_proposals: number;
@@ -69,9 +68,6 @@ export default function VaultsListTab() {
     return vaults.filter((v) => v.name.toLowerCase().includes(q));
   }, [vaults, search]);
 
-  const myVaults = useMemo(() => filtered.filter((v) => v.membership === "explicit"), [filtered]);
-  const otherVaults = useMemo(() => filtered.filter((v) => v.membership === "implicit"), [filtered]);
-
   return (
     <div className="p-8 w-full max-w-[960px]">
       {/* Header */}
@@ -120,41 +116,16 @@ export default function VaultsListTab() {
           {search ? "No vaults match your search." : "No vaults yet."}
         </div>
       ) : (
-        <>
-          {myVaults.length > 0 && (
-            <div className={otherVaults.length > 0 ? "mb-10" : ""}>
-              {otherVaults.length > 0 && (
-                <h2 className="text-sm font-medium text-text-muted uppercase tracking-wide mb-3">My Vaults</h2>
-              )}
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {myVaults.map((vault) => (
-                  <VaultCard
-                    key={vault.id}
-                    vault={vault}
-                    isOwner={auth.is_owner}
-                    onDelete={setDeleteTarget}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-          {otherVaults.length > 0 && (
-            <div>
-              <h2 className="text-sm font-medium text-text-muted uppercase tracking-wide mb-3">Other Vaults</h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {otherVaults.map((vault) => (
-                  <VaultCard
-                    key={vault.id}
-                    vault={vault}
-                    isOwner={auth.is_owner}
-                    onJoined={fetchVaults}
-                    onDelete={setDeleteTarget}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-        </>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {filtered.map((vault) => (
+            <VaultCard
+              key={vault.id}
+              vault={vault}
+              isOwner={auth.is_owner}
+              onDelete={setDeleteTarget}
+            />
+          ))}
+        </div>
       )}
 
       <ConfirmDeleteModal
@@ -174,118 +145,71 @@ export default function VaultsListTab() {
 function VaultCard({
   vault,
   isOwner,
-  onJoined,
   onDelete,
 }: {
   vault: Vault;
   isOwner: boolean;
-  onJoined?: () => void;
   onDelete: (vault: Vault) => void;
 }) {
-  const [joining, setJoining] = useState(false);
-  const [joinError, setJoinError] = useState("");
-  const navigate = useNavigate();
-
-  async function handleJoin(e: React.MouseEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-    setJoining(true);
-    setJoinError("");
-    try {
-      const resp = await apiFetch(`/v1/vaults/${vault.name}/join`, { method: "POST" });
-      if (resp.ok) {
-        onJoined?.();
-      } else {
-        const data = await resp.json();
-        setJoinError(data.error || "Failed to join vault.");
-      }
-    } catch {
-      setJoinError("Network error.");
-    } finally {
-      setJoining(false);
-    }
-  }
-
   function handleDelete(e: React.MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
     onDelete(vault);
   }
 
-  const isImplicit = vault.membership === "implicit";
   const canDelete = isOwner && !vault.is_default;
-
-  const card = (
-    <div
-      className={`bg-surface border border-border rounded-xl p-5 transition-colors ${isImplicit ? "" : "hover:border-border-focus/40 cursor-pointer"}`}
-      onClick={isImplicit ? undefined : () => navigate({ to: "/vaults/$name", params: { name: vault.name } })}
-    >
-      <div className="flex items-start justify-between mb-3">
-        <h3 className="text-base font-semibold text-text tracking-tight">
-          {vault.name}
-        </h3>
-        <div className="flex items-center gap-2">
-          {isImplicit ? (
-            <button
-              onClick={handleJoin}
-              disabled={joining}
-              className="inline-flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-medium bg-primary text-primary-text hover:bg-primary-hover transition-colors disabled:opacity-50"
-            >
-              {joining ? "Joining..." : "Join"}
-            </button>
-          ) : vault.pending_proposals > 0 ? (
-            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-warning-bg text-warning border border-warning/20">
-              {vault.pending_proposals}{" "}
-              {vault.pending_proposals === 1 ? "review needed" : "reviews needed"}
-            </span>
-          ) : null}
-          {canDelete && (
-            <button
-              onClick={handleDelete}
-              className="p-1 rounded text-text-dim hover:text-danger transition-colors"
-              title="Delete vault"
-            >
-              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <polyline points="3 6 5 6 21 6" />
-                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-              </svg>
-            </button>
-          )}
-        </div>
-      </div>
-      {joinError && (
-        <div className="text-xs text-danger mb-2">{joinError}</div>
-      )}
-      <div className="flex items-center gap-3 text-xs text-text-muted">
-        <span className="flex items-center gap-1.5">
-          <svg
-            className="w-3.5 h-3.5"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <circle cx="12" cy="12" r="10" />
-            <polyline points="12 6 12 12 16 14" />
-          </svg>
-          {timeAgo(vault.created_at)}
-        </span>
-        {vault.role && (
-          <span className="text-text-dim">
-            {vault.role}
-          </span>
-        )}
-      </div>
-    </div>
-  );
-
-  if (isImplicit) return card;
 
   return (
     <Link to="/vaults/$name" params={{ name: vault.name }} className="block no-underline">
-      {card}
+      <div className="bg-surface border border-border rounded-xl p-5 transition-colors hover:border-border-focus/40 cursor-pointer">
+        <div className="flex items-start justify-between mb-3">
+          <h3 className="text-base font-semibold text-text tracking-tight">
+            {vault.name}
+          </h3>
+          <div className="flex items-center gap-2">
+            {vault.pending_proposals > 0 && (
+              <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold bg-warning-bg text-warning border border-warning/20">
+                {vault.pending_proposals}{" "}
+                {vault.pending_proposals === 1 ? "review needed" : "reviews needed"}
+              </span>
+            )}
+            {canDelete && (
+              <button
+                onClick={handleDelete}
+                className="p-1 rounded text-text-dim hover:text-danger transition-colors"
+                title="Delete vault"
+              >
+                <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="3 6 5 6 21 6" />
+                  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-3 text-xs text-text-muted">
+          <span className="flex items-center gap-1.5">
+            <svg
+              className="w-3.5 h-3.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <polyline points="12 6 12 12 16 14" />
+            </svg>
+            {timeAgo(vault.created_at)}
+          </span>
+          {vault.role && (
+            <span className="text-text-dim">
+              {vault.role}
+            </span>
+          )}
+        </div>
+      </div>
     </Link>
   );
 }

--- a/web/src/pages/vault/AgentsTab.tsx
+++ b/web/src/pages/vault/AgentsTab.tsx
@@ -10,36 +10,22 @@ import { apiFetch } from "../../lib/api";
 
 interface AgentRow {
   name: string;
-  vault_role: string;
+  role: string;
   status: string;
 }
 
+// Rendered only inside the admin-gated actions column, so no role guard
+// here. Instance role changes happen on the instance-level Agents tab.
 function RowActions({
   agent,
   vaultName,
-  vaultRole,
   onDone,
 }: {
   agent: AgentRow;
   vaultName: string;
-  vaultRole: string;
   onDone: () => void;
 }) {
-  if (vaultRole !== "admin") return null;
   if (agent.status === "revoked") return null;
-
-  const currentRole = agent.vault_role;
-
-  async function handleSetRole(newRole: string) {
-    await apiFetch(
-      `/v1/vaults/${encodeURIComponent(vaultName)}/agents/${encodeURIComponent(agent.name)}/role`,
-      {
-        method: "POST",
-        body: JSON.stringify({ role: newRole }),
-      }
-    );
-    onDone();
-  }
 
   async function handleRemove() {
     await apiFetch(
@@ -49,18 +35,10 @@ function RowActions({
     onDone();
   }
 
-  const roleItems = (["proxy", "member", "admin"] as const)
-    .filter((r) => r !== currentRole)
-    .map((r) => ({
-      label: `Set role: ${r}`,
-      onClick: () => handleSetRole(r),
-    }));
-
   return (
     <DropdownMenu
       width={192}
       items={[
-        ...roleItems,
         { label: "Remove from vault", onClick: handleRemove, variant: "danger" as const },
       ]}
     />
@@ -68,7 +46,7 @@ function RowActions({
 }
 
 export default function AgentsTab() {
-  const { vaultName, vaultRole } = useVaultParams();
+  const { vaultName, isAdmin } = useVaultParams();
   const [rows, setRows] = useState<AgentRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -89,15 +67,15 @@ export default function AgentsTab() {
       render: (agent) => <StatusBadge status={agent.status} />,
     },
     {
-      key: "vault_role",
+      key: "role",
       header: "Role",
       render: (agent) => (
         <span className="text-sm text-text-muted capitalize">
-          {agent.vault_role || "\u2014"}
+          {agent.role || "—"}
         </span>
       ),
     },
-    ...(vaultRole === "admin"
+    ...(isAdmin
       ? [
           {
             key: "actions" as const,
@@ -107,7 +85,6 @@ export default function AgentsTab() {
               <RowActions
                 agent={agent}
                 vaultName={vaultName}
-                vaultRole={vaultRole}
                 onDone={fetchData}
               />
             ),
@@ -137,9 +114,9 @@ export default function AgentsTab() {
       const data = await resp.json();
       setRows(
         (data.agents ?? []).map(
-          (a: { name: string; vault_role: string; status: string }) => ({
+          (a: { name: string; role: string; status: string }) => ({
             name: a.name,
-            vault_role: a.vault_role,
+            role: a.role,
             status: a.status,
           })
         )
@@ -159,10 +136,10 @@ export default function AgentsTab() {
             Agents
           </h2>
           <p className="text-sm text-text-muted">
-            AI agents with access to this vault.
+            AI agents with access to this vault. Permissions inside the vault come from each agent's instance role.
           </p>
         </div>
-        {vaultRole === "admin" && (
+        {isAdmin && (
           <AddAgentButton vaultName={vaultName} vaultAgents={rows} onAdded={fetchData} />
         )}
       </div>
@@ -186,6 +163,7 @@ export default function AgentsTab() {
 
 interface InstanceAgent {
   name: string;
+  role: string;
   status: string;
 }
 
@@ -200,7 +178,6 @@ function AddAgentButton({
 }) {
   const [open, setOpen] = useState(false);
   const [agentName, setAgentName] = useState("");
-  const [role, setRole] = useState("proxy");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [instanceAgents, setInstanceAgents] = useState<InstanceAgent[]>([]);
@@ -213,16 +190,19 @@ function AddAgentButton({
       .catch(() => {});
   }, [open]);
 
+  // Owners auto-access every vault, so they aren't candidates for an
+  // explicit grant. Filter them out alongside agents that already
+  // have access.
   const availableAgents = instanceAgents.filter(
     (a) =>
       (a.status === "active" || a.status === "pending") &&
-      !vaultAgents.some((va) => va.name === a.name)
+      a.role !== "owner" &&
+      !vaultAgents.some((va) => va.name === a.name),
   );
 
   function close() {
     setOpen(false);
     setAgentName("");
-    setRole("proxy");
     setError("");
   }
 
@@ -235,7 +215,7 @@ function AddAgentButton({
         `/v1/vaults/${encodeURIComponent(vaultName)}/agents`,
         {
           method: "POST",
-          body: JSON.stringify({ name: agentName, role }),
+          body: JSON.stringify({ name: agentName }),
         }
       );
       if (resp.ok) {
@@ -274,7 +254,7 @@ function AddAgentButton({
         open={open}
         onClose={close}
         title="Add Agent to Vault"
-        description="Add an existing instance agent to this vault."
+        description="Grant an existing instance agent access to this vault. Effective permissions inside the vault come from the agent's instance role."
         footer={
           <>
             <Button variant="secondary" onClick={close}>Cancel</Button>
@@ -288,7 +268,7 @@ function AddAgentButton({
           <FormField label="Agent">
             {availableAgents.length === 0 ? (
               <p className="text-sm text-text-muted py-2">
-                All instance agents already have access to this vault.
+                Every eligible instance agent already has access to this vault.
               </p>
             ) : (
               <Select
@@ -301,19 +281,11 @@ function AddAgentButton({
                 </option>
                 {availableAgents.map((a) => (
                   <option key={a.name} value={a.name}>
-                    {a.name}
+                    {a.name} ({a.role})
                   </option>
                 ))}
               </Select>
             )}
-          </FormField>
-
-          <FormField label="Role">
-            <Select value={role} onChange={(e) => setRole(e.target.value)}>
-              <option value="proxy">Proxy</option>
-              <option value="member">Member</option>
-              <option value="admin">Admin</option>
-            </Select>
           </FormField>
 
           {error && <ErrorBanner message={error} />}

--- a/web/src/pages/vault/CredentialsTab.tsx
+++ b/web/src/pages/vault/CredentialsTab.tsx
@@ -9,7 +9,7 @@ import FormField from "../../components/FormField";
 import { apiFetch } from "../../lib/api";
 
 export default function CredentialsTab() {
-  const { vaultName, vaultRole } = useVaultParams();
+  const { vaultName, isAdmin: isVaultAdmin, isAgent } = useVaultParams();
   const [keys, setKeys] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -87,8 +87,10 @@ export default function CredentialsTab() {
     }
   }
 
-  const isAdmin = vaultRole === "admin";
-  const canReveal = vaultRole === "member" || vaultRole === "admin";
+  // Owners and admins manage and reveal; instance-`agent` actors are
+  // proxy-only and see neither edit affordances nor decrypted values.
+  const isAdmin = isVaultAdmin;
+  const canReveal = !isAgent;
 
   // Reveal state: tracks which credential values have been fetched and are visible.
   const [revealedValues, setRevealedValues] = useState<Record<string, string>>({});
@@ -437,7 +439,7 @@ function CredentialModal({
       open
       onClose={onClose}
       title={isEdit ? "Edit Credential" : "Add Credential"}
-      description="Credentials are injected into proxied requests via services. Values are encrypted at rest and can be revealed by vault members and admins."
+      description="Credentials are injected into proxied requests via services. Values are encrypted at rest and can be revealed by anyone with vault access except instance `agent` actors."
       footer={
         <>
           <Button variant="secondary" onClick={onClose}>

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -57,7 +57,7 @@ const AUTH_TYPE_OPTIONS: { value: AuthType; label: string }[] = [
 ];
 
 export default function ServicesTab() {
-  const { vaultName, vaultRole } = useVaultParams();
+  const { vaultName, isAdmin: isVaultAdmin } = useVaultParams();
   const [services, setServices] = useState<Service[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -160,7 +160,7 @@ export default function ServicesTab() {
     }
   }
 
-  const isAdmin = vaultRole === "admin";
+  const isAdmin = isVaultAdmin;
 
   const columns: Column<Service>[] = [
     {

--- a/web/src/pages/vault/SettingsTab.tsx
+++ b/web/src/pages/vault/SettingsTab.tsx
@@ -11,9 +11,9 @@ import { apiFetch } from "../../lib/api";
 type UnmatchedHostPolicy = "passthrough" | "deny";
 
 export default function SettingsTab() {
-  const { vaultName, vaultRole, isOwner } = useVaultParams();
+  // isAdmin already covers owner + admin under the unified role model.
+  const { vaultName, isAdmin: canManage } = useVaultParams();
   const navigate = useNavigate();
-  const canManage = vaultRole === "admin" || isOwner;
   const isDefault = vaultName === "default";
 
   // Rename state

--- a/web/src/pages/vault/UsersTab.tsx
+++ b/web/src/pages/vault/UsersTab.tsx
@@ -34,24 +34,6 @@ function RowActions({
 }) {
   if (user.email === currentEmail) return null;
 
-  const newRole = user.role === "admin" ? "member" : "admin";
-
-  async function handleChangeRole() {
-    const resp = await apiFetch(
-      `/v1/vaults/${encodeURIComponent(vaultName)}/users/${encodeURIComponent(user.email)}/role`,
-      {
-        method: "POST",
-        body: JSON.stringify({ role: newRole }),
-      }
-    );
-    if (!resp.ok) {
-      const data = await resp.json().catch(() => ({}));
-      onError(data.error || "Failed to change role");
-      return;
-    }
-    onDone();
-  }
-
   async function handleRemove() {
     const resp = await apiFetch(
       `/v1/vaults/${encodeURIComponent(vaultName)}/users/${encodeURIComponent(user.email)}`,
@@ -65,10 +47,12 @@ function RowActions({
     onDone();
   }
 
+  // Per-vault role is gone. The only remaining mutation is "remove
+  // scope from this vault"; instance role changes happen on the
+  // instance-level Users tab.
   const items: DropdownMenuItem[] = [
-    { label: `Make ${newRole}`, onClick: handleChangeRole },
     {
-      label: "Remove",
+      label: "Remove access",
       onClick: handleRemove,
       variant: "danger" as const,
     },
@@ -78,7 +62,7 @@ function RowActions({
 }
 
 export default function UsersTab() {
-  const { vaultName, vaultRole, email: currentEmail } = useVaultParams();
+  const { vaultName, isAdmin, email: currentEmail } = useVaultParams();
   const [users, setUsers] = useState<VaultUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -101,7 +85,7 @@ export default function UsersTab() {
         <span className="text-sm text-text-muted capitalize">{u.role}</span>
       ),
     },
-    ...(vaultRole === "admin"
+    ...(isAdmin
       ? [
           {
             key: "actions" as const,
@@ -152,10 +136,10 @@ export default function UsersTab() {
             Users
           </h2>
           <p className="text-sm text-text-muted">
-            People with access to this vault.
+            People with access to this vault. Permissions inside the vault come from each user's instance role.
           </p>
         </div>
-        {vaultRole === "admin" && (
+        {isAdmin && (
           <AddUserButton vaultName={vaultName} vaultUsers={users} onAdded={fetchUsers} />
         )}
       </div>
@@ -193,7 +177,6 @@ function AddUserButton({
 }) {
   const [open, setOpen] = useState(false);
   const [email, setEmail] = useState("");
-  const [role, setRole] = useState<"member" | "admin">("member");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [instanceUsers, setInstanceUsers] = useState<InstanceUser[]>([]);
@@ -206,14 +189,18 @@ function AddUserButton({
       .catch(() => {});
   }, [open]);
 
+  // Owners auto-access every vault, so they aren't candidates for an
+  // explicit grant. Filter them out alongside users who already have
+  // access.
   const availableUsers = instanceUsers.filter(
-    (u) => !vaultUsers.some((vu) => vu.email === u.email)
+    (u) =>
+      u.role !== "owner" &&
+      !vaultUsers.some((vu) => vu.email === u.email),
   );
 
   function close() {
     setOpen(false);
     setEmail("");
-    setRole("member");
     setError("");
   }
 
@@ -226,7 +213,7 @@ function AddUserButton({
         `/v1/vaults/${encodeURIComponent(vaultName)}/users`,
         {
           method: "POST",
-          body: JSON.stringify({ email, role }),
+          body: JSON.stringify({ email }),
         }
       );
       if (resp.ok) {
@@ -267,7 +254,7 @@ function AddUserButton({
         open={open}
         onClose={close}
         title="Add User to Vault"
-        description="Grant an existing instance user access to this vault."
+        description="Grant an existing instance user access to this vault. Effective permissions inside the vault come from the user's instance role."
         footer={
           <>
             <Button variant="secondary" onClick={close}>Cancel</Button>
@@ -285,7 +272,7 @@ function AddUserButton({
           <FormField label="User">
             {availableUsers.length === 0 ? (
               <p className="text-sm text-text-muted py-2">
-                All instance users already have access to this vault.
+                Every eligible instance user already has access to this vault.
               </p>
             ) : (
               <Select
@@ -295,24 +282,12 @@ function AddUserButton({
               >
                 <option value="" disabled>Select a user...</option>
                 {availableUsers.map((u) => (
-                  <option key={u.email} value={u.email}>{u.email}</option>
+                  <option key={u.email} value={u.email}>
+                    {u.email} ({u.role})
+                  </option>
                 ))}
               </Select>
             )}
-          </FormField>
-          <FormField
-            label="Role"
-            helperText={<>{role === "member"
-              ? "Manage credentials, use proxy, approve proposals, and manage services."
-              : "All member permissions, plus invite users and agents with any role."} <a href="https://docs.agent-vault.dev/learn/permissions#vault-roles" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Learn more</a></>}
-          >
-            <Select
-              value={role}
-              onChange={(e) => setRole(e.target.value as "member" | "admin")}
-            >
-              <option value="member">Member</option>
-              <option value="admin">Admin</option>
-            </Select>
           </FormField>
           {error && <ErrorBanner message={error} />}
         </div>

--- a/web/src/pages/vault/shared.tsx
+++ b/web/src/pages/vault/shared.tsx
@@ -14,9 +14,13 @@ export {
 export function useVaultParams() {
   const { auth } = useRouteContext({ from: "/_auth" }) as { auth: AuthContext };
   const vaultContext = useRouteContext({ from: "/_auth/vaults/$name" }) as VaultContext;
+  const role = vaultContext.role;
   return {
     vaultName: vaultContext.vault_name,
-    vaultRole: vaultContext.vault_role,
+    // Actor's instance role within this vault (owner | admin | agent).
+    role,
+    isAdmin: role === "owner" || role === "admin",
+    isAgent: role === "agent",
     email: auth.email,
     isOwner: auth.is_owner,
   };

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -38,7 +38,9 @@ export interface AuthContext {
 
 export interface VaultContext {
   vault_name: string;
-  vault_role: string;
+  // Actor's instance role ("owner", "admin", or "agent") with access to
+  // the vault. Effective permissions in the vault come from this role.
+  role: string;
 }
 
 // --- Root Route ---


### PR DESCRIPTION
## Summary

Replaces the two-axis permission model (instance role + per-vault role) with a single instance-level role: `owner`, `admin`, or `agent`. Owners auto-access every vault; admins and agents are scoped via `vault_grants`, which becomes a pure scope table (no role column). The new `agent` role is programmatic-only and proxy-only — agents can use the proxy and raise proposals but cannot reveal credentials or approve/reject proposals.

The plan that drove this change: [`/Users/tuandang/.claude/plans/at-the-moment-there-deep-honey.md`](https://github.com/Infisical/agent-vault/blob/roles/unified-instance-tier/internal/store/migrations/045_unified_instance_roles.sql).

### Highlights

- **Migration `045_unified_instance_roles.sql`** maps existing data with highest-wins semantics: any admin/member grant keeps the admin instance role, proxy-only grants downgrade to `agent`, owner grants are dropped (owners now auto-access every vault).
- **Middleware** collapses to `requireVaultAccess` + `requireVaultAdmin` via a shared `resolveVaultActor` helper that always returns the resolved actor — proposal handlers no longer re-resolve.
- **Inviter constraints**: admins cannot grant a role above their own and cannot pre-assign vaults outside their own scope; agents cannot invite at all. Covered by `TestUserInviteAdmin*` / `TestAgentInviteAdmin*`.
- **Proposal notifications** include all active instance owners alongside scoped admins (owners no longer have explicit grants).
- **Skill docs, public docs, CLI flags, and SPA invite/scope flows** are aligned with the new model. The legacy `vault_role` field is gone everywhere.
- **Cleanup pass**: extracted `actorVaultScope` / `scopeContains` / `canManageInvite` / `vaultGrantsToJSON` / `inviteVaultsToJSON` to deduplicate four scope-build patterns, three invite-auth blocks, and six vault-list flatten loops; replaced raw `\"owner\"` compares with `User.IsOwner()` / `Agent.IsOwner()` predicates on the hot paths.

### Public API changes

- Removed: `POST /v1/vaults/{name}/users/{email}/role`, `POST /v1/vaults/{name}/agents/{name}/role` — per-vault role no longer exists.
- Modified: invite request bodies drop `vault_role` from the per-vault entries; agent-invite `role` accepts `owner | admin | agent`.
- Modified: `GET /v1/vaults/{name}/context` now returns `role` (the actor's instance role) instead of `vault_role`.
- `POST /v1/vaults/{name}/join` becomes a no-op compatibility shim for owners.

## Test plan

- [ ] CI: `make test` (16 packages green locally)
- [ ] CI: `make build` (frontend + Go binary green locally)
- [ ] Migration: stand up a copy of an older dev DB with populated `vault_grants`; run the binary; confirm migration applies, owners auto-access vaults, agents with only proxy grants downgrade to instance `agent`.
- [ ] End-to-end: register as owner, invite a scoped admin, invite a scoped agent. Verify the agent can use the proxy + raise proposals but cannot reveal credentials or approve proposals; the admin can do both.
- [ ] Inviter constraints: scoped admin tries to invite (a) an owner — rejected, (b) an admin scoped to a vault outside their scope — rejected, (c) an agent inside their scope — accepted.
- [ ] Browser: vault `Settings` / `Users` / `Agents` / `Credentials` tabs render correctly under all three roles.