### PR TITLE
docs: rewrite quickstarts around agent-vault run, tighten deploy page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Agent Vault (agent-vault)
 
-A local-first HTTP brokerage layer for AI agents. Sits between development agents (Claude Code, Cursor) and target services (Stripe, GitHub, etc.), proxying requests and injecting credentials so agents never see raw keys or tokens.
+An HTTP brokerage layer for AI agents. Sits between development agents (Claude Code, Cursor) and target services (Stripe, GitHub, etc.), proxying requests and injecting credentials so agents never see raw keys or tokens. Typically deployed to a remote host that agents reach over the network.
 
 ## Build, run, test
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "agent-vault",
-	Short: "Agent Vault, a local-first credential brokerage layer for AI agents",
+	Short: "Agent Vault, a credential brokerage layer for AI agents",
 	Long: `Agent Vault sits between a development agent and target services,
 proxying requests and attaching credentials on behalf of the agent.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -27,7 +27,6 @@
           "quickstart/cursor",
           "quickstart/codex",
           "quickstart/openclaw",
-          "quickstart/nanoclaw",
           "quickstart/hermes-agent",
           "quickstart/opencode",
           "quickstart/custom-agent"

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -85,9 +85,6 @@ Agent Vault matches the target host on the proxied request against the configure
   <Card title="OpenClaw" icon="robot" href="/quickstart/openclaw">
     Connect OpenClaw to Agent Vault.
   </Card>
-  <Card title="NanoClaw" icon="microchip" href="/quickstart/nanoclaw">
-    Connect NanoClaw to Agent Vault.
-  </Card>
   <Card title="Hermes Agent" icon="bolt" href="/quickstart/hermes-agent">
     Connect Hermes Agent to Agent Vault.
   </Card>

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -18,7 +18,7 @@ Each install method below configures a master password at startup. Store it some
     Start the Agent Vault server (pass `-d` to run in the background):
 
     ```bash
-    export AGENT_VAULT_ADDR=http://<your-host>:14321
+    export AGENT_VAULT_ADDR="http://<your-host>:14321"
     agent-vault server
     ```
 
@@ -27,7 +27,7 @@ Each install method below configures a master password at startup. Store it some
     ```bash
     docker run -it -p 14321:14321 -p 14322:14322 \
       -e AGENT_VAULT_MASTER_PASSWORD=your-password \
-      -e AGENT_VAULT_ADDR=http://<your-host>:14321 \
+      -e AGENT_VAULT_ADDR="http://<your-host>:14321" \
       -v agent-vault-data:/data infisical/agent-vault
     ```
 
@@ -47,7 +47,7 @@ Each install method below configures a master password at startup. Store it some
     Start the Agent Vault server (pass `-d` to run in the background):
 
     ```bash
-    export AGENT_VAULT_ADDR=http://<your-host>:14321
+    export AGENT_VAULT_ADDR="http://<your-host>:14321"
     agent-vault server
     ```
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -18,6 +18,7 @@ Each install method below configures a master password at startup. Store it some
     Start the Agent Vault server (pass `-d` to run in the background):
 
     ```bash
+    export AGENT_VAULT_ADDR=http://<your-host>:14321
     agent-vault server
     ```
 
@@ -26,6 +27,7 @@ Each install method below configures a master password at startup. Store it some
     ```bash
     docker run -it -p 14321:14321 -p 14322:14322 \
       -e AGENT_VAULT_MASTER_PASSWORD=your-password \
+      -e AGENT_VAULT_ADDR=http://<your-host>:14321 \
       -v agent-vault-data:/data infisical/agent-vault
     ```
 
@@ -45,6 +47,7 @@ Each install method below configures a master password at startup. Store it some
     Start the Agent Vault server (pass `-d` to run in the background):
 
     ```bash
+    export AGENT_VAULT_ADDR=http://<your-host>:14321
     agent-vault server
     ```
 
@@ -53,16 +56,7 @@ Each install method below configures a master password at startup. Store it some
 
 Agent Vault exposes two listeners: the HTTP API on `14321` and the transparent MITM proxy on `14322` (the canonical ingress for agents).
 
-Open `http://localhost:14321/register` (or your server's hostname at port `14321` for a remote deploy) to create your account. The first user becomes the instance [owner](/learn/permissions#instance-roles) with admin on the default [vault](/learn/vaults).
-
-For remote deploys, set [`AGENT_VAULT_ADDR`](/self-hosting/environment-variables) to your public URL so invite links and MITM cert SANs match.
-
-<Tip>
-  Press enter at the prompt (or leave `AGENT_VAULT_MASTER_PASSWORD` unset on
-  Docker) for passwordless mode. The DEK is stored in plaintext, suitable for
-  environments where volume security is the trust boundary. See [environment
-  variables](/self-hosting/environment-variables) for all options.
-</Tip>
+Open `http://<your-host>:14321/register` (the hostname or address where you deployed Agent Vault) to create your account. The first user becomes the instance [owner](/learn/permissions#instance-roles) with admin on the default [vault](/learn/vaults).
 
 ## Next steps
 

--- a/docs/quickstart/claude-code.mdx
+++ b/docs/quickstart/claude-code.mdx
@@ -73,7 +73,7 @@ Install the Agent Vault CLI on the host or in the container image where Claude C
 </Tabs>
 
 <Tip>
-`agent-vault run` also installs a [Claude Code skill](https://docs.anthropic.com/en/docs/claude-code/skills) at `~/.claude/skills/agent-vault/SKILL.md`. This teaches Claude Code how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
+`agent-vault run` also installs two [Claude Code skills](https://docs.anthropic.com/en/docs/claude-code/skills) at `~/.claude/skills/agent-vault-cli/SKILL.md` and `~/.claude/skills/agent-vault-http/SKILL.md`. These teach Claude Code how to discover services, proxy requests, and raise proposals through Agent Vault. The skills persist across sessions.
 </Tip>
 
 ## Next steps

--- a/docs/quickstart/claude-code.mdx
+++ b/docs/quickstart/claude-code.mdx
@@ -3,59 +3,78 @@ title: "Claude Code"
 description: "Learn how to connect Claude Code to Agent Vault so it can make authenticated API requests without ever seeing your credentials."
 ---
 
+import InstallCommand from "/snippets/install-command.mdx";
+
 ## Prerequisites
 
-- A running Agent Vault instance ([see installation guide](/installation))
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) installed
+- A running Agent Vault instance on a separate host from where Claude Code runs ([see installation guide](/installation)).
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) installed.
+- An agent token from Agent Vault (create one under **Agents → Add agent**).
 
-## Quick start
+Install the Agent Vault CLI on the host or in the container image where Claude Code runs, and point it at your Agent Vault instance. The CLI bootstraps Claude Code's environment so every outbound API call routes through Agent Vault for credential injection.
 
-Launch Claude Code with `vault run`. It wraps Claude Code with a vault-scoped session, pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and CA trust so outbound HTTP and HTTPS traffic both route through Agent Vault transparently, and installs the Agent Vault skill so Claude knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
+<Tabs>
+  <Tab title="Shell">
+    ### 1. Install the Agent Vault CLI
 
-```bash
-agent-vault vault run -- claude
-```
+    Add the `agent-vault` binary to the environment where Claude Code runs.
 
-That's it. Claude Code launches with Agent Vault access — no invite, no token pasting, no URL rewriting.
+    <InstallCommand />
+
+    ### 2. Set environment variables
+
+    The CLI reads these on launch to authenticate with Agent Vault and scope its session to the right vault.
+
+    ```bash
+    export AGENT_VAULT_ADDR="http://<your-host>:14321"
+    export AGENT_VAULT_TOKEN="av_agt_xxx"
+    export AGENT_VAULT_VAULT="<VAULT_NAME>"
+    ```
+
+    ### 3. Run Claude Code under agent-vault
+
+    `agent-vault run` launches Claude Code with `HTTPS_PROXY` and `HTTP_PROXY` pre-set so both its HTTPS and plain HTTP calls route through Agent Vault for credential injection.
+
+    ```bash
+    agent-vault run -- claude
+    ```
+
+  </Tab>
+  <Tab title="Dockerfile">
+    ### 1. Install the Agent Vault CLI
+
+    Add the `agent-vault` binary to the image where Claude Code runs.
+
+    ```dockerfile
+    COPY --from=infisical/agent-vault:latest /usr/local/bin/agent-vault /usr/local/bin/agent-vault
+    ```
+
+    ### 2. Set the entrypoint
+
+    `agent-vault run` launches Claude Code with `HTTPS_PROXY` and `HTTP_PROXY` pre-set so both its HTTPS and plain HTTP calls route through Agent Vault for credential injection.
+
+    ```dockerfile
+    ENTRYPOINT ["agent-vault", "run", "--", "claude"]
+    ```
+
+    ### 3. Pass environment variables at runtime
+
+    Inject the env vars when you run the container so the token never gets baked into the image. The CLI reads them on launch to authenticate with Agent Vault and scope its session to the right vault.
+
+    ```bash
+    docker run --rm -it \
+      -e AGENT_VAULT_ADDR="http://<your-host>:14321" \
+      -e AGENT_VAULT_TOKEN="av_agt_xxx" \
+      -e AGENT_VAULT_VAULT="<VAULT_NAME>" \
+      your-image
+    ```
+
+  </Tab>
+</Tabs>
 
 <Tip>
-`vault run` also installs a [Claude Code skill](https://docs.anthropic.com/en/docs/claude-code/skills) at `~/.claude/skills/agent-vault/SKILL.md`. This teaches Claude Code how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
+`agent-vault run` also installs a [Claude Code skill](https://docs.anthropic.com/en/docs/claude-code/skills) at `~/.claude/skills/agent-vault/SKILL.md`. This teaches Claude Code how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
 </Tip>
-
-### Target a specific vault
-
-```bash
-agent-vault vault run --vault myproject -- claude
-```
-
-## Try it out
-
-Ask Claude Code to do something that requires an external API:
-
-> "Fetch my recent Stripe charges"
-
-Here's what happens — with zero pre-configuration:
-
-1. Claude Code calls `https://api.stripe.com/...` (or `http://internal.example/...`) directly. `HTTPS_PROXY`/`HTTP_PROXY` routes the call through Agent Vault
-2. Agent Vault returns a **403** — Stripe isn't configured yet
-3. Claude Code reads the `proposal_hint` and creates a proposal requesting Stripe access
-4. Claude Code presents you with an approval link
-5. You click the link, paste your Stripe key, and click **Allow**
-6. Claude Code retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
-
-<Note>
-You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
-</Note>
-
-## Alternative: invite-based setup
-
-If you can't use `vault run` (e.g. you're connecting a remote or cloud-hosted Claude Code instance), use the invite flow instead:
-
-```bash
-agent-vault agent invite my-agent
-```
-
-This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Claude Code — it redeems the invite automatically and receives an agent token plus usage instructions inline.
 
 ## Next steps
 

--- a/docs/quickstart/codex.mdx
+++ b/docs/quickstart/codex.mdx
@@ -3,59 +3,78 @@ title: "Codex"
 description: "Learn how to connect Codex to Agent Vault so it can make authenticated API requests without ever seeing your credentials."
 ---
 
+import InstallCommand from "/snippets/install-command.mdx";
+
 ## Prerequisites
 
-- A running Agent Vault instance ([see installation guide](/installation))
-- [Codex](https://github.com/openai/codex) installed
+- A running Agent Vault instance on a separate host from where Codex runs ([see installation guide](/installation)).
+- [Codex](https://github.com/openai/codex) installed.
+- An agent token from Agent Vault (create one under **Agents → Add agent**).
 
-## Quick start
+Install the Agent Vault CLI on the host or in the container image where Codex runs, and point it at your Agent Vault instance. The CLI bootstraps Codex's environment so every outbound API call routes through Agent Vault for credential injection.
 
-Launch Codex with `vault run`. It wraps Codex with a vault-scoped session, pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and CA trust so outbound HTTP and HTTPS traffic both route through Agent Vault transparently, and installs the Agent Vault skill so Codex knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
+<Tabs>
+  <Tab title="Shell">
+    ### 1. Install the Agent Vault CLI
 
-```bash
-agent-vault vault run -- codex
-```
+    Add the `agent-vault` binary to the environment where Codex runs.
 
-That's it. Codex launches with Agent Vault access — no invite, no token pasting, no URL rewriting.
+    <InstallCommand />
+
+    ### 2. Set environment variables
+
+    The CLI reads these on launch to authenticate with Agent Vault and scope its session to the right vault.
+
+    ```bash
+    export AGENT_VAULT_ADDR="http://<your-host>:14321"
+    export AGENT_VAULT_TOKEN="av_agt_xxx"
+    export AGENT_VAULT_VAULT="<VAULT_NAME>"
+    ```
+
+    ### 3. Run Codex under agent-vault
+
+    `agent-vault run` launches Codex with `HTTPS_PROXY` and `HTTP_PROXY` pre-set so both its HTTPS and plain HTTP calls route through Agent Vault for credential injection.
+
+    ```bash
+    agent-vault run -- codex
+    ```
+
+  </Tab>
+  <Tab title="Dockerfile">
+    ### 1. Install the Agent Vault CLI
+
+    Add the `agent-vault` binary to the image where Codex runs.
+
+    ```dockerfile
+    COPY --from=infisical/agent-vault:latest /usr/local/bin/agent-vault /usr/local/bin/agent-vault
+    ```
+
+    ### 2. Set the entrypoint
+
+    `agent-vault run` launches Codex with `HTTPS_PROXY` and `HTTP_PROXY` pre-set so both its HTTPS and plain HTTP calls route through Agent Vault for credential injection.
+
+    ```dockerfile
+    ENTRYPOINT ["agent-vault", "run", "--", "codex"]
+    ```
+
+    ### 3. Pass environment variables at runtime
+
+    Inject the env vars when you run the container so the token never gets baked into the image. The CLI reads them on launch to authenticate with Agent Vault and scope its session to the right vault.
+
+    ```bash
+    docker run --rm -it \
+      -e AGENT_VAULT_ADDR="http://<your-host>:14321" \
+      -e AGENT_VAULT_TOKEN="av_agt_xxx" \
+      -e AGENT_VAULT_VAULT="<VAULT_NAME>" \
+      your-image
+    ```
+
+  </Tab>
+</Tabs>
 
 <Tip>
-`vault run` also installs an Agent Vault skill at `~/.agents/skills/agent-vault/SKILL.md`. This teaches Codex how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
+`agent-vault run` also installs an Agent Vault skill at `~/.agents/skills/agent-vault/SKILL.md`. This teaches Codex how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
 </Tip>
-
-### Target a specific vault
-
-```bash
-agent-vault vault run --vault myproject -- codex
-```
-
-## Try it out
-
-Ask Codex to do something that requires an external API:
-
-> "Fetch my recent Stripe charges"
-
-Here's what happens — with zero pre-configuration:
-
-1. Codex calls `https://api.stripe.com/...` (or `http://internal.example/...`) directly. `HTTPS_PROXY`/`HTTP_PROXY` routes the call through Agent Vault
-2. Agent Vault returns a **403** — Stripe isn't configured yet
-3. Codex reads the `proposal_hint` and creates a proposal requesting Stripe access
-4. Codex presents you with an approval link
-5. You click the link, paste your Stripe key, and click **Allow**
-6. Codex retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
-
-<Note>
-You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
-</Note>
-
-## Alternative: invite-based setup
-
-If you can't use `vault run` (e.g. you're connecting a remote or cloud-hosted Codex instance), use the invite flow instead:
-
-```bash
-agent-vault agent invite my-agent
-```
-
-This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Codex — it redeems the invite automatically and receives an agent token plus usage instructions inline.
 
 ## Next steps
 

--- a/docs/quickstart/codex.mdx
+++ b/docs/quickstart/codex.mdx
@@ -73,7 +73,7 @@ Install the Agent Vault CLI on the host or in the container image where Codex ru
 </Tabs>
 
 <Tip>
-`agent-vault run` also installs an Agent Vault skill at `~/.agents/skills/agent-vault/SKILL.md`. This teaches Codex how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
+`agent-vault run` also installs two Agent Vault skills at `~/.agents/skills/agent-vault-cli/SKILL.md` and `~/.agents/skills/agent-vault-http/SKILL.md`. These teach Codex how to discover services, proxy requests, and raise proposals through Agent Vault. The skills persist across sessions.
 </Tip>
 
 ## Next steps

--- a/docs/quickstart/cursor.mdx
+++ b/docs/quickstart/cursor.mdx
@@ -3,59 +3,78 @@ title: "Cursor"
 description: "Learn how to connect Cursor to Agent Vault so it can make authenticated API requests without ever seeing your credentials."
 ---
 
+import InstallCommand from "/snippets/install-command.mdx";
+
 ## Prerequisites
 
-- A running Agent Vault instance ([see installation guide](/installation))
-- [Cursor](https://www.cursor.com) installed
+- A running Agent Vault instance on a separate host from where Cursor runs ([see installation guide](/installation)).
+- [Cursor](https://www.cursor.com) installed.
+- An agent token from Agent Vault (create one under **Agents → Add agent**).
 
-## Quick start
+Install the Agent Vault CLI on the host or in the container image where Cursor runs, and point it at your Agent Vault instance. The CLI bootstraps Cursor's environment so every outbound API call routes through Agent Vault for credential injection.
 
-Launch Cursor with `vault run`. It wraps Cursor with a vault-scoped session, pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and CA trust so outbound HTTP and HTTPS traffic both route through Agent Vault transparently, and installs the Agent Vault skill so Cursor knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
+<Tabs>
+  <Tab title="Shell">
+    ### 1. Install the Agent Vault CLI
 
-```bash
-agent-vault vault run -- agent
-```
+    Add the `agent-vault` binary to the environment where Cursor runs.
 
-That's it. Cursor launches with Agent Vault access — no invite, no token pasting, no URL rewriting.
+    <InstallCommand />
+
+    ### 2. Set environment variables
+
+    The CLI reads these on launch to authenticate with Agent Vault and scope its session to the right vault.
+
+    ```bash
+    export AGENT_VAULT_ADDR="http://<your-host>:14321"
+    export AGENT_VAULT_TOKEN="av_agt_xxx"
+    export AGENT_VAULT_VAULT="<VAULT_NAME>"
+    ```
+
+    ### 3. Run Cursor under agent-vault
+
+    `agent-vault run` launches Cursor's agent with `HTTPS_PROXY` and `HTTP_PROXY` pre-set so both its HTTPS and plain HTTP calls route through Agent Vault for credential injection.
+
+    ```bash
+    agent-vault run -- agent
+    ```
+
+  </Tab>
+  <Tab title="Dockerfile">
+    ### 1. Install the Agent Vault CLI
+
+    Add the `agent-vault` binary to the image where Cursor runs.
+
+    ```dockerfile
+    COPY --from=infisical/agent-vault:latest /usr/local/bin/agent-vault /usr/local/bin/agent-vault
+    ```
+
+    ### 2. Set the entrypoint
+
+    `agent-vault run` launches Cursor's agent with `HTTPS_PROXY` and `HTTP_PROXY` pre-set so both its HTTPS and plain HTTP calls route through Agent Vault for credential injection.
+
+    ```dockerfile
+    ENTRYPOINT ["agent-vault", "run", "--", "agent"]
+    ```
+
+    ### 3. Pass environment variables at runtime
+
+    Inject the env vars when you run the container so the token never gets baked into the image. The CLI reads them on launch to authenticate with Agent Vault and scope its session to the right vault.
+
+    ```bash
+    docker run --rm -it \
+      -e AGENT_VAULT_ADDR="http://<your-host>:14321" \
+      -e AGENT_VAULT_TOKEN="av_agt_xxx" \
+      -e AGENT_VAULT_VAULT="<VAULT_NAME>" \
+      your-image
+    ```
+
+  </Tab>
+</Tabs>
 
 <Tip>
-`vault run` also installs an Agent Vault skill at `~/.cursor/skills/agent-vault/SKILL.md`. This teaches Cursor how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
+`agent-vault run` also installs an Agent Vault skill at `~/.cursor/skills/agent-vault/SKILL.md`. This teaches Cursor how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
 </Tip>
-
-### Target a specific vault
-
-```bash
-agent-vault vault run --vault myproject -- agent
-```
-
-## Try it out
-
-Ask Cursor to do something that requires an external API:
-
-> "Fetch my recent Stripe charges"
-
-Here's what happens — with zero pre-configuration:
-
-1. Cursor calls `https://api.stripe.com/...` (or `http://internal.example/...`) directly. `HTTPS_PROXY`/`HTTP_PROXY` routes the call through Agent Vault
-2. Agent Vault returns a **403** — Stripe isn't configured yet
-3. Cursor reads the `proposal_hint` and creates a proposal requesting Stripe access
-4. Cursor presents you with an approval link
-5. You click the link, paste your Stripe key, and click **Allow**
-6. Cursor retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
-
-<Note>
-You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
-</Note>
-
-## Alternative: invite-based setup
-
-If you can't use `vault run` (e.g. you're connecting a remote or cloud-hosted Cursor instance), use the invite flow instead:
-
-```bash
-agent-vault agent invite my-agent
-```
-
-This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Cursor — it redeems the invite automatically and receives an agent token plus usage instructions inline.
 
 ## Next steps
 

--- a/docs/quickstart/cursor.mdx
+++ b/docs/quickstart/cursor.mdx
@@ -73,7 +73,7 @@ Install the Agent Vault CLI on the host or in the container image where Cursor r
 </Tabs>
 
 <Tip>
-`agent-vault run` also installs an Agent Vault skill at `~/.cursor/skills/agent-vault/SKILL.md`. This teaches Cursor how to discover services, proxy requests, and raise proposals through Agent Vault. The skill persists across sessions.
+`agent-vault run` also installs two Agent Vault skills at `~/.cursor/skills/agent-vault-cli/SKILL.md` and `~/.cursor/skills/agent-vault-http/SKILL.md`. These teach Cursor how to discover services, proxy requests, and raise proposals through Agent Vault. The skills persist across sessions.
 </Tip>
 
 ## Next steps

--- a/docs/quickstart/hermes-agent.mdx
+++ b/docs/quickstart/hermes-agent.mdx
@@ -3,59 +3,78 @@ title: "Hermes Agent"
 description: "Learn how to connect Hermes Agent to Agent Vault so it can make authenticated API requests without ever seeing your credentials."
 ---
 
+import InstallCommand from "/snippets/install-command.mdx";
+
 ## Prerequisites
 
-- A running Agent Vault instance ([see installation guide](/installation))
-- [Hermes Agent](https://hermesagent.dev/) installed
+- A running Agent Vault instance on a separate host from where Hermes Agent runs ([see installation guide](/installation)).
+- [Hermes Agent](https://hermesagent.dev/) installed.
+- An agent token from Agent Vault (create one under **Agents → Add agent**).
 
-## Quick start
+Install the Agent Vault CLI on the host or in the container image where Hermes Agent runs, and point it at your Agent Vault instance. The CLI bootstraps Hermes Agent's environment so every outbound API call routes through Agent Vault for credential injection.
 
-Launch Hermes Agent with `vault run`. It wraps Hermes with a vault-scoped session, pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and CA trust so outbound HTTP and HTTPS traffic both route through Agent Vault transparently, and installs the Agent Vault skills so Hermes knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
+<Tabs>
+  <Tab title="Shell">
+    ### 1. Install the Agent Vault CLI
 
-```bash
-agent-vault vault run -- hermes
-```
+    Add the `agent-vault` binary to the environment where Hermes Agent runs.
 
-That's it. Hermes Agent launches with Agent Vault access — no invite, no token pasting, no URL rewriting.
+    <InstallCommand />
+
+    ### 2. Set environment variables
+
+    The CLI reads these on launch to authenticate with Agent Vault and scope its session to the right vault.
+
+    ```bash
+    export AGENT_VAULT_ADDR="http://<your-host>:14321"
+    export AGENT_VAULT_TOKEN="av_agt_xxx"
+    export AGENT_VAULT_VAULT="<VAULT_NAME>"
+    ```
+
+    ### 3. Run Hermes Agent under agent-vault
+
+    `agent-vault run` launches Hermes Agent with `HTTPS_PROXY` and `HTTP_PROXY` pre-set so both its HTTPS and plain HTTP calls route through Agent Vault for credential injection.
+
+    ```bash
+    agent-vault run -- hermes
+    ```
+
+  </Tab>
+  <Tab title="Dockerfile">
+    ### 1. Install the Agent Vault CLI
+
+    Add the `agent-vault` binary to the image where Hermes Agent runs.
+
+    ```dockerfile
+    COPY --from=infisical/agent-vault:latest /usr/local/bin/agent-vault /usr/local/bin/agent-vault
+    ```
+
+    ### 2. Set the entrypoint
+
+    `agent-vault run` launches Hermes Agent with `HTTPS_PROXY` and `HTTP_PROXY` pre-set so both its HTTPS and plain HTTP calls route through Agent Vault for credential injection.
+
+    ```dockerfile
+    ENTRYPOINT ["agent-vault", "run", "--", "hermes"]
+    ```
+
+    ### 3. Pass environment variables at runtime
+
+    Inject the env vars when you run the container so the token never gets baked into the image. The CLI reads them on launch to authenticate with Agent Vault and scope its session to the right vault.
+
+    ```bash
+    docker run --rm -it \
+      -e AGENT_VAULT_ADDR="http://<your-host>:14321" \
+      -e AGENT_VAULT_TOKEN="av_agt_xxx" \
+      -e AGENT_VAULT_VAULT="<VAULT_NAME>" \
+      your-image
+    ```
+
+  </Tab>
+</Tabs>
 
 <Tip>
-`vault run` also installs two Agent Vault skills at `~/.hermes/skills/agent-vault-cli/SKILL.md` and `~/.hermes/skills/agent-vault-http/SKILL.md`. These teach Hermes Agent how to discover services, proxy requests, and raise proposals through Agent Vault. The skills persist across sessions.
+`agent-vault run` also installs Agent Vault skills at `~/.hermes/skills/agent-vault-cli/SKILL.md` and `~/.hermes/skills/agent-vault-http/SKILL.md`. These teach Hermes Agent how to discover services, proxy requests, and raise proposals through Agent Vault. The skills persist across sessions.
 </Tip>
-
-### Target a specific vault
-
-```bash
-agent-vault vault run --vault myproject -- hermes
-```
-
-## Try it out
-
-Ask Hermes Agent to do something that requires an external API:
-
-> "Fetch my recent Stripe charges"
-
-Here's what happens — with zero pre-configuration:
-
-1. Hermes Agent calls `https://api.stripe.com/...` (or `http://ai/v1/...`) directly. `HTTPS_PROXY`/`HTTP_PROXY` routes the call through Agent Vault
-2. Agent Vault returns a **403** — Stripe isn't configured yet
-3. Hermes Agent reads the `proposal_hint` and creates a proposal requesting Stripe access
-4. Hermes Agent presents you with an approval link
-5. You click the link, paste your Stripe key, and click **Allow**
-6. Hermes Agent retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
-
-<Note>
-You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
-</Note>
-
-## Alternative: invite-based setup
-
-If you can't use `vault run` (e.g. you're connecting a remote or cloud-hosted Hermes instance), use the invite flow instead:
-
-```bash
-agent-vault agent invite hermes
-```
-
-This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into Hermes Agent — it redeems the invite automatically and receives an agent token plus usage instructions inline.
 
 ## Next steps
 

--- a/docs/quickstart/nanoclaw.mdx
+++ b/docs/quickstart/nanoclaw.mdx
@@ -5,10 +5,8 @@ description: "Learn how to connect NanoClaw to Agent Vault so it can make authen
 
 ## Prerequisites
 
-To get the most out of this guide, you'll need to:
-
-- A deployed Agent Vault instance ([see installation guide](/installation))
-- Have [NanoClaw](https://nanoclaw.dev/) installed
+- A running Agent Vault instance ([see installation guide](/installation)).
+- [NanoClaw](https://nanoclaw.dev/) installed.
 
 ## 1. Create an agent invite
 
@@ -23,29 +21,6 @@ This generates a one-time onboarding prompt and copies it to your clipboard.
 ## 2. Paste the prompt into NanoClaw
 
 Open NanoClaw's chat and paste the invite prompt. NanoClaw redeems the invite automatically and receives an agent token.
-
-## 3. Start using it
-
-Ask NanoClaw to do something that requires an external API:
-
-> "Fetch my recent Stripe charges"
-
-Here's what happens — with zero pre-configuration:
-
-1. NanoClaw routes a request to `https://api.stripe.com/...` (or `http://internal.example/...`) through Agent Vault via `HTTPS_PROXY`/`HTTP_PROXY`
-2. Agent Vault returns a **403** — Stripe isn't configured yet
-3. NanoClaw reads the `proposal_hint` and creates a proposal requesting Stripe access
-4. NanoClaw presents you with an approval link
-5. You click the link, paste your Stripe key, and click **Allow**
-6. NanoClaw retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
-
-<Note>
-Invited agents like NanoClaw build their own `HTTPS_PROXY`/`HTTP_PROXY` from the token + vault returned by the redemption response (both env vars point at the same TLS-wrapped MITM URL so plain `http://` upstreams route through the broker via absolute-form forward-proxy requests) and fetch the root CA from `{AGENT_VAULT_ADDR}/v1/mitm/ca.pem` themselves — the embedded `instructions` field walks them through it. Local agents you wrap with `agent-vault vault run` (Claude Code, Cursor, Codex, Hermes) inherit the same env vars automatically.
-</Note>
-
-<Note>
-You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
-</Note>
 
 ## Next steps
 

--- a/docs/quickstart/openclaw.mdx
+++ b/docs/quickstart/openclaw.mdx
@@ -3,49 +3,74 @@ title: "OpenClaw"
 description: "Learn how to connect OpenClaw to Agent Vault so it can make authenticated API requests without ever seeing your credentials."
 ---
 
+import InstallCommand from "/snippets/install-command.mdx";
+
 ## Prerequisites
 
-To get the most out of this guide, you'll need to:
+- A running Agent Vault instance on a separate host from where OpenClaw runs ([see installation guide](/installation)).
+- [OpenClaw](https://openclaw.ai) installed on your VPS.
+- An agent token from Agent Vault (create one under **Agents → Add agent**).
 
-- A deployed Agent Vault instance ([see installation guide](/installation))
-- Have [OpenClaw](https://openclaw.ai) installed
+Install the Agent Vault CLI on the VPS (or in the container image) where OpenClaw runs, and point it at your Agent Vault instance. The CLI bootstraps OpenClaw's environment so every outbound API call routes through Agent Vault for credential injection.
 
-## 1. Create an agent invite
+<Tabs>
+  <Tab title="Shell">
+    ### 1. Install the Agent Vault CLI
 
-If you haven't logged in yet, you'll be guided through setup automatically.
+    SSH into your VPS and add the `agent-vault` binary alongside OpenClaw.
 
-```bash
-agent-vault agent invite openclaw
-```
+    <InstallCommand />
 
-This generates a one-time onboarding prompt and copies it to your clipboard.
+    ### 2. Set environment variables
 
-## 2. Paste the prompt into OpenClaw
+    The CLI reads these on launch to authenticate with Agent Vault and scope its session to the right vault.
 
-Open OpenClaw's chat and paste the invite prompt. OpenClaw redeems the invite automatically and receives an agent token.
+    ```bash
+    export AGENT_VAULT_ADDR="http://<your-host>:14321"
+    export AGENT_VAULT_TOKEN="av_agt_xxx"
+    export AGENT_VAULT_VAULT="<VAULT_NAME>"
+    ```
 
-## 3. Start using it
+    ### 3. Run the OpenClaw gateway under agent-vault
 
-Ask OpenClaw to do something that requires an external API:
+    `agent-vault run` launches the OpenClaw gateway with `HTTPS_PROXY` and `HTTP_PROXY` pre-set so both its HTTPS and plain HTTP calls route through Agent Vault for credential injection.
 
-> "Fetch my recent Stripe charges"
+    ```bash
+    agent-vault run -- openclaw gateway run
+    ```
 
-Here's what happens — with zero pre-configuration:
+  </Tab>
+  <Tab title="Dockerfile">
+    ### 1. Install the Agent Vault CLI
 
-1. OpenClaw routes a request to `https://api.stripe.com/...` (or `http://internal.example/...`) through Agent Vault via `HTTPS_PROXY`/`HTTP_PROXY`
-2. Agent Vault returns a **403** — Stripe isn't configured yet
-3. OpenClaw reads the `proposal_hint` and creates a proposal requesting Stripe access
-4. OpenClaw presents you with an approval link
-5. You click the link, paste your Stripe key, and click **Allow**
-6. OpenClaw retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
+    Add the `agent-vault` binary to the image where OpenClaw runs.
 
-<Note>
-Invited agents like OpenClaw build their own `HTTPS_PROXY`/`HTTP_PROXY` from the token + vault returned by the redemption response (both env vars point at the same TLS-wrapped MITM URL so plain `http://` upstreams route through the broker via absolute-form forward-proxy requests) and fetch the root CA from `{AGENT_VAULT_ADDR}/v1/mitm/ca.pem` themselves — the embedded `instructions` field walks them through it. Local agents you wrap with `agent-vault vault run` (Claude Code, Cursor, Codex, Hermes) inherit the same env vars automatically.
-</Note>
+    ```dockerfile
+    COPY --from=infisical/agent-vault:latest /usr/local/bin/agent-vault /usr/local/bin/agent-vault
+    ```
 
-<Note>
-You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
-</Note>
+    ### 2. Set the entrypoint
+
+    `agent-vault run` launches the OpenClaw gateway with `HTTPS_PROXY` and `HTTP_PROXY` pre-set so both its HTTPS and plain HTTP calls route through Agent Vault for credential injection.
+
+    ```dockerfile
+    ENTRYPOINT ["agent-vault", "run", "--", "openclaw", "gateway", "run"]
+    ```
+
+    ### 3. Pass environment variables at runtime
+
+    Inject the env vars when you run the container so the token never gets baked into the image. The CLI reads them on launch to authenticate with Agent Vault and scope its session to the right vault.
+
+    ```bash
+    docker run --rm -it \
+      -e AGENT_VAULT_ADDR="http://<your-host>:14321" \
+      -e AGENT_VAULT_TOKEN="av_agt_xxx" \
+      -e AGENT_VAULT_VAULT="<VAULT_NAME>" \
+      your-image
+    ```
+
+  </Tab>
+</Tabs>
 
 ## Next steps
 

--- a/docs/quickstart/opencode.mdx
+++ b/docs/quickstart/opencode.mdx
@@ -73,7 +73,7 @@ Install the Agent Vault CLI on the host or in the container image where OpenCode
 </Tabs>
 
 <Tip>
-`agent-vault run` also installs Agent Vault skill files at `~/.opencode/skills/`. These teach OpenCode how to discover services, proxy requests, and raise proposals through Agent Vault. The skills persist across sessions.
+`agent-vault run` also installs two Agent Vault skills at `~/.opencode/skills/agent-vault-cli/SKILL.md` and `~/.opencode/skills/agent-vault-http/SKILL.md`. These teach OpenCode how to discover services, proxy requests, and raise proposals through Agent Vault. The skills persist across sessions.
 </Tip>
 
 ## Next steps

--- a/docs/quickstart/opencode.mdx
+++ b/docs/quickstart/opencode.mdx
@@ -3,59 +3,78 @@ title: "OpenCode"
 description: "Learn how to connect OpenCode to Agent Vault so it can make authenticated API requests without ever seeing your credentials."
 ---
 
+import InstallCommand from "/snippets/install-command.mdx";
+
 ## Prerequisites
 
-- A running Agent Vault instance ([see installation guide](/installation))
-- [OpenCode](https://opencode.ai) installed
+- A running Agent Vault instance on a separate host from where OpenCode runs ([see installation guide](/installation)).
+- [OpenCode](https://opencode.ai) installed.
+- An agent token from Agent Vault (create one under **Agents → Add agent**).
 
-## Quick start
+Install the Agent Vault CLI on the host or in the container image where OpenCode runs, and point it at your Agent Vault instance. The CLI bootstraps OpenCode's environment so every outbound API call routes through Agent Vault for credential injection.
 
-Launch OpenCode with `vault run`. It wraps OpenCode with a vault-scoped session, pre-configures `HTTPS_PROXY`/`HTTP_PROXY` and CA trust so outbound HTTP and HTTPS traffic both route through Agent Vault transparently, and installs the Agent Vault skills so OpenCode knows how to discover services and raise proposals. If you haven't logged in yet, you'll be guided through setup automatically.
+<Tabs>
+  <Tab title="Shell">
+    ### 1. Install the Agent Vault CLI
 
-```bash
-agent-vault vault run -- opencode
-```
+    Add the `agent-vault` binary to the environment where OpenCode runs.
 
-That's it. OpenCode launches with Agent Vault access — no invite, no token pasting, no URL rewriting.
+    <InstallCommand />
+
+    ### 2. Set environment variables
+
+    The CLI reads these on launch to authenticate with Agent Vault and scope its session to the right vault.
+
+    ```bash
+    export AGENT_VAULT_ADDR="http://<your-host>:14321"
+    export AGENT_VAULT_TOKEN="av_agt_xxx"
+    export AGENT_VAULT_VAULT="<VAULT_NAME>"
+    ```
+
+    ### 3. Run OpenCode under agent-vault
+
+    `agent-vault run` launches OpenCode with `HTTPS_PROXY` and `HTTP_PROXY` pre-set so both its HTTPS and plain HTTP calls route through Agent Vault for credential injection.
+
+    ```bash
+    agent-vault run -- opencode
+    ```
+
+  </Tab>
+  <Tab title="Dockerfile">
+    ### 1. Install the Agent Vault CLI
+
+    Add the `agent-vault` binary to the image where OpenCode runs.
+
+    ```dockerfile
+    COPY --from=infisical/agent-vault:latest /usr/local/bin/agent-vault /usr/local/bin/agent-vault
+    ```
+
+    ### 2. Set the entrypoint
+
+    `agent-vault run` launches OpenCode with `HTTPS_PROXY` and `HTTP_PROXY` pre-set so both its HTTPS and plain HTTP calls route through Agent Vault for credential injection.
+
+    ```dockerfile
+    ENTRYPOINT ["agent-vault", "run", "--", "opencode"]
+    ```
+
+    ### 3. Pass environment variables at runtime
+
+    Inject the env vars when you run the container so the token never gets baked into the image. The CLI reads them on launch to authenticate with Agent Vault and scope its session to the right vault.
+
+    ```bash
+    docker run --rm -it \
+      -e AGENT_VAULT_ADDR="http://<your-host>:14321" \
+      -e AGENT_VAULT_TOKEN="av_agt_xxx" \
+      -e AGENT_VAULT_VAULT="<VAULT_NAME>" \
+      your-image
+    ```
+
+  </Tab>
+</Tabs>
 
 <Tip>
-`vault run` also installs Agent Vault skill files at `~/.opencode/skills/`. These teach OpenCode how to discover services, proxy requests, and raise proposals through Agent Vault. The skills persist across sessions.
+`agent-vault run` also installs Agent Vault skill files at `~/.opencode/skills/`. These teach OpenCode how to discover services, proxy requests, and raise proposals through Agent Vault. The skills persist across sessions.
 </Tip>
-
-### Target a specific vault
-
-```bash
-agent-vault vault run --vault myproject -- opencode
-```
-
-## Try it out
-
-Ask OpenCode to do something that requires an external API:
-
-> "Fetch my recent Stripe charges"
-
-Here's what happens — with zero pre-configuration:
-
-1. OpenCode calls `https://api.stripe.com/...` (or `http://internal.example/...`) directly. `HTTPS_PROXY`/`HTTP_PROXY` routes the call through Agent Vault
-2. Agent Vault returns a **403** — Stripe isn't configured yet
-3. OpenCode reads the `proposal_hint` and creates a proposal requesting Stripe access
-4. OpenCode presents you with an approval link
-5. You click the link, paste your Stripe key, and click **Allow**
-6. OpenCode retries — Agent Vault injects your Stripe credentials at the proxy boundary and the request succeeds
-
-<Note>
-You didn't pre-configure anything. The agent discovered what it needed, asked for approval, and handled the rest.
-</Note>
-
-## Alternative: invite-based setup
-
-If you can't use `vault run` (e.g. you're connecting a remote or cloud-hosted OpenCode instance), use the invite flow instead:
-
-```bash
-agent-vault agent invite my-agent
-```
-
-This generates a one-time onboarding prompt and copies it to your clipboard. Paste it into OpenCode — it redeems the invite automatically and receives an agent token plus usage instructions inline.
 
 ## Next steps
 

--- a/web/src/pages/home/AllAgentsTab.tsx
+++ b/web/src/pages/home/AllAgentsTab.tsx
@@ -454,7 +454,7 @@ function InviteAgentButton({
             <>
               <Button variant="secondary" onClick={close}>Cancel</Button>
               <Button onClick={handleCreate} disabled={!name.trim()} loading={submitting}>
-                Create invite
+                Add
               </Button>
             </>
           )


### PR DESCRIPTION
## Summary

- Quickstart pages for Claude Code, Cursor, Codex, Hermes, OpenCode, and OpenClaw now mirror the in-app Connect Your Agent modal: Shell and Dockerfile tabs, three steps (install CLI, set env vars, `agent-vault run -- <agent>`), and a consistent intro. Drops the old "Try it out" walkthrough and "Alternative: invite-based setup" sections.
- Deploy page tightened: `AGENT_VAULT_ADDR` is now in every install snippet, the open-in-browser line is reframed around `<your-host>` instead of `localhost`, and the passwordless-mode tip is removed.
- `local-first` framing dropped from `CLAUDE.md` and `cmd/root.go` (`agent-vault --help`). Agent Vault is typically deployed to a remote host that agents reach over the network.
- Add Agent modal: relabel the submit button from "Create invite" to "Add" to match what the action actually does.
- NanoClaw quickstart hidden from nav (file kept). NanoClaw hardcodes `@onecli-sh/sdk` as its credential gateway and refuses to spawn containers without it ([container-runner.ts:430](https://github.com/nanocoai/nanoclaw/blob/main/src/container-runner.ts)), so the `agent-vault run` wrap pattern would not actually inject credentials into per-session containers. Real integration would need OneCLI-protocol-compatible endpoints on Agent Vault (`/api/agents` and `/api/container-config`), which is out of scope here.

## Test plan

- [ ] Run docs site locally (`mintlify dev` in `docs/`) and click through Claude Code, Cursor, Codex, Hermes, OpenCode, OpenClaw quickstarts in both Shell and Dockerfile tabs.
- [ ] Verify NanoClaw no longer appears in the Quickstart nav group or on the homepage card grid.
- [ ] Verify the Deploy page renders the three tabs cleanly with `AGENT_VAULT_ADDR` in each.
- [ ] Open the Add Agent modal in the web UI and verify the button reads "Add" before submitting and "Done" after invite generation.
- [ ] `agent-vault --help` shows the updated short description without "local-first".