### PR TITLE
docs: fix release verification commands and pin cosign identity

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -123,13 +123,13 @@ release:
     ## Verify
 
     ```bash
-    # Verify checksum
-    sha256sum --check checksums.txt
+    # Verify checksum (portable across macOS and Linux)
+    shasum -a 256 --ignore-missing -c checksums.txt
 
-    # Verify signature (requires cosign)
+    # Verify signature (requires cosign v2+)
     cosign verify-blob \
-      --bundle checksums.txt.bundle \
-      --certificate-identity-regexp "github.com/Infisical/agent-vault" \
+      --bundle checksums.txt.sig \
+      --certificate-identity-regexp "^https://github\.com/Infisical/agent-vault/\.github/workflows/release\.yml@refs/tags/" \
       --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
       checksums.txt
     ```

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -11,12 +11,9 @@ Agent Vault ships as a single binary that acts as both a server and CLI client.
 
 <Tabs>
   <Tab title="Script">
-    Auto-detects your OS and architecture, downloads the latest release, and installs.
-    Works for both fresh installs and upgrades (backs up your database before upgrading).
+    Auto-detects your OS and architecture (macOS on Intel or Apple Silicon, Linux on x86\_64 or ARM64), downloads the latest release, and installs.
 
     <InstallCommand />
-
-    Supports macOS (Intel + Apple Silicon) and Linux (x86\_64 + ARM64).
 
   </Tab>
   <Tab title="Docker">
@@ -53,15 +50,15 @@ agent-vault --help
 Every release includes SHA-256 checksums and a [cosign](https://github.com/sigstore/cosign) signature for supply-chain security. No keys to manage - verification uses GitHub's OIDC identity.
 
 ```bash
-# Download the checksums and signature bundle from the release page, then:
+# Download checksums.txt and checksums.txt.sig from the release page, then:
 
-# 1. Verify the binary hasn't been tampered with
-sha256sum --check checksums.txt
+# 1. Verify the binary hasn't been tampered with (portable across macOS and Linux)
+shasum -a 256 --ignore-missing -c checksums.txt
 
 # 2. Verify the checksums were signed by the Infisical/agent-vault GitHub Actions workflow
 cosign verify-blob \
-  --bundle checksums.txt.bundle \
-  --certificate-identity-regexp "github.com/Infisical/agent-vault" \
+  --bundle checksums.txt.sig \
+  --certificate-identity-regexp "^https://github\.com/Infisical/agent-vault/\.github/workflows/release\.yml@refs/tags/" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   checksums.txt
 ```

--- a/docs/self-hosting/local.mdx
+++ b/docs/self-hosting/local.mdx
@@ -136,15 +136,15 @@ Database migrations run automatically on server startup — no manual steps requ
 Every release includes SHA-256 checksums and a [cosign](https://github.com/sigstore/cosign) signature for supply-chain security. No keys to manage — verification uses GitHub's OIDC identity.
 
 ```bash
-# Download the checksums and signature bundle from the release page, then:
+# Download checksums.txt and checksums.txt.sig from the release page, then:
 
-# 1. Verify the binary hasn't been tampered with
-sha256sum --check checksums.txt
+# 1. Verify the binary hasn't been tampered with (portable across macOS and Linux)
+shasum -a 256 --ignore-missing -c checksums.txt
 
 # 2. Verify the checksums were signed by the Infisical/agent-vault GitHub Actions workflow
 cosign verify-blob \
-  --bundle checksums.txt.bundle \
-  --certificate-identity-regexp "github.com/Infisical/agent-vault" \
+  --bundle checksums.txt.sig \
+  --certificate-identity-regexp "^https://github\.com/Infisical/agent-vault/\.github/workflows/release\.yml@refs/tags/" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   checksums.txt
 ```


### PR DESCRIPTION
## Summary

The verify-a-release instructions had three issues that broke the documented flow on the actual published releases. Verified end-to-end against the live `v0.19.0` release (the new block produces `Verified OK`).

- **Wrong signature filename.** Goreleaser emits `checksums.txt.sig`, but the docs and release-notes footer said `checksums.txt.bundle`. Anyone copy-pasting the documented `cosign verify-blob` command got an immediate "no such file or directory" error. Confirmed against `gh release view v0.19.0 --repo Infisical/agent-vault` that no `.bundle` file is ever published.
- **`sha256sum --check` is not portable.** Stock macOS has no `sha256sum` (only `/usr/bin/shasum`), and on Linux the documented invocation spammed "No such file" for every other-platform binary listed in `checksums.txt`. Switched to `shasum -a 256 --ignore-missing -c`, which is present on stock macOS and on mainstream Linux distros, and silently skips files the user didn't download.
- **Unanchored cosign identity regex.** The previous `--certificate-identity-regexp "github.com/Infisical/agent-vault"` was an unanchored substring match. A hypothetical sibling repo like `Infisical/agent-vault-fork` in the same org would substring-match. Tightened to pin the exact workflow file and tag refs: `^https://github\.com/Infisical/agent-vault/\.github/workflows/release\.yml@refs/tags/`. Mirrors the [sigstore recommended pattern](https://docs.sigstore.dev/cosign/verifying/verify/#github-actions) for verifying GitHub-Actions-signed artifacts.

Same five-line snippet lives in three places, all updated together: `.goreleaser.yml` (release-notes footer), `docs/installation.mdx`, `docs/self-hosting/local.mdx`.

Note: the release-notes footer fix only takes effect on the next release. v0.19.0 and earlier release pages will continue to display the old broken text until manually edited or superseded.

Also bundles a small unrelated copy polish on the install-script tab in `installation.mdx` (consolidates two trailing sentences into one parenthetical) that was staged locally.

## Test plan

- [x] Downloaded `checksums.txt` and `checksums.txt.sig` from the live `v0.19.0` release.
- [x] Ran the new `shasum -a 256 --ignore-missing -c checksums.txt` against a single downloaded binary on macOS arm64. Exit 0, "OK".
- [x] Ran the new `cosign verify-blob` block verbatim. Output: `Verified OK`.
- [x] Negative test with `refs/heads/` instead of `refs/tags/` in the regex correctly rejects.
- [x] Repo-wide grep for `checksums.txt.bundle` and the old unanchored regex returns no hits.
- [ ] Reviewer to confirm the next release's notes display the fixed footer text after merge.