### PR TITLE
mitm: strip default port from outbound Host header so signature schemes match

### DIFF
--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -123,6 +123,32 @@ func (p *Proxy) handleForward(w http.ResponseWriter, r *http.Request) {
 	p.forwardRequest(w, r, target, host, false, scope)
 }
 
+// hostHeaderForScheme strips target's port when it matches the default for
+// scheme so SigV4/GCS/Azure-SAS signatures over Host match; non-default
+// ports are preserved for vhost routing on internal upstreams.
+func hostHeaderForScheme(scheme, target string) string {
+	host, port, err := net.SplitHostPort(target)
+	if err != nil {
+		return target
+	}
+	var defaultPort string
+	switch strings.ToLower(scheme) {
+	case "https":
+		defaultPort = "443"
+	case "http":
+		defaultPort = "80"
+	default:
+		return target
+	}
+	if port != defaultPort {
+		return target
+	}
+	if strings.ContainsRune(host, ':') {
+		return "[" + host + "]"
+	}
+	return host
+}
+
 // forwardHandler returns an http.Handler that forwards each request to
 // target (the host:port captured from the original CONNECT line). Using
 // a closed-over target rather than r.Host defeats post-tunnel host
@@ -195,14 +221,7 @@ func (p *Proxy) forwardRequest(
 		emit(http.StatusBadGateway, "internal")
 		return
 	}
-	// Wire Host header preserves the port for non-default ports, per
-	// RFC 7230 §5.4 (Host field-value MUST equal the URI authority,
-	// excluding userinfo). Stripping the port broke vhost routing on
-	// internal upstreams that key on host:port (k8s ingress, dev
-	// servers, microservices) — a non-issue for the legacy CONNECT
-	// path because HTTPS:443 is canonical, but the dominant case for
-	// the new plain-HTTP forward path.
-	outReq.Host = target
+	outReq.Host = hostHeaderForScheme(scheme, target)
 	outReq.ContentLength = contentLength
 
 	inject, err := p.creds.Inject(r.Context(), scope.VaultID, host, r.URL.Path)

--- a/internal/mitm/forward_host_header_test.go
+++ b/internal/mitm/forward_host_header_test.go
@@ -1,0 +1,74 @@
+package mitm
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestHostHeaderForScheme(t *testing.T) {
+	cases := []struct {
+		name   string
+		scheme string
+		target string
+		want   string
+	}{
+		{"https default port stripped", "https", "api.example.com:443", "api.example.com"},
+		{"http default port stripped", "http", "k8s-svc:80", "k8s-svc"},
+		{"http non-default preserved", "http", "k8s-svc:8080", "k8s-svc:8080"},
+		{"https non-default preserved", "https", "internal.example:8443", "internal.example:8443"},
+		{"https with :80 preserved", "https", "example.com:80", "example.com:80"},
+		{"http with :443 preserved", "http", "example.com:443", "example.com:443"},
+		{"scheme case-insensitive", "HTTPS", "host:443", "host"},
+		{"ipv6 default port stripped, brackets restored", "https", "[::1]:443", "[::1]"},
+		{"ipv6 non-default preserved with brackets", "http", "[::1]:8080", "[::1]:8080"},
+		{"no port unchanged", "https", "example.com", "example.com"},
+		{"empty scheme unchanged", "", "example.com:443", "example.com:443"},
+		{"unknown scheme unchanged", "ftp", "example.com:21", "example.com:21"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hostHeaderForScheme(tc.scheme, tc.target)
+			if got != tc.want {
+				t.Errorf("hostHeaderForScheme(%q, %q) = %q, want %q", tc.scheme, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHostHeaderForSchemeProducesPortlessWireHost closes the helper→wire
+// chain: prove that net/http's Request.Write emits the helper's output
+// verbatim as the Host: line, with no port re-introduced by Go.
+func TestHostHeaderForSchemeProducesPortlessWireHost(t *testing.T) {
+	cases := []struct {
+		name     string
+		scheme   string
+		urlStr   string
+		target   string
+		wantHost string
+	}{
+		{"https :443 strip", "https", "https://api.example.com:443/x", "api.example.com:443", "api.example.com"},
+		{"http :80 strip", "http", "http://internal.example:80/x", "internal.example:80", "internal.example"},
+		{"ipv6 :443 strip", "https", "https://[::1]:443/x", "[::1]:443", "[::1]"},
+		{"non-default preserve", "http", "http://k8s-svc:8080/x", "k8s-svc:8080", "k8s-svc:8080"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", tc.urlStr, nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			req.Host = hostHeaderForScheme(tc.scheme, tc.target)
+
+			var buf bytes.Buffer
+			if err := req.Write(&buf); err != nil {
+				t.Fatalf("req.Write: %v", err)
+			}
+			wantLine := "Host: " + tc.wantHost + "\r\n"
+			if !strings.Contains(buf.String(), wantLine) {
+				t.Errorf("wire missing %q\nwire:\n%s", wantLine, buf.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- The MITM proxy was setting `outReq.Host = target` unconditionally, which forced `:443` / `:80` onto the wire even for default-port upstreams. Signature schemes that canonicalize over Host (AWS SigV4 presigned URLs, GCS V4 signed URLs, Azure SAS, R2/MinIO presigned) sign over the port-less form per RFC 3986 §3.2.3, so upstreams recomputed a different hash and returned `403 SignatureDoesNotMatch`. Reported failure mode: `docker pull` through Agent Vault, registry redirects (`307`) to a presigned S3 URL, S3 rejects.
- Fix is a small `hostHeaderForScheme(scheme, target)` helper called from `forwardRequest`. It strips the port when it matches the default for the scheme; non-default ports flow through unchanged. IPv6 literals are re-bracketed after the `net.SplitHostPort` round-trip.
- Preserves PR #151's behavior for non-default-port upstreams (k8s ingress, dev servers, the plain-HTTP forward-proxy path). The behavior delta only affects default-port HTTPS/HTTP upstreams, and only moves us from a minority Host form to the majority form every mainstream HTTP client (Go `net/http`, curl, `requests`, `undici`, browsers) already emits.

## Why this is safe for existing users

| Upstream | Before | After |
| --- | --- | --- |
| `https://api.example.com/` (`:443`) | `Host: api.example.com:443` | `Host: api.example.com` |
| `http://api.example.com/` (`:80`) | `Host: api.example.com:80` | `Host: api.example.com` |
| `http://k8s-svc:8080/` | `Host: k8s-svc:8080` | unchanged |
| `https://internal.example:8443/` | `Host: internal.example:8443` | unchanged |
| `https://[::1]/` (`:443`) | `Host: [::1]:443` | `Host: [::1]` |
| `http://[::1]:8080/` | `Host: [::1]:8080` | unchanged |

Both `host` and `host:443` are RFC 7230 §5.4 compliant; any upstream that distinguishes the two would already be 4xx-ing every direct request from curl, Go, Python `requests`, browsers, etc. The proxy was the outlier.

`outReq.URL.Host` is untouched, so dialing and TLS SNI are unaffected. WebSocket inherits via `outReq.Write(tlsConn)`. `ApplySubstitutions` does not read `outReq.Host`. Credential injection already operates on the port-stripped `host`, not the wire Host header.

## Test plan

- [x] `go test ./internal/mitm/...` (full MITM suite)
- [x] `go test ./...` (full repo suite)
- [x] Table-driven `TestHostHeaderForScheme` covers all branches: default-port strip for http and https, non-default-port preserve, IPv6 with brackets, scheme case-insensitivity, no-port input, empty/unknown scheme
- [x] `TestHostHeaderForSchemeProducesPortlessWireHost` closes the helper to wire chain: `http.Request.Write` emits the helper output verbatim as the Host line, no port re-introduced by Go
- [x] [TestMITMForwardIPv6PreservesHostHeader](internal/mitm/forward_test.go#L611) (PR #151 regression guard) still passes
- [x] [TestMITMInjectsCredentials](internal/mitm/proxy_test.go#L149) and [TestMITMForwardPlainHTTPInjectsCredentials](internal/mitm/forward_test.go#L93) (existing non-default-port end-to-end paths) still pass
- [ ] Manual sanity (optional): `vault run` with an AWS SDK call against a real presigned URL, confirm no `SignatureDoesNotMatch`