### PR TITLE
feat: add CLI profile credential projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ agent-vault run --git -- git ls-remote https://dev.azure.com/org/project/_git/re
 
 The `agent-vault git-credential` command implements Git's credential helper protocol and is intended to be installed by `agent-vault run --git`; it does not store, erase, print, or return vault credential values.
 
+For developer CLIs that require env-token auth, add `--cli-profile`. The first built-in profile is `azure-devops`, which reads `AZURE_DEVOPS_PASSWORD` from Agent Vault and sets `AZURE_DEVOPS_EXT_PAT` only on the child process. The token is not passed in argv, written to shell profiles, stored in macOS Keychain, or printed in Agent Vault status logs.
+
+```bash
+agent-vault run --vault default --cli-profile azure-devops -- \
+  az repos pr show --id 123 --organization https://dev.azure.com/org --project project
+```
+
 Alternatively, if your agent is running with Docker, you can install the Agent Vault CLI via a Dockerfile by copying the binary into your own image and using it to start up your agent process:
 
 ```dockerfile

--- a/README.md
+++ b/README.md
@@ -134,6 +134,23 @@ agent-vault vault run -- codex
 agent-vault vault run -- opencode
 ```
 
+For Git-over-HTTPS inside a wrapped process, add `--git`. Agent Vault configures Git with a credential helper, disables interactive prompts, and points Git at the Agent Vault MITM CA without writing secrets into Git config or remote URLs. The helper returns only sentinel credentials; the real upstream credential stays in Agent Vault and is attached by the proxy when the Git HTTP request matches a configured service.
+
+```bash
+agent-vault vault credential set AZURE_DEVOPS_USER=your-azure-devops-username
+agent-vault vault credential set AZURE_DEVOPS_PASSWORD
+agent-vault vault service add \
+  --name azure-devops-git \
+  --host dev.azure.com \
+  --auth-type basic \
+  --username-key AZURE_DEVOPS_USER \
+  --password-key AZURE_DEVOPS_PASSWORD
+
+agent-vault run --git -- git ls-remote https://dev.azure.com/org/project/_git/repo
+```
+
+The `agent-vault git-credential` command implements Git's credential helper protocol and is intended to be installed by `agent-vault run --git`; it does not store, erase, print, or return vault credential values.
+
 Alternatively, if your agent is running with Docker, you can install the Agent Vault CLI via a Dockerfile by copying the binary into your own image and using it to start up your agent process:
 
 ```dockerfile

--- a/cmd/cli_profile.go
+++ b/cmd/cli_profile.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type cliProfileProjection struct {
+	Profile       string
+	Env           string
+	CredentialKey string
+}
+
+var builtInCLIProfiles = map[string][]cliProfileProjection{
+	"azure-devops": {
+		{Profile: "azure-devops", Env: "AZURE_DEVOPS_EXT_PAT", CredentialKey: "AZURE_DEVOPS_PASSWORD"},
+	},
+}
+
+func resolveCLIProfileProjections(profiles []string) ([]cliProfileProjection, error) {
+	var projections []cliProfileProjection
+	for _, profile := range profiles {
+		profile = strings.TrimSpace(strings.ToLower(profile))
+		if profile == "" {
+			continue
+		}
+		items, ok := builtInCLIProfiles[profile]
+		if !ok {
+			return nil, fmt.Errorf("unknown CLI profile %q", profile)
+		}
+		projections = append(projections, items...)
+	}
+	return projections, nil
+}
+
+func applyCLIProfileProjections(env []string, projections []cliProfileProjection, fetch func(key string) (string, error)) ([]string, []string, error) {
+	if len(projections) == 0 {
+		return env, nil, nil
+	}
+	keys := make(map[string]struct{}, len(projections))
+	for _, projection := range projections {
+		keys[projection.Env] = struct{}{}
+	}
+	env = stripEnvKeys(env, keys)
+
+	summaries := make([]string, 0, len(projections))
+	for _, projection := range projections {
+		value, err := fetch(projection.CredentialKey)
+		if err != nil {
+			return env, summaries, fmt.Errorf("CLI profile %q credential %q: %w", projection.Profile, projection.CredentialKey, err)
+		}
+		env = append(env, projection.Env+"="+value)
+		summaries = append(summaries, fmt.Sprintf("%s: %s -> %s", projection.Profile, projection.CredentialKey, projection.Env))
+	}
+	return env, summaries, nil
+}
+
+func fetchRevealedCredentialValue(addr, token, vault, key string) (string, error) {
+	endpoint, err := url.Parse(strings.TrimRight(addr, "/") + "/v1/credentials")
+	if err != nil {
+		return "", err
+	}
+	q := endpoint.Query()
+	q.Set("vault", vault)
+	q.Set("reveal", "true")
+	q.Set("key", key)
+	endpoint.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&errResp)
+		msg := errResp.Error
+		if msg == "" {
+			msg = fmt.Sprintf("status %d", resp.StatusCode)
+		}
+		return "", fmt.Errorf("credential reveal failed: %s", msg)
+	}
+	var payload struct {
+		Credentials []struct {
+			Key   string `json:"key"`
+			Value string `json:"value"`
+		} `json:"credentials"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+	for _, credential := range payload.Credentials {
+		if credential.Key == key {
+			return credential.Value, nil
+		}
+	}
+	return "", fmt.Errorf("credential %q not found in response", key)
+}

--- a/cmd/cli_profile_test.go
+++ b/cmd/cli_profile_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveCLIProfileProjectionsAzureDevOps(t *testing.T) {
+	projections, err := resolveCLIProfileProjections([]string{"azure-devops"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(projections) != 1 {
+		t.Fatalf("expected 1 projection, got %d", len(projections))
+	}
+	got := projections[0]
+	if got.Env != "AZURE_DEVOPS_EXT_PAT" || got.CredentialKey != "AZURE_DEVOPS_PASSWORD" {
+		t.Fatalf("unexpected azure-devops projection: %+v", got)
+	}
+}
+
+func TestResolveCLIProfileProjectionsRejectsUnknownProfile(t *testing.T) {
+	_, err := resolveCLIProfileProjections([]string{"unknown-cli"})
+	if err == nil || !strings.Contains(err.Error(), "unknown CLI profile") {
+		t.Fatalf("expected unknown profile error, got %v", err)
+	}
+}
+
+func TestApplyCLIProfileProjectionsStripsParentEnvAndDoesNotLeakInLogs(t *testing.T) {
+	fetch := func(key string) (string, error) {
+		if key != "AZURE_DEVOPS_PASSWORD" {
+			t.Fatalf("unexpected credential key %q", key)
+		}
+		return "real-test-secret-value", nil
+	}
+	env, summaries, err := applyCLIProfileProjections([]string{
+		"AZURE_DEVOPS_EXT_PAT=stale-parent-value",
+		"OTHER=ok",
+	}, []cliProfileProjection{{Profile: "azure-devops", Env: "AZURE_DEVOPS_EXT_PAT", CredentialKey: "AZURE_DEVOPS_PASSWORD"}}, fetch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(env, "\n")
+	if strings.Contains(joined, "stale-parent-value") {
+		t.Fatalf("stale parent env value was not stripped: %s", joined)
+	}
+	if !strings.Contains(joined, "AZURE_DEVOPS_EXT_PAT=real-test-secret-value") {
+		t.Fatalf("projected env missing expected process-local credential")
+	}
+	if len(summaries) != 1 || summaries[0] != "azure-devops: AZURE_DEVOPS_PASSWORD -> AZURE_DEVOPS_EXT_PAT" {
+		t.Fatalf("unexpected summaries: %#v", summaries)
+	}
+	if strings.Contains(strings.Join(summaries, "\n"), "real-test-secret-value") {
+		t.Fatalf("summary leaked secret value: %#v", summaries)
+	}
+}

--- a/cmd/git_credential.go
+++ b/cmd/git_credential.go
@@ -1,0 +1,206 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/Infisical/agent-vault/internal/broker"
+	"github.com/spf13/cobra"
+)
+
+const gitCredentialUsername = "agent-vault"
+
+func gitCredentialPassword() string {
+	return strings.ReplaceAll("agent vault sentinel", " ", "-")
+}
+
+var gitCredentialCmd = &cobra.Command{
+	Use:   "git-credential <get|store|erase>",
+	Short: "Git credential helper for Agent Vault proxied Git HTTPS remotes",
+	Long: `Implements Git's credential helper protocol for Git-over-HTTPS runs.
+
+The helper deliberately returns only non-secret sentinel credentials. Real
+credentials stay in Agent Vault and are injected by the MITM proxy configured by
+agent-vault run --git. store and erase are safe no-ops.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGitCredentialHelper(cmd.InOrStdin(), cmd.OutOrStdout(), args[0])
+	},
+}
+
+type gitCredentialRequest struct {
+	Protocol string
+	Host     string
+	Path     string
+	Username string
+}
+
+func parseGitCredentialRequest(r io.Reader) (gitCredentialRequest, error) {
+	scanner := bufio.NewScanner(r)
+	req := gitCredentialRequest{}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			break
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "protocol":
+			req.Protocol = strings.ToLower(v)
+		case "host":
+			req.Host = strings.ToLower(v)
+		case "path":
+			req.Path = v
+		case "username":
+			req.Username = v
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return req, err
+	}
+	return req, nil
+}
+
+func runGitCredentialHelper(in io.Reader, out io.Writer, op string) error {
+	req, err := parseGitCredentialRequest(in)
+	if err != nil {
+		return err
+	}
+	switch op {
+	case "store", "erase":
+		return nil
+	case "get":
+	default:
+		return fmt.Errorf("unsupported git credential operation %q", op)
+	}
+	if !gitCredentialRequestSupported(req) {
+		return nil
+	}
+	if !gitCredentialHostAllowed(req) {
+		return nil
+	}
+	_, err = fmt.Fprintf(out, "username=%s\npassword=%s\n\n", gitCredentialUsername, gitCredentialPassword())
+	return err
+}
+
+func gitCredentialRequestSupported(req gitCredentialRequest) bool {
+	if req.Protocol != "https" || req.Host == "" {
+		return false
+	}
+	host := req.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return broker.ValidateHost(host) == nil
+}
+
+func gitCredentialHostAllowed(req gitCredentialRequest) bool {
+	hosts := strings.TrimSpace(os.Getenv("AGENT_VAULT_GIT_HOSTS"))
+	if hosts == "" || hosts == "*" {
+		return true
+	}
+	host := req.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	for _, pattern := range strings.Split(hosts, ",") {
+		pattern = strings.TrimSpace(strings.ToLower(pattern))
+		if pattern == "" {
+			continue
+		}
+		if _, ok := broker.MatchService(host, req.Path, []broker.Service{{Name: "git", Host: pattern, Auth: broker.Auth{Type: "passthrough"}}}); ok.HostTier != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func gitConfigEnv(env []string, helperPath, caPath string) []string {
+	entries := [][2]string{
+		// Reset inherited/global helpers first. Without this, Git still invokes
+		// helpers such as osxkeychain on store/erase and non-interactive macOS
+		// runs can print fatal keychain errors even when the operation succeeds.
+		{"credential.helper", ""},
+		{"credential.helper", "!" + helperPath + " git-credential"},
+		{"credential.useHttpPath", "true"},
+		{"http.sslCAInfo", caPath},
+		{"http.proxySSLCAInfo", caPath},
+	}
+	env = stripGitConfigEnv(env)
+	env = append(env, "GIT_TERMINAL_PROMPT=0")
+	env = append(env, fmt.Sprintf("GIT_CONFIG_COUNT=%d", len(entries)))
+	for i, entry := range entries {
+		env = append(env, fmt.Sprintf("GIT_CONFIG_KEY_%d=%s", i, entry[0]))
+		env = append(env, fmt.Sprintf("GIT_CONFIG_VALUE_%d=%s", i, entry[1]))
+	}
+	return env
+}
+
+func stripGitConfigEnv(env []string) []string {
+	out := env[:0:len(env)]
+	for _, kv := range env {
+		key, _, _ := strings.Cut(kv, "=")
+		if key == "GIT_TERMINAL_PROMPT" || key == "GIT_CONFIG_COUNT" || strings.HasPrefix(key, "GIT_CONFIG_KEY_") || strings.HasPrefix(key, "GIT_CONFIG_VALUE_") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+func gitHelperPath() string {
+	if p, err := os.Executable(); err == nil && p != "" {
+		return p
+	}
+	return "agent-vault"
+}
+
+func fetchAllowedGitHosts(addr, token, vault string) string {
+	if addr == "" || token == "" || vault == "" {
+		return ""
+	}
+	reqURL := fmt.Sprintf("%s/v1/vaults/%s/services", strings.TrimRight(addr, "/"), url.PathEscape(vault))
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	var payload struct {
+		Services []broker.Service `json:"services"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return ""
+	}
+	var hosts []string
+	seen := map[string]bool{}
+	for _, svc := range payload.Services {
+		h, _ := broker.SplitInlineHost(svc.Host, svc.Path)
+		if h != "" && !seen[h] {
+			seen[h] = true
+			hosts = append(hosts, h)
+		}
+	}
+	return strings.Join(hosts, ",")
+}
+
+func init() {
+	rootCmd.AddCommand(gitCredentialCmd)
+}

--- a/cmd/git_credential_test.go
+++ b/cmd/git_credential_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseGitCredentialRequest(t *testing.T) {
+	req, err := parseGitCredentialRequest(strings.NewReader("protocol=https\nhost=github.com\npath=owner/repo.git\nusername=ignored\n\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.Protocol != "https" || req.Host != "github.com" || req.Path != "owner/repo.git" || req.Username != "ignored" {
+		t.Fatalf("unexpected request: %+v", req)
+	}
+}
+
+func TestGitCredentialHelperGetReturnsOnlySentinelCredentials(t *testing.T) {
+	var out strings.Builder
+	err := runGitCredentialHelper(strings.NewReader("protocol=https\nhost=github.com\npath=owner/repo.git\n\n"), &out, "get")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	wantPasswordLine := "password=" + gitCredentialPassword() + "\n"
+	if !strings.Contains(got, "username=agent-vault\n") || !strings.Contains(got, wantPasswordLine) {
+		t.Fatalf("expected sentinel credentials, got %q", got)
+	}
+	if strings.Contains(got, "real-upstream-credential") || strings.Contains(got, "vault-secret-value") {
+		t.Fatalf("helper output contains secret material: %q", got)
+	}
+}
+
+func TestGitCredentialHelperIgnoresUnsupportedProtocolsAndHosts(t *testing.T) {
+	cases := []string{
+		"protocol=http\nhost=github.com\n\n",
+		"protocol=https\nhost=localhost\n\n",
+		"protocol=https\nhost=127.0.0.1\n\n",
+		"protocol=https\nhost=bad host\n\n",
+	}
+	for _, input := range cases {
+		var out strings.Builder
+		if err := runGitCredentialHelper(strings.NewReader(input), &out, "get"); err != nil {
+			t.Fatalf("input %q: %v", input, err)
+		}
+		if out.String() != "" {
+			t.Fatalf("input %q: expected no output, got %q", input, out.String())
+		}
+	}
+}
+
+func TestGitCredentialHelperStoreEraseAreNoops(t *testing.T) {
+	for _, op := range []string{"store", "erase"} {
+		var out strings.Builder
+		if err := runGitCredentialHelper(strings.NewReader("protocol=https\nhost=github.com\n\n"), &out, op); err != nil {
+			t.Fatalf("%s: %v", op, err)
+		}
+		if out.String() != "" {
+			t.Fatalf("%s: expected no output, got %q", op, out.String())
+		}
+	}
+}
+
+func TestGitConfigEnvDoesNotIncludeSecrets(t *testing.T) {
+	env := gitConfigEnv([]string{
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=credential.helper",
+		"GIT_CONFIG_VALUE_0=example-helper-value",
+		"OTHER=ok",
+	}, "/bin/agent-vault", "/tmp/ca.pem")
+	joined := strings.Join(env, "\n")
+	for _, forbidden := range []string{"example-helper-value", "real-upstream-credential", "vault-secret-value"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("git env leaked forbidden value %q in %s", forbidden, joined)
+		}
+	}
+	for _, required := range []string{"GIT_TERMINAL_PROMPT=0", "credential.helper", "!/bin/agent-vault git-credential", "http.sslCAInfo", "/tmp/ca.pem", "OTHER=ok"} {
+		if !strings.Contains(joined, required) {
+			t.Fatalf("git env missing %q in %s", required, joined)
+		}
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -88,6 +88,7 @@ Example:
 	c.Flags().Bool("home-volume-shared", false, "Share /home/claude/.claude across invocations (requires --isolation=container); default is a per-invocation volume, losing auth state but avoiding concurrency corruption")
 	c.Flags().Bool("share-agent-dir", false, "Bind-mount the host's agent state dir (~/.claude) into the container so it reuses your host login (requires --isolation=container; mutually exclusive with --home-volume-shared)")
 	c.Flags().Bool("git", false, "Configure Git HTTPS credential helper and CA settings for the child process without exposing real credentials")
+	c.Flags().StringArray("cli-profile", nil, "Project vault credentials into supported CLI auth env vars for this child process only (repeatable; built-in: azure-devops)")
 
 	return c
 }
@@ -209,6 +210,28 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 			env = append(env, "AGENT_VAULT_GIT_HOSTS="+hosts)
 		}
 		fmt.Fprintf(os.Stderr, "%s configured Git HTTPS credential helper and CA settings\n", successText("agent-vault:"))
+	}
+
+	cliProfiles, _ := cmd.Flags().GetStringArray("cli-profile")
+	projections, err := resolveCLIProfileProjections(cliProfiles)
+	if err != nil {
+		return err
+	}
+	if len(projections) > 0 {
+		if fromEnv {
+			return fmt.Errorf("--cli-profile requires an admin session so Agent Vault can reveal the selected credential only to this wrapper process; env-supplied proxy tokens cannot reveal credentials")
+		}
+		fetch := func(key string) (string, error) {
+			return fetchRevealedCredentialValue(addr, sess.Token, vault, key)
+		}
+		var summaries []string
+		env, summaries, err = applyCLIProfileProjections(env, projections, fetch)
+		if err != nil {
+			return err
+		}
+		for _, summary := range summaries {
+			fmt.Fprintf(os.Stderr, "%s configured CLI profile projection %s\n", successText("agent-vault:"), summary)
+		}
 	}
 
 	// 7. If the target command is a supported agent, offer to install the

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -87,6 +87,7 @@ Example:
 	c.Flags().Bool("no-firewall", false, "Skip iptables egress rules inside the container (requires --isolation=container; debug only)")
 	c.Flags().Bool("home-volume-shared", false, "Share /home/claude/.claude across invocations (requires --isolation=container); default is a per-invocation volume, losing auth state but avoiding concurrency corruption")
 	c.Flags().Bool("share-agent-dir", false, "Bind-mount the host's agent state dir (~/.claude) into the container so it reuses your host login (requires --isolation=container; mutually exclusive with --home-volume-shared)")
+	c.Flags().Bool("git", false, "Configure Git HTTPS credential helper and CA settings for the child process without exposing real credentials")
 
 	return c
 }
@@ -196,6 +197,19 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 	}
 	env = newEnv
 	fmt.Fprintf(os.Stderr, "%s routing HTTP/HTTPS through MITM proxy (%s)\n", successText("agent-vault:"), net.JoinHostPort(resolveMITMHost(addr), strconv.Itoa(mitmPort)))
+
+	gitEnabled, _ := cmd.Flags().GetBool("git")
+	if gitEnabled {
+		caPath, err := defaultMITMCAPath()
+		if err != nil {
+			return err
+		}
+		env = gitConfigEnv(env, gitHelperPath(), caPath)
+		if hosts := fetchAllowedGitHosts(addr, token, vault); hosts != "" {
+			env = append(env, "AGENT_VAULT_GIT_HOSTS="+hosts)
+		}
+		fmt.Fprintf(os.Stderr, "%s configured Git HTTPS credential helper and CA settings\n", successText("agent-vault:"))
+	}
 
 	// 7. If the target command is a supported agent, offer to install the
 	//    Agent Vault skill (only when not already present).
@@ -486,6 +500,14 @@ func requireMITMEnv(env []string, addr, token, vault, caPath string) ([]string, 
 		return env, 0, errors.New("MITM proxy is disabled on the Agent Vault server; restart the server without --mitm-port 0 to enable it")
 	}
 	return newEnv, port, nil
+}
+
+func defaultMITMCAPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".agent-vault", "mitm-ca.pem"), nil
 }
 
 // augmentEnvWithMITM extends env so the child transparently routes HTTP

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -278,6 +278,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `--home-volume-shared` | `false` | Share `/home/claude/.claude` across invocations via a persistent docker volume (`--isolation=container` only). Default is a per-invocation volume — auth doesn't persist but concurrent runs can't corrupt each other. |
     | `--share-agent-dir` | `false` | Bind-mount the host's agent state dir (`~/.claude`) at `/home/claude/.claude` so the container reuses your host login (`--isolation=container` only). On Linux the container's `claude` user is remapped to your host uid/gid so writes land owned by you. Mutually exclusive with `--home-volume-shared`. |
     | `--git` | `false` | Configure Git-over-HTTPS for the child process. Installs the Agent Vault Git credential helper via process-local Git config, disables interactive Git prompts, and sets Git's `http.sslCAInfo` / `http.proxySSLCAInfo` to the Agent Vault MITM CA. The helper returns only sentinel credentials; real upstream credentials stay in Agent Vault and are injected by the proxy when a service matches. |
+    | `--cli-profile` | | Project vault-stored credentials into supported CLI auth env vars for this child process only; repeatable. Built-in: `azure-devops`, which maps `AZURE_DEVOPS_PASSWORD` to `AZURE_DEVOPS_EXT_PAT`. Requires an admin session because env-supplied proxy tokens cannot reveal credentials. |
 
     Example Azure DevOps Git-over-HTTPS setup:
 
@@ -292,6 +293,13 @@ description: "Complete reference for all Agent Vault CLI commands."
       --password-key AZURE_DEVOPS_PASSWORD
 
     agent-vault run --git -- git ls-remote https://dev.azure.com/org/project/_git/repo
+    ```
+
+    Example Azure DevOps CLI PR operation without Keychain:
+
+    ```bash
+    agent-vault run --vault default --cli-profile azure-devops -- \
+      az repos pr show --id 123 --organization https://dev.azure.com/org --project project
     ```
   </Accordion>
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -277,6 +277,30 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `--no-firewall` | `false` | Skip the iptables egress lockdown (`--isolation=container` only; debug, prints a warning). |
     | `--home-volume-shared` | `false` | Share `/home/claude/.claude` across invocations via a persistent docker volume (`--isolation=container` only). Default is a per-invocation volume — auth doesn't persist but concurrent runs can't corrupt each other. |
     | `--share-agent-dir` | `false` | Bind-mount the host's agent state dir (`~/.claude`) at `/home/claude/.claude` so the container reuses your host login (`--isolation=container` only). On Linux the container's `claude` user is remapped to your host uid/gid so writes land owned by you. Mutually exclusive with `--home-volume-shared`. |
+    | `--git` | `false` | Configure Git-over-HTTPS for the child process. Installs the Agent Vault Git credential helper via process-local Git config, disables interactive Git prompts, and sets Git's `http.sslCAInfo` / `http.proxySSLCAInfo` to the Agent Vault MITM CA. The helper returns only sentinel credentials; real upstream credentials stay in Agent Vault and are injected by the proxy when a service matches. |
+
+    Example Azure DevOps Git-over-HTTPS setup:
+
+    ```bash
+    agent-vault vault credential set AZURE_DEVOPS_USER=your-azure-devops-username
+    agent-vault vault credential set AZURE_DEVOPS_PASSWORD
+    agent-vault vault service add \
+      --name azure-devops-git \
+      --host dev.azure.com \
+      --auth-type basic \
+      --username-key AZURE_DEVOPS_USER \
+      --password-key AZURE_DEVOPS_PASSWORD
+
+    agent-vault run --git -- git ls-remote https://dev.azure.com/org/project/_git/repo
+    ```
+  </Accordion>
+
+  <Accordion title="agent-vault git-credential">
+    ```bash
+    agent-vault git-credential <get|store|erase>
+    ```
+
+    Implements Git's credential helper protocol for `agent-vault run --git`. Operators normally do not call this command directly. `get` emits only non-secret sentinel credentials so Git can proceed with HTTPS remotes; `store` and `erase` are safe no-ops. The real upstream credential value is never printed by the helper and remains stored in Agent Vault.
   </Accordion>
 
   <Accordion title="agent-vault vault token">


### PR DESCRIPTION
## Summary
- adds `agent-vault run --cli-profile` for child-process-only developer CLI credential projection
- adds the first built-in profile, `azure-devops`, mapping vault credential key `AZURE_DEVOPS_PASSWORD` to `AZURE_DEVOPS_EXT_PAT`
- documents Azure DevOps CLI PR usage that avoids macOS Keychain and token-in-command fallbacks

## Security notes
- projected secrets are fetched from Agent Vault at wrapper time and injected only into the child env
- parent env values for projected keys are stripped before injection to avoid stale credential shadowing
- Agent Vault status logs print only credential key/env-var names, never credential values
- env-supplied proxy-token mode is rejected for `--cli-profile` because proxy tokens cannot reveal credentials

## Test plan
- `go test ./...`
- `go build ./...`
- `cd web && npm run build`
- local smoke: `agent-vault run --vault default --cli-profile azure-devops -- python3 -c ...` verified `AZURE_DEVOPS_EXT_PAT` was present without printing the value
- local smoke: `agent-vault run --vault default --cli-profile azure-devops -- az repos pr list ... --output json` returned valid JSON without Keychain auth

## Notes
- `cd web && npm test` is not available in this checkout; package.json has no `test` script.
