### PR TITLE
examples: add nginx reverse proxy for the management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ agent-vault server -d
 
 The server starts the HTTP API on port `14321` and a TLS-encrypted transparent HTTP/HTTPS proxy on port `14322` — the same listener handles `CONNECT` for `https://` upstreams and absolute-form forward-proxy requests for `http://` upstreams. A web UI is available at `http://localhost:14321`.
 
+When self-hosting on a platform with a public/private service split, you may find it helpful to keep port `14322` on the private network and front port `14321` with a reverse proxy so humans can reach the management UI without exposing the broker. See [examples/nginx-public-ui-proxy/](examples/nginx-public-ui-proxy/) for a working nginx example.
+
 ## Quickstart
 
 ### CLI — local agents (Claude Code, Cursor, Codex, OpenClaw, Hermes, OpenCode)

--- a/examples/nginx-public-ui-proxy/.dockerignore
+++ b/examples/nginx-public-ui-proxy/.dockerignore
@@ -1,0 +1,3 @@
+README.md
+.dockerignore
+docker-compose.yml

--- a/examples/nginx-public-ui-proxy/Dockerfile
+++ b/examples/nginx-public-ui-proxy/Dockerfile
@@ -2,6 +2,10 @@ FROM nginx:1.27-alpine
 
 RUN rm /etc/nginx/conf.d/default.conf
 
+# Default the listen port to 8080 — PaaS-injected PORT still wins because env
+# vars set at container start override Dockerfile ENV.
+ENV PORT=8080
+
 COPY nginx.conf /etc/nginx/nginx.conf
 
 # Files in /etc/nginx/templates/*.template have ${VAR} expanded by the entrypoint at start.

--- a/examples/nginx-public-ui-proxy/Dockerfile
+++ b/examples/nginx-public-ui-proxy/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:1.27-alpine
+
+RUN rm /etc/nginx/conf.d/default.conf
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Files in /etc/nginx/templates/*.template have ${VAR} expanded by the entrypoint at start.
+COPY default.conf.template /etc/nginx/templates/default.conf.template

--- a/examples/nginx-public-ui-proxy/README.md
+++ b/examples/nginx-public-ui-proxy/README.md
@@ -65,10 +65,12 @@ Set these on the upstream Agent Vault service so it behaves correctly behind a r
 |--------|---------------|
 | Public traffic to port `14322` | The reverse proxy has no route there. The `proxy_pass` only ever points at `14321`. |
 | `CONNECT` tunneling through the reverse proxy | Explicit `return 405` on `CONNECT`. |
-| oauth2-proxy-style header spoofing | `X-Forwarded-User` and `X-Auth-Request-User` are stripped. |
+
+The config also strips `X-Forwarded-User` and `X-Auth-Request-User` preemptively. Agent Vault doesn't trust these headers today, but stripping prevents a client from arriving pre-authed if a future version grows oauth2-proxy-style trusted-header support before this config is reviewed.
 
 ## What this does NOT protect
 
+- **TLS termination at this reverse proxy.** It listens on plain HTTP at `${PORT}`. The example assumes TLS is terminated in front (PaaS load balancer, Cloudflare). On a bare VM or plain Docker host, add an `ssl` listener here too.
 - **In-network traffic encryption.** Reverse proxy → Agent Vault is plain HTTP. Most PaaS private networks are isolated; if your threat model needs in-network encryption, terminate TLS at the upstream too.
 - **A compromised reverse proxy host.** If the reverse proxy VM is rooted, the attacker can reach the upstream. This reverse proxy is one layer of defense in depth, not the only one.
 

--- a/examples/nginx-public-ui-proxy/README.md
+++ b/examples/nginx-public-ui-proxy/README.md
@@ -1,6 +1,6 @@
 # nginx public UI proxy
 
-Reverse proxy that exposes Agent Vault's management UI (port `14321`) on the public internet while keeping the MITM proxy (port `14322`) on the private network. Platform-agnostic — works wherever Docker runs.
+A reverse proxy that exposes Agent Vault's management UI (port `14321`) on the public internet while keeping the MITM proxy (port `14322`) on the private network. Platform-agnostic — works wherever Docker runs.
 
 ## Why
 
@@ -11,20 +11,20 @@ Agent Vault binds two ports on the same host:
 
 Anyone with a leaked `HTTPS_PROXY` value (a single `printenv` from a prompt-injected agent) can call through Agent Vault from anywhere they can reach `14322`. Keeping `14322` unreachable from the public internet is what makes a leaked value useless to an attacker.
 
-Most PaaS providers offer a public/private service split. Deploy Agent Vault as a private service and put this nginx in front of it as a public service. The gateway has no route to `14322` — agents reach it directly over the private network.
+Most PaaS providers offer a public/private service split. Deploy Agent Vault as a private service and put this reverse proxy in front of it as a public service. The reverse proxy has no route to `14322` — agents reach it directly over the private network.
 
 ```
-PUBLIC INTERNET                          PRIVATE NETWORK
-───────────────                          ─────────────────────────────────
-                                           ┌────────────────────────────┐
-[browser] ─HTTPS─► [nginx gateway] ──────► │ Agent Vault                │
-                                           │   :14321  management UI    │
-                                           │   :14322  MITM proxy       │
-                                           └────────────────────────────┘
-                                                  ▲                 │
-                                                  │ HTTPS_PROXY     ▼
-                                           [agent service]   [external APIs]
-                                                              (creds injected)
+PUBLIC INTERNET                              PRIVATE NETWORK
+───────────────                              ─────────────────────────────────
+                                               ┌────────────────────────────┐
+[browser] ─HTTPS─► [nginx reverse proxy] ────► │ Agent Vault                │
+                                               │   :14321  management UI    │
+                                               │   :14322  MITM proxy       │
+                                               └────────────────────────────┘
+                                                      ▲                 │
+                                                      │ HTTPS_PROXY     ▼
+                                               [agent service]   [external APIs]
+                                                                  (creds injected)
 ```
 
 ## Run it locally
@@ -33,15 +33,15 @@ PUBLIC INTERNET                          PRIVATE NETWORK
 docker compose up
 ```
 
-Visit `http://localhost:8080` to reach the management UI through the gateway. Agent Vault stays on the compose-internal network only.
+Visit `http://localhost:8080` to reach the management UI through the reverse proxy. Agent Vault stays on the compose-internal network only.
 
 ## Configure
 
-### On the gateway
+### On the reverse proxy
 
 | Var | Default | Description |
 |-----|---------|-------------|
-| `PORT` | `8080` | Port the gateway listens on. Most PaaS providers inject this automatically. |
+| `PORT` | `8080` | Port the reverse proxy listens on. Most PaaS providers inject this automatically. |
 | `AV_UPSTREAM` | (required) | `host:port` of Agent Vault's management API on the private network. |
 
 Examples for `AV_UPSTREAM`:
@@ -56,30 +56,30 @@ Set these on the upstream Agent Vault service so it behaves correctly behind a r
 
 | Var | Why it matters |
 |-----|----------------|
-| `AGENT_VAULT_ADDR` | Public URL of the gateway. Drives the `av_session` cookie's `Secure` flag and external links in notification emails. If unset, defaults to the bind addr — wrong for public exposure. |
-| `AGENT_VAULT_TRUSTED_PROXIES` | CIDR(s) the gateway sits on. Without it, audit logs record the gateway's IP for every request instead of the real client's. |
+| `AGENT_VAULT_ADDR` | Public URL of the reverse proxy. Drives the `av_session` cookie's `Secure` flag and external links in notification emails. If unset, defaults to the bind addr — wrong for public exposure. |
+| `AGENT_VAULT_TRUSTED_PROXIES` | CIDR(s) the reverse proxy sits on. Without it, audit logs record the reverse proxy's IP for every request instead of the real client's. |
 
 ## What this protects
 
 | Attack | What stops it |
 |--------|---------------|
-| Public traffic to port `14322` | Gateway has no route there. The `proxy_pass` only ever points at `14321`. |
-| `CONNECT` tunneling through the gateway | Explicit `return 405` on `CONNECT`. |
+| Public traffic to port `14322` | The reverse proxy has no route there. The `proxy_pass` only ever points at `14321`. |
+| `CONNECT` tunneling through the reverse proxy | Explicit `return 405` on `CONNECT`. |
 | oauth2-proxy-style header spoofing | `X-Forwarded-User` and `X-Auth-Request-User` are stripped. |
 
 ## What this does NOT protect
 
-- **In-network traffic encryption.** Gateway → Agent Vault is plain HTTP. Most PaaS private networks are isolated; if your threat model needs in-network encryption, terminate TLS at the upstream too.
-- **A compromised gateway host.** If the gateway VM is rooted, the attacker can reach the upstream. This gateway is one layer of defense in depth, not the only one.
+- **In-network traffic encryption.** Reverse proxy → Agent Vault is plain HTTP. Most PaaS private networks are isolated; if your threat model needs in-network encryption, terminate TLS at the upstream too.
+- **A compromised reverse proxy host.** If the reverse proxy VM is rooted, the attacker can reach the upstream. This reverse proxy is one layer of defense in depth, not the only one.
 
 ## Why we don't strip `Authorization`
 
-Most reverse-proxy guides tell you to strip `Authorization` so a client can't arrive pre-authed. That advice assumes the gateway *injects* auth on the client's behalf. This gateway is passthrough — Agent Vault's management API uses `Authorization: Bearer <token>` for its CLI and any non-browser caller, and validates the token against its own session store. A forged Authorization gets a 401. Stripping it would break the CLI and any agent that hits the management API.
+Most reverse-proxy guides tell you to strip `Authorization` so a client can't arrive pre-authed. That advice assumes the reverse proxy *injects* auth on the client's behalf. This config is passthrough — Agent Vault's management API uses `Authorization: Bearer <token>` for its CLI and any non-browser caller, and validates the token against its own session store. A forged Authorization gets a 401. Stripping it would break the CLI and any agent that hits the management API.
 
 ## Verify
 
 ```bash
-# Gateway is alive
+# Reverse proxy is alive
 curl -fsS http://localhost:8080/healthz       # → ok
 
 # Agent Vault's /health forwards through
@@ -89,7 +89,7 @@ curl -fsS http://localhost:8080/health        # → {"status":"ok"}
 curl -i -X CONNECT http://localhost:8080/     # → 405
 ```
 
-To verify trust-header stripping in isolation, uncomment the `echo` service in `docker-compose.yml`, change the gateway's `AV_UPSTREAM` to `echo:8080`, then send a request with `X-Forwarded-User: attacker` and `Authorization: Bearer should-pass-through`. The echoed headers should show `Authorization` present and `X-Forwarded-User` absent.
+To verify trust-header stripping in isolation, uncomment the `echo` service in `docker-compose.yml`, change the reverse proxy's `AV_UPSTREAM` to `echo:8080`, then send a request with `X-Forwarded-User: attacker` and `Authorization: Bearer should-pass-through`. The echoed headers should show `Authorization` present and `X-Forwarded-User` absent.
 
 ## Adapt
 

--- a/examples/nginx-public-ui-proxy/README.md
+++ b/examples/nginx-public-ui-proxy/README.md
@@ -1,0 +1,96 @@
+# nginx public UI proxy
+
+Reverse proxy that exposes Agent Vault's management UI (port `14321`) on the public internet while keeping the MITM proxy (port `14322`) on the private network. Platform-agnostic — works wherever Docker runs.
+
+## Why
+
+Agent Vault binds two ports on the same host:
+
+- `14321` — management UI/API. Humans need this to add credentials, approve proposals, etc.
+- `14322` — transparent MITM proxy. Agents call through it with `HTTPS_PROXY=user:pw@vault:14322`.
+
+Anyone with a leaked `HTTPS_PROXY` value (a single `printenv` from a prompt-injected agent) can call through Agent Vault from anywhere they can reach `14322`. Keeping `14322` unreachable from the public internet is what makes a leaked value useless to an attacker.
+
+Most PaaS providers offer a public/private service split. Deploy Agent Vault as a private service and put this nginx in front of it as a public service. The gateway has no route to `14322` — agents reach it directly over the private network.
+
+```
+PUBLIC INTERNET                          PRIVATE NETWORK
+───────────────                          ─────────────────────────────────
+                                           ┌────────────────────────────┐
+[browser] ─HTTPS─► [nginx gateway] ──────► │ Agent Vault                │
+                                           │   :14321  management UI    │
+                                           │   :14322  MITM proxy       │
+                                           └────────────────────────────┘
+                                                  ▲                 │
+                                                  │ HTTPS_PROXY     ▼
+                                           [agent service]   [external APIs]
+                                                              (creds injected)
+```
+
+## Run it locally
+
+```bash
+docker compose up
+```
+
+Visit `http://localhost:8080` to reach the management UI through the gateway. Agent Vault stays on the compose-internal network only.
+
+## Configure
+
+### On the gateway
+
+| Var | Default | Description |
+|-----|---------|-------------|
+| `PORT` | `8080` | Port the gateway listens on. Most PaaS providers inject this automatically. |
+| `AV_UPSTREAM` | (required) | `host:port` of Agent Vault's management API on the private network. |
+
+Examples for `AV_UPSTREAM`:
+
+- Render: `agent-vault-ab12:14321`
+- Fly.io: `agent-vault.internal:14321`
+- Docker Compose: `agent-vault:14321`
+
+### On the Agent Vault side
+
+Set these on the upstream Agent Vault service so it behaves correctly behind a reverse proxy (see [environment-variables.mdx](../../docs/self-hosting/environment-variables.mdx)):
+
+| Var | Why it matters |
+|-----|----------------|
+| `AGENT_VAULT_ADDR` | Public URL of the gateway. Drives the `av_session` cookie's `Secure` flag and external links in notification emails. If unset, defaults to the bind addr — wrong for public exposure. |
+| `AGENT_VAULT_TRUSTED_PROXIES` | CIDR(s) the gateway sits on. Without it, audit logs record the gateway's IP for every request instead of the real client's. |
+
+## What this protects
+
+| Attack | What stops it |
+|--------|---------------|
+| Public traffic to port `14322` | Gateway has no route there. The `proxy_pass` only ever points at `14321`. |
+| `CONNECT` tunneling through the gateway | Explicit `return 405` on `CONNECT`. |
+| oauth2-proxy-style header spoofing | `X-Forwarded-User` and `X-Auth-Request-User` are stripped. |
+
+## What this does NOT protect
+
+- **In-network traffic encryption.** Gateway → Agent Vault is plain HTTP. Most PaaS private networks are isolated; if your threat model needs in-network encryption, terminate TLS at the upstream too.
+- **A compromised gateway host.** If the gateway VM is rooted, the attacker can reach the upstream. This gateway is one layer of defense in depth, not the only one.
+
+## Why we don't strip `Authorization`
+
+Most reverse-proxy guides tell you to strip `Authorization` so a client can't arrive pre-authed. That advice assumes the gateway *injects* auth on the client's behalf. This gateway is passthrough — Agent Vault's management API uses `Authorization: Bearer <token>` for its CLI and any non-browser caller, and validates the token against its own session store. A forged Authorization gets a 401. Stripping it would break the CLI and any agent that hits the management API.
+
+## Verify
+
+```bash
+# Gateway is alive
+curl -fsS http://localhost:8080/healthz       # → ok
+
+# Agent Vault's /health forwards through
+curl -fsS http://localhost:8080/health        # → {"status":"ok"}
+
+# CONNECT is refused
+curl -i -X CONNECT http://localhost:8080/     # → 405
+```
+
+To verify trust-header stripping in isolation, uncomment the `echo` service in `docker-compose.yml`, change the gateway's `AV_UPSTREAM` to `echo:8080`, then send a request with `X-Forwarded-User: attacker` and `Authorization: Bearer should-pass-through`. The echoed headers should show `Authorization` present and `X-Forwarded-User` absent.
+
+## Adapt
+
+Change ports, add rate limits (`limit_req_zone`), restrict source IPs (`allow`/`deny`), or swap nginx for Caddy — see the [nginx docs](https://nginx.org/en/docs/). Keep `proxy_pass` pointed at the management port only.

--- a/examples/nginx-public-ui-proxy/default.conf.template
+++ b/examples/nginx-public-ui-proxy/default.conf.template
@@ -10,7 +10,7 @@ server {
     # Local liveness probe; Agent Vault's own /health forwards through normally.
     location = /healthz {
         access_log off;
-        add_header Content-Type text/plain;
+        default_type text/plain;
         return 200 "ok\n";
     }
 

--- a/examples/nginx-public-ui-proxy/default.conf.template
+++ b/examples/nginx-public-ui-proxy/default.conf.template
@@ -7,14 +7,14 @@ server {
     listen ${PORT};
     server_name _;
 
-    # Gateway-local liveness probe; Agent Vault's own /health forwards through normally.
+    # Local liveness probe; Agent Vault's own /health forwards through normally.
     location = /healthz {
         access_log off;
         add_header Content-Type text/plain;
         return 200 "ok\n";
     }
 
-    # Refuse CONNECT — accepting it would turn this gateway into an open forward proxy.
+    # Refuse CONNECT — accepting it would turn this reverse proxy into an open forward proxy.
     if ($request_method = CONNECT) {
         return 405;
     }

--- a/examples/nginx-public-ui-proxy/default.conf.template
+++ b/examples/nginx-public-ui-proxy/default.conf.template
@@ -1,0 +1,42 @@
+upstream agent_vault {
+    server ${AV_UPSTREAM};
+    keepalive 16;
+}
+
+server {
+    listen ${PORT};
+    server_name _;
+
+    # Gateway-local liveness probe; Agent Vault's own /health forwards through normally.
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+    }
+
+    # Refuse CONNECT — accepting it would turn this gateway into an open forward proxy.
+    if ($request_method = CONNECT) {
+        return 405;
+    }
+
+    # MITM port 14322 is intentionally absent — never add it. See README.
+    location / {
+        proxy_pass http://agent_vault;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Strip oauth2-proxy-style headers in case future Vault versions trust them.
+        proxy_set_header X-Forwarded-User    "";
+        proxy_set_header X-Auth-Request-User "";
+
+        # Authorization is intentionally NOT stripped — see README "Why we don't strip Authorization".
+
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
+    }
+}

--- a/examples/nginx-public-ui-proxy/docker-compose.yml
+++ b/examples/nginx-public-ui-proxy/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  agent-vault:
+    image: infisical/agent-vault:latest
+    environment:
+      AGENT_VAULT_MASTER_PASSWORD: changeme-for-local-testing
+      # Public URL the user hits — drives av_session Secure flag and email links.
+      AGENT_VAULT_ADDR: http://localhost:8080
+      # Demo only: trust the whole compose network. Scope to gateway CIDR in prod.
+      AGENT_VAULT_TRUSTED_PROXIES: 0.0.0.0/0
+    volumes:
+      - agent-vault-data:/data
+
+  gateway:
+    build: .
+    environment:
+      PORT: 8080
+      AV_UPSTREAM: agent-vault:14321
+    ports:
+      - "8080:8080"
+    depends_on:
+      - agent-vault
+
+  # Verification harness for trust-header stripping: uncomment, then in the
+  # gateway service set AV_UPSTREAM=echo:8080.
+  #
+  # echo:
+  #   image: mendhak/http-https-echo:34
+  #   environment:
+  #     HTTP_PORT: 8080
+
+volumes:
+  agent-vault-data:

--- a/examples/nginx-public-ui-proxy/docker-compose.yml
+++ b/examples/nginx-public-ui-proxy/docker-compose.yml
@@ -5,12 +5,12 @@ services:
       AGENT_VAULT_MASTER_PASSWORD: changeme-for-local-testing
       # Public URL the user hits — drives av_session Secure flag and email links.
       AGENT_VAULT_ADDR: http://localhost:8080
-      # Demo only: trust the whole compose network. Scope to gateway CIDR in prod.
+      # Demo only: trust the whole compose network. Scope to the reverse proxy CIDR in prod.
       AGENT_VAULT_TRUSTED_PROXIES: 0.0.0.0/0
     volumes:
       - agent-vault-data:/data
 
-  gateway:
+  reverse-proxy:
     build: .
     environment:
       PORT: 8080
@@ -21,7 +21,7 @@ services:
       - agent-vault
 
   # Verification harness for trust-header stripping: uncomment, then in the
-  # gateway service set AV_UPSTREAM=echo:8080.
+  # reverse-proxy service set AV_UPSTREAM=echo:8080.
   #
   # echo:
   #   image: mendhak/http-https-echo:34

--- a/examples/nginx-public-ui-proxy/nginx.conf
+++ b/examples/nginx-public-ui-proxy/nginx.conf
@@ -1,0 +1,24 @@
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent"';
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+    keepalive_timeout 65;
+
+    server_tokens off;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
## Summary

- Adds [examples/nginx-public-ui-proxy/](examples/nginx-public-ui-proxy/) — a small, platform-agnostic nginx config for self-hosters who want to expose Agent Vault's management UI (port `14321`) publicly while keeping the transparent MITM proxy (port `14322`) on the private network. The reverse proxy has no route to `14322`, refuses `CONNECT` (defense in depth against being coerced into an open forward proxy), strips oauth2-proxy-style trust headers preemptively, and **passes `Authorization` through** so the CLI and any non-browser caller keep working — the management API uses `Authorization: Bearer ...` and validates against its own session store.
- Ships `docker-compose.yml` that doubles as a local verification harness (commented-out echo service for header-stripping verification in isolation).
- Adds a one-paragraph cross-link from the top-level `README.md` Installation section.

## Test plan

Local (requires Docker):

- [ ] `docker build -t av-rp-test examples/nginx-public-ui-proxy/ && docker run --rm -e PORT=8080 -e AV_UPSTREAM=u:14321 av-rp-test nginx -t` — config parses
- [ ] From `examples/nginx-public-ui-proxy/`: `docker compose up -d`
- [ ] `curl -fsS http://localhost:8080/healthz` → `ok`
- [ ] `curl -fsS http://localhost:8080/health` → `{"status":"ok"}` (forwards through to upstream)
- [ ] `curl -i -X CONNECT http://localhost:8080/` → `405`
- [ ] Uncomment `echo` service, set `AV_UPSTREAM=echo:8080`, send `X-Forwarded-User: attacker` and `Authorization: Bearer x` — echoed headers show `X-Forwarded-User` absent and `Authorization` present
- [ ] `docker compose down -v`

Cloud-platform smoke tests (Render, Fly) are left to whoever has the accounts.

## Notes

- Pinned to `nginx:1.27-alpine` — bump via PR.
- Upstream block uses `keepalive 16` so `proxy_http_version 1.1` actually reuses sockets.
- The reverse proxy listens on plain HTTP; the example assumes TLS is terminated in front (PaaS LB, Cloudflare). README calls this out under "What this does NOT protect".
- No `docs/self-hosting/` page in this PR; deferring as a follow-up.