### PR TITLE
fix: only count proxy auth failures against TierAuth rate limit

### DIFF
--- a/docs/guides/hermes-on-vps.mdx
+++ b/docs/guides/hermes-on-vps.mdx
@@ -510,20 +510,6 @@ The unit needs Agent Vault's environment wired explicitly, since systemd doesn't
 
 <Steps>
 
-<Step title="Disable rate limiting">
-
-In the AV UI tab on your laptop: click your email (top right) → **Manage Instance** → scroll to **Rate Limiting**. Set **Profile** to **off (disable all limits)** and click **Save Rate Limits**.
-
-![Instance Settings page with Rate Limiting Profile set to off](/images/hermes-on-vps/hermes-on-vps-rate-limits.png)
-
-The gateway daemon opens fresh CONNECTs every time `httpx` resets its connection pool (startup, retries, network blips), which trips the per-IP auth limit within seconds. Disabling rate limits is the cleanest fix; see [Instance settings](/guides/instance-settings) for the per-tier alternative.
-
-<Note>
-Rate limits throttle brute force at the login endpoint and the proxy. Agent Vault is bound to `10.0.0.2` and only `hermes-vps` can reach it, so the per-IP gates aren't load-bearing here. Re-enable rate limiting if you ever bind Agent Vault to `0.0.0.0`.
-</Note>
-
-</Step>
-
 <Step title="Paste 1: write /root/.hermes/gateway.env">
 
 In the SSH shell on `hermes-vps` where `$AGENT_VAULT_TOKEN` is still set:

--- a/docs/learn/security.mdx
+++ b/docs/learn/security.mdx
@@ -140,7 +140,7 @@ Agent Vault enforces a tiered, in-memory rate limiter on every HTTP ingress. Eac
 
 | Tier | Keyed on | Covers |
 | ---- | -------- | ------ |
-| `AUTH` | Client IP | Anonymous endpoints (login, registration, password reset) |
+| `AUTH` | Client IP | Anonymous endpoints (login, registration, password reset) and proxy auth failures |
 | `AUTHED` | Session token hash | Proposal approval, authenticated CRUD |
 | `PROXY` | `(actor, vault)` scope | Proxy path and MITM ingress |
 | `GLOBAL` | Server-wide | In-flight request ceiling and RPS backstop |

--- a/internal/mitm/connect.go
+++ b/internal/mitm/connect.go
@@ -47,11 +47,12 @@ func isLoopbackPeer(r *http.Request) bool {
 // CONNECT request line (r.Host) and captured in a closure so subsequent
 // Host-header rewrites by the client cannot redirect the tunnel.
 func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
-	// Gate before ParseProxyAuth + session lookup so a bad-auth flood
-	// can't burn CPU. Per-IP on the raw TCP peer, shared with the
-	// TierAuth budget. Loopback is exempt — see isLoopbackPeer.
+	// Read-only pre-gate: if this IP has exhausted its auth-failure
+	// budget, reject immediately. Only auth failures are recorded
+	// (below) so legitimate agents don't burn the budget. Loopback
+	// is exempt — see isLoopbackPeer.
 	if p.rateLimit != nil && !isLoopbackPeer(r) {
-		if d := p.rateLimit.Allow(ratelimit.TierAuth, mitmIPKey(r)); !d.Allow {
+		if d := p.rateLimit.Check(ratelimit.TierAuth, mitmIPKey(r)); !d.Allow {
 			ratelimit.WriteDenial(w, d, "Too many CONNECT attempts")
 			return
 		}
@@ -73,11 +74,13 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// connection is hijacked — once hijacked, no HTTP status can be sent.
 	token, hint, err := brokercore.ParseProxyAuth(r)
 	if err != nil {
+		p.recordAuthFailure(r)
 		writeProxyAuthChallenge(w, "Proxy-Authorization required")
 		return
 	}
 	scope, err := p.sessions.ResolveForProxy(r.Context(), token, hint)
 	if err != nil {
+		p.recordAuthFailure(r)
 		writeAuthError(w, err)
 		return
 	}
@@ -145,6 +148,17 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 	_ = srv.Serve(listener)
+}
+
+// recordAuthFailure records one auth-failure event against the per-IP
+// TierAuth budget so the read-only pre-gate in handleConnect /
+// handleForward will reject subsequent requests once the budget is
+// exhausted. Only called on auth failure — successful requests skip
+// TierAuth entirely (TierProxy covers them). Loopback peers are exempt.
+func (p *Proxy) recordAuthFailure(r *http.Request) {
+	if p.rateLimit != nil && !isLoopbackPeer(r) {
+		p.rateLimit.Allow(ratelimit.TierAuth, mitmIPKey(r))
+	}
 }
 
 // writeProxyAuthChallenge writes a 407 with a Proxy-Authenticate header so

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -67,12 +67,11 @@ func isAbsoluteForwardProxyRequest(r *http.Request) bool {
 // and the scope is resolved per request rather than once
 // per tunnel.
 func (p *Proxy) handleForward(w http.ResponseWriter, r *http.Request) {
-	// Per-IP flood gate before ParseProxyAuth + session lookup so a
-	// bad-auth flood can't burn CPU. Loopback is exempt — see
-	// isLoopbackPeer. Shares the TierAuth budget and key shape with
-	// CONNECT: one peer = one budget regardless of ingress shape.
+	// Read-only pre-gate: reject if this IP's auth-failure budget is
+	// exhausted. Only auth failures are recorded (below). Shares the
+	// TierAuth budget and key shape with CONNECT. Loopback is exempt.
 	if p.rateLimit != nil && !isLoopbackPeer(r) {
-		if d := p.rateLimit.Allow(ratelimit.TierAuth, mitmIPKey(r)); !d.Allow {
+		if d := p.rateLimit.Check(ratelimit.TierAuth, mitmIPKey(r)); !d.Allow {
 			ratelimit.WriteDenial(w, d, "Too many proxy requests")
 			return
 		}
@@ -112,11 +111,13 @@ func (p *Proxy) handleForward(w http.ResponseWriter, r *http.Request) {
 
 	token, hint, err := brokercore.ParseProxyAuth(r)
 	if err != nil {
+		p.recordAuthFailure(r)
 		writeProxyAuthChallenge(w, "Proxy-Authorization required")
 		return
 	}
 	scope, err := p.sessions.ResolveForProxy(r.Context(), token, hint)
 	if err != nil {
+		p.recordAuthFailure(r)
 		writeAuthError(w, err)
 		return
 	}

--- a/internal/mitm/forward_test.go
+++ b/internal/mitm/forward_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Infisical/agent-vault/internal/brokercore"
 	"github.com/Infisical/agent-vault/internal/netguard"
+	"github.com/Infisical/agent-vault/internal/ratelimit"
 	"github.com/Infisical/agent-vault/internal/requestlog"
 )
 
@@ -649,5 +650,84 @@ func TestMITMForwardIPv6PreservesHostHeader(t *testing.T) {
 	wantHost := "[::1]:" + port
 	if sawHost != wantHost {
 		t.Errorf("upstream Host = %q, want %q (IPv6 brackets must round-trip)", sawHost, wantHost)
+	}
+}
+
+func TestMITMForwardAuthRateLimitSkipsSuccessfulAuth(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+
+	upHost, upPort, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "http://"))
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upHost: {result: &brokercore.InjectResult{Passthrough: true}},
+	}}
+	proxyURL, _, p := setupProxy(t, sr, cp)
+
+	cfg := ratelimit.DefaultsFor(ratelimit.ProfileDefault)
+	cfg.Tiers[ratelimit.TierAuth].Max = 3
+	p.rateLimit = ratelimit.New(cfg)
+	overrideRemoteAddr(p, "10.0.0.5:12345")
+
+	auth := base64.StdEncoding.EncodeToString([]byte("av_sess_ok:"))
+	for i := 0; i < 10; i++ {
+		conn := dialProxy(t, proxyURL)
+		resp := writeRawRequestLine(t, conn,
+			fmt.Sprintf("GET http://%s:%s/x HTTP/1.1", upHost, upPort),
+			map[string]string{
+				"Host":                upstream.Listener.Addr().String(),
+				"Proxy-Authorization": "Basic " + auth,
+			})
+		resp.Body.Close()
+		conn.Close()
+		if resp.StatusCode == http.StatusTooManyRequests {
+			t.Fatalf("forward %d got 429; successful auth should not consume TierAuth budget", i+1)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("forward %d got %d, want 200", i+1, resp.StatusCode)
+		}
+	}
+}
+
+func TestMITMForwardAuthRateLimitCountsFailures(t *testing.T) {
+	sr := validTokenResolver("good-token", nil)
+	cp := &fakeCredProvider{}
+	proxyURL, _, p := setupProxy(t, sr, cp)
+
+	cfg := ratelimit.DefaultsFor(ratelimit.ProfileDefault)
+	cfg.Tiers[ratelimit.TierAuth].Max = 3
+	p.rateLimit = ratelimit.New(cfg)
+	overrideRemoteAddr(p, "10.0.0.5:12345")
+
+	auth := base64.StdEncoding.EncodeToString([]byte("bad-token:"))
+	for i := 0; i < 3; i++ {
+		conn := dialProxy(t, proxyURL)
+		resp := writeRawRequestLine(t, conn,
+			"GET http://example.com/x HTTP/1.1",
+			map[string]string{
+				"Host":                "example.com",
+				"Proxy-Authorization": "Basic " + auth,
+			})
+		resp.Body.Close()
+		conn.Close()
+		if resp.StatusCode == http.StatusTooManyRequests {
+			t.Fatalf("forward %d got 429 before budget should be exhausted", i+1)
+		}
+	}
+
+	conn := dialProxy(t, proxyURL)
+	defer conn.Close()
+	resp := writeRawRequestLine(t, conn,
+		"GET http://example.com/x HTTP/1.1",
+		map[string]string{
+			"Host":                "example.com",
+			"Proxy-Authorization": "Basic " + auth,
+		})
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("forward 4 got %d, want 429 after budget exhausted", resp.StatusCode)
 	}
 }

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -1517,6 +1517,104 @@ func TestMITMSubstitutionRewritesQueryAndHeader(t *testing.T) {
 	}
 }
 
+// overrideRemoteAddr wraps the proxy's HTTP handler to set RemoteAddr to
+// a non-loopback IP so rate-limit tests exercise the non-exempt path.
+// Must be called after setupProxy but before any requests are made.
+func overrideRemoteAddr(p *Proxy, addr string) {
+	orig := p.httpServer.Handler
+	p.httpServer.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.RemoteAddr = addr
+		orig.ServeHTTP(w, r)
+	})
+}
+
+func TestMITMConnectAuthRateLimitSkipsSuccessfulAuth(t *testing.T) {
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{}
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+
+	cfg := ratelimit.DefaultsFor(ratelimit.ProfileDefault)
+	cfg.Tiers[ratelimit.TierAuth].Max = 3
+	p.rateLimit = ratelimit.New(cfg)
+	overrideRemoteAddr(p, "10.0.0.5:12345")
+
+	// Send more CONNECT requests than the TierAuth budget (3). All should
+	// succeed because successful auth doesn't consume the budget.
+	auth := base64.StdEncoding.EncodeToString([]byte("av_sess_ok:"))
+	for i := 0; i < 10; i++ {
+		resp := rawConnect(t, proxyURL, clientRoots,
+			fmt.Sprintf("Proxy-Authorization: Basic %s\r\n", auth))
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusTooManyRequests {
+			t.Fatalf("CONNECT %d got 429; successful auth should not consume TierAuth budget", i+1)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("CONNECT %d got %d, want 200", i+1, resp.StatusCode)
+		}
+	}
+}
+
+func TestMITMConnectAuthRateLimitCountsFailures(t *testing.T) {
+	sr := validTokenResolver("good-token", nil)
+	cp := &fakeCredProvider{}
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+
+	cfg := ratelimit.DefaultsFor(ratelimit.ProfileDefault)
+	cfg.Tiers[ratelimit.TierAuth].Max = 3
+	p.rateLimit = ratelimit.New(cfg)
+	overrideRemoteAddr(p, "10.0.0.5:12345")
+
+	// 3 requests with bad auth should exhaust the budget.
+	auth := base64.StdEncoding.EncodeToString([]byte("bad-token:"))
+	for i := 0; i < 3; i++ {
+		resp := rawConnect(t, proxyURL, clientRoots,
+			fmt.Sprintf("Proxy-Authorization: Basic %s\r\n", auth))
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusTooManyRequests {
+			t.Fatalf("CONNECT %d got 429 before budget should be exhausted", i+1)
+		}
+	}
+
+	// 4th bad-auth request should be 429'd by the pre-gate.
+	resp := rawConnect(t, proxyURL, clientRoots,
+		fmt.Sprintf("Proxy-Authorization: Basic %s\r\n", auth))
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("CONNECT 4 got %d, want 429 after budget exhausted", resp.StatusCode)
+	}
+}
+
+func TestMITMConnectAuthRateLimitCountsMissingAuth(t *testing.T) {
+	sr := errResolver(brokercore.ErrInvalidSession)
+	cp := &fakeCredProvider{}
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+
+	cfg := ratelimit.DefaultsFor(ratelimit.ProfileDefault)
+	cfg.Tiers[ratelimit.TierAuth].Max = 3
+	p.rateLimit = ratelimit.New(cfg)
+	overrideRemoteAddr(p, "10.0.0.5:12345")
+
+	// Requests with no Proxy-Authorization header should consume budget.
+	for i := 0; i < 3; i++ {
+		resp := rawConnect(t, proxyURL, clientRoots, "")
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusTooManyRequests {
+			t.Fatalf("CONNECT %d got 429 before budget should be exhausted", i+1)
+		}
+		if resp.StatusCode != http.StatusProxyAuthRequired {
+			t.Fatalf("CONNECT %d got %d, want 407", i+1, resp.StatusCode)
+		}
+	}
+
+	// 4th should be 429.
+	resp := rawConnect(t, proxyURL, clientRoots, "")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("CONNECT 4 got %d, want 429", resp.StatusCode)
+	}
+}
+
 func TestIsValidHost(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/internal/ratelimit/config.go
+++ b/internal/ratelimit/config.go
@@ -51,7 +51,7 @@ func DefaultsFor(profile Profile) Config {
 	}
 	mul := profileMultiplier(profile)
 	// Unauthenticated surface: login/register/forgot/reset/verify,
-	// invite/approval-token redemption.
+	// invite/approval-token redemption, and proxy auth failures.
 	c.Tiers[TierAuth] = TierConfig{
 		Algorithm: AlgSliding, Window: 5 * time.Minute, Max: scaleMax(10, mul), MaxKeys: 10000,
 	}

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -15,12 +15,15 @@ import (
 type Tier int
 
 const (
-	// TierAuth covers every unauthenticated endpoint: login, register,
+	// TierAuth covers unauthenticated endpoints (login, register,
 	// forgot/reset password, email verification, invite redemption,
-	// approval-token lookups. Sliding window. The
-	// caller picks the keyer — IPKey for IP-flood defense, IPTokenKey
-	// for token-enumeration, and the login handler uses both an IP
-	// and email key against this tier (reject if either is exhausted).
+	// approval-token lookups) and proxy auth failures (CONNECT and
+	// forward-proxy requests where authentication fails). Sliding
+	// window. The caller picks the keyer — IPKey for IP-flood
+	// defense, IPTokenKey for token-enumeration, and the login
+	// handler uses both an IP and email key against this tier (reject
+	// if either is exhausted). On the MITM proxy path, only auth
+	// failures are recorded; successful requests skip this tier.
 	TierAuth Tier = iota
 
 	// TierProxy is the /proxy and MITM rate limit keyed on

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -45,6 +45,54 @@ func TestSlidingWindowAllowThenDeny(t *testing.T) {
 	}
 }
 
+func TestCheckDoesNotRecord(t *testing.T) {
+	cfg := DefaultsFor(ProfileDefault)
+	cfg.Tiers[TierAuth].Max = 3
+	r := New(cfg)
+
+	key := "ip:10.0.0.5"
+
+	// Check many times — none should consume budget.
+	for i := 0; i < 20; i++ {
+		d := r.Check(TierAuth, key)
+		if !d.Allow {
+			t.Fatalf("Check %d denied, but no events were recorded", i+1)
+		}
+	}
+
+	// Now record 3 events via Allow to fill the budget.
+	for i := 0; i < 3; i++ {
+		d := r.Allow(TierAuth, key)
+		if !d.Allow {
+			t.Fatalf("Allow %d denied unexpectedly", i+1)
+		}
+	}
+
+	// Check should now return Deny.
+	d := r.Check(TierAuth, key)
+	if d.Allow {
+		t.Fatal("Check should deny after budget is exhausted")
+	}
+	if d.RetryAfter <= 0 {
+		t.Fatalf("RetryAfter should be positive, got %v", d.RetryAfter)
+	}
+
+	// Allow should also deny (and not double-count).
+	d = r.Allow(TierAuth, key)
+	if d.Allow {
+		t.Fatal("Allow should also deny after budget is exhausted")
+	}
+}
+
+func TestCheckOffConfigAllows(t *testing.T) {
+	r := New(DefaultsFor(ProfileOff))
+	for i := 0; i < 100; i++ {
+		if d := r.Check(TierAuth, "ip:1.2.3.4"); !d.Allow {
+			t.Fatalf("off config denied Check at attempt %d", i)
+		}
+	}
+}
+
 func TestSlidingWindowEvictionCap(t *testing.T) {
 	// Tight map cap + tight window so eviction fires on an old entry.
 	cfg := DefaultsFor(ProfileDefault)

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -81,6 +82,28 @@ func TestCheckDoesNotRecord(t *testing.T) {
 	d = r.Allow(TierAuth, key)
 	if d.Allow {
 		t.Fatal("Allow should also deny after budget is exhausted")
+	}
+}
+
+func TestCheckEvictsColdKeys(t *testing.T) {
+	cfg := DefaultsFor(ProfileDefault)
+	cfg.Tiers[TierAuth].MaxKeys = 4
+	cfg.Tiers[TierAuth].Window = 50 * time.Millisecond
+	r := New(cfg)
+
+	// Check (not Allow) 6 unique keys — more than maxKeys.
+	for i := 0; i < 6; i++ {
+		r.Check(TierAuth, fmt.Sprintf("mitm:%d", i))
+	}
+
+	// Let entries expire so they become cold.
+	time.Sleep(60 * time.Millisecond)
+
+	// One more Check should trigger eviction of cold keys.
+	r.Check(TierAuth, "mitm:trigger")
+
+	if sz := r.sliding[TierAuth].size(); sz > cfg.Tiers[TierAuth].MaxKeys+2 {
+		t.Fatalf("check() did not evict cold keys: size=%d, maxKeys=%d", sz, cfg.Tiers[TierAuth].MaxKeys)
 	}
 }
 

--- a/internal/ratelimit/registry.go
+++ b/internal/ratelimit/registry.go
@@ -118,7 +118,9 @@ func (r *Registry) build(cfg Config) {
 // Check peeks at the current state for tier+key without recording an
 // event. Returns Deny when the budget is exhausted, AllowOK otherwise.
 // Used as a pre-gate before expensive work (auth lookups) so that
-// recording can be deferred to the failure path via Allow.
+// recording can be deferred to the failure path via Allow. Only
+// sliding-window tiers support a true read-only peek; other tier
+// types fail open so they never silently consume budget.
 func (r *Registry) Check(tier Tier, key string) Decision {
 	if r.cfg.Load().Off || key == "" {
 		return AllowOK(0, 0)
@@ -127,9 +129,6 @@ func (r *Registry) Check(tier Tier, key string) Decision {
 	defer r.mu.RUnlock()
 	if sw := r.sliding[tier]; sw != nil {
 		return sw.check(key)
-	}
-	if tb := r.buckets[tier]; tb != nil {
-		return tb.allow(key)
 	}
 	return AllowOK(0, 0)
 }

--- a/internal/ratelimit/registry.go
+++ b/internal/ratelimit/registry.go
@@ -115,6 +115,25 @@ func (r *Registry) build(cfg Config) {
 	})
 }
 
+// Check peeks at the current state for tier+key without recording an
+// event. Returns Deny when the budget is exhausted, AllowOK otherwise.
+// Used as a pre-gate before expensive work (auth lookups) so that
+// recording can be deferred to the failure path via Allow.
+func (r *Registry) Check(tier Tier, key string) Decision {
+	if r.cfg.Load().Off || key == "" {
+		return AllowOK(0, 0)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if sw := r.sliding[tier]; sw != nil {
+		return sw.check(key)
+	}
+	if tb := r.buckets[tier]; tb != nil {
+		return tb.allow(key)
+	}
+	return AllowOK(0, 0)
+}
+
 // Allow records one event against tier for key and returns a Decision.
 // Off configs return AllowOK. Unknown/unset tiers fail open (AllowOK).
 // Empty key fails open too (the middleware treats "" as "skip").

--- a/internal/ratelimit/sliding.go
+++ b/internal/ratelimit/sliding.go
@@ -106,6 +106,38 @@ func (l *slidingWindow) allow(key string) Decision {
 	return AllowOK(l.max-len(recent)-1, l.max)
 }
 
+// check peeks at the current state for key without recording a new
+// event. Used by the MITM proxy to pre-gate requests before running
+// auth — only auth failures are recorded via allow().
+func (l *slidingWindow) check(key string) Decision {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	cutoff := now.Add(-l.window)
+
+	recent := l.attempts[key][:0]
+	for _, t := range l.attempts[key] {
+		if t.After(cutoff) {
+			recent = append(recent, t)
+		}
+	}
+	l.attempts[key] = recent
+
+	if len(recent) >= l.max {
+		var wait time.Duration
+		if len(recent) > 0 {
+			wait = recent[0].Add(l.window).Sub(now)
+		}
+		if wait < time.Second {
+			wait = time.Second
+		}
+		return Deny("rate", wait, l.max)
+	}
+
+	return AllowOK(l.max-len(recent), l.max)
+}
+
 // size returns the number of tracked keys (for gauges/tests).
 func (l *slidingWindow) size() int {
 	l.mu.Lock()

--- a/internal/ratelimit/sliding.go
+++ b/internal/ratelimit/sliding.go
@@ -135,6 +135,14 @@ func (l *slidingWindow) check(key string) Decision {
 		return Deny("rate", wait, l.max)
 	}
 
+	if l.maxKeys > 0 && len(l.attempts) > l.maxKeys {
+		for k, v := range l.attempts {
+			if len(v) == 0 || v[len(v)-1].Before(cutoff) {
+				delete(l.attempts, k)
+			}
+		}
+	}
+
 	return AllowOK(l.max-len(recent), l.max)
 }
 

--- a/web/src/pages/instance/SettingsTab.tsx
+++ b/web/src/pages/instance/SettingsTab.tsx
@@ -31,7 +31,7 @@ const TIER_LABELS: Record<string, string> = {
 };
 
 const TIER_TOOLTIPS: Record<string, string> = {
-  AUTH: "Every unauthenticated endpoint: login, register, forgot/reset password, email verification, invite redemption, approval-token lookups. Keyed on client IP (and additionally on email for login; rejected when either bucket is exhausted).",
+  AUTH: "Unauthenticated endpoints (login, register, forgot/reset password, email verification, invite redemption, approval-token lookups) and proxy auth failures (CONNECT/forward requests where authentication fails — successful proxy requests skip this tier). Keyed on client IP (and additionally on email for login; rejected when either bucket is exhausted).",
   PROXY: "MITM forward path, keyed on (agent, vault). Defaults allow normal agent fan-out; a per-scope concurrency semaphore still bounds in-flight upstream calls.",
   AUTHED: "Everything behind requireAuth — CRUD, reads, admin, proposals, /discover. One bucket per actor. Defaults accommodate the heaviest legitimate agent workload; tighten only if abuse is observed.",
   GLOBAL: "Server-wide backstop: Rate + Burst drive a requests-per-second ceiling; Concurrency caps total in-flight requests. Outermost safety net — sheds load before per-tier limits engage.",


### PR DESCRIPTION
## Summary

Remote agents (Docker, VPS) get 429'd after ~10 CONNECT tunnels because every connection eats from the AUTH rate limit budget (10 per 5 min per IP) — even when the agent has valid credentials. Client libraries surface this as a generic "connection error" with no hint it's a rate limit.

The AUTH rate limit was designed for brute-force protection on login. But the MITM proxy checked it on every CONNECT/forward request before running auth, so legitimate agents burned through the budget just by connecting to a few services on startup.

**What changed:**

Added a read-only `Check()` to the rate limiter alongside the existing `Allow()`. The proxy now peeks before auth and only records when auth fails. Successful connections skip AUTH entirely — they're already covered by the PROXY tier.

Also updated the AUTH tier descriptions across Go comments, frontend tooltip, and docs. Removed the "disable rate limiting" workaround from the Hermes-on-VPS guide since it was a bandaid for this bug.

Closes #224

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

<!-- How did you verify this works? -->

- [x] Existing tests pass (`make test`)
- [x] Added/updated tests for new behavior
- [x] Manual testing (describe below)

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)