### PR TITLE
run: agent mode for unattended/containerized deploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,15 @@
 # If omitted, the DEK is stored unwrapped (passwordless mode).
 # AGENT_VAULT_MASTER_PASSWORD=
 
-# External base URL (for links in emails, invites, discovery)
+# External base URL (for links in emails, invites, discovery).
+# Also read on the agent side by `agent-vault run` and the SDKs to locate the broker.
 # AGENT_VAULT_ADDR=http://localhost:14321
+
+# Agent-side credentials (read by `agent-vault run` and the SDKs in containerized
+# / unattended deployments where there's no on-disk admin session).
+# AGENT_VAULT_TOKEN=                       # bearer token: vault-scoped session OR long-lived agent token
+# AGENT_VAULT_SESSION_TOKEN=               # deprecated alias of AGENT_VAULT_TOKEN; honored with a one-time warning
+# AGENT_VAULT_VAULT=                       # which vault to scope the run to (required for agent tokens)
 
 # SMTP (optional – if unset, email notifications are silently disabled)
 # AGENT_VAULT_SMTP_HOST=

--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@
 # / unattended deployments where there's no on-disk admin session).
 # AGENT_VAULT_TOKEN=                       # bearer token: vault-scoped session OR long-lived agent token
 # AGENT_VAULT_SESSION_TOKEN=               # deprecated alias of AGENT_VAULT_TOKEN; honored with a one-time warning
-# AGENT_VAULT_VAULT=                       # which vault to scope the run to (required for agent tokens)
+# AGENT_VAULT_VAULT=                       # which vault to scope the run to (required in agent mode for both token types)
 
 # SMTP (optional – if unset, email notifications are silently disabled)
 # AGENT_VAULT_SMTP_HOST=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Agent Vault is an HTTP proxy that attaches credentials to your outbound requests
 
 ## The X-Vault header
 
-If you received your token via an agent invite (instance-level agent token), you must include `X-Vault: {vault_name}` on all vault-scoped requests (discover, proxy, proposals). If `AGENT_VAULT_VAULT` is set, use that value. Vault-scoped sessions (from `vault run`) do not need this header.
+If you received your token via an agent invite (instance-level agent token), you must include `X-Vault: {vault_name}` on all control-plane requests (`/discover`, `/v1/proposals`). If `AGENT_VAULT_VAULT` is set, use that value. Vault-scoped sessions (from `vault run`) do not need this header. Proxied requests don't use `X-Vault` either — vault for proxy traffic is communicated via the `Proxy-Authorization` userinfo (`token:vault`) baked into `HTTPS_PROXY`/`HTTP_PROXY`, which `vault run` configures for you.
 
 ## Discover available services
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Agent Vault is an HTTP proxy that attaches credentials to your outbound requests
 
 ## When to use
 
-1. Check that `AGENT_VAULT_SESSION_TOKEN` is set — if not, Agent Vault is not available
+1. Check that `AGENT_VAULT_TOKEN` is set — if not, Agent Vault is not available
 2. Call `/discover` to get the list of brokerable services
 3. For requests to hosts listed in the discover response, route through Agent Vault
 4. For all other requests, make them directly
@@ -14,8 +14,10 @@ Agent Vault is an HTTP proxy that attaches credentials to your outbound requests
 | Variable | Description |
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
-| `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault |
+| `AGENT_VAULT_TOKEN` | Bearer token for authenticating with Agent Vault. Either a vault-scoped session token or a long-lived agent token. |
 | `AGENT_VAULT_VAULT` | Vault the session is scoped to |
+
+> `AGENT_VAULT_SESSION_TOKEN` is the deprecated alias of `AGENT_VAULT_TOKEN` and is still honored.
 
 ## The X-Vault header
 
@@ -27,7 +29,7 @@ Always call this first to learn which services have credentials configured:
 
 ```
 GET {AGENT_VAULT_ADDR}/discover
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Authorization: Bearer {AGENT_VAULT_TOKEN}
 X-Vault: {vault_name}
 ```
 
@@ -60,7 +62,7 @@ When you get a `403` for a host not in `/discover`, create a proposal to request
 
 ```json
 POST {AGENT_VAULT_ADDR}/v1/proposals
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Authorization: Bearer {AGENT_VAULT_TOKEN}
 Content-Type: application/json
 
 {
@@ -101,7 +103,7 @@ Content-Type: application/json
 
 | Status | Meaning | Action |
 |--------|---------|--------|
-| 401 | Invalid or expired token | Check `AGENT_VAULT_SESSION_TOKEN` |
+| 401 | Invalid or expired token | Check `AGENT_VAULT_TOKEN` |
 | 403 | Host not allowed | Propose a proposal |
 | 429 | Too many pending proposals | Wait for review |
 | 502 | Missing credential or upstream unreachable | Tell user a credential may need to be added |
@@ -109,6 +111,6 @@ Content-Type: application/json
 ## Rules
 
 - **Never** extract, log, or display credential values
-- **Never** hardcode tokens — always read from `AGENT_VAULT_SESSION_TOKEN`
+- **Never** hardcode tokens — always read from `AGENT_VAULT_TOKEN`
 - **Only** request hosts returned by `/discover` — if not listed, propose a proposal
 - Do not modify or forge the `Authorization` header beyond using your token

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ agent-vault run --isolation=container --share-agent-dir -- claude
 
 See [Container isolation](https://docs.agent-vault.dev/guides/container-isolation) for the threat model and flags.
 
+For **unattended / containerized deployments** (k8s, Fly, ECS — no human to `auth login`), set `AGENT_VAULT_TOKEN`, `AGENT_VAULT_ADDR`, and `AGENT_VAULT_VAULT` on the agent's env and `agent-vault run` will use the supplied token directly instead of minting a new one. See [Deploy your agent in a container](https://docs.agent-vault.dev/guides/deploy-agent-container).
+
 To mint, list, and revoke vault-scoped tokens without wrapping a child process, use either `agent-vault vault token` or the **Tokens** tab inside each vault in the web UI.
 
 ### SDK — sandboxed agents (Docker, Daytona, E2B)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -768,6 +768,40 @@ func TestValidateEnvToken(t *testing.T) {
 			t.Errorf("expected friendly 'rejected by broker' message; got: %v", err)
 		}
 	})
+
+	t.Run("vault mismatch is rejected", func(t *testing.T) {
+		// Broker returns the session's baked-in vault, ignoring the
+		// X-Vault header on a vault-scoped session token.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"vault":"actual-vault","services":[],"available_credentials":[]}`))
+		}))
+		defer srv.Close()
+
+		err := validateEnvToken(srv.URL, "tok", "requested-vault")
+		if err == nil {
+			t.Fatal("expected mismatch error")
+		}
+		if !strings.Contains(err.Error(), "vault mismatch") {
+			t.Errorf("expected 'vault mismatch' wording; got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "actual-vault") || !strings.Contains(err.Error(), "requested-vault") {
+			t.Errorf("expected both vault names in error; got: %v", err)
+		}
+	})
+
+	t.Run("matching vaults pass", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"vault":"prod"}`))
+		}))
+		defer srv.Close()
+
+		if err := validateEnvToken(srv.URL, "tok", "prod"); err != nil {
+			t.Fatalf("expected nil err for matching vaults, got: %v", err)
+		}
+	})
 }
 
 func TestProposalCreateFlagsRegistered(t *testing.T) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -658,12 +658,12 @@ func TestResolveSessionFromEnvVars(t *testing.T) {
 		t.Setenv("AGENT_VAULT_TOKEN", "test-token-123")
 		t.Setenv("AGENT_VAULT_ADDR", "http://localhost:9999")
 
-		sess, fromEnv, err := resolveSession()
+		sess, tokenSource, err := resolveSession()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !fromEnv {
-			t.Error("expected fromEnv=true when token came from env")
+		if tokenSource != "AGENT_VAULT_TOKEN" {
+			t.Errorf("expected tokenSource=AGENT_VAULT_TOKEN, got %q", tokenSource)
 		}
 		if sess.Token != "test-token-123" {
 			t.Errorf("expected token %q, got %q", "test-token-123", sess.Token)
@@ -679,12 +679,12 @@ func TestResolveSessionFromEnvVars(t *testing.T) {
 		t.Setenv("AGENT_VAULT_SESSION_TOKEN", "legacy-token")
 		t.Setenv("AGENT_VAULT_ADDR", "http://localhost:9999")
 
-		sess, fromEnv, err := resolveSession()
+		sess, tokenSource, err := resolveSession()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !fromEnv {
-			t.Error("expected fromEnv=true")
+		if tokenSource != "AGENT_VAULT_SESSION_TOKEN" {
+			t.Errorf("expected tokenSource=AGENT_VAULT_SESSION_TOKEN (legacy), got %q", tokenSource)
 		}
 		if sess.Token != "legacy-token" {
 			t.Errorf("expected legacy token to be honored; got %q", sess.Token)
@@ -743,7 +743,7 @@ func TestValidateEnvToken(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		if err := validateEnvToken(srv.URL, "tok123", "myvault"); err != nil {
+		if err := validateEnvToken(srv.URL, "tok123", "myvault", "AGENT_VAULT_TOKEN"); err != nil {
 			t.Fatalf("expected nil err, got %v", err)
 		}
 		if gotAuth != "Bearer tok123" {
@@ -754,18 +754,24 @@ func TestValidateEnvToken(t *testing.T) {
 		}
 	})
 
-	t.Run("401 produces friendly error", func(t *testing.T) {
+	t.Run("401 produces friendly error naming the user-supplied env var", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusUnauthorized)
 		}))
 		defer srv.Close()
 
-		err := validateEnvToken(srv.URL, "bad", "v")
+		// Pass the legacy alias as tokenSource — the rejection error must
+		// name it back, not the canonical-name constant, so users see the
+		// variable they actually set.
+		err := validateEnvToken(srv.URL, "bad", "v", "AGENT_VAULT_SESSION_TOKEN")
 		if err == nil {
 			t.Fatal("expected error on 401")
 		}
 		if !strings.Contains(err.Error(), "rejected by broker") {
 			t.Errorf("expected friendly 'rejected by broker' message; got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "AGENT_VAULT_SESSION_TOKEN") {
+			t.Errorf("expected error to name the legacy env var the caller used; got: %v", err)
 		}
 	})
 
@@ -779,7 +785,7 @@ func TestValidateEnvToken(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		err := validateEnvToken(srv.URL, "tok", "requested-vault")
+		err := validateEnvToken(srv.URL, "tok", "requested-vault", "AGENT_VAULT_TOKEN")
 		if err == nil {
 			t.Fatal("expected mismatch error")
 		}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -733,13 +733,13 @@ func TestResolveSessionFromEnvVars(t *testing.T) {
 }
 
 func TestValidateEnvToken(t *testing.T) {
-	t.Run("happy path: 200 OK", func(t *testing.T) {
+	t.Run("happy path: 200 OK with matching vault", func(t *testing.T) {
 		var gotAuth, gotVault string
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotAuth = r.Header.Get("Authorization")
 			gotVault = r.Header.Get("X-Vault")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("{}"))
+			_, _ = w.Write([]byte(`{"vault":"myvault"}`))
 		}))
 		defer srv.Close()
 
@@ -791,17 +791,6 @@ func TestValidateEnvToken(t *testing.T) {
 		}
 	})
 
-	t.Run("matching vaults pass", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"vault":"prod"}`))
-		}))
-		defer srv.Close()
-
-		if err := validateEnvToken(srv.URL, "tok", "prod"); err != nil {
-			t.Fatalf("expected nil err for matching vaults, got: %v", err)
-		}
-	})
 }
 
 func TestProposalCreateFlagsRegistered(t *testing.T) {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -3,10 +3,13 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/Infisical/agent-vault/internal/pidfile"
@@ -651,13 +654,16 @@ func TestResolveVaultWithEnvVar(t *testing.T) {
 }
 
 func TestResolveSessionFromEnvVars(t *testing.T) {
-	t.Run("returns session from env vars", func(t *testing.T) {
-		t.Setenv("AGENT_VAULT_SESSION_TOKEN", "test-token-123")
+	t.Run("returns session from new env var name", func(t *testing.T) {
+		t.Setenv("AGENT_VAULT_TOKEN", "test-token-123")
 		t.Setenv("AGENT_VAULT_ADDR", "http://localhost:9999")
 
-		sess, err := resolveSession()
+		sess, fromEnv, err := resolveSession()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+		if !fromEnv {
+			t.Error("expected fromEnv=true when token came from env")
 		}
 		if sess.Token != "test-token-123" {
 			t.Errorf("expected token %q, got %q", "test-token-123", sess.Token)
@@ -667,16 +673,99 @@ func TestResolveSessionFromEnvVars(t *testing.T) {
 		}
 	})
 
+	t.Run("legacy env var name still works (deprecation path)", func(t *testing.T) {
+		legacyTokenWarnOnce = sync.Once{} // reset gate so the warn-once path is exercisable
+		t.Setenv("AGENT_VAULT_TOKEN", "")
+		t.Setenv("AGENT_VAULT_SESSION_TOKEN", "legacy-token")
+		t.Setenv("AGENT_VAULT_ADDR", "http://localhost:9999")
+
+		sess, fromEnv, err := resolveSession()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !fromEnv {
+			t.Error("expected fromEnv=true")
+		}
+		if sess.Token != "legacy-token" {
+			t.Errorf("expected legacy token to be honored; got %q", sess.Token)
+		}
+	})
+
+	t.Run("new env var preferred over legacy when both set", func(t *testing.T) {
+		t.Setenv("AGENT_VAULT_TOKEN", "new-token")
+		t.Setenv("AGENT_VAULT_SESSION_TOKEN", "legacy-token")
+		t.Setenv("AGENT_VAULT_ADDR", "http://localhost:9999")
+
+		sess, _, err := resolveSession()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sess.Token != "new-token" {
+			t.Errorf("expected new token to win; got %q", sess.Token)
+		}
+	})
+
+	t.Run("token without addr is a clear error", func(t *testing.T) {
+		t.Setenv("AGENT_VAULT_TOKEN", "test-token")
+		t.Setenv("AGENT_VAULT_ADDR", "")
+
+		_, _, err := resolveSession()
+		if err == nil {
+			t.Fatal("expected error when token is set but addr is missing")
+		}
+		if !strings.Contains(err.Error(), "AGENT_VAULT_ADDR") {
+			t.Errorf("error should mention AGENT_VAULT_ADDR; got: %v", err)
+		}
+	})
+
 	t.Run("trims trailing slash from address", func(t *testing.T) {
-		t.Setenv("AGENT_VAULT_SESSION_TOKEN", "test-token")
+		t.Setenv("AGENT_VAULT_TOKEN", "test-token")
 		t.Setenv("AGENT_VAULT_ADDR", "http://localhost:9999/")
 
-		sess, err := resolveSession()
+		sess, _, err := resolveSession()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if sess.Address != "http://localhost:9999" {
 			t.Errorf("expected address without trailing slash, got %q", sess.Address)
+		}
+	})
+}
+
+func TestValidateEnvToken(t *testing.T) {
+	t.Run("happy path: 200 OK", func(t *testing.T) {
+		var gotAuth, gotVault string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			gotVault = r.Header.Get("X-Vault")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("{}"))
+		}))
+		defer srv.Close()
+
+		if err := validateEnvToken(srv.URL, "tok123", "myvault"); err != nil {
+			t.Fatalf("expected nil err, got %v", err)
+		}
+		if gotAuth != "Bearer tok123" {
+			t.Errorf("Authorization header = %q, want Bearer tok123", gotAuth)
+		}
+		if gotVault != "myvault" {
+			t.Errorf("X-Vault header = %q, want myvault", gotVault)
+		}
+	})
+
+	t.Run("401 produces friendly error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		err := validateEnvToken(srv.URL, "bad", "v")
+		if err == nil {
+			t.Fatal("expected error on 401")
+		}
+		if !strings.Contains(err.Error(), "rejected by broker") {
+			t.Errorf("expected friendly 'rejected by broker' message; got: %v", err)
 		}
 	})
 }

--- a/cmd/credential.go
+++ b/cmd/credential.go
@@ -21,12 +21,15 @@ var credentialListCmd = &cobra.Command{
 	Short: "List credential keys in a vault",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := ensureSession()
+		sess, tokenSource, err := resolveSession()
 		if err != nil {
 			return err
 		}
 
-		vault := resolveVault(cmd)
+		vault, err := resolveVaultForCommand(cmd, tokenSource)
+		if err != nil {
+			return err
+		}
 		reveal, _ := cmd.Flags().GetBool("reveal")
 
 		reqURL := sess.Address + "/v1/credentials?vault=" + url.QueryEscape(vault)
@@ -76,12 +79,15 @@ var credentialGetCmd = &cobra.Command{
 	Short: "Get the decrypted value of a credential",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := ensureSession()
+		sess, tokenSource, err := resolveSession()
 		if err != nil {
 			return err
 		}
 
-		vault := resolveVault(cmd)
+		vault, err := resolveVaultForCommand(cmd, tokenSource)
+		if err != nil {
+			return err
+		}
 		key := args[0]
 
 		reqURL := sess.Address + "/v1/credentials?vault=" + url.QueryEscape(vault) + "&reveal=true&key=" + url.QueryEscape(key)
@@ -115,12 +121,15 @@ var credentialSetCmd = &cobra.Command{
 	Short: "Set one or more credentials",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := ensureSession()
+		sess, tokenSource, err := resolveSession()
 		if err != nil {
 			return err
 		}
 
-		vault := resolveVault(cmd)
+		vault, err := resolveVaultForCommand(cmd, tokenSource)
+		if err != nil {
+			return err
+		}
 
 		creds := make(map[string]string, len(args))
 		for _, arg := range args {
@@ -164,12 +173,15 @@ var credentialDeleteCmd = &cobra.Command{
 	Short: "Delete one or more credentials",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sess, err := ensureSession()
+		sess, tokenSource, err := resolveSession()
 		if err != nil {
 			return err
 		}
 
-		vault := resolveVault(cmd)
+		vault, err := resolveVaultForCommand(cmd, tokenSource)
+		if err != nil {
+			return err
+		}
 
 		body, err := json.Marshal(map[string]interface{}{
 			"vault": vault,

--- a/cmd/credential.go
+++ b/cmd/credential.go
@@ -19,7 +19,11 @@ var credentialCmd = &cobra.Command{
 var credentialListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List credential keys in a vault",
-	Args:  cobra.NoArgs,
+	Long: `List credential keys in a vault.
+
+In agent mode (AGENT_VAULT_TOKEN set), AGENT_VAULT_VAULT (or --vault) is
+required — there is no project-file or interactive-picker fallback.`,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sess, tokenSource, err := resolveSession()
 		if err != nil {
@@ -77,7 +81,11 @@ var credentialListCmd = &cobra.Command{
 var credentialGetCmd = &cobra.Command{
 	Use:   "get <key>",
 	Short: "Get the decrypted value of a credential",
-	Args:  cobra.ExactArgs(1),
+	Long: `Get the decrypted value of a credential.
+
+In agent mode (AGENT_VAULT_TOKEN set), AGENT_VAULT_VAULT (or --vault) is
+required — there is no project-file or interactive-picker fallback.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sess, tokenSource, err := resolveSession()
 		if err != nil {
@@ -119,7 +127,11 @@ var credentialGetCmd = &cobra.Command{
 var credentialSetCmd = &cobra.Command{
 	Use:   "set <key=value> [key2=value2 ...]",
 	Short: "Set one or more credentials",
-	Args:  cobra.MinimumNArgs(1),
+	Long: `Set one or more credentials in a vault.
+
+In agent mode (AGENT_VAULT_TOKEN set), AGENT_VAULT_VAULT (or --vault) is
+required — there is no project-file or interactive-picker fallback.`,
+	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sess, tokenSource, err := resolveSession()
 		if err != nil {
@@ -171,7 +183,11 @@ var credentialSetCmd = &cobra.Command{
 var credentialDeleteCmd = &cobra.Command{
 	Use:   "delete <key> [key2 ...]",
 	Short: "Delete one or more credentials",
-	Args:  cobra.MinimumNArgs(1),
+	Long: `Delete one or more credentials from a vault.
+
+In agent mode (AGENT_VAULT_TOKEN set), AGENT_VAULT_VAULT (or --vault) is
+required — there is no project-file or interactive-picker fallback.`,
+	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sess, tokenSource, err := resolveSession()
 		if err != nil {

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -13,9 +13,9 @@ var discoverCmd = &cobra.Command{
 	Short: "Show available services and credentials for the current vault",
 	Long: `Show the services and credentials available in the current vault.
 
-Requires a vault-scoped session (e.g. via agent-vault vault run or
-AGENT_VAULT_TOKEN + AGENT_VAULT_ADDR environment variables;
-AGENT_VAULT_SESSION_TOKEN is the deprecated alias and still works).
+Requires a vault-scoped session token or long-lived agent token (e.g. via
+agent-vault vault run or AGENT_VAULT_TOKEN + AGENT_VAULT_ADDR environment
+variables; AGENT_VAULT_SESSION_TOKEN is the deprecated alias and still works).
 In agent mode (AGENT_VAULT_TOKEN set), AGENT_VAULT_VAULT (or --vault) is
 required — there is no project-file or interactive-picker fallback.`,
 	Args: cobra.NoArgs,

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -14,10 +14,11 @@ var discoverCmd = &cobra.Command{
 	Long: `Show the services and credentials available in the current vault.
 
 Requires a vault-scoped session (e.g. via agent-vault vault run or
-AGENT_VAULT_SESSION_TOKEN + AGENT_VAULT_ADDR environment variables).`,
+AGENT_VAULT_TOKEN + AGENT_VAULT_ADDR environment variables;
+AGENT_VAULT_SESSION_TOKEN is the deprecated alias and still works).`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		sess, err := resolveSession()
+		sess, _, err := resolveSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -25,8 +25,11 @@ AGENT_VAULT_SESSION_TOKEN is the deprecated alias and still works).`,
 
 		jsonOut, _ := cmd.Flags().GetBool("json")
 
+		// Pass the resolved vault as X-Vault so instance-level agent tokens
+		// (which carry no baked-in vault) can be used here too — the broker
+		// rejects agent-token /discover calls without this header.
 		url := fmt.Sprintf("%s/discover", sess.Address)
-		respBody, err := doAdminRequestWithBody("GET", url, sess.Token, nil)
+		respBody, err := doVaultScopedRequestWithBody("GET", url, sess.Token, resolveVault(cmd), nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -15,21 +15,33 @@ var discoverCmd = &cobra.Command{
 
 Requires a vault-scoped session (e.g. via agent-vault vault run or
 AGENT_VAULT_TOKEN + AGENT_VAULT_ADDR environment variables;
-AGENT_VAULT_SESSION_TOKEN is the deprecated alias and still works).`,
+AGENT_VAULT_SESSION_TOKEN is the deprecated alias and still works).
+In agent mode (AGENT_VAULT_TOKEN set), AGENT_VAULT_VAULT (or --vault) is
+required — there is no project-file or interactive-picker fallback.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		sess, _, err := resolveSession()
+		sess, tokenSource, err := resolveSession()
 		if err != nil {
 			return err
 		}
 
 		jsonOut, _ := cmd.Flags().GetBool("json")
 
+		// Resolve the target vault. In agent mode we require an explicit
+		// --vault or AGENT_VAULT_VAULT — falling through to "default"
+		// would silently route the request at the wrong vault (or produce
+		// a confusing 404 referencing a vault the user never named).
+		// Mirrors the agent-mode contract `vault run` already enforces.
+		vault, err := resolveVaultForCommand(cmd, tokenSource)
+		if err != nil {
+			return err
+		}
+
 		// Pass the resolved vault as X-Vault so instance-level agent tokens
 		// (which carry no baked-in vault) can be used here too — the broker
 		// rejects agent-token /discover calls without this header.
 		url := fmt.Sprintf("%s/discover", sess.Address)
-		respBody, err := doVaultScopedRequestWithBody("GET", url, sess.Token, resolveVault(cmd), nil)
+		respBody, err := doVaultScopedRequestWithBody("GET", url, sess.Token, vault, nil)
 		if err != nil {
 			return err
 		}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -583,8 +583,11 @@ func validateEnvToken(addr, token, vault string) error {
 	// stops at the first JSON value's closing brace).
 	_, _ = io.Copy(io.Discard, resp.Body)
 	if vault != "" && dr.Vault != "" && dr.Vault != vault {
-		return fmt.Errorf("vault mismatch: AGENT_VAULT_VAULT=%q but the supplied token is scoped to vault %q — drop AGENT_VAULT_VAULT or use a token for %q",
-			vault, dr.Vault, vault)
+		// resolveVaultForAgentMode prioritizes --vault over AGENT_VAULT_VAULT,
+		// so name both surfaces in the remediation rather than hardcoding the
+		// env var (which may not even be set if the user passed --vault).
+		return fmt.Errorf("vault mismatch: requested vault %q does not match the supplied token's vault %q — set AGENT_VAULT_VAULT (or --vault) to %q, or use a token for %q",
+			vault, dr.Vault, dr.Vault, vault)
 	}
 	return nil
 }
@@ -627,6 +630,16 @@ func fetchAndDecode[T any](method, path string) (*T, error) {
 
 // doAdminRequestWithBody makes an authenticated HTTP request to the server and returns the response body.
 func doAdminRequestWithBody(method, url, token string, body []byte) ([]byte, error) {
+	return doVaultScopedRequestWithBody(method, url, token, "", body)
+}
+
+// doVaultScopedRequestWithBody is like doAdminRequestWithBody but also sends
+// X-Vault: vault. Required for vault-scoped endpoints (/discover, /v1/proposals)
+// when the token may be an instance-level agent token — the broker returns
+// HTTP 400 ("Agent tokens require X-Vault header") without it. Vault-scoped
+// session tokens carry their vault on the session row, so the header is
+// ignored in that case; passing it unconditionally is safe.
+func doVaultScopedRequestWithBody(method, url, token, vault string, body []byte) ([]byte, error) {
 	var bodyReader io.Reader
 	if body != nil {
 		bodyReader = bytes.NewReader(body)
@@ -637,6 +650,9 @@ func doAdminRequestWithBody(method, url, token string, body []byte) ([]byte, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
+	if vault != "" {
+		req.Header.Set("X-Vault", vault)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -519,6 +519,7 @@ var legacyTokenWarnOnce sync.Once
 // rather than silently falling through to interactive login — masking that
 // misconfig produces "why don't my creds work" tickets.
 func resolveSession() (*session.ClientSession, bool, error) {
+	tokenSource := envVarToken
 	token := os.Getenv(envVarToken)
 	if token == "" {
 		if legacy := os.Getenv(envVarTokenLegacy); legacy != "" {
@@ -527,11 +528,12 @@ func resolveSession() (*session.ClientSession, bool, error) {
 					mutedText("agent-vault:"), envVarTokenLegacy, envVarToken)
 			})
 			token = legacy
+			tokenSource = envVarTokenLegacy
 		}
 	}
 	addr := os.Getenv("AGENT_VAULT_ADDR")
 	if token != "" && addr == "" {
-		return nil, false, fmt.Errorf("%s is set but AGENT_VAULT_ADDR is empty — both are required for agent mode", envVarToken)
+		return nil, false, fmt.Errorf("%s is set but AGENT_VAULT_ADDR is empty — both are required for agent mode", tokenSource)
 	}
 	if token != "" {
 		return &session.ClientSession{Token: token, Address: strings.TrimRight(addr, "/")}, true, nil

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -539,6 +539,12 @@ func resolveSession() (*session.ClientSession, bool, error) {
 // instead of producing 401s on every proxied call. /discover is the same
 // auth path the proxy will use a moment later, so success here means the
 // token works end-to-end.
+//
+// Also catches a quiet footgun: if a vault-scoped session token is supplied
+// but AGENT_VAULT_VAULT names a different vault, the broker silently uses
+// the session's baked-in vault and ignores X-Vault. The discover response
+// echoes the actual vault, so we compare and reject the mismatch — otherwise
+// the child would see a misleading AGENT_VAULT_VAULT in its environment.
 func validateEnvToken(addr, token, vault string) error {
 	url := strings.TrimRight(addr, "/") + "/discover"
 	req, err := http.NewRequest("GET", url, nil)
@@ -553,7 +559,7 @@ func validateEnvToken(addr, token, vault string) error {
 	if err != nil {
 		return fmt.Errorf("validate token: contacting %s: %w", addr, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return fmt.Errorf("agent token rejected by broker (HTTP %d) — verify %s is current and has access to vault %q", resp.StatusCode, envVarToken, vault)
 	}
@@ -561,8 +567,17 @@ func validateEnvToken(addr, token, vault string) error {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		return fmt.Errorf("validate token: server returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
-	// Drain so net/http can reuse the keep-alive connection.
-	_, _ = io.Copy(io.Discard, resp.Body)
+	var dr struct {
+		Vault string `json:"vault"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&dr); err != nil {
+		return fmt.Errorf("validate token: parsing /discover response: %w", err)
+	}
+	if vault != "" && dr.Vault != "" && dr.Vault != vault {
+		return fmt.Errorf("vault mismatch: AGENT_VAULT_VAULT=%q but the supplied token is scoped to vault %q — "+
+			"either drop AGENT_VAULT_VAULT (it has no effect on a vault-scoped session token) or supply a token for vault %q",
+			vault, dr.Vault, vault)
+	}
 	return nil
 }
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -491,14 +492,78 @@ func resolveVault(cmd *cobra.Command) string {
 	return store.DefaultVault
 }
 
-// resolveSession returns a client session from env vars (agent mode) or falls back to ensureSession (human mode).
-func resolveSession() (*session.ClientSession, error) {
-	token := os.Getenv("AGENT_VAULT_SESSION_TOKEN")
-	addr := os.Getenv("AGENT_VAULT_ADDR")
-	if token != "" && addr != "" {
-		return &session.ClientSession{Token: token, Address: strings.TrimRight(addr, "/")}, nil
+// envVarToken is the canonical env var name for an Agent Vault bearer token
+// (vault-scoped session or long-lived agent token). envVarTokenLegacy is the
+// pre-rename alias kept for backward compatibility; reads still honor it but
+// emit a one-time deprecation warning. Drop the legacy name in a future
+// major version.
+const (
+	envVarToken       = "AGENT_VAULT_TOKEN"
+	envVarTokenLegacy = "AGENT_VAULT_SESSION_TOKEN"
+)
+
+var legacyTokenWarnOnce sync.Once
+
+// resolveSession returns a client session from env vars (agent mode) or falls
+// back to ensureSession (human mode). The bool is true when the session came
+// from env vars — callers use it to skip mintScopedSession and treat the
+// env-supplied token as the credential to thread to the child.
+//
+// If a token is set but AGENT_VAULT_ADDR is missing, returns a clear error
+// rather than silently falling through to interactive login — masking that
+// misconfig produces "why don't my creds work" tickets.
+func resolveSession() (*session.ClientSession, bool, error) {
+	token := os.Getenv(envVarToken)
+	if token == "" {
+		if legacy := os.Getenv(envVarTokenLegacy); legacy != "" {
+			legacyTokenWarnOnce.Do(func() {
+				fmt.Fprintf(os.Stderr, "%s %s is deprecated; use %s instead.\n",
+					mutedText("agent-vault:"), envVarTokenLegacy, envVarToken)
+			})
+			token = legacy
+		}
 	}
-	return ensureSession()
+	addr := os.Getenv("AGENT_VAULT_ADDR")
+	if token != "" && addr == "" {
+		return nil, false, fmt.Errorf("%s is set but AGENT_VAULT_ADDR is empty — both are required for agent mode", envVarToken)
+	}
+	if token != "" {
+		return &session.ClientSession{Token: token, Address: strings.TrimRight(addr, "/")}, true, nil
+	}
+	sess, err := ensureSession()
+	return sess, false, err
+}
+
+// validateEnvToken probes /discover with the env-supplied token before
+// `vault run` execs the child, so a bad/expired token fails fast at startup
+// instead of producing 401s on every proxied call. /discover is the same
+// auth path the proxy will use a moment later, so success here means the
+// token works end-to-end.
+func validateEnvToken(addr, token, vault string) error {
+	url := strings.TrimRight(addr, "/") + "/discover"
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("validate token: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if vault != "" {
+		req.Header.Set("X-Vault", vault)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("validate token: contacting %s: %w", addr, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("agent token rejected by broker (HTTP %d) — verify %s is current and has access to vault %q", resp.StatusCode, envVarToken, vault)
+	}
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("validate token: server returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	// Drain so net/http can reuse the keep-alive connection.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
 }
 
 // resolveAddress determines the server address from flags, env vars, or session.

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -511,14 +511,17 @@ const (
 var legacyTokenWarnOnce sync.Once
 
 // resolveSession returns a client session from env vars (agent mode) or falls
-// back to ensureSession (human mode). The bool is true when the session came
-// from env vars — callers use it to skip mintScopedSession and treat the
-// env-supplied token as the credential to thread to the child.
+// back to ensureSession (human mode). When the session came from env, the
+// returned string names the env var the token was read from (envVarToken or
+// the deprecated envVarTokenLegacy); callers thread it through to downstream
+// error messages so users see the variable they actually set. "" when the
+// session came from ensureSession — callers treat that as "not from env" and
+// branch on `tokenSource != ""` instead of a separate bool.
 //
 // If a token is set but AGENT_VAULT_ADDR is missing, returns a clear error
 // rather than silently falling through to interactive login — masking that
 // misconfig produces "why don't my creds work" tickets.
-func resolveSession() (*session.ClientSession, bool, error) {
+func resolveSession() (*session.ClientSession, string, error) {
 	tokenSource := envVarToken
 	token := os.Getenv(envVarToken)
 	if token == "" {
@@ -533,13 +536,13 @@ func resolveSession() (*session.ClientSession, bool, error) {
 	}
 	addr := os.Getenv("AGENT_VAULT_ADDR")
 	if token != "" && addr == "" {
-		return nil, false, fmt.Errorf("%s is set but AGENT_VAULT_ADDR is empty — both are required for agent mode", tokenSource)
+		return nil, "", fmt.Errorf("%s is set but AGENT_VAULT_ADDR is empty — both are required for agent mode", tokenSource)
 	}
 	if token != "" {
-		return &session.ClientSession{Token: token, Address: strings.TrimRight(addr, "/")}, true, nil
+		return &session.ClientSession{Token: token, Address: strings.TrimRight(addr, "/")}, tokenSource, nil
 	}
 	sess, err := ensureSession()
-	return sess, false, err
+	return sess, "", err
 }
 
 // validateEnvToken probes /discover with the env-supplied token before
@@ -553,7 +556,10 @@ func resolveSession() (*session.ClientSession, bool, error) {
 // the session's baked-in vault and ignores X-Vault. The discover response
 // echoes the actual vault, so we compare and reject the mismatch — otherwise
 // the child would see a misleading AGENT_VAULT_VAULT in its environment.
-func validateEnvToken(addr, token, vault string) error {
+func validateEnvToken(addr, token, vault, tokenSource string) error {
+	if tokenSource == "" {
+		tokenSource = envVarToken
+	}
 	url := strings.TrimRight(addr, "/") + "/discover"
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -569,7 +575,7 @@ func validateEnvToken(addr, token, vault string) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return fmt.Errorf("agent token rejected by broker (HTTP %d) — verify %s is current and has access to vault %q", resp.StatusCode, envVarToken, vault)
+		return fmt.Errorf("agent token rejected by broker (HTTP %d) — verify %s is current and has access to vault %q", resp.StatusCode, tokenSource, vault)
 	}
 	if resp.StatusCode/100 != 2 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -500,6 +500,12 @@ func resolveVault(cmd *cobra.Command) string {
 const (
 	envVarToken       = "AGENT_VAULT_TOKEN"
 	envVarTokenLegacy = "AGENT_VAULT_SESSION_TOKEN"
+
+	// discoverRespMaxBytes caps JSON parsing of the /discover response so
+	// a hostile or misbehaving server can't make `vault run` hang on a
+	// multi-GB body. 1 MiB comfortably covers a vault with thousands of
+	// services + credential keys.
+	discoverRespMaxBytes = 1 << 20
 )
 
 var legacyTokenWarnOnce sync.Once
@@ -570,12 +576,14 @@ func validateEnvToken(addr, token, vault string) error {
 	var dr struct {
 		Vault string `json:"vault"`
 	}
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&dr); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, discoverRespMaxBytes)).Decode(&dr); err != nil {
 		return fmt.Errorf("validate token: parsing /discover response: %w", err)
 	}
+	// Drain trailing bytes so net/http can pool the connection (Decode
+	// stops at the first JSON value's closing brace).
+	_, _ = io.Copy(io.Discard, resp.Body)
 	if vault != "" && dr.Vault != "" && dr.Vault != vault {
-		return fmt.Errorf("vault mismatch: AGENT_VAULT_VAULT=%q but the supplied token is scoped to vault %q — "+
-			"either drop AGENT_VAULT_VAULT (it has no effect on a vault-scoped session token) or supply a token for vault %q",
+		return fmt.Errorf("vault mismatch: AGENT_VAULT_VAULT=%q but the supplied token is scoped to vault %q — drop AGENT_VAULT_VAULT or use a token for %q",
 			vault, dr.Vault, vault)
 	}
 	return nil

--- a/cmd/proposal_create.go
+++ b/cmd/proposal_create.go
@@ -41,7 +41,7 @@ JSON mode (complex/multi-service proposals):
   echo '{"services":[...],"credentials":[...]}' | agent-vault vault proposal create -f -`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		sess, err := resolveSession()
+		sess, _, err := resolveSession()
 		if err != nil {
 			return err
 		}

--- a/cmd/proposal_create.go
+++ b/cmd/proposal_create.go
@@ -24,6 +24,9 @@ var proposalCreateCmd = &cobra.Command{
 	Short: "Create a proposal to request services or credentials",
 	Long: `Create a proposal to request services or credentials for a vault.
 
+In agent mode (AGENT_VAULT_TOKEN set), AGENT_VAULT_VAULT (or --vault) is
+required — there is no project-file or interactive-picker fallback.
+
 Flag-driven mode (common cases):
 
   # Service + credential

--- a/cmd/proposal_create.go
+++ b/cmd/proposal_create.go
@@ -71,8 +71,11 @@ JSON mode (complex/multi-service proposals):
 			return err
 		}
 
+		// Pass the resolved vault as X-Vault so instance-level agent tokens
+		// (which carry no baked-in vault) can create proposals here too — the
+		// broker rejects agent-token POST /v1/proposals calls without it.
 		url := fmt.Sprintf("%s/v1/proposals", sess.Address)
-		respBody, err := doAdminRequestWithBody("POST", url, sess.Token, reqBody)
+		respBody, err := doVaultScopedRequestWithBody("POST", url, sess.Token, resolveVault(cmd), reqBody)
 		if err != nil {
 			return err
 		}

--- a/cmd/proposal_create.go
+++ b/cmd/proposal_create.go
@@ -41,7 +41,16 @@ JSON mode (complex/multi-service proposals):
   echo '{"services":[...],"credentials":[...]}' | agent-vault vault proposal create -f -`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		sess, _, err := resolveSession()
+		sess, tokenSource, err := resolveSession()
+		if err != nil {
+			return err
+		}
+
+		// Resolve the target vault. In agent mode, require an explicit
+		// --vault or AGENT_VAULT_VAULT — falling through to "default"
+		// would silently route the proposal at the wrong vault. Mirrors
+		// the agent-mode contract `vault run` already enforces.
+		vault, err := resolveVaultForCommand(cmd, tokenSource)
 		if err != nil {
 			return err
 		}
@@ -75,7 +84,7 @@ JSON mode (complex/multi-service proposals):
 		// (which carry no baked-in vault) can create proposals here too — the
 		// broker rejects agent-token POST /v1/proposals calls without it.
 		url := fmt.Sprintf("%s/v1/proposals", sess.Address)
-		respBody, err := doVaultScopedRequestWithBody("POST", url, sess.Token, resolveVault(cmd), reqBody)
+		respBody, err := doVaultScopedRequestWithBody("POST", url, sess.Token, vault, reqBody)
 		if err != nil {
 			return err
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -307,6 +307,21 @@ func resolveVaultForAgentMode(cmd *cobra.Command) (string, error) {
 	return "", fmt.Errorf("vault is required in agent mode: set AGENT_VAULT_VAULT or pass --vault")
 }
 
+// resolveVaultForCommand is the agent-mode-aware vault resolver shared by
+// peer commands that talk to vault-scoped endpoints (discover, proposal
+// create). When tokenSource is non-empty (env-mode), it requires --vault or
+// AGENT_VAULT_VAULT — same contract `vault run` enforces — so a
+// misconfigured deploy fails fast with a clear remediation instead of
+// silently sending `X-Vault: default` and routing at the wrong vault.
+// In human mode it delegates to resolveVault, which falls back to project
+// file / vault context / "default".
+func resolveVaultForCommand(cmd *cobra.Command, tokenSource string) (string, error) {
+	if tokenSource != "" {
+		return resolveVaultForAgentMode(cmd)
+	}
+	return resolveVault(cmd), nil
+}
+
 // resolveVaultForRun picks the vault for a run session. Priority:
 // --vault flag > project file > vault context > interactive select (if multiple) > "default".
 func resolveVaultForRun(cmd *cobra.Command, addr, token string) (string, error) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -199,7 +199,10 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 	// 8. Confirm, then exec — replaces this process entirely so the child
 	//    (e.g. Claude Code) gets direct terminal control.
 	fmt.Fprintf(os.Stderr, "%s agent-vault connected. Starting %s...\n\n", successText("agent-vault:"), boldText(args[0]))
-	return syscall.Exec(binary, args, env)
+	// gosec G702: this is an exec wrapper — the whole purpose is to run a
+	// user-specified binary with user-specified args, identical to the
+	// rationale for the G204 exclusion in .golangci.yml.
+	return syscall.Exec(binary, args, env) //nolint:gosec
 }
 
 // knownAgents maps CLI binary base-names to the (agentName, skillsDir)
@@ -488,7 +491,10 @@ func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]stri
 	// The parent directory is already 0o700 so anyone with read access to
 	// the file is also the file owner — 0o600 adds no real restriction,
 	// but keeps gosec G306 happy.
-	if err := os.WriteFile(caPath, pem, 0o600); err != nil {
+	// gosec G703: caPath is derived from --mitm-ca flag or $HOME, both of
+	// which are user-controlled by design (same rationale as the existing
+	// G304 exclusion in .golangci.yml).
+	if err := os.WriteFile(caPath, pem, 0o600); err != nil { //nolint:gosec
 		return env, 0, false, fmt.Errorf("write CA: %w", err)
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -46,7 +46,7 @@ Two modes:
     deployments where there's no human to interactively log in.
       AGENT_VAULT_TOKEN  — vault-scoped session token or long-lived agent token
       AGENT_VAULT_ADDR   — broker base URL
-      AGENT_VAULT_VAULT  — vault to scope the run to (required for agent tokens)
+      AGENT_VAULT_VAULT  — vault to scope the run to (required in agent mode for both token types)
     The token is validated against the broker once before the child is exec'd.
     --ttl has no effect in agent mode and is rejected (the token's lifetime
     is fixed at mint time).

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -39,8 +39,21 @@ func newRunCmd(examplePrefix string) *cobra.Command {
 		Long: `Start an agent process (e.g. claude, agent, codex, hermes, opencode) with an Agent Vault session.
 Everything after -- is treated as the command to execute.
 
+Two modes:
+  Admin mode (default): use the on-disk session from 'agent-vault auth login'.
+    Mints a fresh vault-scoped session token for the child.
+  Agent mode: pre-supply a token via env. Used for unattended / containerized
+    deployments where there's no human to interactively log in.
+      AGENT_VAULT_TOKEN  — vault-scoped session token or long-lived agent token
+      AGENT_VAULT_ADDR   — broker base URL
+      AGENT_VAULT_VAULT  — vault to scope the run to (required for agent tokens)
+    The token is validated against the broker once before the child is exec'd.
+    --ttl has no effect in agent mode and is rejected (the token's lifetime
+    is fixed at mint time).
+
 Environment variables set on the child:
-  AGENT_VAULT_SESSION_TOKEN  — vault-scoped bearer token for the Agent Vault server
+  AGENT_VAULT_TOKEN          — bearer token for the Agent Vault server
+  AGENT_VAULT_SESSION_TOKEN  — alias of AGENT_VAULT_TOKEN (deprecated; will be removed in a future major version)
   AGENT_VAULT_ADDR           — base URL of the Agent Vault HTTP control server
   AGENT_VAULT_VAULT          — vault the session is scoped to
 
@@ -101,8 +114,10 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// 1. Load the admin session from agent-vault auth login.
-	sess, err := ensureSession()
+	// 1. Resolve session: env-supplied token (agent mode) or on-disk admin
+	//    session (human mode). Agent mode is the path used by containerized
+	//    deployments where there's no TTY and no on-disk session.
+	sess, fromEnv, err := resolveSession()
 	if err != nil {
 		return err
 	}
@@ -112,16 +127,42 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 		addr = sess.Address
 	}
 
-	// 2-3. Resolve the vault and mint a vault-scoped session token,
-	//      retrying on session expiry. Shared with `vault token`.
-	ttl, _ := cmd.Flags().GetInt("ttl")
-	vault, scopedToken, err := mintScopedSession(cmd, sess, addr, ttl)
-	if err != nil {
-		return err
+	// 2-3. Determine the token + vault. In agent mode the env-supplied
+	//      token IS the credential; we validate it once against the broker
+	//      so a bad token fails fast at startup instead of producing 401s
+	//      on every proxied call. In admin mode we mint a fresh
+	//      vault-scoped token (existing behavior).
+	var (
+		vault, token string
+	)
+	if fromEnv {
+		// Hard-error on --ttl: the env-supplied token's lifetime is fixed
+		// at mint time, so silently ignoring would mislead users who
+		// believed they bounded the run.
+		if cmd.Flags().Changed("ttl") {
+			return fmt.Errorf("--ttl has no effect when %s is supplied; the token's lifetime is fixed at mint time", envVarToken)
+		}
+		v, err := resolveVaultForAgentMode(cmd)
+		if err != nil {
+			return err
+		}
+		vault = v
+		token = sess.Token
+		if err := validateEnvToken(addr, token, vault); err != nil {
+			return err
+		}
+	} else {
+		ttl, _ := cmd.Flags().GetInt("ttl")
+		v, scopedToken, err := mintScopedSession(cmd, sess, addr, ttl)
+		if err != nil {
+			return err
+		}
+		vault = v
+		token = scopedToken
 	}
 
 	if mode == IsolationContainer {
-		return runContainer(cmd, args, scopedToken, addr, vault)
+		return runContainer(cmd, args, token, addr, vault)
 	}
 
 	// 4. Resolve the target binary.
@@ -133,7 +174,8 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 	// 5. Build env: inherit current env + inject Agent Vault vars.
 	env := os.Environ()
 	env = append(env,
-		"AGENT_VAULT_SESSION_TOKEN="+scopedToken,
+		"AGENT_VAULT_TOKEN="+token,
+		"AGENT_VAULT_SESSION_TOKEN="+token, // deprecated alias
 		"AGENT_VAULT_ADDR="+addr,
 		"AGENT_VAULT_VAULT="+vault,
 	)
@@ -141,7 +183,7 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 	// 6. Route the child's HTTP and HTTPS traffic through the transparent
 	//    MITM proxy. The MITM ingress is the only credential-injection
 	//    path, so a failure here is fatal.
-	newEnv, mitmPort, err := requireMITMEnv(env, addr, scopedToken, vault, "")
+	newEnv, mitmPort, err := requireMITMEnv(env, addr, token, vault, "")
 	if err != nil {
 		return err
 	}
@@ -235,6 +277,20 @@ func maybeInstallSkills(agentName, baseDir string) {
 		}
 	}
 	fmt.Fprintf(os.Stderr, "%s Installed Agent Vault skills for %s.\n", successText("agent-vault:"), agentName)
+}
+
+// resolveVaultForAgentMode picks the vault when the token is supplied via env
+// (agent / containerized run). No project-file or interactive-picker fallback
+// — neither makes sense in an unattended container, and silently defaulting
+// to "default" would mask misconfig. Priority: --vault > AGENT_VAULT_VAULT > error.
+func resolveVaultForAgentMode(cmd *cobra.Command) (string, error) {
+	if name, _ := cmd.Flags().GetString("vault"); name != "" {
+		return name, nil
+	}
+	if v := os.Getenv("AGENT_VAULT_VAULT"); v != "" {
+		return v, nil
+	}
+	return "", fmt.Errorf("vault is required in agent mode: set AGENT_VAULT_VAULT or pass --vault")
 }
 
 // resolveVaultForRun picks the vault for a run session. Priority:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -171,8 +171,15 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("command not found: %s", args[0])
 	}
 
-	// 5. Build env: inherit current env + inject Agent Vault vars.
+	// 5. Build env: inherit current env + inject Agent Vault vars. Strip
+	//    any pre-existing AGENT_VAULT_* keys first — POSIX getenv returns
+	//    the *first* match (glibc, curl, libcurl-backed Python, Go's own
+	//    syscall.Getenv), so a stale parent-env value would otherwise
+	//    silently shadow the freshly-injected one. Particularly important
+	//    in agent mode, where the parent env is *guaranteed* to carry these
+	//    keys (that's how agent mode is detected).
 	env := os.Environ()
+	env = stripEnvKeys(env, agentVaultInjectedKeys)
 	env = append(env,
 		"AGENT_VAULT_TOKEN="+token,
 		"AGENT_VAULT_SESSION_TOKEN="+token, // deprecated alias
@@ -408,6 +415,19 @@ var mitmInjectedKeys = func() map[string]struct{} {
 	}
 	return m
 }()
+
+// agentVaultInjectedKeys is the AGENT_VAULT_* keyset injected into the child
+// in step 5 of runCmdRunE. Same rationale as mitmInjectedKeys: in agent mode
+// the parent env is guaranteed to already carry these keys (that's how agent
+// mode is detected), and POSIX getenv returns the first match — so a stale
+// AGENT_VAULT_VAULT from the parent shell would silently override the value
+// we just resolved from --vault.
+var agentVaultInjectedKeys = map[string]struct{}{
+	"AGENT_VAULT_TOKEN":         {},
+	"AGENT_VAULT_SESSION_TOKEN": {},
+	"AGENT_VAULT_ADDR":          {},
+	"AGENT_VAULT_VAULT":         {},
+}
 
 // stripEnvKeys returns env with every entry whose key (the part before
 // '=') appears in keys removed. Case-sensitive, matching how the kernel

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -117,10 +117,14 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 	// 1. Resolve session: env-supplied token (agent mode) or on-disk admin
 	//    session (human mode). Agent mode is the path used by containerized
 	//    deployments where there's no TTY and no on-disk session.
-	sess, fromEnv, err := resolveSession()
+	//    tokenSource is "" in human mode; in agent mode it names the env var
+	//    the token was read from (envVarToken or the deprecated alias) so
+	//    downstream errors can reference the variable the user actually set.
+	sess, tokenSource, err := resolveSession()
 	if err != nil {
 		return err
 	}
+	fromEnv := tokenSource != ""
 
 	addr, _ := cmd.Flags().GetString("address")
 	if addr == "" {
@@ -140,7 +144,7 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 		// at mint time, so silently ignoring would mislead users who
 		// believed they bounded the run.
 		if cmd.Flags().Changed("ttl") {
-			return fmt.Errorf("--ttl has no effect when %s is supplied; the token's lifetime is fixed at mint time", envVarToken)
+			return fmt.Errorf("--ttl has no effect when %s is supplied; the token's lifetime is fixed at mint time", tokenSource)
 		}
 		v, err := resolveVaultForAgentMode(cmd)
 		if err != nil {
@@ -148,7 +152,7 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 		}
 		vault = v
 		token = sess.Token
-		if err := validateEnvToken(addr, token, vault); err != nil {
+		if err := validateEnvToken(addr, token, vault, tokenSource); err != nil {
 			return err
 		}
 	} else {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // expectedRunFlags is the single source of truth for flags both `vault run`
@@ -335,4 +337,70 @@ func envMap(env []string) map[string]string {
 		}
 	}
 	return m
+}
+
+// newRunCmdForTest builds a run command with --vault registered locally so
+// tests don't depend on the persistent flag inherited from vaultCmd.
+func newRunCmdForTest() *cobra.Command {
+	c := newRunCmd("test")
+	c.Flags().String("vault", "", "target vault")
+	return c
+}
+
+func TestResolveVaultForAgentMode(t *testing.T) {
+	t.Run("flag wins", func(t *testing.T) {
+		t.Setenv("AGENT_VAULT_VAULT", "env-vault")
+		c := newRunCmdForTest()
+		_ = c.Flags().Set("vault", "flag-vault")
+		got, err := resolveVaultForAgentMode(c)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "flag-vault" {
+			t.Errorf("got %q, want flag-vault", got)
+		}
+	})
+
+	t.Run("env when no flag", func(t *testing.T) {
+		t.Setenv("AGENT_VAULT_VAULT", "env-vault")
+		c := newRunCmdForTest()
+		got, err := resolveVaultForAgentMode(c)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "env-vault" {
+			t.Errorf("got %q, want env-vault", got)
+		}
+	})
+
+	t.Run("error when neither set", func(t *testing.T) {
+		t.Setenv("AGENT_VAULT_VAULT", "")
+		c := newRunCmdForTest()
+		_, err := resolveVaultForAgentMode(c)
+		if err == nil {
+			t.Fatal("expected error when no vault is configured")
+		}
+		if !strings.Contains(err.Error(), "AGENT_VAULT_VAULT") {
+			t.Errorf("error should mention AGENT_VAULT_VAULT; got: %v", err)
+		}
+	})
+}
+
+// TestRunCmdAgentMode_RejectsTTL exercises the runCmdRunE early-exit when a
+// pre-supplied token is used together with --ttl. The token's lifetime is
+// fixed at mint time, so --ttl is meaningless in agent mode.
+func TestRunCmdAgentMode_RejectsTTL(t *testing.T) {
+	t.Setenv("AGENT_VAULT_TOKEN", "tok123")
+	t.Setenv("AGENT_VAULT_ADDR", "http://example.invalid")
+	t.Setenv("AGENT_VAULT_VAULT", "myvault")
+
+	c := newRunCmd("test")
+	_ = c.Flags().Set("ttl", "3600")
+	err := runCmdRunE(c, []string{"true"})
+	if err == nil {
+		t.Fatal("expected error rejecting --ttl in agent mode")
+	}
+	if !strings.Contains(err.Error(), "--ttl has no effect") {
+		t.Errorf("error should mention --ttl rejection; got: %v", err)
+	}
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -386,6 +386,44 @@ func TestResolveVaultForAgentMode(t *testing.T) {
 	})
 }
 
+// TestStripEnvKeys_AgentVaultInjectedKeys is the AGENT_VAULT_* analogue of
+// TestAugmentEnvWithMITM_DedupesParentEnv. In agent mode the parent env is
+// guaranteed to already carry AGENT_VAULT_TOKEN/ADDR/VAULT (that's how agent
+// mode is detected), so without this strip the parent's stale value would
+// silently win in the child via POSIX getenv first-match semantics — most
+// dangerously, --vault would be overridden by a stale AGENT_VAULT_VAULT.
+func TestStripEnvKeys_AgentVaultInjectedKeys(t *testing.T) {
+	parent := []string{
+		"AGENT_VAULT_TOKEN=stale-tok",
+		"AGENT_VAULT_SESSION_TOKEN=stale-legacy",
+		"AGENT_VAULT_ADDR=https://stale.example/",
+		"AGENT_VAULT_VAULT=stale-vault",
+		"UNRELATED=keep-me",
+	}
+	stripped := stripEnvKeys(parent, agentVaultInjectedKeys)
+	for _, kv := range stripped {
+		key := kv
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			key = kv[:i]
+		}
+		if _, dropped := agentVaultInjectedKeys[key]; dropped {
+			t.Errorf("expected %q to be stripped from parent env, still present as %q", key, kv)
+		}
+	}
+	if !contains(stripped, "UNRELATED=keep-me") {
+		t.Error("unrelated parent env vars must be preserved")
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
 // TestRunCmdAgentMode_RejectsTTL exercises the runCmdRunE early-exit when a
 // pre-supplied token is used together with --ttl. The token's lifetime is
 // fixed at mint time, so --ttl is meaningless in agent mode.

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -63,7 +63,7 @@ For unattended deployments (k8s/Fly/ECS, where there's no human to `auth login`)
 
 ```dockerfile
 FROM node:20-slim
-COPY --from=ghcr.io/infisical/agent-vault:latest /agent-vault /usr/local/bin/
+COPY --from=infisical/agent-vault:latest /usr/local/bin/agent-vault /usr/local/bin/agent-vault
 WORKDIR /app
 COPY . .
 RUN npm ci
@@ -78,7 +78,7 @@ AGENT_VAULT_TOKEN=av_agent_token_xxx
 AGENT_VAULT_VAULT=production
 ```
 
-The token is either a vault-scoped session token (mint via `agent-vault vault token`) or — more commonly for production — a long-lived agent token minted from an agent identity (`agent-vault agent token <id>`). `agent-vault run` validates the token against the broker once at startup; bad/expired tokens fail fast with a clear error rather than producing 401s on every proxied call. `--ttl` is rejected in this mode since the token's lifetime is fixed at mint time.
+The token is either a vault-scoped session token (mint via `agent-vault vault token`) or — more commonly for production — a long-lived agent token issued out-of-band by an operator (see [Agents](https://docs.infisical.com/agents/overview)). `agent-vault run` validates the token against the broker once at startup; bad/expired tokens fail fast with a clear error rather than producing 401s on every proxied call. `--ttl` is rejected in this mode since the token's lifetime is fixed at mint time.
 
 ## Discover Available Services (Start Here)
 

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -39,7 +39,7 @@ By default each vault forwards unmatched hosts as plain proxy traffic (no creden
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_TOKEN` | Bearer token for authenticating with Agent Vault's control-plane endpoints (`discover`, proposals, etc.). Either a vault-scoped session token or a long-lived agent token. |
-| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `agent-vault run`) |
+| `AGENT_VAULT_VAULT` | Vault name. Set automatically by `agent-vault run` in admin mode; supplied by the operator in agent mode. |
 
 > `AGENT_VAULT_SESSION_TOKEN` is the deprecated alias of `AGENT_VAULT_TOKEN` and is still honored with a one-time stderr warning. It will be removed in a future major version.
 
@@ -74,7 +74,7 @@ Set three env vars at deploy time:
 
 ```
 AGENT_VAULT_ADDR=https://vault.example.com
-AGENT_VAULT_TOKEN=av_agent_token_xxx
+AGENT_VAULT_TOKEN=av_agt_xxx
 AGENT_VAULT_VAULT=production
 ```
 

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -6,7 +6,7 @@ description: >-
   binary. Use when the task involves interacting with any third-party API or
   service that requires credentials, or when writing code that needs
   environment variables for secrets/API keys.
-compatibility: Requires a running Agent Vault server, the agent-vault binary on $PATH, and AGENT_VAULT_SESSION_TOKEN environment variable
+compatibility: Requires a running Agent Vault server, the agent-vault binary on $PATH, and AGENT_VAULT_TOKEN environment variable
 metadata:
   author: dangtony98
   version: "0.4.0"
@@ -21,7 +21,7 @@ You have access to Agent Vault, a transparent HTTP/HTTPS proxy that injects cred
 **Before telling the user you cannot access an external service, you MUST check Agent Vault.** This applies whenever a task involves any third-party service or API -- project management (Linear, Jira, Asana), source control (GitHub, GitLab), communication (Slack, Discord), payments (Stripe), databases, or any other authenticated service.
 
 **Your workflow for ANY external service interaction:**
-1. Check that `AGENT_VAULT_SESSION_TOKEN` is set (it should be if you were launched via `agent-vault run` — `agent-vault vault run` is the long form)
+1. Check that `AGENT_VAULT_TOKEN` is set (it should be if you were launched via `agent-vault run` — `agent-vault vault run` is the long form)
 2. Run `agent-vault vault discover --json` to see which hosts have credentials configured
 3. If the host is listed, **just make the request to the real API URL** -- Agent Vault transparently injects the credential
 4. If the host is NOT listed, create a proposal via CLI (the user approves and provides credentials)
@@ -38,8 +38,10 @@ By default each vault forwards unmatched hosts as plain proxy traffic (no creden
 | Variable | Description |
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
-| `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault's control-plane endpoints (`discover`, proposals, etc.) |
+| `AGENT_VAULT_TOKEN` | Bearer token for authenticating with Agent Vault's control-plane endpoints (`discover`, proposals, etc.). Either a vault-scoped session token or a long-lived agent token. |
 | `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `agent-vault run`) |
+
+> `AGENT_VAULT_SESSION_TOKEN` is the deprecated alias of `AGENT_VAULT_TOKEN` and is still honored with a one-time stderr warning. It will be removed in a future major version.
 
 `agent-vault run` also pre-configures `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`, `NODE_USE_ENV_PROXY`, and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) so HTTP and HTTPS calls from your process both route through the broker transparently. You don't manage these yourself.
 
@@ -53,7 +55,30 @@ You almost never need to mint your own token — `agent-vault run` already provi
 agent-vault vault token --ttl 3600
 ```
 
-Flag: `--ttl` (seconds, 300–604800; default 24h). Tokens are minted with vault role `proxy`. The token is printed to stdout — pipe it into `AGENT_VAULT_SESSION_TOKEN` for the child process. Operators can list/revoke tokens from each vault's **Tokens** tab in the UI.
+Flag: `--ttl` (seconds, 300–604800; default 24h). Tokens are minted with vault role `proxy`. The token is printed to stdout — pipe it into `AGENT_VAULT_TOKEN` for the child process. Operators can list/revoke tokens from each vault's **Tokens** tab in the UI.
+
+### Containerized agent deployment
+
+For unattended deployments (k8s/Fly/ECS, where there's no human to `auth login`), supply the token via env. `agent-vault run` then skips the mint step and treats the env-supplied token as the credential:
+
+```dockerfile
+FROM node:20-slim
+COPY --from=ghcr.io/infisical/agent-vault:latest /agent-vault /usr/local/bin/
+WORKDIR /app
+COPY . .
+RUN npm ci
+ENTRYPOINT ["agent-vault", "run", "--", "npm", "start"]
+```
+
+Set three env vars at deploy time:
+
+```
+AGENT_VAULT_ADDR=https://vault.example.com
+AGENT_VAULT_TOKEN=av_agent_token_xxx
+AGENT_VAULT_VAULT=production
+```
+
+The token is either a vault-scoped session token (mint via `agent-vault vault token`) or — more commonly for production — a long-lived agent token minted from an agent identity (`agent-vault agent token <id>`). `agent-vault run` validates the token against the broker once at startup; bad/expired tokens fail fast with a clear error rather than producing 401s on every proxied call. `--ttl` is rejected in this mode since the token's lifetime is fixed at mint time.
 
 ## Discover Available Services (Start Here)
 
@@ -213,11 +238,11 @@ Key fields (JSON mode):
 2. Immediately start polling `GET {AGENT_VAULT_ADDR}/v1/proposals/{id}` -- do NOT wait for the user to say "go on" or confirm. Poll every 3s for the first 30s, then every 10s. Stop after 10 minutes (proposal may have expired).
 3. Once status is `applied`, automatically retry your original request and continue your task
 
-**Check status:** `GET {AGENT_VAULT_ADDR}/v1/proposals/{id}` with `Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}` -- returns `pending`, `applied`, `rejected`, or `expired`
+**Check status:** `GET {AGENT_VAULT_ADDR}/v1/proposals/{id}` with `Authorization: Bearer {AGENT_VAULT_TOKEN}` -- returns `pending`, `applied`, `rejected`, or `expired`
 
 ## Request Logs
 
-Agent Vault keeps a per-vault audit log of proxied requests (method, host, path, status, latency -- never bodies or query strings). The CLI does not wrap this yet; fetch via the HTTP API: `GET {AGENT_VAULT_ADDR}/v1/vaults/{vault}/logs` with `Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}`. Requires vault `member` or `admin` role. See `skill_http.md` for query params.
+Agent Vault keeps a per-vault audit log of proxied requests (method, host, path, status, latency -- never bodies or query strings). The CLI does not wrap this yet; fetch via the HTTP API: `GET {AGENT_VAULT_ADDR}/v1/vaults/{vault}/logs` with `Authorization: Bearer {AGENT_VAULT_TOKEN}`. Requires vault `member` or `admin` role. See `skill_http.md` for query params.
 
 ## Building Code That Needs Credentials
 
@@ -266,7 +291,7 @@ Prints the raw value to stdout (pipe-friendly). Useful for configuration tasks w
 
 ## Error Handling
 
-- 401: Invalid or expired token -- check `AGENT_VAULT_SESSION_TOKEN`
+- 401: Invalid or expired token -- check `AGENT_VAULT_TOKEN`
 - 403 `forbidden`: Host not allowed (only fires under `unmatched_host_policy=deny`) -- create a proposal
 - 403 `service_disabled`: Host is configured but currently disabled by an operator. Don't create a new proposal; surface the error to the user so they can re-enable it (UI toggle, or `agent-vault vault service enable <host>`)
 - 403 `Instance member role required`: Your instance role is `no-access` and you tried an instance-scoped action (create vault, create invites, list users/agents). You can still operate within vaults you've been granted -- proxy traffic, raise proposals, and read credentials at vault scope. If you genuinely need an instance-scoped action, surface this to the user; an instance owner must change your role.
@@ -276,7 +301,7 @@ Prints the raw value to stdout (pipe-friendly). Useful for configuration tasks w
 ## Rules
 
 - **Never** attempt to extract, log, or display credentials
-- **Never** hardcode tokens -- always read from `AGENT_VAULT_SESSION_TOKEN`
+- **Never** hardcode tokens -- always read from `AGENT_VAULT_TOKEN`
 - **Only** request hosts returned by discover -- if a host isn't listed, create a proposal
 - If you receive a `credential_not_found` error, inform the user which credential is missing
 - Do not modify or forge the `Authorization` header beyond using your session token

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -78,7 +78,7 @@ AGENT_VAULT_TOKEN=av_agent_token_xxx
 AGENT_VAULT_VAULT=production
 ```
 
-The token is either a vault-scoped session token (mint via `agent-vault vault token`) or — more commonly for production — a long-lived agent token issued out-of-band by an operator (see [Agents](https://docs.infisical.com/agents/overview)). `agent-vault run` validates the token against the broker once at startup; bad/expired tokens fail fast with a clear error rather than producing 401s on every proxied call. `--ttl` is rejected in this mode since the token's lifetime is fixed at mint time.
+The token is either a vault-scoped session token (mint via `agent-vault vault token`) or — more commonly for production — a long-lived agent token issued out-of-band by an operator (see [Agents](https://docs.agent-vault.dev/agents/overview)). `agent-vault run` validates the token against the broker once at startup; bad/expired tokens fail fast with a clear error rather than producing 401s on every proxied call. `--ttl` is rejected in this mode since the token's lifetime is fixed at mint time.
 
 ## Discover Available Services (Start Here)
 

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -38,7 +38,7 @@ By default each vault forwards unmatched hosts as plain proxy traffic (no creden
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_TOKEN` | Bearer token for authenticating with Agent Vault's control-plane endpoints (`/discover`, proposals, etc.). Either a vault-scoped session token or a long-lived agent token. |
-| `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`) |
+| `AGENT_VAULT_VAULT` | Vault name. Set automatically by `agent-vault run` in admin mode; supplied by the operator in agent mode. |
 
 > `AGENT_VAULT_SESSION_TOKEN` is the deprecated alias of `AGENT_VAULT_TOKEN` and is still honored with a one-time stderr warning. It will be removed in a future major version.
 
@@ -79,7 +79,7 @@ Set three env vars at deploy time:
 
 ```
 AGENT_VAULT_ADDR=https://vault.example.com
-AGENT_VAULT_TOKEN=av_agent_token_xxx
+AGENT_VAULT_TOKEN=av_agt_xxx
 AGENT_VAULT_VAULT=production
 ```
 

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -5,7 +5,7 @@ description: >-
   external services (Linear, GitHub, Stripe, Slack, Jira, etc.). Use when the
   task involves any third-party API or service that requires credentials, or
   when writing code that needs environment variables for secrets/API keys.
-compatibility: Requires a running Agent Vault server and AGENT_VAULT_SESSION_TOKEN environment variable
+compatibility: Requires a running Agent Vault server and AGENT_VAULT_TOKEN environment variable
 metadata:
   author: dangtony98
   version: "0.4.0"
@@ -20,7 +20,7 @@ You have access to Agent Vault, a transparent HTTP/HTTPS proxy that injects cred
 **Before telling the user you cannot access an external service, you MUST check Agent Vault.** This applies whenever a task involves any third-party service or API -- project management (Linear, Jira, Asana), source control (GitHub, GitLab), communication (Slack, Discord), payments (Stripe), databases, or any other authenticated service.
 
 **Your workflow for ANY external service interaction:**
-1. Check that `AGENT_VAULT_SESSION_TOKEN` is set
+1. Check that `AGENT_VAULT_TOKEN` is set
 2. Call `GET {AGENT_VAULT_ADDR}/discover` to see which hosts have credentials configured
 3. If the host is listed, **just make the request to the real API URL** -- Agent Vault transparently injects the credential
 4. If the host is NOT listed, create a proposal (the user approves and provides credentials)
@@ -37,8 +37,10 @@ By default each vault forwards unmatched hosts as plain proxy traffic (no creden
 | Variable | Description |
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
-| `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault's control-plane endpoints (`/discover`, proposals, etc.) |
+| `AGENT_VAULT_TOKEN` | Bearer token for authenticating with Agent Vault's control-plane endpoints (`/discover`, proposals, etc.). Either a vault-scoped session token or a long-lived agent token. |
 | `AGENT_VAULT_VAULT` | Vault name (set for user-scoped sessions via `vault run`) |
+
+> `AGENT_VAULT_SESSION_TOKEN` is the deprecated alias of `AGENT_VAULT_TOKEN` and is still honored with a one-time stderr warning. It will be removed in a future major version.
 
 `vault run` also pre-configures `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`, `NODE_USE_ENV_PROXY`, and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) so HTTP and HTTPS calls from your process both route through the broker transparently. You don't manage these yourself.
 
@@ -60,13 +62,36 @@ POST /v1/sessions
 
 Tokens are minted with vault role `proxy`. Operators manage them via the **Tokens** tab in each vault, which uses `GET /v1/sessions?vault=<name>` (member+) and `DELETE /v1/sessions/{public_id}?vault=<name>` (member+). The raw token is only returned at creation; subsequent reads only ever show the `public_id`.
 
+### Containerized agent deployment
+
+For unattended deployments (k8s/Fly/ECS, where there's no human to `auth login`), supply the token via env. `agent-vault run` then skips the mint step and treats the env-supplied token as the credential:
+
+```dockerfile
+FROM node:20-slim
+COPY --from=ghcr.io/infisical/agent-vault:latest /agent-vault /usr/local/bin/
+WORKDIR /app
+COPY . .
+RUN npm ci
+ENTRYPOINT ["agent-vault", "run", "--", "npm", "start"]
+```
+
+Set three env vars at deploy time:
+
+```
+AGENT_VAULT_ADDR=https://vault.example.com
+AGENT_VAULT_TOKEN=av_agent_token_xxx
+AGENT_VAULT_VAULT=production
+```
+
+Use a long-lived agent token (no expiry) for production: an operator creates an agent identity with `agent-vault agent create <name>` and mints a token via `agent-vault agent token <id>`. `agent-vault run` validates the token against the broker once at startup; bad/expired tokens fail fast with a clear error. `--ttl` is rejected in this mode since the token's lifetime is fixed at mint time.
+
 ## Discover Available Services (Start Here)
 
 **Always call this first** to learn which hosts have credentials configured:
 
 ```
 GET {AGENT_VAULT_ADDR}/discover
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Authorization: Bearer {AGENT_VAULT_TOKEN}
 X-Vault: {vault_name}
 ```
 
@@ -155,7 +180,7 @@ Example proposal (Twilio: basic auth header + path SID substitution):
 
 ```
 POST {AGENT_VAULT_ADDR}/v1/proposals
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Authorization: Bearer {AGENT_VAULT_TOKEN}
 Content-Type: application/json
 
 {
@@ -183,7 +208,7 @@ Placeholder safety: must be ≥4 characters, contain at least one alphanumeric c
 
 ```
 POST {AGENT_VAULT_ADDR}/v1/proposals
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Authorization: Bearer {AGENT_VAULT_TOKEN}
 Content-Type: application/json
 
 {
@@ -209,7 +234,7 @@ Key fields:
 2. Immediately start polling `GET {AGENT_VAULT_ADDR}/v1/proposals/{id}` -- do NOT wait for the user to say "go on" or confirm. Poll every 3s for the first 30s, then every 10s. Stop after 10 minutes (proposal may have expired).
 3. Once status is `applied`, automatically retry your original request and continue your task
 
-**Check status:** `GET {AGENT_VAULT_ADDR}/v1/proposals/{id}` with `Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}` -- returns `pending`, `applied`, `rejected`, or `expired`
+**Check status:** `GET {AGENT_VAULT_ADDR}/v1/proposals/{id}` with `Authorization: Bearer {AGENT_VAULT_TOKEN}` -- returns `pending`, `applied`, `rejected`, or `expired`
 
 **List proposals:** `GET {AGENT_VAULT_ADDR}/v1/proposals?status=pending`
 
@@ -219,7 +244,7 @@ Agent Vault persists a per-request audit log for each vault (method, host, path,
 
 ```
 GET {AGENT_VAULT_ADDR}/v1/vaults/{vault}/logs
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Authorization: Bearer {AGENT_VAULT_TOKEN}
 ```
 
 Query params: `status_bucket` (`2xx`|`3xx`|`4xx`|`5xx`|`err`), `service`, `limit` (default 50, max 200), `before=<id>` (page back), `after=<id>` (tail forward for new rows). Response: `{ "logs": [...], "next_cursor": <id|null>, "latest_id": <id> }`.
@@ -236,7 +261,7 @@ When you are writing or modifying application code that requires secrets or API 
 
 ```
 POST {AGENT_VAULT_ADDR}/v1/proposals
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Authorization: Bearer {AGENT_VAULT_TOKEN}
 Content-Type: application/json
 
 {
@@ -268,7 +293,7 @@ Content-Type: application/json
 
 ## Error Handling
 
-- 401: Invalid or expired token -- check `AGENT_VAULT_SESSION_TOKEN`
+- 401: Invalid or expired token -- check `AGENT_VAULT_TOKEN`
 - 403 `forbidden`: Host not allowed (only fires under `unmatched_host_policy=deny`) -- create a proposal
 - 403 `service_disabled`: Host is configured but currently disabled by an operator. Don't create a new proposal; surface the error to the user so they can re-enable it
 - 403 `Instance member role required`: Your instance role is `no-access` and you tried an instance-scoped endpoint (create vault, create invites, list users/agents). You can still operate within vaults you've been granted -- stay on `/v1/vaults/{name}/...` endpoints and proxied calls. If you genuinely need to take an instance-scoped action, surface this to the user; an instance owner must change your role.
@@ -278,7 +303,7 @@ Content-Type: application/json
 ## Rules
 
 - **Never** attempt to extract, log, or display credentials
-- **Never** hardcode tokens -- always read from `AGENT_VAULT_SESSION_TOKEN`
+- **Never** hardcode tokens -- always read from `AGENT_VAULT_TOKEN`
 - **Only** request hosts returned by `/discover` -- if a host isn't listed, create a proposal
 - If you receive a `credential_not_found` error, inform the user which credential is missing
 - Do not modify or forge the `Authorization` header beyond using your token

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -60,7 +60,7 @@ POST /v1/sessions
 → { "token": "...", "expires_at": "...", "av_addr": "..." }
 ```
 
-Tokens are minted with vault role `proxy`. Operators manage them via the **Tokens** tab in each vault, which uses `GET /v1/sessions?vault=<name>` (member+) and `DELETE /v1/sessions/{public_id}?vault=<name>` (member+). The raw token is only returned at creation; subsequent reads only ever show the `public_id`.
+Tokens are minted with vault role `proxy`. Operators manage them via the **Tokens** tab in each vault, which uses `GET /v1/sessions?vault=<name>` (member+) and `DELETE /v1/sessions/{id}?vault=<name>` (member+) — substitute `{id}` with the `id` field from the list response (a public-facing identifier, not the raw token). The raw token is only returned at creation; subsequent reads only ever show the `id`.
 
 ### Containerized agent deployment
 
@@ -83,7 +83,7 @@ AGENT_VAULT_TOKEN=av_agent_token_xxx
 AGENT_VAULT_VAULT=production
 ```
 
-Use a long-lived agent token (no expiry) for production. Operators mint these out-of-band — see [Agents](https://docs.infisical.com/agents/overview) for how to create the agent identity and obtain its token. `agent-vault run` validates the token against the broker once at startup; bad/expired tokens fail fast with a clear error. `--ttl` is rejected in this mode since the token's lifetime is fixed at mint time.
+Use a long-lived agent token (no expiry) for production. Operators mint these out-of-band — see [Agents](https://docs.agent-vault.dev/agents/overview) for how to create the agent identity and obtain its token. `agent-vault run` validates the token against the broker once at startup; bad/expired tokens fail fast with a clear error. `--ttl` is rejected in this mode since the token's lifetime is fixed at mint time.
 
 ## Discover Available Services (Start Here)
 
@@ -95,7 +95,7 @@ Authorization: Bearer {AGENT_VAULT_TOKEN}
 X-Vault: {vault_name}
 ```
 
-**Note:** If `AGENT_VAULT_VAULT` is set, the server uses it automatically. Instance-level agent tokens (persistent agents) must include the `X-Vault` header on all vault-scoped requests.
+**Note:** Instance-level agent tokens (persistent agents) must include the `X-Vault: {vault_name}` header on every control-plane call (`/discover`, `/v1/proposals`). The server only reads vault scope from this header — `AGENT_VAULT_VAULT` is a client-side env var; it is your responsibility to copy its value into the `X-Vault` header on each request. Vault-scoped session tokens carry the vault on the session row, so the header is ignored for those (passing it unconditionally is safe).
 
 Response includes `vault`, `services` (host + description), and `available_credentials` (key names only, values are never exposed). Use `available_credentials` to reference existing credentials in proposals instead of creating duplicate slots.
 

--- a/cmd/skill_http.md
+++ b/cmd/skill_http.md
@@ -68,7 +68,7 @@ For unattended deployments (k8s/Fly/ECS, where there's no human to `auth login`)
 
 ```dockerfile
 FROM node:20-slim
-COPY --from=ghcr.io/infisical/agent-vault:latest /agent-vault /usr/local/bin/
+COPY --from=infisical/agent-vault:latest /usr/local/bin/agent-vault /usr/local/bin/agent-vault
 WORKDIR /app
 COPY . .
 RUN npm ci
@@ -83,7 +83,7 @@ AGENT_VAULT_TOKEN=av_agent_token_xxx
 AGENT_VAULT_VAULT=production
 ```
 
-Use a long-lived agent token (no expiry) for production: an operator creates an agent identity with `agent-vault agent create <name>` and mints a token via `agent-vault agent token <id>`. `agent-vault run` validates the token against the broker once at startup; bad/expired tokens fail fast with a clear error. `--ttl` is rejected in this mode since the token's lifetime is fixed at mint time.
+Use a long-lived agent token (no expiry) for production. Operators mint these out-of-band — see [Agents](https://docs.infisical.com/agents/overview) for how to create the agent identity and obtain its token. `agent-vault run` validates the token against the broker once at startup; bad/expired tokens fail fast with a clear error. `--ttl` is rejected in this mode since the token's lifetime is fixed at mint time.
 
 ## Discover Available Services (Start Here)
 

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -12,11 +12,12 @@ var tokenCmd = &cobra.Command{
 	Long: `Create a temporary vault-scoped session token and print it to stdout.
 
 This is useful when you need a scoped token without wrapping a child process
-via "vault run". The token can be used with AGENT_VAULT_SESSION_TOKEN and
-AGENT_VAULT_ADDR environment variables.
+via "vault run". The token can be used with AGENT_VAULT_TOKEN and
+AGENT_VAULT_ADDR environment variables. (AGENT_VAULT_SESSION_TOKEN is the
+deprecated alias and still works.)
 
 Example:
-  export AGENT_VAULT_SESSION_TOKEN=$(agent-vault vault token)
+  export AGENT_VAULT_TOKEN=$(agent-vault vault token)
   export AGENT_VAULT_ADDR=http://localhost:14321
   export AGENT_VAULT_VAULT=default`,
 	Args: cobra.NoArgs,

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -137,7 +137,7 @@ Instance-level agent tokens are not scoped to a single vault. Instead, agents se
 
 ```
 GET /discover
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Authorization: Bearer {AGENT_VAULT_TOKEN}
 X-Vault: my-vault
 ```
 

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -141,7 +141,7 @@ Authorization: Bearer {AGENT_VAULT_TOKEN}
 X-Vault: my-vault
 ```
 
-This applies to all vault-scoped requests: `/discover`, `/v1/proposals`, and `/v1/credentials`.
+This applies to `/discover` and `/v1/proposals`. (Endpoints like `/v1/credentials` resolve the vault from a `?vault=` query parameter or request body instead.)
 
 <Note>
 Agents created via `agent-vault vault run` receive vault-scoped sessions and do not need the `X-Vault` header — the vault is embedded in the session.

--- a/docs/agents/protocol.mdx
+++ b/docs/agents/protocol.mdx
@@ -34,7 +34,7 @@ There are two session types:
 
 ### The X-Vault header
 
-Instance-level agent tokens must include `X-Vault: {vault_name}` on all vault-scoped requests (discover, proposals, credentials):
+Instance-level agent tokens must include `X-Vault: {vault_name}` on `/discover` and `/v1/proposals` requests:
 
 ```
 GET {AGENT_VAULT_ADDR}/discover

--- a/docs/agents/protocol.mdx
+++ b/docs/agents/protocol.mdx
@@ -15,7 +15,7 @@ Every request an agent makes to Agent Vault requires a bearer token. How the age
 
 | Method | How the agent gets a token |
 |---|---|
-| `agent-vault vault run` | Agent Vault sets `AGENT_VAULT_SESSION_TOKEN` on the child process automatically |
+| `agent-vault vault run` | Agent Vault sets `AGENT_VAULT_TOKEN` on the child process automatically |
 | Agent invite | Agent calls `POST {invite_url}` and receives an agent token |
 
 Both methods deliver the same core connection details:
@@ -23,7 +23,7 @@ Both methods deliver the same core connection details:
 | Variable | Description |
 |---|---|
 | `AGENT_VAULT_ADDR` | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
-| `AGENT_VAULT_SESSION_TOKEN` | Bearer token for all Agent Vault requests |
+| `AGENT_VAULT_TOKEN` | Bearer token for all Agent Vault requests. (`AGENT_VAULT_SESSION_TOKEN` is the deprecated alias and still works.) |
 
 ### Session types
 
@@ -38,7 +38,7 @@ Instance-level agent tokens must include `X-Vault: {vault_name}` on all vault-sc
 
 ```
 GET {AGENT_VAULT_ADDR}/discover
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Authorization: Bearer {AGENT_VAULT_TOKEN}
 X-Vault: my-vault
 ```
 
@@ -50,7 +50,7 @@ Before making any proxied request, the agent calls `/discover` to learn which ho
 
 ```
 GET {AGENT_VAULT_ADDR}/discover
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Authorization: Bearer {AGENT_VAULT_TOKEN}
 X-Vault: my-vault
 ```
 
@@ -102,7 +102,7 @@ When an agent needs access to a service that is not in the vault's services, it 
 
 ```json
 POST {AGENT_VAULT_ADDR}/v1/proposals
-Authorization: Bearer {AGENT_VAULT_SESSION_TOKEN}
+Authorization: Bearer {AGENT_VAULT_TOKEN}
 Content-Type: application/json
 
 {
@@ -152,7 +152,7 @@ See [Proposals](/learn/proposals) for the full proposal lifecycle, including sto
 
 | Status | Meaning | What the agent does |
 |---|---|---|
-| 401 | Invalid or expired token | Re-check `AGENT_VAULT_SESSION_TOKEN`. Contact operator for a new token or [rotation](/agents/overview#rotating-an-agent-token). |
+| 401 | Invalid or expired token | Re-check `AGENT_VAULT_TOKEN`. Contact operator for a new token or [rotation](/agents/overview#rotating-an-agent-token). |
 | 403 `forbidden` | Host not allowed (only fires when the vault has `unmatched_host_policy=deny`; the default is passthrough) | Create a proposal to request access. The response includes a `proposal_hint`. |
 | 403 `service_disabled` | Host is configured but disabled | Surface to the user — don't create a duplicate proposal. |
 | 429 | Rate limited | Respect the `Retry-After` header. |
@@ -161,6 +161,6 @@ See [Proposals](/learn/proposals) for the full proposal lifecycle, including sto
 ## Security constraints
 
 - Never extract, log, or display credential values
-- Never hardcode tokens. Always read from `AGENT_VAULT_SESSION_TOKEN`.
+- Never hardcode tokens. Always read from `AGENT_VAULT_TOKEN`.
 - Only reach hosts returned by `/discover`. For unlisted hosts, create a proposal.
 - If a `credential_not_found` error occurs, inform the user which key is missing.

--- a/docs/agents/protocol.mdx
+++ b/docs/agents/protocol.mdx
@@ -30,7 +30,7 @@ Both methods deliver the same core connection details:
 There are two session types:
 
 - **Vault-scoped sessions** — created by `agent-vault vault run`. The vault is embedded in the session. No extra headers needed.
-- **Instance-level agent tokens** — created via agent invites. The agent must include an `X-Vault` header on every vault-scoped request to select which vault to use.
+- **Instance-level agent tokens** — created via agent invites. The agent must include an `X-Vault` header on `/discover` and `/v1/proposals` requests to select which vault to use.
 
 ### The X-Vault header
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -41,7 +41,8 @@
             "pages": [
               "guides/connect-coding-agent",
               "guides/connect-custom-agent",
-              "guides/container-isolation"
+              "guides/container-isolation",
+              "guides/deploy-agent-container"
             ]
           },
           {

--- a/docs/guides/connect-custom-agent.mdx
+++ b/docs/guides/connect-custom-agent.mdx
@@ -40,7 +40,7 @@ If you're using Claude Code, Cursor, or another supported agent, see the [Quicks
 
     Invited agents don't get `HTTPS_PROXY`/`HTTP_PROXY` auto-configured — set them yourself (see [Set the proxy env vars manually](#set-the-proxy-env-vars-manually)).
 
-    Instance-level agent tokens require the `X-Vault` header on every vault-scoped request.
+    Instance-level agent tokens require the `X-Vault` header on `/discover` and `/v1/proposals` requests.
   </Tab>
 </Tabs>
 
@@ -53,7 +53,7 @@ Your agent needs these values to operate:
 | `AGENT_VAULT_ADDR` | Yes | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
 | `AGENT_VAULT_TOKEN` | Yes | Bearer token for authenticating control-plane requests (`/discover`, proposals) |
 
-For instance-level agent tokens (from agent invites), the agent must also send the `X-Vault` header on every vault-scoped request. For vault-scoped sessions (from `vault run`), the vault is embedded in the session.
+For instance-level agent tokens (from agent invites), the agent must also send the `X-Vault` header on `/discover` and `/v1/proposals` requests. For vault-scoped sessions (from `vault run`), the vault is embedded in the session.
 
 When the agent is launched via `vault run`, these additional variables are also set automatically on the child:
 

--- a/docs/guides/connect-custom-agent.mdx
+++ b/docs/guides/connect-custom-agent.mdx
@@ -180,6 +180,9 @@ Discovery is optional. If your agent already knows which hosts are configured, i
 ## Next steps
 
 <CardGroup cols={2}>
+  <Card title="Deploy your agent in a container" icon="docker" href="/guides/deploy-agent-container">
+    Ship your agent as a container image (k8s, Fly, ECS) using a pre-supplied `AGENT_VAULT_TOKEN` instead of an interactive `auth login`.
+  </Card>
   <Card title="Agent protocol" icon="code" href="/agents/protocol">
     Full HTTP reference for sessions, discovery, and proposals.
   </Card>

--- a/docs/guides/connect-custom-agent.mdx
+++ b/docs/guides/connect-custom-agent.mdx
@@ -24,7 +24,7 @@ If you're using Claude Code, Cursor, or another supported agent, see the [Quicks
     agent-vault vault run -- my-agent
     ```
 
-    `vault run` sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT` on the child, then pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and the CA trust chain so standard HTTP clients route both HTTP and HTTPS traffic through the broker transparently. No invite needed.
+    `vault run` sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_TOKEN`, and `AGENT_VAULT_VAULT` on the child, then pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and the CA trust chain so standard HTTP clients route both HTTP and HTTPS traffic through the broker transparently. No invite needed.
   </Tab>
   <Tab title="Agent invite">
     For CI pipelines, cloud-hosted agents, or when you need the agent to redeem an invite via HTTP:
@@ -51,7 +51,7 @@ Your agent needs these values to operate:
 | Variable | Required | Description |
 |---|---|---|
 | `AGENT_VAULT_ADDR` | Yes | Base URL of the Agent Vault server (e.g. `http://127.0.0.1:14321`) |
-| `AGENT_VAULT_SESSION_TOKEN` | Yes | Bearer token for authenticating control-plane requests (`/discover`, proposals) |
+| `AGENT_VAULT_TOKEN` | Yes | Bearer token for authenticating control-plane requests (`/discover`, proposals) |
 
 For instance-level agent tokens (from agent invites), the agent must also send the `X-Vault` header on every vault-scoped request. For vault-scoped sessions (from `vault run`), the vault is embedded in the session.
 
@@ -125,7 +125,7 @@ If your agent wasn't launched via `vault run` (e.g. an invited agent, a Docker c
 agent-vault ca fetch -o /etc/ssl/certs/agent-vault-ca.pem
 
 # 2. Build the proxy URL (basic auth: token:vault)
-export HTTPS_PROXY="https://${AGENT_VAULT_SESSION_TOKEN}:my-vault@127.0.0.1:14322"
+export HTTPS_PROXY="https://${AGENT_VAULT_TOKEN}:my-vault@127.0.0.1:14322"
 export HTTP_PROXY="$HTTPS_PROXY"
 export NO_PROXY="localhost,127.0.0.1"
 export NODE_USE_ENV_PROXY=1
@@ -147,7 +147,7 @@ Your agent can call `/discover` to check which hosts have credentials configured
 
 ```bash
 curl ${AGENT_VAULT_ADDR}/discover \
-  -H "Authorization: Bearer ${AGENT_VAULT_SESSION_TOKEN}"
+  -H "Authorization: Bearer ${AGENT_VAULT_TOKEN}"
 ```
 
 ```json Response

--- a/docs/guides/container-isolation.mdx
+++ b/docs/guides/container-isolation.mdx
@@ -12,6 +12,10 @@ description: "Run `vault run` agents inside a Docker container with iptables-loc
   Container mode is opt-in while it stabilizes. Host mode remains the default.
 </Note>
 
+<Note>
+  This guide is about running `vault run` on a developer machine and having it sandbox the child agent in a Docker container. If instead you want to ship *your own* agent as a container image (k8s, Fly, ECS) with `agent-vault run` as the entrypoint and a pre-supplied token, see [Deploy your agent in a container](/guides/deploy-agent-container).
+</Note>
+
 ## Quick start
 
 ```bash

--- a/docs/guides/deploy-agent-container.mdx
+++ b/docs/guides/deploy-agent-container.mdx
@@ -8,20 +8,13 @@ For local development, `agent-vault run` uses the on-disk admin session created 
 ## Prerequisites
 
 - An Agent Vault instance reachable from where the container runs.
-- An [agent identity](/agents/overview) with access to the target vault. Mint a long-lived token:
-
-  ```bash
-  agent-vault agent create my-prod-agent --vault production:proxy
-  agent-vault agent token <agent-id>
-  ```
-
-  No `--ttl` makes the token long-lived, which is the right default for production. Operators can revoke it from the **Tokens** tab in the UI at any time.
+- A long-lived agent token with access to the target vault. See [Agents](/agents/overview) for how to create the agent identity and obtain its token — this guide picks up once you have the token in hand. Operators can revoke the token from the **Tokens** tab in the UI at any time.
 
 ## Dockerfile
 
 ```dockerfile
 FROM node:20-slim
-COPY --from=ghcr.io/infisical/agent-vault:latest /agent-vault /usr/local/bin/
+COPY --from=infisical/agent-vault:latest /usr/local/bin/agent-vault /usr/local/bin/agent-vault
 WORKDIR /app
 COPY . .
 RUN npm ci
@@ -37,7 +30,7 @@ Set these on the container's environment (k8s `env:`, Fly `[env]`, ECS task defi
 | Variable | Description |
 |---|---|
 | `AGENT_VAULT_ADDR` | Broker base URL (e.g. `https://vault.example.com`) |
-| `AGENT_VAULT_TOKEN` | Bearer token from `agent-vault agent token <id>` (or `agent-vault vault token` for short-lived runs) |
+| `AGENT_VAULT_TOKEN` | Long-lived agent token (see [Agents](/agents/overview); or `agent-vault vault token` for short-lived runs) |
 | `AGENT_VAULT_VAULT` | Vault to scope the run to. Required for agent tokens. |
 
 `agent-vault run` accepts both vault-scoped session tokens and long-lived agent tokens via `AGENT_VAULT_TOKEN` — the broker treats them identically for proxy / discover / proposal calls.
@@ -51,9 +44,7 @@ Set these on the container's environment (k8s `env:`, Fly `[env]`, ECS task defi
 
 ## Rotating the token
 
-1. Mint a new token: `agent-vault agent token <agent-id>`.
-2. Roll the deployment with the new `AGENT_VAULT_TOKEN`.
-3. Revoke the old token from the **Tokens** tab in the vault UI.
+Mint a new token the same way you minted the original (see [Agents](/agents/overview#rotating-an-agent-token)), then roll the deployment with the new `AGENT_VAULT_TOKEN`. Old tokens for the agent are invalidated automatically by the rotation step.
 
 ## Troubleshooting
 

--- a/docs/guides/deploy-agent-container.mdx
+++ b/docs/guides/deploy-agent-container.mdx
@@ -8,7 +8,7 @@ For local development, `agent-vault run` uses the on-disk admin session created 
 ## Prerequisites
 
 - An Agent Vault instance reachable from where the container runs.
-- A long-lived agent token with access to the target vault. See [Agents](/agents/overview) for how to create the agent identity and obtain its token — this guide picks up once you have the token in hand. Operators can revoke the token from the **Tokens** tab in the UI at any time.
+- A long-lived agent token with access to the target vault. See [Agents](/agents/overview) for how to create the agent identity and obtain its token — this guide picks up once you have the token in hand. Operators can rotate or revoke the token from the **Agents** tab in the UI (or via `agent-vault agent rotate <name>` / `agent-vault agent delete <name>`) at any time.
 
 ## Dockerfile
 
@@ -31,7 +31,7 @@ Set these on the container's environment (k8s `env:`, Fly `[env]`, ECS task defi
 |---|---|
 | `AGENT_VAULT_ADDR` | Broker base URL (e.g. `https://vault.example.com`) |
 | `AGENT_VAULT_TOKEN` | Long-lived agent token (see [Agents](/agents/overview); or `agent-vault vault token` for short-lived runs) |
-| `AGENT_VAULT_VAULT` | Vault to scope the run to. Required for agent tokens. |
+| `AGENT_VAULT_VAULT` | Vault to scope the run to. Required in agent mode (no project-file or interactive-picker fallback, regardless of token type). |
 
 `agent-vault run` accepts both vault-scoped session tokens and long-lived agent tokens via `AGENT_VAULT_TOKEN` — the broker treats them identically for proxy / discover / proposal calls.
 
@@ -44,7 +44,7 @@ Set these on the container's environment (k8s `env:`, Fly `[env]`, ECS task defi
 
 ## Rotating the token
 
-Mint a new token the same way you minted the original (see [Agents](/agents/overview#rotating-an-agent-token)), then roll the deployment with the new `AGENT_VAULT_TOKEN`. Old tokens for the agent are invalidated automatically by the rotation step.
+Mint a new token the same way you minted the original (see [Agents](/agents/overview#rotating-an-agent-token)), then roll the deployment with the new `AGENT_VAULT_TOKEN`. Old tokens for the agent are invalidated when the agent redeems the rotation invite, not at the moment `agent-vault agent rotate` is run — so finish redeeming and rolling the deployment together to avoid a window where the in-flight container is still using the soon-to-be-invalid token.
 
 ## Troubleshooting
 

--- a/docs/guides/deploy-agent-container.mdx
+++ b/docs/guides/deploy-agent-container.mdx
@@ -1,0 +1,68 @@
+---
+title: "Deploy your agent in a container"
+description: "Run an Agent Vault-wrapped agent in an unattended container (k8s, Fly, ECS) using a pre-supplied token — no interactive `auth login` required."
+---
+
+For local development, `agent-vault run` uses the on-disk admin session created by `auth login`. That doesn't fit unattended container deploys: there's no TTY to prompt and no session file to mount. This guide covers the **agent mode** flow — pre-supply a token via env, and `agent-vault run` skips the mint step and uses it as the credential for the child.
+
+## Prerequisites
+
+- An Agent Vault instance reachable from where the container runs.
+- An [agent identity](/agents/overview) with access to the target vault. Mint a long-lived token:
+
+  ```bash
+  agent-vault agent create my-prod-agent --vault production:proxy
+  agent-vault agent token <agent-id>
+  ```
+
+  No `--ttl` makes the token long-lived, which is the right default for production. Operators can revoke it from the **Tokens** tab in the UI at any time.
+
+## Dockerfile
+
+```dockerfile
+FROM node:20-slim
+COPY --from=ghcr.io/infisical/agent-vault:latest /agent-vault /usr/local/bin/
+WORKDIR /app
+COPY . .
+RUN npm ci
+ENTRYPOINT ["agent-vault", "run", "--", "npm", "start"]
+```
+
+`agent-vault run` validates the token against the broker once at startup, then execs `npm start` with `HTTPS_PROXY` / `HTTP_PROXY` and the CA-trust env vars pre-configured — your application just calls real API URLs and Agent Vault attaches credentials at the proxy boundary.
+
+## Deploy-time env vars
+
+Set these on the container's environment (k8s `env:`, Fly `[env]`, ECS task definition, etc.):
+
+| Variable | Description |
+|---|---|
+| `AGENT_VAULT_ADDR` | Broker base URL (e.g. `https://vault.example.com`) |
+| `AGENT_VAULT_TOKEN` | Bearer token from `agent-vault agent token <id>` (or `agent-vault vault token` for short-lived runs) |
+| `AGENT_VAULT_VAULT` | Vault to scope the run to. Required for agent tokens. |
+
+`agent-vault run` accepts both vault-scoped session tokens and long-lived agent tokens via `AGENT_VAULT_TOKEN` — the broker treats them identically for proxy / discover / proposal calls.
+
+## What changes vs. local mode
+
+- `agent-vault run` does **not** call the broker's mint endpoint; the env-supplied token is the credential.
+- The token is validated against `/discover` once before the child is exec'd. A bad/expired token fails fast with a clear error rather than producing 401s on every proxied call.
+- `--ttl` is rejected — the token's lifetime is fixed at mint time, so the flag has no effect.
+- `AGENT_VAULT_VAULT` is required (no project file or interactive picker fallback in agent mode).
+
+## Rotating the token
+
+1. Mint a new token: `agent-vault agent token <agent-id>`.
+2. Roll the deployment with the new `AGENT_VAULT_TOKEN`.
+3. Revoke the old token from the **Tokens** tab in the vault UI.
+
+## Troubleshooting
+
+- **"agent token rejected by broker (HTTP 401)"** at startup — the token has been revoked or expired, or doesn't have access to `AGENT_VAULT_VAULT`. Verify with `curl -H "Authorization: Bearer $AGENT_VAULT_TOKEN" -H "X-Vault: $AGENT_VAULT_VAULT" $AGENT_VAULT_ADDR/discover`.
+- **"vault is required in agent mode"** — set `AGENT_VAULT_VAULT` (or pass `--vault`).
+- **`--ttl has no effect when AGENT_VAULT_TOKEN is supplied`** — drop the flag; it only applies when `agent-vault run` mints a fresh token.
+
+## Related
+
+- [Connect a custom agent](/guides/connect-custom-agent) — interactive / `vault run` flow on a developer machine.
+- [Container isolation](/guides/container-isolation) — `--isolation=container` for non-cooperative dev-machine sandboxing (different from this guide; that mode wraps the agent in a Docker container *from* `vault run`, this guide ships *as* a container).
+- [Agent overview](/agents/overview) — agent identities, tokens, and rotation.

--- a/docs/quickstart/custom-agent.mdx
+++ b/docs/quickstart/custom-agent.mdx
@@ -10,7 +10,7 @@ description: "Connect any HTTP-capable agent or script to Agent Vault through HT
 
 ## Quick start
 
-Wrap your agent process with `vault run`. It sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT`, then pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and the CA trust chain so standard HTTP clients route both HTTP and HTTPS traffic through the broker transparently:
+Wrap your agent process with `vault run`. It sets `AGENT_VAULT_ADDR`, `AGENT_VAULT_TOKEN`, and `AGENT_VAULT_VAULT`, then pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and the CA trust chain so standard HTTP clients route both HTTP and HTTPS traffic through the broker transparently:
 
 ```bash
 agent-vault vault run -- my-agent
@@ -67,7 +67,7 @@ Call `/discover` to check which hosts have credentials configured:
 
 ```bash
 curl ${AGENT_VAULT_ADDR}/discover \
-  -H "Authorization: Bearer ${AGENT_VAULT_SESSION_TOKEN}"
+  -H "Authorization: Bearer ${AGENT_VAULT_TOKEN}"
 ```
 
 ```json Response

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -246,7 +246,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault discover [flags]
     ```
 
-    Show available services and credentials for the current vault. Requires a vault-scoped session (via `agent-vault run` or `AGENT_VAULT_TOKEN` + `AGENT_VAULT_ADDR` env vars; `AGENT_VAULT_SESSION_TOKEN` is the deprecated alias and still works). In agent mode (`AGENT_VAULT_TOKEN` set), `AGENT_VAULT_VAULT` (or `--vault`) is required — there is no project-file or interactive-picker fallback.
+    Show available services and credentials for the current vault. Requires a vault-scoped session token or long-lived agent token (via `agent-vault run` or `AGENT_VAULT_TOKEN` + `AGENT_VAULT_ADDR` env vars; `AGENT_VAULT_SESSION_TOKEN` is the deprecated alias and still works). In agent mode (`AGENT_VAULT_TOKEN` set), `AGENT_VAULT_VAULT` (or `--vault`) is required — there is no project-file or interactive-picker fallback.
 
     | Flag | Default | Description |
     |------|---------|-------------|
@@ -601,7 +601,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault proposal create [flags]
     ```
 
-    Create a proposal to request services or credentials. Supports two modes: flag-driven (for simple single-service proposals) and JSON file (for complex or multi-service proposals).
+    Create a proposal to request services or credentials. Supports two modes: flag-driven (for simple single-service proposals) and JSON file (for complex or multi-service proposals). In agent mode (`AGENT_VAULT_TOKEN` set), `AGENT_VAULT_VAULT` (or `--vault`) is required — there is no project-file or interactive-picker fallback.
 
     | Flag | Default | Description |
     |------|---------|-------------|

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -246,7 +246,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault discover [flags]
     ```
 
-    Show available services and credentials for the current vault. Requires a vault-scoped session (via `agent-vault run` or `AGENT_VAULT_TOKEN` + `AGENT_VAULT_ADDR` env vars; `AGENT_VAULT_SESSION_TOKEN` is the deprecated alias and still works).
+    Show available services and credentials for the current vault. Requires a vault-scoped session (via `agent-vault run` or `AGENT_VAULT_TOKEN` + `AGENT_VAULT_ADDR` env vars; `AGENT_VAULT_SESSION_TOKEN` is the deprecated alias and still works). In agent mode (`AGENT_VAULT_TOKEN` set), `AGENT_VAULT_VAULT` (or `--vault`) is required — there is no project-file or interactive-picker fallback.
 
     | Flag | Default | Description |
     |------|---------|-------------|

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -523,7 +523,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault credential list [flags]
     ```
 
-    List credential keys in a vault. Alias: `agent-vault vault creds list`.
+    List credential keys in a vault. Alias: `agent-vault vault creds list`. In agent mode (`AGENT_VAULT_TOKEN` set), `AGENT_VAULT_VAULT` (or `--vault`) is required — there is no project-file or interactive-picker fallback.
 
     | Flag | Default | Description |
     |------|---------|-------------|
@@ -536,7 +536,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault credential get <KEY> [flags]
     ```
 
-    Print the decrypted value of a single credential to stdout. Pipe-friendly. Requires member+ role. Alias: `agent-vault vault creds get`.
+    Print the decrypted value of a single credential to stdout. Pipe-friendly. Requires member+ role. Alias: `agent-vault vault creds get`. In agent mode (`AGENT_VAULT_TOKEN` set), `AGENT_VAULT_VAULT` (or `--vault`) is required — there is no project-file or interactive-picker fallback.
 
     | Flag | Default | Description |
     |------|---------|-------------|
@@ -548,7 +548,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault credential set <KEY=VALUE> [KEY2=VALUE2 ...] [flags]
     ```
 
-    Store one or more credentials using `KEY=VALUE` format. Alias: `agent-vault vault creds set`.
+    Store one or more credentials using `KEY=VALUE` format. Alias: `agent-vault vault creds set`. In agent mode (`AGENT_VAULT_TOKEN` set), `AGENT_VAULT_VAULT` (or `--vault`) is required — there is no project-file or interactive-picker fallback.
 
     | Flag | Default | Description |
     |------|---------|-------------|
@@ -560,7 +560,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault credential delete <KEY> [KEY2 ...] [flags]
     ```
 
-    Delete one or more credentials. Alias: `agent-vault vault creds delete`.
+    Delete one or more credentials. Alias: `agent-vault vault creds delete`. In agent mode (`AGENT_VAULT_TOKEN` set), `AGENT_VAULT_VAULT` (or `--vault`) is required — there is no project-file or interactive-picker fallback.
 
     | Flag | Default | Description |
     |------|---------|-------------|

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -246,7 +246,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault discover [flags]
     ```
 
-    Show available services and credentials for the current vault. Requires a vault-scoped session (via `agent-vault run` or `AGENT_VAULT_SESSION_TOKEN` + `AGENT_VAULT_ADDR` env vars).
+    Show available services and credentials for the current vault. Requires a vault-scoped session (via `agent-vault run` or `AGENT_VAULT_TOKEN` + `AGENT_VAULT_ADDR` env vars; `AGENT_VAULT_SESSION_TOKEN` is the deprecated alias and still works).
 
     | Flag | Default | Description |
     |------|---------|-------------|
@@ -262,7 +262,9 @@ description: "Complete reference for all Agent Vault CLI commands."
 
     Wrap a process with Agent Vault environment variables. `agent-vault run` is the shorthand; `agent-vault vault run` is the long form. Both are identical in behavior and flags.
 
-    The child process receives `AGENT_VAULT_ADDR`, `AGENT_VAULT_SESSION_TOKEN`, and `AGENT_VAULT_VAULT`, plus `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `NODE_USE_ENV_PROXY` and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) pointing at `~/.agent-vault/mitm-ca.pem`, so standard HTTP and HTTPS clients transparently route through the broker. `HTTPS_PROXY` and `HTTP_PROXY` both point at the same TLS-wrapped proxy URL — the listener handles CONNECT for `https://` upstreams and absolute-form forward-proxy requests for `http://` upstreams on the same port. If the server's MITM proxy is unreachable, `vault run` aborts.
+    The child process receives `AGENT_VAULT_ADDR`, `AGENT_VAULT_TOKEN` (and the deprecated alias `AGENT_VAULT_SESSION_TOKEN`), and `AGENT_VAULT_VAULT`, plus `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` / `NODE_USE_ENV_PROXY` and CA-trust variables (`SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `DENO_CERT`) pointing at `~/.agent-vault/mitm-ca.pem`, so standard HTTP and HTTPS clients transparently route through the broker. `HTTPS_PROXY` and `HTTP_PROXY` both point at the same TLS-wrapped proxy URL — the listener handles CONNECT for `https://` upstreams and absolute-form forward-proxy requests for `http://` upstreams on the same port. If the server's MITM proxy is unreachable, `vault run` aborts.
+
+    **Agent mode (containerized / unattended deployments).** When `AGENT_VAULT_TOKEN` and `AGENT_VAULT_ADDR` are pre-set on the environment, `vault run` skips the admin-session login and uses the env-supplied token as the credential — `--ttl` is rejected in this mode since the token's lifetime is fixed at mint time. The token is validated against the broker once at startup so bad/expired tokens fail fast with a clear error rather than producing 401s on every proxied call. See [Deploy your agent in a container](/guides/deploy-agent-container).
 
     | Flag | Default | Description |
     |------|---------|-------------|
@@ -291,7 +293,7 @@ description: "Complete reference for all Agent Vault CLI commands."
 
     ```bash
     # Export token for use in other commands
-    export AGENT_VAULT_SESSION_TOKEN=$(agent-vault vault token)
+    export AGENT_VAULT_TOKEN=$(agent-vault vault token)
     export AGENT_VAULT_ADDR=http://localhost:14321
     export AGENT_VAULT_VAULT=default
 

--- a/docs/self-hosting/environment-variables.mdx
+++ b/docs/self-hosting/environment-variables.mdx
@@ -62,14 +62,17 @@ Configure SMTP to enable Agent Vault to send emails for verification codes, vaul
 
 ## Agent runtime variables
 
-These variables are set automatically by `agent-vault vault run` on the agent's environment. You do not need to set them manually.
+These variables are set automatically by `agent-vault vault run` on the agent's environment for local / interactive use. You do not need to set them manually in that case.
+
+For **unattended / containerized deployments** (no human to `auth login`), set them yourself on the agent process — `agent-vault run` will skip the mint step and use the supplied token as the credential. See [Deploy your agent in a container](/guides/deploy-agent-container) for the full recipe.
 
 ### Control-plane
 
 | Variable | Description |
 |----------|-------------|
 | `AGENT_VAULT_ADDR` | Server base URL (e.g., `http://127.0.0.1:14321`) |
-| `AGENT_VAULT_SESSION_TOKEN` | Bearer token for authenticating with Agent Vault (control-plane: `/discover`, proposals, credentials). Scoped to the vault. |
+| `AGENT_VAULT_TOKEN` | Bearer token for authenticating with Agent Vault (control-plane: `/discover`, proposals, credentials). Either a vault-scoped session token or a long-lived agent token. |
+| `AGENT_VAULT_SESSION_TOKEN` | Deprecated alias of `AGENT_VAULT_TOKEN`. Still honored with a one-time stderr warning; will be removed in a future major version. |
 | `AGENT_VAULT_VAULT` | Name of the vault the session is scoped to |
 
 ### Transparent proxy

--- a/internal/isolation/env.go
+++ b/internal/isolation/env.go
@@ -93,7 +93,8 @@ func BuildContainerEnv(token, vault string, httpPort, mitmPort int, mitmTLS bool
 		MITMTLS: mitmTLS,
 	})
 	return append(env,
-		"AGENT_VAULT_SESSION_TOKEN="+token,
+		"AGENT_VAULT_TOKEN="+token,
+		"AGENT_VAULT_SESSION_TOKEN="+token, // deprecated alias
 		"AGENT_VAULT_ADDR="+fmt.Sprintf("http://%s:%d", ContainerProxyHost, httpPort),
 		"AGENT_VAULT_VAULT="+vault,
 		fmt.Sprintf("VAULT_HTTP_PORT=%d", httpPort),

--- a/internal/isolation/env_test.go
+++ b/internal/isolation/env_test.go
@@ -74,8 +74,11 @@ func TestBuildContainerEnv_AgentVaultAddrUsesContainerHost(t *testing.T) {
 	if vars["AGENT_VAULT_ADDR"] != want {
 		t.Errorf("AGENT_VAULT_ADDR = %q, want %q", vars["AGENT_VAULT_ADDR"], want)
 	}
+	if vars["AGENT_VAULT_TOKEN"] != "tok" {
+		t.Errorf("AGENT_VAULT_TOKEN = %q", vars["AGENT_VAULT_TOKEN"])
+	}
 	if vars["AGENT_VAULT_SESSION_TOKEN"] != "tok" {
-		t.Errorf("session token = %q", vars["AGENT_VAULT_SESSION_TOKEN"])
+		t.Errorf("AGENT_VAULT_SESSION_TOKEN (deprecated alias) = %q", vars["AGENT_VAULT_SESSION_TOKEN"])
 	}
 	if vars["AGENT_VAULT_VAULT"] != "v" {
 		t.Errorf("vault = %q", vars["AGENT_VAULT_VAULT"])

--- a/sdks/sdk-typescript/src/http.ts
+++ b/sdks/sdk-typescript/src/http.ts
@@ -33,8 +33,28 @@ const SDK_VERSION = "0.1.0";
 const USER_AGENT = `agent-vault-sdk-typescript/${SDK_VERSION}`;
 const DEFAULT_TIMEOUT = 30_000;
 const DEFAULT_ADDRESS = "http://localhost:14321";
-const ENV_TOKEN = "AGENT_VAULT_SESSION_TOKEN";
+const ENV_TOKEN = "AGENT_VAULT_TOKEN";
+const ENV_TOKEN_LEGACY = "AGENT_VAULT_SESSION_TOKEN";
 const ENV_ADDR = "AGENT_VAULT_ADDR";
+
+let legacyTokenWarned = false;
+
+/**
+ * Resolve a token from env: prefer AGENT_VAULT_TOKEN, fall back to the
+ * deprecated AGENT_VAULT_SESSION_TOKEN with a one-time warning. Returns
+ * undefined if neither is set.
+ */
+function readEnvToken(): string | undefined {
+  const fresh = process.env[ENV_TOKEN];
+  if (fresh) return fresh;
+  const legacy = process.env[ENV_TOKEN_LEGACY];
+  if (legacy && !legacyTokenWarned) {
+    legacyTokenWarned = true;
+    // eslint-disable-next-line no-console
+    console.warn(`agent-vault: ${ENV_TOKEN_LEGACY} is deprecated; use ${ENV_TOKEN} instead.`);
+  }
+  return legacy;
+}
 
 /**
  * Internal HTTP client that wraps `fetch` with Agent Vault conventions.
@@ -65,7 +85,7 @@ export class HttpClient {
    */
   static fromConfig(config?: ClientConfig): HttpClient {
     const cfg = config ?? {};
-    const token = cfg.token ?? process.env[ENV_TOKEN];
+    const token = cfg.token ?? readEnvToken();
     if (!token) {
       throw new AgentVaultError(
         `Token is required. Provide it in the config or set the ${ENV_TOKEN} environment variable.`,

--- a/sdks/sdk-typescript/src/types.ts
+++ b/sdks/sdk-typescript/src/types.ts
@@ -7,7 +7,8 @@
 export interface ClientConfig {
   /**
    * Authentication token.
-   * Falls back to `AGENT_VAULT_SESSION_TOKEN` environment variable.
+   * Falls back to `AGENT_VAULT_TOKEN` environment variable
+   * (or the deprecated `AGENT_VAULT_SESSION_TOKEN` with a one-time warning).
    */
   token?: string;
 

--- a/sdks/sdk-typescript/tests/client.test.ts
+++ b/sdks/sdk-typescript/tests/client.test.ts
@@ -8,6 +8,7 @@ describe("AgentVault", () => {
 
   beforeEach(() => {
     process.env = { ...originalEnv };
+    delete process.env.AGENT_VAULT_TOKEN;
     delete process.env.AGENT_VAULT_SESSION_TOKEN;
     delete process.env.AGENT_VAULT_ADDR;
   });
@@ -27,21 +28,35 @@ describe("AgentVault", () => {
       expect(() => new AgentVault()).toThrow("Token is required");
     });
 
-    it("reads token from AGENT_VAULT_SESSION_TOKEN env var", () => {
-      process.env.AGENT_VAULT_SESSION_TOKEN = "env-token";
+    it("reads token from AGENT_VAULT_TOKEN env var", () => {
+      process.env.AGENT_VAULT_TOKEN = "env-token";
+      const av = new AgentVault();
+      expect(av).toBeInstanceOf(AgentVault);
+    });
+
+    it("falls back to deprecated AGENT_VAULT_SESSION_TOKEN env var", () => {
+      process.env.AGENT_VAULT_SESSION_TOKEN = "legacy-token";
+      const av = new AgentVault();
+      expect(av).toBeInstanceOf(AgentVault);
+    });
+
+    it("prefers AGENT_VAULT_TOKEN over the deprecated alias", () => {
+      process.env.AGENT_VAULT_TOKEN = "new-token";
+      process.env.AGENT_VAULT_SESSION_TOKEN = "legacy-token";
+      // Doesn't throw — new var wins; this just exercises the precedence path.
       const av = new AgentVault();
       expect(av).toBeInstanceOf(AgentVault);
     });
 
     it("prefers config token over env var", () => {
-      process.env.AGENT_VAULT_SESSION_TOKEN = "env-token";
+      process.env.AGENT_VAULT_TOKEN = "env-token";
       // Should not throw — config token takes precedence
       const av = new AgentVault({ token: "config-token" });
       expect(av).toBeInstanceOf(AgentVault);
     });
 
     it("reads address from AGENT_VAULT_ADDR env var", () => {
-      process.env.AGENT_VAULT_SESSION_TOKEN = "test-token";
+      process.env.AGENT_VAULT_TOKEN = "test-token";
       process.env.AGENT_VAULT_ADDR = "http://custom:9999";
       const av = new AgentVault();
       expect(av).toBeInstanceOf(AgentVault);

--- a/sdks/sdk-typescript/tests/vault.test.ts
+++ b/sdks/sdk-typescript/tests/vault.test.ts
@@ -8,6 +8,7 @@ describe("VaultClient", () => {
 
   beforeEach(() => {
     process.env = { ...originalEnv };
+    delete process.env.AGENT_VAULT_TOKEN;
     delete process.env.AGENT_VAULT_SESSION_TOKEN;
     delete process.env.AGENT_VAULT_ADDR;
   });
@@ -27,8 +28,14 @@ describe("VaultClient", () => {
       expect(() => new VaultClient()).toThrow("Token is required");
     });
 
-    it("reads token from AGENT_VAULT_SESSION_TOKEN env var", () => {
-      process.env.AGENT_VAULT_SESSION_TOKEN = "env-token";
+    it("reads token from AGENT_VAULT_TOKEN env var", () => {
+      process.env.AGENT_VAULT_TOKEN = "env-token";
+      const vault = new VaultClient();
+      expect(vault).toBeInstanceOf(VaultClient);
+    });
+
+    it("falls back to deprecated AGENT_VAULT_SESSION_TOKEN env var", () => {
+      process.env.AGENT_VAULT_SESSION_TOKEN = "legacy-token";
       const vault = new VaultClient();
       expect(vault).toBeInstanceOf(VaultClient);
     });

--- a/web/src/pages/vault/TokensTab.tsx
+++ b/web/src/pages/vault/TokensTab.tsx
@@ -359,7 +359,7 @@ function MintTokenButton({
               <Input
                 value={label}
                 onChange={(e) => setLabel(e.target.value)}
-                placeholder="claude-code laptop"
+                placeholder="claude-code"
                 maxLength={100}
                 autoFocus
               />

--- a/web/src/pages/vault/TokensTab.tsx
+++ b/web/src/pages/vault/TokensTab.tsx
@@ -349,7 +349,7 @@ function MintTokenButton({
               />
             </div>
             <p className="text-xs text-text-dim">
-              Use with <code className="text-text-muted">AGENT_VAULT_SESSION_TOKEN</code>, or in
+              Use with <code className="text-text-muted">AGENT_VAULT_TOKEN</code>, or in
               an <code className="text-text-muted">HTTPS_PROXY</code> URL as the userinfo.
             </p>
           </div>


### PR DESCRIPTION
## Summary

- `agent-vault run` now accepts a pre-supplied token via env (`AGENT_VAULT_TOKEN` + `AGENT_VAULT_ADDR` + `AGENT_VAULT_VAULT`) and skips the admin-session/mint flow — the path needed for unattended container deploys (k8s, Fly, ECS) where there's no TTY and no on-disk session. The token is validated against `/discover` once at startup so bad/expired tokens fail fast with a clear error rather than producing 401s on every proxied call. `--ttl` is rejected in this mode (token lifetime is fixed at mint time).
- Renames `AGENT_VAULT_SESSION_TOKEN` → `AGENT_VAULT_TOKEN` to match industry convention (`GITHUB_TOKEN`, `STRIPE_API_KEY`). The old name remains a backward-compat alias with a one-time stderr deprecation warning; `vault run` sets both names on the child env during the deprecation window so SDK consumers keep working until they update.
- Both surfaces of the agent-facing contract updated as a pair (`cmd/skill_cli.md`, `cmd/skill_http.md`); env-var docs updated in all three required places (`.env.example`, `docs/self-hosting/environment-variables.mdx`, `docs/reference/cli.mdx`); TypeScript SDK adopts the same fallback-with-deprecation-warning pattern; new `docs/guides/deploy-agent-container.mdx` walks through the Dockerfile + 3-env-var deploy recipe.

## Test plan

- [x] `go test ./...` — `cmd/` green, SDK 94/94 green. (`internal/isolation/TestParseAndValidateMount_RejectDockerSocket` fails the same way on `main` — pre-existing, unrelated.)
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [x] New unit coverage in `cmd/cmd_test.go` and `cmd/run_test.go`: agent-mode env-var resolution (new + legacy + precedence + missing-addr error), `validateEnvToken` happy path + 401, `resolveVaultForAgentMode` (flag/env/error), `--ttl` rejection in agent mode.
- [ ] Local end-to-end smoke: admin mode (`auth login` → `agent-vault run -- env | grep AGENT_VAULT` shows both env-var names).
- [ ] Local end-to-end smoke: agent mode with no on-disk session — `AGENT_VAULT_TOKEN=… AGENT_VAULT_ADDR=… AGENT_VAULT_VAULT=… ./agent-vault run -- curl https://api.github.com/zen` validates, sets up MITM, exec's curl.
- [ ] Local end-to-end smoke: deliberately bad token → friendly startup error before exec; `--ttl 3600` with token pre-set → hard error.
- [ ] Container smoke test: build the Dockerfile from the new guide; `docker run` with the three env vars against a local broker.

## Notes

- `AGENT_VAULT_SESSION_TOKEN` removal is deferred to a future major version. Worth tracking in the changelog so it's not forgotten.
- Out of scope (deferred per the design discussion): `--ca-path` for distroless images, `AGENT_VAULT_URL` connection-string env, multi-vault default policy when `AGENT_VAULT_VAULT` is unset, published `ghcr.io/infisical/agent-vault` binary distribution.