### PR TITLE
tokens: add UI for managing vault-scoped session tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ agent-vault run --isolation=container --share-agent-dir -- claude
 
 See [Container isolation](https://docs.agent-vault.dev/guides/container-isolation) for the threat model and flags.
 
+To mint, list, and revoke vault-scoped tokens without wrapping a child process, use either `agent-vault vault token` or the **Tokens** tab inside each vault in the web UI.
+
 ### SDK — sandboxed agents (Docker, Daytona, E2B)
 
 For agents running inside containers, use the SDK from your orchestrator to mint a session and pass proxy config into the sandbox:

--- a/cmd/reauth_test.go
+++ b/cmd/reauth_test.go
@@ -63,7 +63,7 @@ func TestRequestScopedSession_401MessagePreservesPrefix(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := requestScopedSession(srv.URL, "tok", "default", "", 0)
+	_, err := requestScopedSession(srv.URL, "tok", "default", 0)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -96,7 +96,7 @@ func TestRequestScopedSession_401WrapsErrSessionExpired(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := requestScopedSession(srv.URL, "stale-token", "default", "", 0)
+	_, err := requestScopedSession(srv.URL, "stale-token", "default", 0)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -189,7 +189,7 @@ func TestMintScopedSession_VaultResolutionMemoized(t *testing.T) {
 	cmd.Flags().String("vault", "", "")
 
 	sess := &session.ClientSession{Token: "stale", Address: srv.URL}
-	vault, token, err := mintScopedSession(cmd, sess, srv.URL, "", 0)
+	vault, token, err := mintScopedSession(cmd, sess, srv.URL, 0)
 	if err != nil {
 		t.Fatalf("expected nil error, got %v", err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -67,7 +67,6 @@ Example:
 	c.Flags().Var(&iso, "isolation", "Isolation mode: host (default) or container")
 
 	c.Flags().String("address", "", "Agent Vault server address (defaults to session address)")
-	c.Flags().String("role", "", "Vault role for the agent session (proxy, member, admin; default: proxy)")
 	c.Flags().Int("ttl", 0, "Session TTL in seconds (300–604800; default: server default 24h)")
 
 	c.Flags().String("image", "", "Container image override (requires --isolation=container)")
@@ -115,9 +114,8 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 
 	// 2-3. Resolve the vault and mint a vault-scoped session token,
 	//      retrying on session expiry. Shared with `vault token`.
-	role, _ := cmd.Flags().GetString("role")
 	ttl, _ := cmd.Flags().GetInt("ttl")
-	vault, scopedToken, err := mintScopedSession(cmd, sess, addr, role, ttl)
+	vault, scopedToken, err := mintScopedSession(cmd, sess, addr, ttl)
 	if err != nil {
 		return err
 	}
@@ -457,7 +455,7 @@ func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]stri
 // re-auth would be a UX regression, and the user's earlier choice is
 // still valid because vault membership is rechecked server-side when
 // requestScopedSession fires.
-func mintScopedSession(cmd *cobra.Command, sess *session.ClientSession, addr, role string, ttl int) (vault, scopedToken string, err error) {
+func mintScopedSession(cmd *cobra.Command, sess *session.ClientSession, addr string, ttl int) (vault, scopedToken string, err error) {
 	err = withReauthRetry(sess, addr, func(s *session.ClientSession) error {
 		if vault == "" {
 			v, verr := resolveVaultForRun(cmd, addr, s.Token)
@@ -466,7 +464,7 @@ func mintScopedSession(cmd *cobra.Command, sess *session.ClientSession, addr, ro
 			}
 			vault = v
 		}
-		token, terr := requestScopedSession(addr, s.Token, vault, role, ttl)
+		token, terr := requestScopedSession(addr, s.Token, vault, ttl)
 		if terr != nil {
 			return terr
 		}
@@ -477,12 +475,11 @@ func mintScopedSession(cmd *cobra.Command, sess *session.ClientSession, addr, ro
 }
 
 // requestScopedSession calls the server to create a vault-scoped session
-// and returns the scoped token.
-func requestScopedSession(addr, adminToken, vault, role string, ttlSeconds int) (string, error) {
+// and returns the scoped token. Tokens are always minted with role
+// `proxy`; the server enforces this and the CLI no longer exposes a flag
+// for it.
+func requestScopedSession(addr, adminToken, vault string, ttlSeconds int) (string, error) {
 	body := map[string]any{"vault": vault}
-	if role != "" {
-		body["vault_role"] = role
-	}
 	if ttlSeconds > 0 {
 		body["ttl_seconds"] = ttlSeconds
 	}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -16,7 +16,7 @@ import (
 // the other is a bug. `vault` is inherited from vaultCmd's persistent flags
 // on `vault run` and registered locally on the top-level `run`.
 var expectedRunFlags = []string{
-	"address", "role", "ttl", "vault",
+	"address", "ttl", "vault",
 	"isolation", "image", "mount", "keep", "no-firewall",
 	"home-volume-shared", "share-agent-dir",
 }

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -47,13 +47,13 @@ Under `--isolation=container`, the same env shape is injected inside a Docker co
 
 ### Scoped session tokens
 
-You almost never need to mint your own token — `agent-vault run` already provides one. But if you must scope a child process down, run:
+You almost never need to mint your own token — `agent-vault run` already provides one. But if you must hand a separate token to a child process, run:
 
 ```bash
-agent-vault vault token --role proxy --ttl 3600
+agent-vault vault token --ttl 3600
 ```
 
-Flags: `--role` (`proxy`/`member`/`admin`, capped to your own role; default `proxy`), `--ttl` (seconds, 300–604800; default 24h). The token is printed to stdout — pipe it into `AGENT_VAULT_SESSION_TOKEN` for the child process. Operators can list/revoke tokens from each vault's **Tokens** tab in the UI.
+Flag: `--ttl` (seconds, 300–604800; default 24h). Tokens are minted with vault role `proxy`. The token is printed to stdout — pipe it into `AGENT_VAULT_SESSION_TOKEN` for the child process. Operators can list/revoke tokens from each vault's **Tokens** tab in the UI.
 
 ## Discover Available Services (Start Here)
 

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -45,6 +45,16 @@ By default each vault forwards unmatched hosts as plain proxy traffic (no creden
 
 Under `--isolation=container`, the same env shape is injected inside a Docker container, but the proxy URL host is `host.docker.internal` instead of `127.0.0.1` and egress to any other destination is blocked by iptables. From your perspective nothing changes — standard HTTP clients pick up the envvars as normal.
 
+### Scoped session tokens
+
+You almost never need to mint your own token — `agent-vault run` already provides one. But if you must scope a child process down, run:
+
+```bash
+agent-vault vault token --role proxy --ttl 3600
+```
+
+Flags: `--role` (`proxy`/`member`/`admin`, capped to your own role; default `proxy`), `--ttl` (seconds, 300–604800; default 24h). The token is printed to stdout — pipe it into `AGENT_VAULT_SESSION_TOKEN` for the child process. Operators can list/revoke tokens from each vault's **Tokens** tab in the UI.
+
 ## Discover Available Services (Start Here)
 
 **Always run this first** to learn which hosts have credentials configured:

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -44,6 +44,23 @@ By default each vault forwards unmatched hosts as plain proxy traffic (no creden
 
 Under `--isolation=container`, the same env shape is injected inside a Docker container, but the proxy URL host is `host.docker.internal` instead of `127.0.0.1` and egress to any other destination is blocked by iptables. From your perspective nothing changes — standard HTTP clients pick up the envvars as normal.
 
+### Scoped session tokens
+
+You almost never need to mint your own token — `vault run` already provides one. But if you must scope a child process down (e.g. a sub-agent that should only have proxy rights), call:
+
+```
+POST /v1/sessions
+{
+  "vault": "<vault-name>",
+  "vault_role": "proxy" | "member" | "admin",   // defaults to "proxy"; capped to your role
+  "ttl_seconds": 3600,                          // 300–604800; defaults to 24h
+  "label": "<optional, ≤100 chars>"             // shown in the Tokens UI
+}
+→ { "token": "...", "expires_at": "...", "av_addr": "..." }
+```
+
+Operators manage these via the **Tokens** tab in each vault, which uses `GET /v1/sessions?vault=<name>` (member+) and `DELETE /v1/sessions/{public_id}?vault=<name>` (member+). The raw token is only returned at creation; subsequent reads only ever show the `public_id`.
+
 ## Discover Available Services (Start Here)
 
 **Always call this first** to learn which hosts have credentials configured:

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -46,20 +46,19 @@ Under `--isolation=container`, the same env shape is injected inside a Docker co
 
 ### Scoped session tokens
 
-You almost never need to mint your own token — `vault run` already provides one. But if you must scope a child process down (e.g. a sub-agent that should only have proxy rights), call:
+You almost never need to mint your own token — `vault run` already provides one. But if you must hand a separate token to a child process, call:
 
 ```
 POST /v1/sessions
 {
-  "vault": "<vault-name>",
-  "vault_role": "proxy" | "member" | "admin",   // defaults to "proxy"; capped to your role
-  "ttl_seconds": 3600,                          // 300–604800; defaults to 24h
-  "label": "<optional, ≤100 chars>"             // shown in the Tokens UI
+  "vault":       "<vault-name>",
+  "ttl_seconds": 3600,                       // optional, 300–604800; defaults to 24h
+  "label":       "<optional, ≤100 chars>"    // shown in the Tokens UI
 }
 → { "token": "...", "expires_at": "...", "av_addr": "..." }
 ```
 
-Operators manage these via the **Tokens** tab in each vault, which uses `GET /v1/sessions?vault=<name>` (member+) and `DELETE /v1/sessions/{public_id}?vault=<name>` (member+). The raw token is only returned at creation; subsequent reads only ever show the `public_id`.
+Tokens are minted with vault role `proxy`. Operators manage them via the **Tokens** tab in each vault, which uses `GET /v1/sessions?vault=<name>` (member+) and `DELETE /v1/sessions/{public_id}?vault=<name>` (member+). The raw token is only returned at creation; subsequent reads only ever show the `public_id`.
 
 ## Discover Available Services (Start Here)
 

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -31,9 +31,8 @@ Example:
 			addr = sess.Address
 		}
 
-		role, _ := cmd.Flags().GetString("role")
 		ttl, _ := cmd.Flags().GetInt("ttl")
-		_, token, err := mintScopedSession(cmd, sess, addr, role, ttl)
+		_, token, err := mintScopedSession(cmd, sess, addr, ttl)
 		if err != nil {
 			return err
 		}
@@ -45,7 +44,6 @@ Example:
 
 func init() {
 	tokenCmd.Flags().String("address", "", "Agent Vault server address (defaults to session address)")
-	tokenCmd.Flags().String("role", "", "Vault role for the session (proxy, member, admin; default: proxy)")
 	tokenCmd.Flags().Int("ttl", 0, "Session TTL in seconds (300–604800; default: server default 24h)")
 
 	vaultCmd.AddCommand(tokenCmd)

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -267,7 +267,6 @@ description: "Complete reference for all Agent Vault CLI commands."
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--address` | | Server address override |
-    | `--role` | `proxy` | Vault role for the session: `proxy`, `member`, or `admin` |
     | `--ttl` | `0` | Session TTL in seconds (300–604800). Default: server default (24h). |
     | `--isolation` | `host` | Isolation mode for the child: `host` (default, cooperative — runs on the host with `HTTPS_PROXY`/`HTTP_PROXY`) or `container` (non-cooperative Docker container; see [Container isolation](/guides/container-isolation)). Also read from `AGENT_VAULT_ISOLATION`. |
     | `--image` | | Override the bundled container image (`--isolation=container` only). |
@@ -283,12 +282,11 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault token [flags]
     ```
 
-    Mint a vault-scoped session token and print it to stdout. Useful when you need a scoped token without wrapping a child process via `agent-vault run`.
+    Mint a vault-scoped session token and print it to stdout. Useful when you need a scoped token without wrapping a child process via `agent-vault run`. Tokens are minted with vault role `proxy`.
 
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--address` | | Server address override |
-    | `--role` | `proxy` | Vault role for the session: `proxy`, `member`, or `admin` |
     | `--ttl` | `0` | Session TTL in seconds (300–604800). Default: server default (24h). |
 
     ```bash
@@ -297,8 +295,8 @@ description: "Complete reference for all Agent Vault CLI commands."
     export AGENT_VAULT_ADDR=http://localhost:14321
     export AGENT_VAULT_VAULT=default
 
-    # Mint a short-lived token with member role
-    agent-vault vault token --vault myproject --role member --ttl 3600
+    # Mint a short-lived token (1 hour TTL)
+    agent-vault vault token --vault myproject --ttl 3600
     ```
   </Accordion>
 </AccordionGroup>

--- a/internal/server/handle_sessions.go
+++ b/internal/server/handle_sessions.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Infisical/agent-vault/internal/store"
@@ -73,7 +74,8 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Cap label length so the Tokens UI table stays legible.
+	// Trim before length-checking so a payload of all-spaces doesn't pass.
+	req.Label = strings.TrimSpace(req.Label)
 	if len(req.Label) > maxScopedSessionLabel {
 		jsonError(w, http.StatusBadRequest, fmt.Sprintf(
 			"label must be at most %d characters", maxScopedSessionLabel,
@@ -147,8 +149,10 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleListScopedSessions returns the active vault-scoped tokens for a
-// vault, sorted most recent first. Any caller with vault access can view
-// the list (mirrors how the Users/Agents tabs are visible to all members).
+// vault, sorted most recent first. Requires vault `member` or higher: the
+// list view exposes the email/name of whoever minted each token via
+// created_by.display_name, which is more identifying than what a
+// proxy-only caller should see.
 // The raw token is never returned — rows are referenced by public_id.
 func (s *Server) handleListScopedSessions(w http.ResponseWriter, r *http.Request) {
 	vaultName := r.URL.Query().Get("vault")
@@ -164,7 +168,7 @@ func (s *Server) handleListScopedSessions(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if _, err := s.requireVaultAccess(w, r, ns.ID); err != nil {
+	if _, err := s.requireVaultMember(w, r, ns.ID); err != nil {
 		return
 	}
 

--- a/internal/server/handle_sessions.go
+++ b/internal/server/handle_sessions.go
@@ -118,8 +118,13 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check that the caller has access to this vault.
-	if _, err := s.requireVaultAccess(w, r, ns.ID); err != nil {
+	// Caller must be at least a vault `member`. A `proxy`-role caller
+	// (user, agent, or scoped session) can ONLY proxy requests through
+	// Agent Vault — they cannot mint new tokens, even at proxy role.
+	// requireVaultMember enforces this for instance-level user/agent
+	// sessions; capRequestedRole below handles the same floor for
+	// scoped-session callers.
+	if _, err := s.requireVaultMember(w, r, ns.ID); err != nil {
 		return
 	}
 

--- a/internal/server/handle_sessions.go
+++ b/internal/server/handle_sessions.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -78,8 +77,8 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 
 	// Tokens are minted with role `proxy` only; minting at member/admin
 	// is intentionally not exposed via this endpoint right now. The
-	// server-side cap in capRequestedRole still rejects scoped-session
-	// callers that lack member+ on the vault.
+	// member+ floor on the caller is enforced by requireVaultMember
+	// below for users/agents and scoped sessions alike.
 	if req.VaultRole != "" && req.VaultRole != "proxy" {
 		jsonError(w, http.StatusBadRequest, "vault_role must be 'proxy'")
 		return
@@ -121,24 +120,16 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 	// Caller must be at least a vault `member`. A `proxy`-role caller
 	// (user, agent, or scoped session) can ONLY proxy requests through
 	// Agent Vault — they cannot mint new tokens, even at proxy role.
-	// requireVaultMember enforces this for instance-level user/agent
-	// sessions; capRequestedRole below handles the same floor for
-	// scoped-session callers.
 	if _, err := s.requireVaultMember(w, r, ns.ID); err != nil {
 		return
 	}
-
-	// Default to "proxy" if no role specified; cap to caller's own role.
-	requestedRole := req.VaultRole
-	if requestedRole == "" {
-		requestedRole = "proxy"
-	}
 	parentSess := sessionFromContext(ctx)
-	cappedRole, errMsg := s.capRequestedRole(ctx, parentSess, ns.ID, requestedRole)
-	if errMsg != "" {
-		jsonError(w, http.StatusForbidden, errMsg)
-		return
-	}
+
+	// vault_role is locked to "proxy" by the validator above, and any
+	// member+ caller trivially satisfies that, so no role-cap check is
+	// needed here. If non-proxy minting is ever re-enabled, restore
+	// capRequestedRole (or equivalent) to gate role escalation.
+	cappedRole := "proxy"
 
 	// Compute expiry: use ttl_seconds if provided, otherwise default 24h.
 	var expiresAt *time.Time
@@ -282,41 +273,4 @@ func (s *Server) handleRevokeScopedSession(w http.ResponseWriter, r *http.Reques
 	jsonOK(w, map[string]string{"status": "revoked"})
 }
 
-// capRequestedRole enforces role-capping rules: the requested role cannot
-// exceed the caller's own vault role. Proxy-role agents cannot mint sessions at all.
-// Returns the validated role, or an error string if the caller lacks permission.
-func (s *Server) capRequestedRole(ctx context.Context, sess *store.Session, vaultID, requestedRole string) (string, string) {
-	if requestedRole == "" {
-		requestedRole = "proxy"
-	}
-
-	var callerRole string
-
-	if sess.VaultID != "" {
-		// Scoped session (agent or temp invite).
-		if sess.VaultID != vaultID {
-			return "", "Session not authorized for this vault"
-		}
-		if !roleSatisfies(sess.VaultRole, "member") {
-			return "", "Member role required"
-		}
-		callerRole = sess.VaultRole
-	} else {
-		// Instance-level session: resolve actor and check vault access.
-		actor, err := s.actorFromSession(ctx, sess)
-		if err != nil || actor == nil {
-			return "", "Invalid session"
-		}
-		role, err2 := s.store.GetVaultRole(ctx, actor.ID, vaultID)
-		if err2 != nil {
-			return "", "No access to this vault"
-		}
-		callerRole = role
-	}
-
-	if !roleSatisfies(callerRole, requestedRole) {
-		return "", fmt.Sprintf("Your vault role (%s) cannot mint sessions with role %s", callerRole, requestedRole)
-	}
-	return requestedRole, ""
-}
 

--- a/internal/server/handle_sessions.go
+++ b/internal/server/handle_sessions.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -14,6 +16,7 @@ type scopedSessionRequest struct {
 	Vault      string `json:"vault"`
 	VaultRole  string `json:"vault_role"`
 	TTLSeconds *int   `json:"ttl_seconds,omitempty"`
+	Label      string `json:"label,omitempty"`
 }
 
 type scopedSessionResponse struct {
@@ -21,6 +24,29 @@ type scopedSessionResponse struct {
 	ExpiresAt string `json:"expires_at"`
 	AVAddr    string `json:"av_addr,omitempty"`
 }
+
+// scopedSessionView is the JSON projection returned by GET /v1/sessions.
+// The raw token is intentionally absent — it is shown only at creation
+// time and never re-readable. Rows are referenced by `id` (the public_id).
+type scopedSessionView struct {
+	ID        string                  `json:"id"`
+	Label     string                  `json:"label,omitempty"`
+	VaultRole string                  `json:"vault_role"`
+	CreatedBy *scopedSessionActorView `json:"created_by,omitempty"`
+	CreatedAt string                  `json:"created_at"`
+	ExpiresAt string                  `json:"expires_at,omitempty"`
+}
+
+type scopedSessionActorView struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	DisplayName string `json:"display_name"`
+}
+
+// maxScopedSessionLabel caps the label length stored on a scoped session.
+// Labels are user-supplied free-form text shown in the Tokens UI, so we
+// keep them short to avoid table layout issues.
+const maxScopedSessionLabel = 100
 
 func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 	var req scopedSessionRequest
@@ -45,6 +71,14 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 			))
 			return
 		}
+	}
+
+	// Cap label length so the Tokens UI table stays legible.
+	if len(req.Label) > maxScopedSessionLabel {
+		jsonError(w, http.StatusBadRequest, fmt.Sprintf(
+			"label must be at most %d characters", maxScopedSessionLabel,
+		))
+		return
 	}
 
 	ctx := r.Context()
@@ -82,7 +116,24 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 		expiresAt = &t
 	}
 
-	sess, err := s.store.CreateScopedSession(ctx, ns.ID, cappedRole, expiresAt)
+	// Resolve the calling actor so the Tokens UI can show "minted by X".
+	// A nil actor here means the caller is itself a vault-scoped session
+	// (e.g. an agent token or a previously-minted scoped token); we leave
+	// the created_by fields blank in that case rather than failing the mint.
+	var createdByID, createdByType string
+	if actor, err := s.actorFromSession(ctx, parentSess); err == nil && actor != nil {
+		createdByID = actor.ID
+		createdByType = actor.Type
+	}
+
+	sess, err := s.store.CreateScopedSession(ctx, store.CreateScopedSessionParams{
+		VaultID:            ns.ID,
+		VaultRole:          cappedRole,
+		ExpiresAt:          expiresAt,
+		Label:              req.Label,
+		CreatedByActorID:   createdByID,
+		CreatedByActorType: createdByType,
+	})
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create scoped session")
 		return
@@ -93,6 +144,106 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 		ExpiresAt: formatExpiresAt(sess.ExpiresAt),
 		AVAddr:    s.baseURL,
 	})
+}
+
+// handleListScopedSessions returns the active vault-scoped tokens for a
+// vault, sorted most recent first. Any caller with vault access can view
+// the list (mirrors how the Users/Agents tabs are visible to all members).
+// The raw token is never returned — rows are referenced by public_id.
+func (s *Server) handleListScopedSessions(w http.ResponseWriter, r *http.Request) {
+	vaultName := r.URL.Query().Get("vault")
+	if vaultName == "" {
+		jsonError(w, http.StatusBadRequest, "vault is required")
+		return
+	}
+
+	ctx := r.Context()
+	ns, err := s.store.GetVault(ctx, vaultName)
+	if err != nil || ns == nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", vaultName))
+		return
+	}
+
+	if _, err := s.requireVaultAccess(w, r, ns.ID); err != nil {
+		return
+	}
+
+	rows, err := s.store.ListScopedSessionsByVault(ctx, ns.ID)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to list scoped sessions")
+		return
+	}
+
+	displayNames := make(map[string]string, len(rows))
+	out := make([]scopedSessionView, 0, len(rows))
+	for _, sess := range rows {
+		view := scopedSessionView{
+			ID:        sess.PublicID,
+			Label:     sess.Label,
+			VaultRole: sess.VaultRole,
+			CreatedAt: formatExpiresAt(&sess.CreatedAt),
+			ExpiresAt: formatExpiresAt(sess.ExpiresAt),
+		}
+		if sess.CreatedByActorID != "" && sess.CreatedByActorType != "" {
+			cacheKey := sess.CreatedByActorType + ":" + sess.CreatedByActorID
+			displayName, ok := displayNames[cacheKey]
+			if !ok {
+				if actor, err := s.actorByID(ctx, sess.CreatedByActorID, sess.CreatedByActorType); err == nil {
+					displayName = actor.DisplayLabel()
+				} else {
+					displayName = sess.CreatedByActorID
+				}
+				displayNames[cacheKey] = displayName
+			}
+			view.CreatedBy = &scopedSessionActorView{
+				ID:          sess.CreatedByActorID,
+				Type:        sess.CreatedByActorType,
+				DisplayName: displayName,
+			}
+		}
+		out = append(out, view)
+	}
+	jsonOK(w, map[string]interface{}{"sessions": out})
+}
+
+// handleRevokeScopedSession deletes one vault-scoped token by its
+// public_id. The caller must be at least a vault `member` of the row's
+// vault — proxy-only sessions cannot revoke. Cross-vault revocation is
+// blocked at the store level via the vault_id filter.
+func (s *Server) handleRevokeScopedSession(w http.ResponseWriter, r *http.Request) {
+	publicID := r.PathValue("id")
+	if publicID == "" {
+		jsonError(w, http.StatusBadRequest, "Session id is required")
+		return
+	}
+
+	vaultName := r.URL.Query().Get("vault")
+	if vaultName == "" {
+		jsonError(w, http.StatusBadRequest, "vault is required")
+		return
+	}
+
+	ctx := r.Context()
+	ns, err := s.store.GetVault(ctx, vaultName)
+	if err != nil || ns == nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", vaultName))
+		return
+	}
+
+	if _, err := s.requireVaultMember(w, r, ns.ID); err != nil {
+		return
+	}
+
+	err = s.store.RevokeScopedSession(ctx, ns.ID, publicID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			jsonError(w, http.StatusNotFound, "Session not found")
+			return
+		}
+		jsonError(w, http.StatusInternalServerError, "Failed to revoke scoped session")
+		return
+	}
+	jsonOK(w, map[string]string{"status": "revoked"})
 }
 
 // capRequestedRole enforces role-capping rules: the requested role cannot

--- a/internal/server/handle_sessions.go
+++ b/internal/server/handle_sessions.go
@@ -56,9 +56,12 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate role if provided.
-	if req.VaultRole != "" && req.VaultRole != "proxy" && req.VaultRole != "member" && req.VaultRole != "admin" {
-		jsonError(w, http.StatusBadRequest, "vault_role must be one of: proxy, member, admin")
+	// Tokens are minted with role `proxy` only; minting at member/admin
+	// is intentionally not exposed via this endpoint right now. The
+	// server-side cap in capRequestedRole still rejects scoped-session
+	// callers that lack member+ on the vault.
+	if req.VaultRole != "" && req.VaultRole != "proxy" {
+		jsonError(w, http.StatusBadRequest, "vault_role must be 'proxy'")
 		return
 	}
 

--- a/internal/server/handle_sessions.go
+++ b/internal/server/handle_sessions.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Infisical/agent-vault/internal/store"
 )
@@ -49,6 +50,25 @@ type scopedSessionActorView struct {
 // keep them short to avoid table layout issues.
 const maxScopedSessionLabel = 100
 
+// sanitizeScopedSessionLabel trims surrounding whitespace and strips
+// ASCII control characters. Mirrors truncateDeviceLabel's policy for
+// user-session device labels, except it does not silently truncate —
+// the caller checks rune count and rejects with 400.
+func sanitizeScopedSessionLabel(label string) string {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return ""
+	}
+	cleaned := make([]rune, 0, len(label))
+	for _, r := range label {
+		if r < 0x20 || r == 0x7f {
+			continue
+		}
+		cleaned = append(cleaned, r)
+	}
+	return string(cleaned)
+}
+
 func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 	var req scopedSessionRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Vault == "" {
@@ -77,9 +97,13 @@ func (s *Server) handleScopedSession(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Trim before length-checking so a payload of all-spaces doesn't pass.
-	req.Label = strings.TrimSpace(req.Label)
-	if len(req.Label) > maxScopedSessionLabel {
+	// Trim and strip control chars before length-checking. Control chars
+	// (\n, \t, etc.) would break the Tokens table layout — the same
+	// concern truncateDeviceLabel addresses for user-session device
+	// labels. Length is measured in runes, not bytes, so a CJK or emoji
+	// label that fits the frontend's maxLength={100} also passes here.
+	req.Label = sanitizeScopedSessionLabel(req.Label)
+	if utf8.RuneCountInString(req.Label) > maxScopedSessionLabel {
 		jsonError(w, http.StatusBadRequest, fmt.Sprintf(
 			"label must be at most %d characters", maxScopedSessionLabel,
 		))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -144,13 +144,15 @@ type Store interface {
 	CountUsers(ctx context.Context) (int, error)
 	RegisterFirstUser(ctx context.Context, email string, passwordHash, passwordSalt []byte, defaultVaultID string, kdfTime uint32, kdfMemory uint32, kdfThreads uint8) (*store.User, error)
 	CreateUserSession(ctx context.Context, p store.CreateUserSessionParams) (*store.Session, error)
-	CreateScopedSession(ctx context.Context, vaultID, vaultRole string, expiresAt *time.Time) (*store.Session, error)
+	CreateScopedSession(ctx context.Context, p store.CreateScopedSessionParams) (*store.Session, error)
 	GetSession(ctx context.Context, id string) (*store.Session, error)
 	DeleteSession(ctx context.Context, id string) error
 	DeleteUserSessions(ctx context.Context, userID string) error
 	TouchSession(ctx context.Context, rawToken, ip, userAgent string) error
 	ListUserSessions(ctx context.Context, userID string) ([]store.Session, error)
 	RevokeUserSession(ctx context.Context, userID, publicID string) error
+	ListScopedSessionsByVault(ctx context.Context, vaultID string) ([]store.Session, error)
+	RevokeScopedSession(ctx context.Context, vaultID, publicID string) error
 
 	// Vaults
 	CreateVault(ctx context.Context, name string) (*store.Vault, error)
@@ -305,6 +307,27 @@ func (a *Actor) DisplayLabel() string {
 		return a.Agent.Name
 	}
 	return a.ID
+}
+
+// actorByID hydrates an Actor from a stored (id, type) pair. Used when an
+// actor is referenced by foreign-key columns (e.g. created_by on a scoped
+// session row) rather than by the calling session.
+func (s *Server) actorByID(ctx context.Context, actorID, actorType string) (*Actor, error) {
+	switch actorType {
+	case "user":
+		user, err := s.store.GetUserByID(ctx, actorID)
+		if err != nil || user == nil {
+			return nil, fmt.Errorf("user not found")
+		}
+		return &Actor{ID: user.ID, Type: "user", Role: user.Role, User: user}, nil
+	case "agent":
+		agent, err := s.store.GetAgentByID(ctx, actorID)
+		if err != nil || agent == nil {
+			return nil, fmt.Errorf("agent not found")
+		}
+		return &Actor{ID: agent.ID, Type: "agent", Role: agent.Role, Agent: agent}, nil
+	}
+	return nil, fmt.Errorf("unknown actor type: %s", actorType)
 }
 
 // actorFromSession resolves any session to an Actor.
@@ -604,6 +627,8 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("GET /v1/auth/sessions", s.requireInitialized(s.requireAuth(actorAuthed(s.handleListUserSessions))))
 	mux.HandleFunc("DELETE /v1/auth/sessions/{id}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleRevokeUserSession))))
 	mux.HandleFunc("POST /v1/sessions", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleScopedSession)))))
+	mux.HandleFunc("GET /v1/sessions", s.requireInitialized(s.requireAuth(actorAuthed(s.handleListScopedSessions))))
+	mux.HandleFunc("DELETE /v1/sessions/{id}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleRevokeScopedSession))))
 	mux.HandleFunc("GET /v1/credentials", s.requireInitialized(s.requireAuth(actorAuthed(s.handleCredentialsList))))
 	mux.HandleFunc("POST /v1/credentials", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleCredentialsSet)))))
 	mux.HandleFunc("DELETE /v1/credentials", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleCredentialsDelete)))))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4821,6 +4821,53 @@ func TestScopedSessionMintWithLabel(t *testing.T) {
 	}
 }
 
+func TestScopedSessionLabelCJKWithinRuneLimit(t *testing.T) {
+	// 50 CJK characters = 150 bytes UTF-8, well under the 100-byte len()
+	// cap that previously rejected this — but within the 100-rune cap.
+	ms, token := setupMockStoreWithSession(t)
+	srv := newTestServer(withStore(ms))
+
+	cjk := strings.Repeat("我", 50)
+	body := fmt.Sprintf(`{"vault":"default","label":%q}`, cjk)
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for 50-rune CJK label, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp scopedSessionResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if got := ms.sessions[resp.Token]; got == nil || got.Label != cjk {
+		t.Fatalf("expected label preserved, got %+v", got)
+	}
+}
+
+func TestScopedSessionLabelStripsControlChars(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	srv := newTestServer(withStore(ms))
+
+	body := `{"vault":"default","label":"line1\nline2\ttab"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp scopedSessionResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	got := ms.sessions[resp.Token]
+	if got == nil || got.Label != "line1line2tab" {
+		t.Fatalf("expected control chars stripped, got %q", func() string {
+			if got == nil {
+				return "<nil>"
+			}
+			return got.Label
+		}())
+	}
+}
+
 func TestScopedSessionLabelTooLong(t *testing.T) {
 	ms, token := setupMockStoreWithSession(t)
 	srv := newTestServer(withStore(ms))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1979,10 +1979,8 @@ func TestScopedSessionSuccess(t *testing.T) {
 // owner with vault-admin can no longer request a non-proxy role through
 // POST /v1/sessions. Tokens are minted with role `proxy` only.
 // TestScopedSessionProxyUserRejected covers the rule that a proxy-role
-// vault user cannot mint scoped tokens — proxy is a "can only proxy
-// requests" tier and explicitly excludes the mint capability, even
-// though the legacy capRequestedRole fall-through previously allowed
-// proxy→proxy minting via the instance-level branch.
+// vault user cannot mint scoped tokens. Proxy is a "can only proxy
+// requests" tier and explicitly excludes mint, even at proxy role.
 func TestScopedSessionProxyUserRejected(t *testing.T) {
 	ms := newMockStore()
 	ms.users["proxy@test.com"] = &store.User{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -175,16 +175,49 @@ func (m *mockStore) RevokeUserSession(_ context.Context, userID, publicID string
 	return sql.ErrNoRows
 }
 
-func (m *mockStore) CreateScopedSession(_ context.Context, vaultID, vaultRole string, expiresAt *time.Time) (*store.Session, error) {
+func (m *mockStore) CreateScopedSession(_ context.Context, p store.CreateScopedSessionParams) (*store.Session, error) {
+	publicID := fmt.Sprintf("scoped-public-%d", len(m.sessions))
 	s := &store.Session{
-		ID:        "scoped-session-id",
-		VaultID:   vaultID,
-		VaultRole: vaultRole,
-		ExpiresAt: expiresAt,
-		CreatedAt: time.Now(),
+		ID:                 "scoped-session-id",
+		VaultID:            p.VaultID,
+		VaultRole:          p.VaultRole,
+		ExpiresAt:          p.ExpiresAt,
+		CreatedAt:          time.Now(),
+		PublicID:           publicID,
+		Label:              p.Label,
+		CreatedByActorID:   p.CreatedByActorID,
+		CreatedByActorType: p.CreatedByActorType,
 	}
 	m.sessions[s.ID] = s
 	return s, nil
+}
+
+func (m *mockStore) ListScopedSessionsByVault(_ context.Context, vaultID string) ([]store.Session, error) {
+	now := time.Now()
+	var out []store.Session
+	for _, sess := range m.sessions {
+		if sess.VaultID != vaultID || sess.PublicID == "" || sess.UserID != "" || sess.AgentID != "" {
+			continue
+		}
+		if sess.ExpiresAt != nil && sess.ExpiresAt.Before(now) {
+			continue
+		}
+		out = append(out, *sess)
+	}
+	return out, nil
+}
+
+func (m *mockStore) RevokeScopedSession(_ context.Context, vaultID, publicID string) error {
+	if vaultID == "" || publicID == "" {
+		return sql.ErrNoRows
+	}
+	for id, sess := range m.sessions {
+		if sess.VaultID == vaultID && sess.PublicID == publicID && sess.UserID == "" && sess.AgentID == "" {
+			delete(m.sessions, id)
+			return nil
+		}
+	}
+	return sql.ErrNoRows
 }
 
 func (m *mockStore) GetSession(_ context.Context, id string) (*store.Session, error) {
@@ -2082,7 +2115,11 @@ func setupMockStoreWithScopedSessionRole(t *testing.T, vaultName, vaultID, role 
 		ms.vaults[vaultName] = &store.Vault{ID: vaultID, Name: vaultName}
 	}
 	// Create a scoped session locked to the given vault
-	sess, err := ms.CreateScopedSession(context.Background(), vaultID, role, tp(time.Now().Add(time.Hour)))
+	sess, err := ms.CreateScopedSession(context.Background(), store.CreateScopedSessionParams{
+		VaultID:   vaultID,
+		VaultRole: role,
+		ExpiresAt: tp(time.Now().Add(time.Hour)),
+	})
 	if err != nil {
 		t.Fatalf("CreateScopedSession: %v", err)
 	}
@@ -2419,7 +2456,11 @@ func setupVaultWithCredential(t *testing.T, servicesJSON string) (*mockStore, st
 	ms := newMockStore()
 	encKey := make([]byte, 32)
 
-	sess, err := ms.CreateScopedSession(context.Background(), "root-ns-id", "proxy", tp(time.Now().Add(time.Hour)))
+	sess, err := ms.CreateScopedSession(context.Background(), store.CreateScopedSessionParams{
+		VaultID:   "root-ns-id",
+		VaultRole: "proxy",
+		ExpiresAt: tp(time.Now().Add(time.Hour)),
+	})
 	if err != nil {
 		t.Fatalf("CreateScopedSession: %v", err)
 	}
@@ -2545,7 +2586,11 @@ func TestDiscoverEmptyRules(t *testing.T) {
 
 func TestDiscoverNoCredentials(t *testing.T) {
 	ms := newMockStore()
-	sess, err := ms.CreateScopedSession(context.Background(), "root-ns-id", "proxy", tp(time.Now().Add(time.Hour)))
+	sess, err := ms.CreateScopedSession(context.Background(), store.CreateScopedSessionParams{
+		VaultID:   "root-ns-id",
+		VaultRole: "proxy",
+		ExpiresAt: tp(time.Now().Add(time.Hour)),
+	})
 	if err != nil {
 		t.Fatalf("CreateScopedSession: %v", err)
 	}
@@ -4803,6 +4848,141 @@ func TestScopedSessionInvalidRole(t *testing.T) {
 	srv.httpServer.Handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid role, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// --- Tokens UI: list + revoke + label ---
+
+func TestScopedSessionMintWithLabel(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	srv := newTestServer(withStore(ms))
+
+	body := `{"vault":"default","label":"ci-bot"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp scopedSessionResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	stored := ms.sessions[resp.Token]
+	if stored == nil {
+		t.Fatal("scoped session not stored")
+	}
+	if stored.Label != "ci-bot" {
+		t.Fatalf("expected label ci-bot, got %q", stored.Label)
+	}
+	if stored.CreatedByActorID != "owner-user-id" || stored.CreatedByActorType != "user" {
+		t.Fatalf("expected created_by user/owner-user-id, got %s/%s", stored.CreatedByActorType, stored.CreatedByActorID)
+	}
+	if stored.PublicID == "" {
+		t.Fatal("expected public_id to be populated on scoped session")
+	}
+}
+
+func TestScopedSessionLabelTooLong(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	srv := newTestServer(withStore(ms))
+
+	tooLong := strings.Repeat("a", maxScopedSessionLabel+1)
+	body := fmt.Sprintf(`{"vault":"default","label":%q}`, tooLong)
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for oversized label, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestScopedSessionListAndRevoke(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	srv := newTestServer(withStore(ms))
+
+	mintBody := `{"vault":"default","label":"laptop"}`
+	mintReq := httptest.NewRequest(http.MethodPost, "/v1/sessions", strings.NewReader(mintBody))
+	mintReq.Header.Set("Authorization", "Bearer "+token)
+	mintRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(mintRec, mintReq)
+	if mintRec.Code != http.StatusOK {
+		t.Fatalf("mint: expected 200, got %d: %s", mintRec.Code, mintRec.Body.String())
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/sessions?vault=default", nil)
+	listReq.Header.Set("Authorization", "Bearer "+token)
+	listRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d: %s", listRec.Code, listRec.Body.String())
+	}
+	var listResp struct {
+		Sessions []scopedSessionView `json:"sessions"`
+	}
+	if err := json.NewDecoder(listRec.Body).Decode(&listResp); err != nil {
+		t.Fatalf("list decode: %v", err)
+	}
+	if len(listResp.Sessions) != 1 {
+		t.Fatalf("expected 1 scoped session, got %d", len(listResp.Sessions))
+	}
+	row := listResp.Sessions[0]
+	if row.Label != "laptop" {
+		t.Fatalf("expected label laptop, got %q", row.Label)
+	}
+	if row.ID == "" {
+		t.Fatal("expected non-empty public_id in list view")
+	}
+	if row.CreatedBy == nil || row.CreatedBy.DisplayName != "owner@test.com" {
+		t.Fatalf("expected created_by display_name owner@test.com, got %+v", row.CreatedBy)
+	}
+
+	revokeReq := httptest.NewRequest(http.MethodDelete, "/v1/sessions/"+row.ID+"?vault=default", nil)
+	revokeReq.Header.Set("Authorization", "Bearer "+token)
+	revokeRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(revokeRec, revokeReq)
+	if revokeRec.Code != http.StatusOK {
+		t.Fatalf("revoke: expected 200, got %d: %s", revokeRec.Code, revokeRec.Body.String())
+	}
+
+	listReq2 := httptest.NewRequest(http.MethodGet, "/v1/sessions?vault=default", nil)
+	listReq2.Header.Set("Authorization", "Bearer "+token)
+	listRec2 := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(listRec2, listReq2)
+	var listResp2 struct {
+		Sessions []scopedSessionView `json:"sessions"`
+	}
+	_ = json.NewDecoder(listRec2.Body).Decode(&listResp2)
+	if len(listResp2.Sessions) != 0 {
+		t.Fatalf("expected 0 sessions after revoke, got %d", len(listResp2.Sessions))
+	}
+}
+
+func TestScopedSessionRevokeNotFound(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	srv := newTestServer(withStore(ms))
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/sessions/does-not-exist?vault=default", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestScopedSessionListRequiresAuth(t *testing.T) {
+	ms := newMockStore()
+	srv := newTestServer(withStore(ms))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions?vault=default", nil)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1975,7 +1975,10 @@ func TestScopedSessionSuccess(t *testing.T) {
 	}
 }
 
-func TestScopedSessionExplicitRole(t *testing.T) {
+// TestScopedSessionRoleAdminRejected covers the new restriction: even an
+// owner with vault-admin can no longer request a non-proxy role through
+// POST /v1/sessions. Tokens are minted with role `proxy` only.
+func TestScopedSessionRoleAdminRejected(t *testing.T) {
 	ms, token := setupMockStoreWithSession(t)
 	srv := newTestServer(withStore(ms))
 
@@ -1983,90 +1986,23 @@ func TestScopedSessionExplicitRole(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", strings.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
-
 	srv.httpServer.Handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	var resp scopedSessionResponse
-	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	scopedSess := ms.sessions[resp.Token]
-	if scopedSess == nil {
-		t.Fatal("scoped session not found in store")
-	}
-	if scopedSess.VaultRole != "admin" {
-		t.Fatalf("expected vault_role admin, got %q", scopedSess.VaultRole)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
-func TestScopedSessionRoleRejected(t *testing.T) {
-	// Create a member-role user (not admin) to verify role escalation is rejected.
-	ms := newMockStore()
-	ms.users["member@test.com"] = &store.User{
-		ID: "member-user-id", Email: "member@test.com",
-		Role: "member", IsActive: true,
-	}
-	ms.GrantVaultRole(context.Background(), "member-user-id", "user", "root-ns-id", "member")
-	sess, err := ms.CreateSession(context.Background(), "member-user-id", time.Now().Add(time.Hour))
-	if err != nil {
-		t.Fatalf("CreateSession: %v", err)
-	}
-
-	srv := newTestServer(withStore(ms))
-
-	// Member requests admin — should be rejected.
-	body := `{"vault":"default","vault_role":"admin"}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", strings.NewReader(body))
-	req.Header.Set("Authorization", "Bearer "+sess.ID)
-	rec := httptest.NewRecorder()
-
-	srv.httpServer.Handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
-	}
-}
-
-func TestScopedSessionMemberGetsMember(t *testing.T) {
-	// A vault member requesting member role should succeed.
-	ms := newMockStore()
-	ms.users["member@test.com"] = &store.User{
-		ID: "member-user-id", Email: "member@test.com",
-		Role: "member", IsActive: true,
-	}
-	ms.GrantVaultRole(context.Background(), "member-user-id", "user", "root-ns-id", "member")
-	sess, err := ms.CreateSession(context.Background(), "member-user-id", time.Now().Add(time.Hour))
-	if err != nil {
-		t.Fatalf("CreateSession: %v", err)
-	}
-
+func TestScopedSessionRoleMemberRejected(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
 	srv := newTestServer(withStore(ms))
 
 	body := `{"vault":"default","vault_role":"member"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", strings.NewReader(body))
-	req.Header.Set("Authorization", "Bearer "+sess.ID)
+	req.Header.Set("Authorization", "Bearer "+token)
 	rec := httptest.NewRecorder()
-
 	srv.httpServer.Handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	var resp scopedSessionResponse
-	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	scopedSess := ms.sessions[resp.Token]
-	if scopedSess == nil {
-		t.Fatal("scoped session not found in store")
-	}
-	if scopedSess.VaultRole != "member" {
-		t.Fatalf("expected vault_role member, got %q", scopedSess.VaultRole)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1978,6 +1978,35 @@ func TestScopedSessionSuccess(t *testing.T) {
 // TestScopedSessionRoleAdminRejected covers the new restriction: even an
 // owner with vault-admin can no longer request a non-proxy role through
 // POST /v1/sessions. Tokens are minted with role `proxy` only.
+// TestScopedSessionProxyUserRejected covers the rule that a proxy-role
+// vault user cannot mint scoped tokens — proxy is a "can only proxy
+// requests" tier and explicitly excludes the mint capability, even
+// though the legacy capRequestedRole fall-through previously allowed
+// proxy→proxy minting via the instance-level branch.
+func TestScopedSessionProxyUserRejected(t *testing.T) {
+	ms := newMockStore()
+	ms.users["proxy@test.com"] = &store.User{
+		ID: "proxy-user-id", Email: "proxy@test.com",
+		Role: "member", IsActive: true,
+	}
+	ms.GrantVaultRole(context.Background(), "proxy-user-id", "user", "root-ns-id", "proxy")
+	sess, err := ms.CreateSession(context.Background(), "proxy-user-id", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	srv := newTestServer(withStore(ms))
+
+	body := `{"vault":"default"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+sess.ID)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for proxy-role mint, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestScopedSessionRoleAdminRejected(t *testing.T) {
 	ms, token := setupMockStoreWithSession(t)
 	srv := newTestServer(withStore(ms))

--- a/internal/store/migrations/044_scoped_session_metadata.sql
+++ b/internal/store/migrations/044_scoped_session_metadata.sql
@@ -1,0 +1,9 @@
+-- Tracking metadata for vault-scoped session tokens so they can be listed
+-- and revoked from a UI. created_by_actor_id and _type mirror the actor
+-- model from migration 036. The label column already exists from
+-- migration 029 and is reused.
+
+ALTER TABLE sessions ADD COLUMN created_by_actor_id TEXT;
+ALTER TABLE sessions ADD COLUMN created_by_actor_type TEXT;
+
+CREATE INDEX idx_sessions_vault_id ON sessions(vault_id);

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -559,6 +559,16 @@ func (s *SQLiteStore) DeleteUser(ctx context.Context, userID string) error {
 	if _, err := tx.ExecContext(ctx, "DELETE FROM vault_grants WHERE actor_id = ?", userID); err != nil {
 		return fmt.Errorf("cleaning up vault grants: %w", err)
 	}
+	// Revoke scoped tokens this user minted on behalf of others. Without
+	// this, an orphan token keeps proxying upstream APIs until its TTL
+	// expires (up to scopedSessionMaxTTL).
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM sessions
+		 WHERE created_by_actor_id = ? AND created_by_actor_type = 'user'`,
+		userID,
+	); err != nil {
+		return fmt.Errorf("cleaning up scoped tokens minted by user: %w", err)
+	}
 	return tx.Commit()
 }
 
@@ -2561,8 +2571,16 @@ func (s *SQLiteStore) RevokeAgent(ctx context.Context, id string) error {
 		return sql.ErrNoRows
 	}
 
-	// Cascade: delete all tokens minted for this agent.
-	_, err = tx.ExecContext(ctx, "DELETE FROM sessions WHERE agent_id = ?", id)
+	// Cascade: delete tokens authenticating AS this agent and scoped
+	// tokens this agent minted on behalf of others. Without the second
+	// branch, a revoked agent's orphan token keeps proxying upstream APIs
+	// until its TTL expires (up to scopedSessionMaxTTL).
+	_, err = tx.ExecContext(ctx,
+		`DELETE FROM sessions
+		 WHERE agent_id = ?
+		    OR (created_by_actor_id = ? AND created_by_actor_type = 'agent')`,
+		id, id,
+	)
 	if err != nil {
 		return fmt.Errorf("deleting agent tokens: %w", err)
 	}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -789,32 +789,124 @@ func (s *SQLiteStore) CreateUserSession(ctx context.Context, p CreateUserSession
 	}, nil
 }
 
-func (s *SQLiteStore) CreateScopedSession(ctx context.Context, vaultID, vaultRole string, expiresAt *time.Time) (*Session, error) {
+func (s *SQLiteStore) CreateScopedSession(ctx context.Context, p CreateScopedSessionParams) (*Session, error) {
 	rawToken := newSessionToken()
 	tokenHash := hashSessionToken(rawToken)
+	publicID := newPublicID()
 	now := time.Now().UTC()
 
 	var expiresAtStr sql.NullString
-	if expiresAt != nil {
-		expiresAtStr = sql.NullString{String: expiresAt.UTC().Format(time.DateTime), Valid: true}
+	if p.ExpiresAt != nil {
+		expiresAtStr = sql.NullString{String: p.ExpiresAt.UTC().Format(time.DateTime), Valid: true}
 	}
 
 	_, err := s.db.ExecContext(ctx,
-		"INSERT INTO sessions (id, vault_id, vault_role, expires_at, created_at) VALUES (?, ?, ?, ?, ?)",
-		tokenHash, vaultID, vaultRole, expiresAtStr, now.Format(time.DateTime),
+		`INSERT INTO sessions
+		   (id, vault_id, vault_role, expires_at, created_at,
+		    public_id, label, created_by_actor_id, created_by_actor_type)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		tokenHash, p.VaultID, p.VaultRole, expiresAtStr, now.Format(time.DateTime),
+		publicID,
+		nullableString(p.Label),
+		nullableString(p.CreatedByActorID),
+		nullableString(p.CreatedByActorType),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating scoped session: %w", err)
 	}
 
-	return &Session{ID: rawToken, VaultID: vaultID, VaultRole: vaultRole, ExpiresAt: utcTimePtr(expiresAt), CreatedAt: now}, nil
+	return &Session{
+		ID:                 rawToken,
+		VaultID:            p.VaultID,
+		VaultRole:          p.VaultRole,
+		ExpiresAt:          utcTimePtr(p.ExpiresAt),
+		CreatedAt:          now,
+		PublicID:           publicID,
+		Label:              p.Label,
+		CreatedByActorID:   p.CreatedByActorID,
+		CreatedByActorType: p.CreatedByActorType,
+	}, nil
+}
+
+// ListScopedSessionsByVault returns active scoped tokens for the vault,
+// most recent first. Stale rows past their absolute expiry are filtered
+// in SQL; rows with a NULL public_id (legacy scoped rows from before
+// migration 044) are excluded so the UI can revoke every row it shows.
+func (s *SQLiteStore) ListScopedSessionsByVault(ctx context.Context, vaultID string) ([]Session, error) {
+	if vaultID == "" {
+		return nil, fmt.Errorf("ListScopedSessionsByVault: vaultID is required")
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT vault_role, expires_at, created_at, public_id,
+		        label, created_by_actor_id, created_by_actor_type
+		   FROM sessions
+		  WHERE vault_id = ?
+		    AND public_id IS NOT NULL
+		    AND user_id IS NULL
+		    AND agent_id IS NULL
+		    AND (expires_at IS NULL OR expires_at > datetime('now'))
+		  ORDER BY created_at DESC`,
+		vaultID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing scoped sessions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Session
+	for rows.Next() {
+		var sess Session
+		var vaultRole, expiresAt, publicID sql.NullString
+		var label, createdByActorID, createdByActorType sql.NullString
+		var createdAt string
+		if err := rows.Scan(&vaultRole, &expiresAt, &createdAt, &publicID,
+			&label, &createdByActorID, &createdByActorType); err != nil {
+			return nil, fmt.Errorf("scanning scoped session: %w", err)
+		}
+		sess.VaultID = vaultID
+		sess.VaultRole = vaultRole.String
+		sess.PublicID = publicID.String
+		sess.Label = label.String
+		sess.CreatedByActorID = createdByActorID.String
+		sess.CreatedByActorType = createdByActorType.String
+		if expiresAt.Valid {
+			t, _ := time.Parse(time.DateTime, expiresAt.String)
+			sess.ExpiresAt = &t
+		}
+		sess.CreatedAt, _ = time.Parse(time.DateTime, createdAt)
+		out = append(out, sess)
+	}
+	return out, rows.Err()
+}
+
+// RevokeScopedSession deletes one scoped session by (vaultID, publicID).
+// Returns sql.ErrNoRows when no matching row exists. Vault scoping in the
+// WHERE clause prevents one vault's admin from revoking another vault's
+// token by guessing a public_id.
+func (s *SQLiteStore) RevokeScopedSession(ctx context.Context, vaultID, publicID string) error {
+	if vaultID == "" || publicID == "" {
+		return sql.ErrNoRows
+	}
+	res, err := s.db.ExecContext(ctx,
+		"DELETE FROM sessions WHERE vault_id = ? AND public_id = ? AND user_id IS NULL AND agent_id IS NULL",
+		vaultID, publicID,
+	)
+	if err != nil {
+		return fmt.Errorf("revoking scoped session: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }
 
 func (s *SQLiteStore) GetSession(ctx context.Context, rawToken string) (*Session, error) {
 	tokenHash := hashSessionToken(rawToken)
 	row := s.db.QueryRowContext(ctx,
 		`SELECT id, user_id, vault_id, agent_id, vault_role, expires_at, created_at,
-		        last_used_at, idle_ttl_seconds, device_label, last_ip, last_user_agent, public_id
+		        last_used_at, idle_ttl_seconds, device_label, last_ip, last_user_agent, public_id,
+		        label, created_by_actor_id, created_by_actor_type
 		 FROM sessions WHERE id = ?`, tokenHash,
 	)
 
@@ -822,10 +914,12 @@ func (s *SQLiteStore) GetSession(ctx context.Context, rawToken string) (*Session
 	var storedID string
 	var userID, vaultID, agentID, vaultRole, expiresAt sql.NullString
 	var lastUsedAt, deviceLabel, lastIP, lastUserAgent, publicID sql.NullString
+	var label, createdByActorID, createdByActorType sql.NullString
 	var idleSecs sql.NullInt64
 	var createdAt string
 	if err := row.Scan(&storedID, &userID, &vaultID, &agentID, &vaultRole, &expiresAt, &createdAt,
-		&lastUsedAt, &idleSecs, &deviceLabel, &lastIP, &lastUserAgent, &publicID); err != nil {
+		&lastUsedAt, &idleSecs, &deviceLabel, &lastIP, &lastUserAgent, &publicID,
+		&label, &createdByActorID, &createdByActorType); err != nil {
 		return nil, err
 	}
 	// Return the raw token as ID (not the hash) so callers can reference it.
@@ -850,6 +944,9 @@ func (s *SQLiteStore) GetSession(ctx context.Context, rawToken string) (*Session
 	sess.LastIP = lastIP.String
 	sess.LastUserAgent = lastUserAgent.String
 	sess.PublicID = publicID.String
+	sess.Label = label.String
+	sess.CreatedByActorID = createdByActorID.String
+	sess.CreatedByActorType = createdByActorType.String
 	return &sess, nil
 }
 

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -28,8 +28,8 @@ func TestOpenAndMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("querying schema_migrations: %v", err)
 	}
-	if version != 43 {
-		t.Fatalf("expected migration version 43, got %d", version)
+	if version != 44 {
+		t.Fatalf("expected migration version 44, got %d", version)
 	}
 }
 
@@ -338,7 +338,11 @@ func TestScopedSessionCRUD(t *testing.T) {
 
 	expires := time.Now().Add(1 * time.Hour).UTC().Truncate(time.Second)
 
-	sess, err := s.CreateScopedSession(ctx, ns.ID, "proxy", &expires)
+	sess, err := s.CreateScopedSession(ctx, CreateScopedSessionParams{
+		VaultID:   ns.ID,
+		VaultRole: "proxy",
+		ExpiresAt: &expires,
+	})
 	if err != nil {
 		t.Fatalf("CreateScopedSession: %v", err)
 	}
@@ -1834,7 +1838,11 @@ func TestGetSessionBackwardCompat(t *testing.T) {
 	ctx := context.Background()
 
 	ns, _ := s.GetVault(ctx, "default")
-	sess, _ := s.CreateScopedSession(ctx, ns.ID, "proxy", tp(time.Now().Add(24*time.Hour)))
+	sess, _ := s.CreateScopedSession(ctx, CreateScopedSessionParams{
+		VaultID:   ns.ID,
+		VaultRole: "proxy",
+		ExpiresAt: tp(time.Now().Add(24 * time.Hour)),
+	})
 
 	fetched, err := s.GetSession(ctx, sess.ID)
 	if err != nil {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -365,6 +365,135 @@ func TestScopedSessionCRUD(t *testing.T) {
 	}
 }
 
+func TestListAndRevokeScopedSessions(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	ns, err := s.GetVault(ctx, "default")
+	if err != nil {
+		t.Fatalf("GetVault: %v", err)
+	}
+
+	// Mint two scoped sessions in `default` and one in a second vault to
+	// confirm vault scoping in both list and revoke.
+	other, err := s.CreateVault(ctx, "other")
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+
+	first, err := s.CreateScopedSession(ctx, CreateScopedSessionParams{
+		VaultID:            ns.ID,
+		VaultRole:          "proxy",
+		ExpiresAt:          tp(time.Now().Add(time.Hour)),
+		Label:              "ci-bot",
+		CreatedByActorID:   "user-1",
+		CreatedByActorType: "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateScopedSession default#1: %v", err)
+	}
+	// Sleep 1s so the second row sorts strictly after the first by created_at
+	// (sqlite's datetime resolution is per-second).
+	time.Sleep(1100 * time.Millisecond)
+	second, err := s.CreateScopedSession(ctx, CreateScopedSessionParams{
+		VaultID:   ns.ID,
+		VaultRole: "member",
+		ExpiresAt: tp(time.Now().Add(time.Hour)),
+	})
+	if err != nil {
+		t.Fatalf("CreateScopedSession default#2: %v", err)
+	}
+	if _, err := s.CreateScopedSession(ctx, CreateScopedSessionParams{
+		VaultID:   other.ID,
+		VaultRole: "proxy",
+		ExpiresAt: tp(time.Now().Add(time.Hour)),
+	}); err != nil {
+		t.Fatalf("CreateScopedSession other: %v", err)
+	}
+
+	rows, err := s.ListScopedSessionsByVault(ctx, ns.ID)
+	if err != nil {
+		t.Fatalf("ListScopedSessionsByVault: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows scoped to default, got %d", len(rows))
+	}
+	if rows[0].PublicID != second.PublicID || rows[1].PublicID != first.PublicID {
+		t.Fatalf("expected newest-first ordering: %s,%s — got %s,%s",
+			second.PublicID, first.PublicID, rows[0].PublicID, rows[1].PublicID)
+	}
+	if rows[1].Label != "ci-bot" {
+		t.Fatalf("expected label 'ci-bot' on first row, got %q", rows[1].Label)
+	}
+	if rows[1].CreatedByActorID != "user-1" || rows[1].CreatedByActorType != "user" {
+		t.Fatalf("expected created_by user/user-1, got %s/%s",
+			rows[1].CreatedByActorType, rows[1].CreatedByActorID)
+	}
+
+	// Cross-vault revoke must fail (publicID belongs to default, not other).
+	if err := s.RevokeScopedSession(ctx, other.ID, first.PublicID); err != sql.ErrNoRows {
+		t.Fatalf("expected sql.ErrNoRows on cross-vault revoke, got %v", err)
+	}
+
+	// Same-vault revoke succeeds and removes the row from list.
+	if err := s.RevokeScopedSession(ctx, ns.ID, first.PublicID); err != nil {
+		t.Fatalf("RevokeScopedSession: %v", err)
+	}
+	rows, err = s.ListScopedSessionsByVault(ctx, ns.ID)
+	if err != nil {
+		t.Fatalf("ListScopedSessionsByVault after revoke: %v", err)
+	}
+	if len(rows) != 1 || rows[0].PublicID != second.PublicID {
+		t.Fatalf("expected only second row to remain, got %+v", rows)
+	}
+
+	// Re-revoke is a no-op (sql.ErrNoRows).
+	if err := s.RevokeScopedSession(ctx, ns.ID, first.PublicID); err != sql.ErrNoRows {
+		t.Fatalf("expected sql.ErrNoRows on second revoke, got %v", err)
+	}
+}
+
+func TestListScopedSessionsExcludesExpiredAndUserRows(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	ns, _ := s.GetVault(ctx, "default")
+
+	// Active scoped row → included.
+	active, _ := s.CreateScopedSession(ctx, CreateScopedSessionParams{
+		VaultID:   ns.ID,
+		VaultRole: "proxy",
+		ExpiresAt: tp(time.Now().Add(time.Hour)),
+	})
+
+	// Expired scoped row → excluded by the SQL filter.
+	if _, err := s.CreateScopedSession(ctx, CreateScopedSessionParams{
+		VaultID:   ns.ID,
+		VaultRole: "proxy",
+		ExpiresAt: tp(time.Now().Add(-time.Hour)),
+	}); err != nil {
+		t.Fatalf("CreateScopedSession (expired): %v", err)
+	}
+
+	// User-login row that happens to carry the same vault_id (none today, but
+	// the list query must defend against future cross-pollution by filtering
+	// user_id IS NULL AND agent_id IS NULL).
+	u, _ := s.CreateUser(ctx, "scoped-list@test.com", []byte("h"), []byte("s"), "owner", 3, 65536, 4)
+	if _, err := s.CreateUserSession(ctx, CreateUserSessionParams{
+		UserID: u.ID, ExpiresAt: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("CreateUserSession: %v", err)
+	}
+
+	rows, err := s.ListScopedSessionsByVault(ctx, ns.ID)
+	if err != nil {
+		t.Fatalf("ListScopedSessionsByVault: %v", err)
+	}
+	if len(rows) != 1 || rows[0].PublicID != active.PublicID {
+		t.Fatalf("expected only the active scoped row, got %+v", rows)
+	}
+}
+
 func TestGlobalSessionHasEmptyVaultID(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -365,6 +365,94 @@ func TestScopedSessionCRUD(t *testing.T) {
 	}
 }
 
+func TestDeleteUserCascadesScopedTokensMintedByUser(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	ns, _ := s.GetVault(ctx, "default")
+	u, err := s.CreateUser(ctx, "minter@test.com", []byte("h"), []byte("s"), "owner", 3, 65536, 4)
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	keeper, err := s.CreateUser(ctx, "keeper@test.com", []byte("h"), []byte("s"), "owner", 3, 65536, 4)
+	if err != nil {
+		t.Fatalf("CreateUser keeper: %v", err)
+	}
+
+	// Token minted by `u`.
+	mintedByU, err := s.CreateScopedSession(ctx, CreateScopedSessionParams{
+		VaultID:            ns.ID,
+		VaultRole:          "proxy",
+		ExpiresAt:          tp(time.Now().Add(time.Hour)),
+		CreatedByActorID:   u.ID,
+		CreatedByActorType: "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateScopedSession u: %v", err)
+	}
+	// Token minted by `keeper` — must survive `u`'s deletion.
+	mintedByKeeper, err := s.CreateScopedSession(ctx, CreateScopedSessionParams{
+		VaultID:            ns.ID,
+		VaultRole:          "proxy",
+		ExpiresAt:          tp(time.Now().Add(time.Hour)),
+		CreatedByActorID:   keeper.ID,
+		CreatedByActorType: "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateScopedSession keeper: %v", err)
+	}
+
+	if err := s.DeleteUser(ctx, u.ID); err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+
+	if got, _ := s.GetSession(ctx, mintedByU.ID); got != nil {
+		t.Fatal("expected u's minted token to be cascaded away")
+	}
+	if got, err := s.GetSession(ctx, mintedByKeeper.ID); err != nil || got == nil {
+		t.Fatalf("expected keeper's token to survive: got=%v err=%v", got, err)
+	}
+}
+
+func TestRevokeAgentCascadesScopedTokensMintedByAgent(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	ns, _ := s.GetVault(ctx, "default")
+	agent, err := s.CreateAgent(ctx, "minter-agent", "system", "member")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// Agent's own auth token (agent_id = agent.ID).
+	agentToken, err := s.CreateAgentToken(ctx, agent.ID, tp(time.Now().Add(time.Hour)))
+	if err != nil {
+		t.Fatalf("CreateAgentToken: %v", err)
+	}
+	// Scoped token the agent minted on behalf of itself for a child process.
+	mintedByAgent, err := s.CreateScopedSession(ctx, CreateScopedSessionParams{
+		VaultID:            ns.ID,
+		VaultRole:          "proxy",
+		ExpiresAt:          tp(time.Now().Add(time.Hour)),
+		CreatedByActorID:   agent.ID,
+		CreatedByActorType: "agent",
+	})
+	if err != nil {
+		t.Fatalf("CreateScopedSession: %v", err)
+	}
+
+	if err := s.RevokeAgent(ctx, agent.ID); err != nil {
+		t.Fatalf("RevokeAgent: %v", err)
+	}
+
+	if got, _ := s.GetSession(ctx, agentToken.ID); got != nil {
+		t.Fatal("expected agent token to be cascaded away")
+	}
+	if got, _ := s.GetSession(ctx, mintedByAgent.ID); got != nil {
+		t.Fatal("expected scoped token minted by agent to be cascaded away")
+	}
+}
+
 func TestListAndRevokeScopedSessions(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -82,6 +82,14 @@ type Session struct {
 	DeviceLabel   string        // user-visible label, e.g. hostname
 	LastIP        string
 	LastUserAgent string
+
+	// Scoped-session metadata (populated only for vault-scoped tokens; left
+	// empty on user login sessions and agent tokens). Label is a
+	// user-supplied tag shown in the Tokens UI; CreatedByActorID/Type
+	// record the actor that minted the token.
+	Label              string
+	CreatedByActorID   string
+	CreatedByActorType string
 }
 
 // IsExpired reports whether the session is past its absolute expiry or its
@@ -107,6 +115,18 @@ type CreateUserSessionParams struct {
 	DeviceLabel   string
 	LastIP        string
 	LastUserAgent string
+}
+
+// CreateScopedSessionParams carries the fields persisted on a vault-scoped
+// session token. ExpiresAt is optional (nil = never expires); Label and
+// the CreatedBy fields are optional metadata for the Tokens UI.
+type CreateScopedSessionParams struct {
+	VaultID            string
+	VaultRole          string
+	ExpiresAt          *time.Time
+	Label              string
+	CreatedByActorID   string
+	CreatedByActorType string // "user" or "agent"
 }
 
 // User represents a human user account.
@@ -320,9 +340,15 @@ type Store interface {
 
 	// Sessions
 	CreateUserSession(ctx context.Context, p CreateUserSessionParams) (*Session, error)
-	CreateScopedSession(ctx context.Context, vaultID, vaultRole string, expiresAt *time.Time) (*Session, error)
+	CreateScopedSession(ctx context.Context, p CreateScopedSessionParams) (*Session, error)
 	GetSession(ctx context.Context, id string) (*Session, error)
 	DeleteSession(ctx context.Context, id string) error
+	// ListScopedSessionsByVault returns active vault-scoped tokens for the
+	// vault, most recent first. Used by the Tokens tab.
+	ListScopedSessionsByVault(ctx context.Context, vaultID string) ([]Session, error)
+	// RevokeScopedSession deletes one scoped session by (vaultID, publicID).
+	// Vault scoping prevents cross-vault revocation.
+	RevokeScopedSession(ctx context.Context, vaultID, publicID string) error
 	// TouchSession bumps last_used_at for the given raw token and
 	// refreshes last_ip + last_user_agent (empty values leave the
 	// existing column unchanged). Throttled internally so per-request

--- a/web/src/components/VaultLayout.tsx
+++ b/web/src/components/VaultLayout.tsx
@@ -3,7 +3,7 @@ import { Link, Outlet, useLocation, useNavigate, useRouteContext } from "@tansta
 import type { AuthContext, VaultContext } from "../router";
 import Navbar from "./Navbar";
 
-type VaultTab = "proposals" | "logs" | "services" | "credentials" | "users" | "agents" | "settings";
+type VaultTab = "proposals" | "logs" | "services" | "credentials" | "users" | "agents" | "tokens" | "settings";
 
 interface NavItem {
   id: VaultTab;
@@ -43,7 +43,7 @@ export default function VaultLayout() {
   // Derive active tab from current URL path
   const pathSegments = location.pathname.split("/");
   const lastSegment = pathSegments[pathSegments.length - 1] as VaultTab;
-  const activeTab: VaultTab = ["proposals", "logs", "services", "credentials", "users", "agents", "settings"].includes(lastSegment)
+  const activeTab: VaultTab = ["proposals", "logs", "services", "credentials", "users", "agents", "tokens", "settings"].includes(lastSegment)
     ? lastSegment
     : "services";
 
@@ -118,6 +118,18 @@ export default function VaultLayout() {
           <line x1="20" y1="14" x2="23" y2="14" />
           <line x1="1" y1="9" x2="4" y2="9" />
           <line x1="1" y1="14" x2="4" y2="14" />
+        </svg>
+      ),
+    },
+    {
+      id: "tokens",
+      label: "Tokens",
+      icon: (
+        <svg className="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="8" cy="15" r="4" />
+          <path d="M10.85 12.15L19 4" />
+          <path d="M18 5l2 2" />
+          <path d="M15 8l3 3" />
         </svg>
       ),
     },

--- a/web/src/components/VaultLayout.tsx
+++ b/web/src/components/VaultLayout.tsx
@@ -21,6 +21,13 @@ export default function VaultLayout() {
   const sidebarRef = useRef<HTMLElement>(null);
   const [pendingCount, setPendingCount] = useState(0);
 
+  // The Members section (Users / Agents / Tokens) is only meaningful at
+  // vault `member` or higher: a `proxy`-role caller can only proxy
+  // requests through Agent Vault — they have no read or mutation rights
+  // on the people/agents/tokens lists, and the underlying GET endpoints
+  // require `member`+ anyway.
+  const showMembersNav = vaultContext.vault_role !== "proxy";
+
   useEffect(() => {
     async function fetchPendingCount() {
       try {
@@ -179,21 +186,25 @@ export default function VaultLayout() {
               ))}
             </ul>
 
-            <div className="mt-6 mb-2 px-3">
-              <span className="text-[11px] font-semibold text-text-dim uppercase tracking-wider">
-                Members
-              </span>
-            </div>
-            <ul className="space-y-0.5">
-              {memberNav.map((item) => (
-                <SidebarItem
-                  key={item.id}
-                  item={item}
-                  active={activeTab === item.id}
-                  vaultName={vaultContext.vault_name}
-                />
-              ))}
-            </ul>
+            {showMembersNav && (
+              <>
+                <div className="mt-6 mb-2 px-3">
+                  <span className="text-[11px] font-semibold text-text-dim uppercase tracking-wider">
+                    Members
+                  </span>
+                </div>
+                <ul className="space-y-0.5">
+                  {memberNav.map((item) => (
+                    <SidebarItem
+                      key={item.id}
+                      item={item}
+                      active={activeTab === item.id}
+                      vaultName={vaultContext.vault_name}
+                    />
+                  ))}
+                </ul>
+              </>
+            )}
 
             <div className="mt-auto pt-4">
               <ul className="space-y-0.5">

--- a/web/src/pages/vault/TokensTab.tsx
+++ b/web/src/pages/vault/TokensTab.tsx
@@ -19,17 +19,10 @@ import { apiFetch } from "../../lib/api";
 
 type VaultRole = "proxy" | "member" | "admin";
 
-interface CreatedBy {
-  id: string;
-  type: "user" | "agent";
-  display_name: string;
-}
-
 interface VaultToken {
   id: string;
   label?: string;
   vault_role: VaultRole;
-  created_by?: CreatedBy;
   created_at: string;
   expires_at?: string;
 }
@@ -40,12 +33,6 @@ const TTL_PRESETS: { label: string; seconds: number | "custom" }[] = [
   { label: "7 days", seconds: 604800 },
   { label: "Custom", seconds: "custom" },
 ];
-
-const ROLE_DESCRIPTIONS: Record<VaultRole, string> = {
-  proxy: "Proxy — use the proxy and raise proposals",
-  member: "Member — manage credentials and services",
-  admin: "Admin — invite humans",
-};
 
 const MIN_TTL_SECONDS = 300;
 const MAX_TTL_SECONDS = 604800;
@@ -139,19 +126,6 @@ export default function TokensTab() {
       ),
     },
     {
-      key: "created_by",
-      header: "Created by",
-      render: (t) =>
-        t.created_by ? (
-          <span className="text-sm text-text-muted">
-            {t.created_by.display_name}
-            <span className="text-text-dim ml-1.5">({t.created_by.type})</span>
-          </span>
-        ) : (
-          <span className="text-text-dim text-sm">&mdash;</span>
-        ),
-    },
-    {
       key: "created_at",
       header: "Created",
       render: (t) => (
@@ -217,11 +191,7 @@ export default function TokensTab() {
           </p>
         </div>
         {canManageTokens && (
-          <MintTokenButton
-            vaultName={vaultName}
-            vaultRole={vaultRole}
-            onMinted={fetchTokens}
-          />
+          <MintTokenButton vaultName={vaultName} onMinted={fetchTokens} />
         )}
       </div>
 
@@ -244,30 +214,22 @@ export default function TokensTab() {
 
 function MintTokenButton({
   vaultName,
-  vaultRole,
   onMinted,
 }: {
   vaultName: string;
-  vaultRole: string;
   onMinted: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const [label, setLabel] = useState("");
-  const [role, setRole] = useState<VaultRole>("proxy");
   const [ttlPreset, setTtlPreset] = useState<number | "custom">(86400);
   const [customTtl, setCustomTtl] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [mintedToken, setMintedToken] = useState<string | null>(null);
 
-  const availableRoles: VaultRole[] = (["proxy", "member", "admin"] as const).filter(
-    (r) => roleSatisfies(vaultRole, r)
-  );
-
   function close() {
     setOpen(false);
     setLabel("");
-    setRole("proxy");
     setTtlPreset(86400);
     setCustomTtl("");
     setError("");
@@ -296,7 +258,7 @@ function MintTokenButton({
         method: "POST",
         body: JSON.stringify({
           vault: vaultName,
-          vault_role: role,
+          vault_role: "proxy",
           ttl_seconds: ttlSeconds,
           label: label.trim(),
         }),
@@ -385,14 +347,6 @@ function MintTokenButton({
                 maxLength={100}
                 autoFocus
               />
-            </FormField>
-
-            <FormField label="Role">
-              <Select value={role} onChange={(e) => setRole(e.target.value as VaultRole)}>
-                {availableRoles.map((r) => (
-                  <option key={r} value={r}>{ROLE_DESCRIPTIONS[r]}</option>
-                ))}
-              </Select>
             </FormField>
 
             <FormField label="Lifetime">

--- a/web/src/pages/vault/TokensTab.tsx
+++ b/web/src/pages/vault/TokensTab.tsx
@@ -19,10 +19,21 @@ import { apiFetch } from "../../lib/api";
 
 type VaultRole = "proxy" | "member" | "admin";
 
+interface CreatedBy {
+  id: string;
+  type: "user" | "agent";
+  display_name: string;
+}
+
+// Mirrors GET /v1/sessions's row shape (handle_sessions.go scopedSessionView).
+// `created_by` is populated server-side but not currently rendered in the
+// table; kept on the type so the API contract is faithful and a future
+// column or tooltip can read it without a schema change.
 interface VaultToken {
   id: string;
   label?: string;
   vault_role: VaultRole;
+  created_by?: CreatedBy;
   created_at: string;
   expires_at?: string;
 }

--- a/web/src/pages/vault/TokensTab.tsx
+++ b/web/src/pages/vault/TokensTab.tsx
@@ -1,0 +1,433 @@
+import { useState, useEffect } from "react";
+import {
+  useVaultParams,
+  LoadingSpinner,
+  ErrorBanner,
+  timeAgo,
+  timeUntil,
+} from "./shared";
+import DataTable, { type Column } from "../../components/DataTable";
+import Modal from "../../components/Modal";
+import DropdownMenu from "../../components/DropdownMenu";
+import Button from "../../components/Button";
+import Select from "../../components/Select";
+import Input from "../../components/Input";
+import FormField from "../../components/FormField";
+import CopyButton from "../../components/CopyButton";
+import ConfirmDeleteModal from "../../components/ConfirmDeleteModal";
+import { apiFetch } from "../../lib/api";
+
+type VaultRole = "proxy" | "member" | "admin";
+
+interface CreatedBy {
+  id: string;
+  type: "user" | "agent";
+  display_name: string;
+}
+
+interface VaultToken {
+  id: string;
+  label?: string;
+  vault_role: VaultRole;
+  created_by?: CreatedBy;
+  created_at: string;
+  expires_at?: string;
+}
+
+const TTL_PRESETS: { label: string; seconds: number | "custom" }[] = [
+  { label: "1 hour", seconds: 3600 },
+  { label: "24 hours (default)", seconds: 86400 },
+  { label: "7 days", seconds: 604800 },
+  { label: "Custom", seconds: "custom" },
+];
+
+const ROLE_DESCRIPTIONS: Record<VaultRole, string> = {
+  proxy: "Proxy — use the proxy and raise proposals",
+  member: "Member — manage credentials and services",
+  admin: "Admin — invite humans",
+};
+
+const MIN_TTL_SECONDS = 300;
+const MAX_TTL_SECONDS = 604800;
+
+function roleSatisfies(callerRole: string, requested: VaultRole): boolean {
+  const order: Record<string, number> = { proxy: 0, member: 1, admin: 2 };
+  return (order[callerRole] ?? -1) >= order[requested];
+}
+
+function RowActions({
+  token,
+  vaultName,
+  onRevoked,
+}: {
+  token: VaultToken;
+  vaultName: string;
+  onRevoked: () => void;
+}) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  async function handleRevoke() {
+    const resp = await apiFetch(
+      `/v1/sessions/${encodeURIComponent(token.id)}?vault=${encodeURIComponent(vaultName)}`,
+      { method: "DELETE" }
+    );
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({}));
+      throw new Error(data.error || "Failed to revoke token");
+    }
+    setConfirmOpen(false);
+    onRevoked();
+  }
+
+  return (
+    <>
+      <DropdownMenu
+        width={160}
+        items={[
+          {
+            label: "Revoke",
+            onClick: () => setConfirmOpen(true),
+            variant: "danger" as const,
+          },
+        ]}
+      />
+      <ConfirmDeleteModal
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={handleRevoke}
+        title="Revoke token"
+        description={
+          token.label
+            ? `Revoke "${token.label}"? Any agent using this token will immediately lose access.`
+            : "Revoke this token? Any agent using it will immediately lose access."
+        }
+        confirmLabel="Revoke token"
+        confirmValue={token.label || token.id}
+        inputLabel={
+          token.label
+            ? `Type the label "${token.label}" to confirm`
+            : `Type the token id to confirm`
+        }
+      />
+    </>
+  );
+}
+
+export default function TokensTab() {
+  const { vaultName, vaultRole } = useVaultParams();
+  const [rows, setRows] = useState<VaultToken[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const canManageTokens = roleSatisfies(vaultRole, "member");
+
+  const columns: Column<VaultToken>[] = [
+    {
+      key: "label",
+      header: "Label",
+      render: (t) => (
+        <span className="text-sm text-text">
+          {t.label || <span className="text-text-dim">&mdash;</span>}
+        </span>
+      ),
+    },
+    {
+      key: "vault_role",
+      header: "Role",
+      render: (t) => (
+        <span className="text-sm text-text-muted capitalize">{t.vault_role}</span>
+      ),
+    },
+    {
+      key: "created_by",
+      header: "Created by",
+      render: (t) =>
+        t.created_by ? (
+          <span className="text-sm text-text-muted">
+            {t.created_by.display_name}
+            <span className="text-text-dim ml-1.5">({t.created_by.type})</span>
+          </span>
+        ) : (
+          <span className="text-text-dim text-sm">&mdash;</span>
+        ),
+    },
+    {
+      key: "created_at",
+      header: "Created",
+      render: (t) => (
+        <span className="text-sm text-text-muted">{timeAgo(t.created_at)}</span>
+      ),
+    },
+    {
+      key: "expires_at",
+      header: "Expires",
+      render: (t) => (
+        <span className="text-sm text-text-muted">
+          {t.expires_at ? timeUntil(t.expires_at) : "never"}
+        </span>
+      ),
+    },
+    ...(canManageTokens
+      ? [
+          {
+            key: "actions" as const,
+            header: "",
+            align: "right" as const,
+            render: (t: VaultToken) => (
+              <RowActions token={t} vaultName={vaultName} onRevoked={fetchTokens} />
+            ),
+          },
+        ]
+      : []),
+  ];
+
+  useEffect(() => {
+    fetchTokens();
+  }, []);
+
+  async function fetchTokens() {
+    try {
+      const resp = await apiFetch(
+        `/v1/sessions?vault=${encodeURIComponent(vaultName)}`
+      );
+      if (!resp.ok) {
+        const data = await resp.json().catch(() => ({}));
+        setError(data.error || "Failed to load tokens.");
+        return;
+      }
+      const data = await resp.json();
+      setRows(data.sessions ?? []);
+      setError("");
+    } catch {
+      setError("Network error.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="p-8 w-full max-w-[960px]">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-[22px] font-semibold text-text tracking-tight mb-1">
+            Tokens
+          </h2>
+          <p className="text-sm text-text-muted">
+            Vault-scoped session tokens for agents and one-off workflows.
+          </p>
+        </div>
+        {canManageTokens && (
+          <MintTokenButton
+            vaultName={vaultName}
+            vaultRole={vaultRole}
+            onMinted={fetchTokens}
+          />
+        )}
+      </div>
+
+      {loading ? (
+        <LoadingSpinner />
+      ) : error ? (
+        <ErrorBanner message={error} />
+      ) : (
+        <DataTable
+          columns={columns}
+          data={rows}
+          rowKey={(t) => t.id}
+          emptyTitle="No tokens yet"
+          emptyDescription="Mint a token to scope a session for a specific agent or workflow."
+        />
+      )}
+    </div>
+  );
+}
+
+function MintTokenButton({
+  vaultName,
+  vaultRole,
+  onMinted,
+}: {
+  vaultName: string;
+  vaultRole: string;
+  onMinted: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [label, setLabel] = useState("");
+  const [role, setRole] = useState<VaultRole>("proxy");
+  const [ttlPreset, setTtlPreset] = useState<number | "custom">(86400);
+  const [customTtl, setCustomTtl] = useState<string>("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [mintedToken, setMintedToken] = useState<string | null>(null);
+
+  const availableRoles: VaultRole[] = (["proxy", "member", "admin"] as const).filter(
+    (r) => roleSatisfies(vaultRole, r)
+  );
+
+  function close() {
+    setOpen(false);
+    setLabel("");
+    setRole("proxy");
+    setTtlPreset(86400);
+    setCustomTtl("");
+    setError("");
+    setMintedToken(null);
+    if (mintedToken) onMinted();
+  }
+
+  async function handleMint() {
+    setError("");
+
+    let ttlSeconds: number;
+    if (ttlPreset === "custom") {
+      const parsed = parseInt(customTtl, 10);
+      if (!Number.isFinite(parsed) || parsed < MIN_TTL_SECONDS || parsed > MAX_TTL_SECONDS) {
+        setError(`Custom TTL must be between ${MIN_TTL_SECONDS} and ${MAX_TTL_SECONDS} seconds.`);
+        return;
+      }
+      ttlSeconds = parsed;
+    } else {
+      ttlSeconds = ttlPreset;
+    }
+
+    setSubmitting(true);
+    try {
+      const resp = await apiFetch("/v1/sessions", {
+        method: "POST",
+        body: JSON.stringify({
+          vault: vaultName,
+          vault_role: role,
+          ttl_seconds: ttlSeconds,
+          label: label.trim(),
+        }),
+      });
+      if (!resp.ok) {
+        const data = await resp.json().catch(() => ({}));
+        setError(data.error || "Failed to mint token.");
+        return;
+      }
+      const data = await resp.json();
+      setMintedToken(data.token as string);
+    } catch {
+      setError("Network error.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>
+        <svg
+          className="w-4 h-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="12" y1="5" x2="12" y2="19" />
+          <line x1="5" y1="12" x2="19" y2="12" />
+        </svg>
+        Mint token
+      </Button>
+
+      <Modal
+        open={open}
+        onClose={close}
+        title={mintedToken ? "Token created" : "Mint vault-scoped token"}
+        description={
+          mintedToken
+            ? "Copy the token now — this is the only time it will be shown."
+            : "Create a session token scoped to this vault."
+        }
+        footer={
+          mintedToken ? (
+            <Button onClick={close}>Done</Button>
+          ) : (
+            <>
+              <Button variant="secondary" onClick={close}>Cancel</Button>
+              <Button onClick={handleMint} loading={submitting}>
+                Mint token
+              </Button>
+            </>
+          )
+        }
+      >
+        {mintedToken ? (
+          <div className="space-y-3">
+            <div className="relative">
+              <textarea
+                readOnly
+                value={mintedToken}
+                rows={3}
+                className="w-full px-4 py-3 bg-bg border border-border rounded-lg text-text text-sm font-mono outline-none select-all resize-none break-all"
+                onFocus={(e) => e.target.select()}
+              />
+              <CopyButton
+                value={mintedToken}
+                className="absolute top-2 right-2 px-3 py-1.5 bg-primary text-primary-text rounded-md text-xs font-semibold hover:bg-primary-hover transition-colors"
+              />
+            </div>
+            <p className="text-xs text-text-dim">
+              Use with <code className="text-text-muted">AGENT_VAULT_SESSION_TOKEN</code>, or in
+              an <code className="text-text-muted">HTTPS_PROXY</code> URL as the userinfo.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <FormField label="Label (optional)">
+              <Input
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="claude-code laptop"
+                maxLength={100}
+                autoFocus
+              />
+            </FormField>
+
+            <FormField label="Role">
+              <Select value={role} onChange={(e) => setRole(e.target.value as VaultRole)}>
+                {availableRoles.map((r) => (
+                  <option key={r} value={r}>{ROLE_DESCRIPTIONS[r]}</option>
+                ))}
+              </Select>
+            </FormField>
+
+            <FormField label="Lifetime">
+              <Select
+                value={String(ttlPreset)}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setTtlPreset(v === "custom" ? "custom" : parseInt(v, 10));
+                }}
+              >
+                {TTL_PRESETS.map((p) => (
+                  <option key={String(p.seconds)} value={String(p.seconds)}>
+                    {p.label}
+                  </option>
+                ))}
+              </Select>
+            </FormField>
+
+            {ttlPreset === "custom" && (
+              <FormField label={`Custom TTL (seconds, ${MIN_TTL_SECONDS}–${MAX_TTL_SECONDS})`}>
+                <Input
+                  type="number"
+                  value={customTtl}
+                  onChange={(e) => setCustomTtl(e.target.value)}
+                  min={MIN_TTL_SECONDS}
+                  max={MAX_TTL_SECONDS}
+                  placeholder={String(MIN_TTL_SECONDS)}
+                />
+              </FormField>
+            )}
+
+            {error && <ErrorBanner message={error} />}
+          </div>
+        )}
+      </Modal>
+    </>
+  );
+}

--- a/web/src/pages/vault/TokensTab.tsx
+++ b/web/src/pages/vault/TokensTab.tsx
@@ -307,7 +307,7 @@ function MintTokenButton({
         description={
           mintedToken
             ? "Copy the token now — this is the only time it will be shown."
-            : "Create a session token scoped to this vault."
+            : "Routes outbound requests through this vault. Cannot manage credentials, services, or members."
         }
         footer={
           mintedToken ? (

--- a/web/src/pages/vault/TokensTab.tsx
+++ b/web/src/pages/vault/TokensTab.tsx
@@ -228,6 +228,11 @@ function MintTokenButton({
   const [mintedToken, setMintedToken] = useState<string | null>(null);
 
   function close() {
+    // Block all close paths (ESC, backdrop, X, Cancel) while a mint is
+    // in flight. Otherwise the post-await setMintedToken would write into
+    // a hidden modal and the freshly-minted token would only surface on
+    // the next "Mint token" click — looking like an orphan to the user.
+    if (submitting) return;
     setOpen(false);
     setLabel("");
     setTtlPreset(86400);

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -22,6 +22,7 @@ import ServicesTab from "./pages/vault/ServicesTab";
 import CredentialsTab from "./pages/vault/CredentialsTab";
 import UsersTab from "./pages/vault/UsersTab";
 import AgentsTab from "./pages/vault/AgentsTab";
+import TokensTab from "./pages/vault/TokensTab";
 import SettingsTab from "./pages/vault/SettingsTab";
 import InstanceLayout from "./components/InstanceLayout";
 import AccountLayout from "./components/AccountLayout";
@@ -311,6 +312,12 @@ const agentsTabRoute = createRoute({
   component: AgentsTab,
 });
 
+const tokensTabRoute = createRoute({
+  getParentRoute: () => vaultLayoutRoute,
+  path: "/tokens",
+  component: TokensTab,
+});
+
 const settingsTabRoute = createRoute({
   getParentRoute: () => vaultLayoutRoute,
   path: "/settings",
@@ -347,6 +354,7 @@ const routeTree = rootRoute.addChildren([
       credentialsTabRoute,
       usersTabRoute,
       agentsTabRoute,
+      tokensTabRoute,
       settingsTabRoute,
     ]),
   ]),


### PR DESCRIPTION
## Summary

- Adds a per-vault **Tokens** tab in the Members sidebar group so vault members can mint, list, and revoke vault-scoped session tokens from the UI. Previously these were CLI-only (`agent-vault vault token`).
- Adds backing endpoints `GET /v1/sessions?vault=<name>` and `DELETE /v1/sessions/{publicID}?vault=<name>`, plus an optional `label` field on `POST /v1/sessions`. Migration 044 adds `created_by_actor_id`/`_type` columns and a `vault_id` index; the pre-existing `label` and `public_id` columns are reused.
- Refactors `Store.CreateScopedSession` to take a `CreateScopedSessionParams` struct so future fields don't cause positional drift; all callers updated.

## Permission model

- **Mint**: any caller with vault `member`+ (existing rule on `POST /v1/sessions`); role-cap is enforced server-side via `capRequestedRole` and surfaced in the UI by hiding higher-role options from the dropdown.
- **List**: any caller with vault access — mirrors how Users/Agents tabs are visible to all members. Raw tokens are never returned in the list view; rows are referenced by opaque `public_id`.
- **Revoke**: vault `member`+. Vault scoping in the SQL WHERE clause prevents cross-vault revocation by `public_id` guess.

## Test plan

- [x] `go test ./internal/server/ ./internal/store/ -count=1`
- [x] `go build ./...`
- [x] `cd web && npm run build`
- [x] New tests: mint-with-label, label length cap, list-then-revoke round trip, cross-vault revoke 404, list-requires-auth.
- [ ] Manual: open a vault → **Tokens** sidebar → Mint a token (try labels, the three role options as admin, all TTL presets + custom) → verify reveal panel + copy → revoke via row action and confirm it disappears from the list.
- [ ] Manual: copy the revealed token; run `HTTPS_PROXY=https://<token>@localhost:14322 curl ...` against an upstream and confirm it succeeds, then revoke and confirm the same call fails.
- [ ] Manual: as a vault `member`, confirm only `proxy`/`member` roles appear in the mint dropdown; as `proxy`, confirm the **Mint token** button is hidden.
- [ ] Manual: mint a token via `agent-vault vault token` from CLI and verify it appears in the new UI table with `created_by` matching the user's email.