### PR TITLE
brokercore: make MITM response-body cap configurable (default 1 GiB)

### DIFF
--- a/internal/brokercore/brokercore.go
+++ b/internal/brokercore/brokercore.go
@@ -10,15 +10,76 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 
 	"github.com/Infisical/agent-vault/internal/broker"
 )
 
-// MaxResponseBytes caps response bodies streamed back to agents on the
-// MITM proxy ingress.
-const MaxResponseBytes = 100 << 20
+// DefaultMaxResponseBytes caps response bodies streamed back to agents
+// on the MITM proxy ingress. The default is generous (1 GiB) because
+// agents proxy not just JSON LLM responses but also git clones, model
+// artifact downloads, datasets, and other bulk transfers that easily
+// exceed the old 100 MiB cap (silent truncation surfaced as
+// `fetch-pack: invalid index-pack output` for git, broken downloads
+// otherwise). Override with AGENT_VAULT_MAX_RESPONSE_BYTES — accepts a
+// plain byte count or a human suffix ("256MB", "5GB"). "0" disables
+// the cap entirely.
+const DefaultMaxResponseBytes int64 = 1 << 30
+
+// MaxResponseBytes returns the resolved response-body cap for the
+// current process. Computed once on first call; env changes after
+// startup are ignored to keep the value deterministic for the lifetime
+// of the proxy.
+var MaxResponseBytes = resolveMaxResponseBytes()
+
+func resolveMaxResponseBytes() int64 {
+	v := strings.TrimSpace(os.Getenv("AGENT_VAULT_MAX_RESPONSE_BYTES"))
+	if v == "" {
+		return DefaultMaxResponseBytes
+	}
+	if n, err := parseByteSize(v); err == nil {
+		if n == 0 {
+			return math.MaxInt64 // operator opt-out — effectively unbounded
+		}
+		return n
+	}
+	return DefaultMaxResponseBytes
+}
+
+// parseByteSize accepts a raw integer or one of the common
+// case-insensitive suffixes (KB, MB, GB, TB — base 1024 to match how
+// operators typically reason about HTTP payload sizes). Negative values
+// and trailing garbage are rejected.
+func parseByteSize(s string) (int64, error) {
+	s = strings.TrimSpace(strings.ToUpper(s))
+	mult := int64(1)
+	switch {
+	case strings.HasSuffix(s, "TB"):
+		mult = 1 << 40
+		s = strings.TrimSuffix(s, "TB")
+	case strings.HasSuffix(s, "GB"):
+		mult = 1 << 30
+		s = strings.TrimSuffix(s, "GB")
+	case strings.HasSuffix(s, "MB"):
+		mult = 1 << 20
+		s = strings.TrimSuffix(s, "MB")
+	case strings.HasSuffix(s, "KB"):
+		mult = 1 << 10
+		s = strings.TrimSuffix(s, "KB")
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid byte size %q", s)
+	}
+	if n != 0 && n > math.MaxInt64/mult {
+		return 0, fmt.Errorf("byte size %q overflows int64", s)
+	}
+	return n * mult, nil
+}
 
 // ProxyErrorHeader is the response header Agent Vault sets on broker-layer
 // error responses so SDK clients can distinguish them from upstream

--- a/internal/brokercore/brokercore_test.go
+++ b/internal/brokercore/brokercore_test.go
@@ -314,3 +314,61 @@ func TestForbiddenHintBody_EmptyBaseURL(t *testing.T) {
 		t.Fatal("help field should be absent when baseURL is empty")
 	}
 }
+
+func TestParseByteSize(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    int64
+		wantErr bool
+	}{
+		{"0", 0, false},
+		{"1024", 1024, false},
+		{"100MB", 100 << 20, false},
+		{"1GB", 1 << 30, false},
+		{"5gb", 5 << 30, false},   // case-insensitive
+		{"  256MB  ", 256 << 20, false}, // whitespace tolerant
+		{"2TB", 2 << 40, false},
+		{"abc", 0, true},
+		{"-1", 0, true},
+		{"99999999999999999999GB", 0, true}, // overflow
+	}
+	for _, c := range cases {
+		got, err := parseByteSize(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parseByteSize(%q) = %d, want error", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseByteSize(%q) unexpected error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("parseByteSize(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestResolveMaxResponseBytes(t *testing.T) {
+	// Default kicks in when env is unset.
+	t.Setenv("AGENT_VAULT_MAX_RESPONSE_BYTES", "")
+	if got := resolveMaxResponseBytes(); got != DefaultMaxResponseBytes {
+		t.Errorf("default = %d, want %d", got, DefaultMaxResponseBytes)
+	}
+	// Explicit override.
+	t.Setenv("AGENT_VAULT_MAX_RESPONSE_BYTES", "256MB")
+	if got := resolveMaxResponseBytes(); got != 256<<20 {
+		t.Errorf("override = %d, want 256MB", got)
+	}
+	// "0" → unbounded (MaxInt64) for operator opt-out.
+	t.Setenv("AGENT_VAULT_MAX_RESPONSE_BYTES", "0")
+	if got := resolveMaxResponseBytes(); got <= DefaultMaxResponseBytes {
+		t.Errorf("0 should disable the cap; got %d", got)
+	}
+	// Malformed → falls back to default.
+	t.Setenv("AGENT_VAULT_MAX_RESPONSE_BYTES", "garbage")
+	if got := resolveMaxResponseBytes(); got != DefaultMaxResponseBytes {
+		t.Errorf("malformed = %d, want %d (fallback to default)", got, DefaultMaxResponseBytes)
+	}
+}


### PR DESCRIPTION
## Problem

`brokercore.MaxResponseBytes` is a hardcoded `100 << 20` (100 MiB) cap on the response body streamed back to agents on the MITM proxy ingress, applied via `io.Copy(w, io.LimitReader(resp.Body, MaxResponseBytes))` in `internal/mitm/forward.go` and `internal/mitm/websocket.go`.

That bound makes sense for JSON LLM completions but silently truncates anything bulkier than 100 MiB:

- **`git clone` over HTTPS** of a medium-or-larger repo: hits the cap mid-pack → surfaces to the user as

  ```
  error: X bytes of body are still expected
  fetch-pack: unexpected disconnect while reading sideband packet
  fatal: early EOF
  fatal: fetch-pack: invalid index-pack output
  ```

  Concretely, a 282 MiB pack on a real repo got truncated at exactly 100 MiB (deterministic, reproduces 1:1 across runs).

- **Model artifact downloads** (Hugging Face checkpoints, ONNX bundles): truncated bundles fail integrity checks downstream.

- **Datasets / backups / any other bulk transfer**: short-reads with no error logged.

The truncation point itself isn't logged today either — the agent just sees a malformed end-of-stream and has to guess at the cause.

## Change

1. Raise the default to **1 GiB** (`DefaultMaxResponseBytes`). That covers ~all real-world bulk transfers an agent does day-to-day while still keeping a reasonable defense-in-depth ceiling.
2. Make it overridable via `AGENT_VAULT_MAX_RESPONSE_BYTES`. Accepts:
   - A bare byte count: `1073741824`
   - One of `KB` / `MB` / `GB` / `TB` (base 1024, case-insensitive, whitespace-tolerant): `5GB`, `256mb`, `2TB`
   - `0` to opt out of the cap entirely (operator's call)
3. Resolved once at process start and cached in `var MaxResponseBytes`. Env mutations after startup are ignored — same lifecycle as the configurable `ResponseHeaderTimeout` in #196.

## Tests

- `TestParseByteSize` — positive cases (raw ints, all suffix forms, case-insensitivity, whitespace), negative cases (junk, negative numbers, int64 overflow).
- `TestResolveMaxResponseBytes` — default, explicit override, `0` opt-out, malformed env value falling back to default.

Both green; the full `internal/mitm/` suite is also green with the new value plumbed through (`io.LimitReader` already takes an `int64`, so call sites needed no changes).

## Combined with #197

This is the third in a small series that came out of trying to `git clone` through the proxy on a real repo:

- #196 raises `ResponseHeaderTimeout` for reasoning-model latencies
- #197 fixes the streaming-response delivery so chunks reach the client live
- this PR removes the size cap that truncates anything bigger than 100 MiB

With all three landed (or workable env vars set), a 282 MiB git clone completes through the proxy in ~1m30s end-to-end — same throughput as direct.

Opening as a draft. Happy to adjust the default (the prior 100 MiB → 1 GiB is a 10× bump; some operators may want a smaller bump like 256 MiB or 512 MiB), the env-var name, or the suffix grammar.