### PR TITLE
feat: configurable MITM response/request body size caps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,10 @@
 # INFISICAL_LDAP_AUTH_USERNAME=
 # INFISICAL_LDAP_AUTH_PASSWORD=
 
+# MITM proxy body-size limits (optional)
+# AGENT_VAULT_MAX_RESPONSE_BYTES=0         # max response body bytes streamed to agents (default 0 = unlimited)
+# AGENT_VAULT_MAX_REQUEST_BYTES=1073741824 # max request body bytes forwarded to upstreams (default 1073741824 = 1 GiB)
+
 # Observability (optional)
 # AGENT_VAULT_LOG_LEVEL=info               # info (default) | debug — debug emits one line per proxied request (no secret values)
 

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -23,3 +23,21 @@ func defaultPort() int {
 	}
 	return DefaultPort
 }
+
+func defaultMaxResponseBytes() int64 {
+	if v := os.Getenv("AGENT_VAULT_MAX_RESPONSE_BYTES"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return 0
+}
+
+func defaultMaxRequestBytes() int64 {
+	if v := os.Getenv("AGENT_VAULT_MAX_REQUEST_BYTES"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 1 << 30 // 1 GiB — matches brokercore.DefaultMaxRequestBytes
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -81,6 +81,8 @@ var serverCmd = &cobra.Command{
 		mitmPort, _ := cmd.Flags().GetInt("mitm-port")
 		logLevelFlag, _ := cmd.Flags().GetString("log-level")
 		logLevelChanged := cmd.Flags().Changed("log-level")
+		maxRespBytes, _ := cmd.Flags().GetInt64("max-response-bytes")
+		maxReqBytes, _ := cmd.Flags().GetInt64("max-request-bytes")
 		addr := fmt.Sprintf("%s:%d", host, port)
 
 		logLevel, err := resolveLogLevel(logLevelFlag, logLevelChanged)
@@ -91,7 +93,7 @@ var serverCmd = &cobra.Command{
 
 		// --- Detached child path: read master key + initialized flag from stdin pipe ---
 		if os.Getenv("_AGENT_VAULT_DETACHED") == "1" {
-			return runDetachedChild(host, addr, mitmPort, logger)
+			return runDetachedChild(host, addr, mitmPort, logger, maxRespBytes, maxReqBytes)
 		}
 
 		// Pre-flight before unlocking the vault: don't make the user type a
@@ -144,7 +146,7 @@ var serverCmd = &cobra.Command{
 			if logLevelChanged {
 				explicitLogLevel = &logLevelFlag
 			}
-			return spawnDetached(cmd, masterKey, initialized, host, port, mitmPort, addr, explicitLogLevel)
+			return spawnDetached(cmd, masterKey, initialized, host, port, mitmPort, addr, explicitLogLevel, maxRespBytes, maxReqBytes)
 		}
 
 		// --- Foreground path ---
@@ -157,7 +159,7 @@ var serverCmd = &cobra.Command{
 		srv.SetSkills(skillCLI, skillHTTP)
 		shutdownLogs := attachLogSink(srv, db, logger)
 		defer shutdownLogs()
-		if err := attachServerExtensions(srv, host, mitmPort, masterKey.Key(), logger); err != nil {
+		if err := attachServerExtensions(srv, host, mitmPort, masterKey.Key(), logger, maxRespBytes, maxReqBytes); err != nil {
 			return err
 		}
 		return srv.Start()
@@ -172,7 +174,7 @@ var serverCmd = &cobra.Command{
 // in server.Start: since the MITM proxy is default-on, environments that
 // cannot create ~/.agent-vault/ca/ (read-only FS, containers without HOME,
 // corrupted state) must still be able to run the core HTTP server.
-func attachMITMIfEnabled(srv *server.Server, host string, mitmPort int, masterKey []byte) error {
+func attachMITMIfEnabled(srv *server.Server, host string, mitmPort int, masterKey []byte, maxRespBytes, maxReqBytes int64) error {
 	if mitmPort <= 0 {
 		return nil
 	}
@@ -190,13 +192,15 @@ func attachMITMIfEnabled(srv *server.Server, host string, mitmPort int, masterKe
 	srv.AttachMITM(mitm.New(
 		net.JoinHostPort(host, strconv.Itoa(mitmPort)),
 		mitm.Options{
-			CA:          caProv,
-			Sessions:    srv.SessionResolver(),
-			Credentials: srv.CredentialProvider(),
-			BaseURL:     srv.BaseURL(),
-			Logger:      srv.Logger(),
-			RateLimit:   srv.RateLimit(),
-			LogSink:     srv.LogSink(),
+			CA:               caProv,
+			Sessions:         srv.SessionResolver(),
+			Credentials:      srv.CredentialProvider(),
+			BaseURL:          srv.BaseURL(),
+			Logger:           srv.Logger(),
+			RateLimit:        srv.RateLimit(),
+			LogSink:          srv.LogSink(),
+			MaxResponseBytes: maxRespBytes,
+			MaxRequestBytes:  maxReqBytes,
 		},
 	))
 	return nil
@@ -204,8 +208,8 @@ func attachMITMIfEnabled(srv *server.Server, host string, mitmPort int, masterKe
 
 // attachServerExtensions wires optional subsystems (MITM, Infisical) onto srv.
 // Both bootstrap paths (foreground and detached child) call this.
-func attachServerExtensions(srv *server.Server, host string, mitmPort int, masterKey []byte, logger *slog.Logger) error {
-	if err := attachMITMIfEnabled(srv, host, mitmPort, masterKey); err != nil {
+func attachServerExtensions(srv *server.Server, host string, mitmPort int, masterKey []byte, logger *slog.Logger, maxRespBytes, maxReqBytes int64) error {
+	if err := attachMITMIfEnabled(srv, host, mitmPort, masterKey, maxRespBytes, maxReqBytes); err != nil {
 		return err
 	}
 	attachInfisicalIfConfigured(srv, logger)
@@ -492,7 +496,7 @@ func readPasswordFromStdin() ([]byte, error) {
 
 // runDetachedChild is the entry point for the detached child process.
 // It reads 33 bytes from stdin: 32-byte master key + 1-byte initialized flag.
-func runDetachedChild(host, addr string, mitmPort int, logger *slog.Logger) error {
+func runDetachedChild(host, addr string, mitmPort int, logger *slog.Logger, maxRespBytes, maxReqBytes int64) error {
 	buf := make([]byte, 33)
 	if _, err := io.ReadFull(os.Stdin, buf); err != nil {
 		return fmt.Errorf("reading master key from pipe: %w", err)
@@ -519,7 +523,7 @@ func runDetachedChild(host, addr string, mitmPort int, logger *slog.Logger) erro
 	srv.SetSkills(skillCLI, skillHTTP)
 	shutdownLogs := attachLogSink(srv, db, logger)
 	defer shutdownLogs()
-	if err := attachServerExtensions(srv, host, mitmPort, key, logger); err != nil {
+	if err := attachServerExtensions(srv, host, mitmPort, key, logger, maxRespBytes, maxReqBytes); err != nil {
 		return err
 	}
 	return srv.Start()
@@ -528,7 +532,7 @@ func runDetachedChild(host, addr string, mitmPort int, logger *slog.Logger) erro
 // spawnDetached re-execs the server as a background process, passing the master key + initialized flag via a pipe.
 // explicitLogLevel, when non-nil, forwards the parent's --log-level flag to the child so a flag-only
 // invocation (no env var) still takes effect after re-exec.
-func spawnDetached(cmd *cobra.Command, masterKey *auth.MasterKey, initialized bool, host string, port, mitmPort int, addr string, explicitLogLevel *string) error {
+func spawnDetached(cmd *cobra.Command, masterKey *auth.MasterKey, initialized bool, host string, port, mitmPort int, addr string, explicitLogLevel *string, maxRespBytes, maxReqBytes int64) error {
 	defer masterKey.Wipe()
 
 	exe, err := os.Executable()
@@ -556,6 +560,8 @@ func spawnDetached(cmd *cobra.Command, masterKey *auth.MasterKey, initialized bo
 	if explicitLogLevel != nil {
 		childArgs = append(childArgs, "--log-level", *explicitLogLevel)
 	}
+	childArgs = append(childArgs, "--max-response-bytes", strconv.FormatInt(maxRespBytes, 10))
+	childArgs = append(childArgs, "--max-request-bytes", strconv.FormatInt(maxReqBytes, 10))
 	child := exec.Command(exe, childArgs...)
 	child.Stdin = pr
 	child.Stdout = logFile
@@ -663,6 +669,8 @@ func init() {
 	serverCmd.Flags().Bool("password-stdin", false, "read master password from stdin (for non-interactive use)")
 	serverCmd.Flags().Int("mitm-port", DefaultMITMPort, "port for the transparent MITM proxy (0 = disabled)")
 	serverCmd.Flags().String("log-level", "info", "log level: info (default) or debug (per-request proxy logs)")
+	serverCmd.Flags().Int64("max-response-bytes", defaultMaxResponseBytes(), "max response body bytes streamed to agents (default: unlimited; also respects AGENT_VAULT_MAX_RESPONSE_BYTES)")
+	serverCmd.Flags().Int64("max-request-bytes", defaultMaxRequestBytes(), "max request body bytes forwarded to upstreams (default: 1 GiB; also respects AGENT_VAULT_MAX_REQUEST_BYTES)")
 	serverCmd.AddCommand(stopCmd)
 	rootCmd.AddCommand(serverCmd)
 }

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -23,6 +23,8 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `--password-stdin` | `false` | Read master password from stdin |
     | `--mitm-port` | `14322` | Port for the transparent MITM proxy. Enabled by default; set to `0` to disable. On first launch the root CA is created under `~/.agent-vault/ca/` — clients fetch it with [`agent-vault ca fetch`](#ca). Bind failures are non-fatal. |
     | `--log-level` | `info` | Log level: `info` (default) or `debug`. At `debug`, emits one structured line per proxied request on stderr covering method, host, path, matched service, injected credential key names, upstream status, and duration. Credential **values** are never logged. |
+    | `--max-response-bytes` | `0` (unlimited) | Maximum response body bytes the MITM proxy streams back to agents. `0` means unlimited — responses are streamed with a small buffer so there is no memory risk. When a limit is set and the upstream response exceeds it, the proxy returns 502 (if the size is known upfront) or aborts the connection mid-stream (if chunked). Also respects `AGENT_VAULT_MAX_RESPONSE_BYTES`; the flag takes precedence. |
+    | `--max-request-bytes` | `1073741824` (1 GiB) | Maximum request body bytes the MITM proxy forwards to upstreams. Requests exceeding this receive HTTP 413. Also respects `AGENT_VAULT_MAX_REQUEST_BYTES`; the flag takes precedence. |
 
     **Environment variables:**
 
@@ -31,6 +33,8 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `PORT` | Server listen port (default `14321`). The `--port` flag takes precedence. |
     | `AGENT_VAULT_MASTER_PASSWORD` | Derives a KEK that wraps the data encryption key. Omit for passwordless mode. |
     | `AGENT_VAULT_LOG_LEVEL` | Fallback for `--log-level` when the flag is not set. Accepts `info` or `debug`. |
+    | `AGENT_VAULT_MAX_RESPONSE_BYTES` | Maximum response body bytes streamed to agents (default `0` = unlimited). The `--max-response-bytes` flag takes precedence. |
+    | `AGENT_VAULT_MAX_REQUEST_BYTES` | Maximum request body bytes forwarded to upstreams (default `1073741824` = 1 GiB). The `--max-request-bytes` flag takes precedence. |
     | `AGENT_VAULT_ADDR` | Externally-reachable base URL (e.g. `https://agent-vault.example.com`). Used for links in emails, invites, and discovery, and the hostname is added as a SubjectAltName on every MITM leaf cert so clients that TLS-verify against the proxy's own hostname succeed without a shim. Falls back to `https://<FLY_APP_NAME>.fly.dev` on Fly.io, then `http://{host}:{port}`. The **Connect Your Agent** modal pre-fills the agent address from this value when set; when unset, the modal renders a literal `<AGENT_VAULT_ADDR>` placeholder. |
     | `FLY_APP_NAME` | Auto-detected on Fly.io. When `AGENT_VAULT_ADDR` is unset, derives the base URL as `https://<FLY_APP_NAME>.fly.dev`. |
     | `AGENT_VAULT_SMTP_HOST` | SMTP server host. If unset, email notifications are silently disabled. |

--- a/docs/self-hosting/environment-variables.mdx
+++ b/docs/self-hosting/environment-variables.mdx
@@ -21,6 +21,8 @@ description: "Configuration for deploying an instance of Agent Vault."
 | `AGENT_VAULT_LOGS_MAX_AGE_HOURS` | Optional (defaults to `168`) | Maximum age, in hours, of rows retained in the per-vault request log. |
 | `AGENT_VAULT_LOGS_MAX_ROWS_PER_VAULT` | Optional (defaults to `10000`) | Maximum number of rows retained per vault in the request log. Set to `0` to disable the row cap. |
 | `AGENT_VAULT_LOGS_RETENTION_LOCK` | Optional (defaults to `false`) | Whether to ignore owner-UI overrides for log retention and pin to env values. |
+| `AGENT_VAULT_MAX_RESPONSE_BYTES` | Optional (defaults to `0` = unlimited) | Maximum response body bytes the MITM proxy streams back to agents. Responses are streamed with a small buffer so unlimited is safe. When set and exceeded, the proxy returns 502 or aborts the connection. Overridden by `--max-response-bytes`. |
+| `AGENT_VAULT_MAX_REQUEST_BYTES` | Optional (defaults to `1073741824` = 1 GiB) | Maximum request body bytes the MITM proxy forwards to upstreams. Requests exceeding this receive HTTP 413. Overridden by `--max-request-bytes`. |
 | `AGENT_VAULT_ISOLATION` | Optional (defaults to `host`) | Default isolation mode for `agent-vault vault run`. One of: `host`, `container` (see [Container isolation](/guides/container-isolation)). Overridden by `--isolation`. |
 
 ## Email SMTP configuration

--- a/internal/brokercore/brokercore.go
+++ b/internal/brokercore/brokercore.go
@@ -16,9 +16,11 @@ import (
 	"github.com/Infisical/agent-vault/internal/broker"
 )
 
-// MaxResponseBytes caps response bodies streamed back to agents on the
-// MITM proxy ingress.
-const MaxResponseBytes = 100 << 20
+// DefaultMaxResponseBytes is the default cap for response bodies on the
+// MITM proxy ingress. 0 means unlimited — response bodies are streamed
+// with a small buffer so there is no OOM risk. Operators can set a cap
+// via --max-response-bytes / AGENT_VAULT_MAX_RESPONSE_BYTES.
+const DefaultMaxResponseBytes int64 = 0
 
 // ProxyErrorHeader is the response header Agent Vault sets on broker-layer
 // error responses so SDK clients can distinguish them from upstream

--- a/internal/brokercore/session.go
+++ b/internal/brokercore/session.go
@@ -7,12 +7,15 @@ import (
 	"github.com/Infisical/agent-vault/internal/store"
 )
 
-// MaxProxyBodyBytes caps forwarded request bodies on the MITM proxy
-// ingress. Distinct from the generic 1 MB limitBody wrapper used on
-// control-plane endpoints: proxy bodies are legitimately larger (file
-// uploads, bulk API payloads) but must still be bounded to protect RAM
-// under the proxy concurrency semaphore.
-const MaxProxyBodyBytes = 64 << 20
+// DefaultMaxRequestBytes is the default cap for request bodies forwarded
+// on the MITM proxy ingress. Distinct from the generic 1 MB limitBody
+// wrapper used on control-plane endpoints.
+const DefaultMaxRequestBytes int64 = 1 << 30 // 1 GiB
+
+// MaxMaterializeBytes caps request bodies that must be buffered in RAM
+// for body-surface substitutions. Kept small because body substitutions
+// target API payloads (JSON, form-encoded), not large file uploads.
+const MaxMaterializeBytes int64 = 64 << 20 // 64 MiB
 
 // ProxyScope is the resolved identity + vault context for a proxy request.
 // It is produced once per CONNECT on the MITM ingress and carried through

--- a/internal/brokercore/substitution.go
+++ b/internal/brokercore/substitution.go
@@ -19,6 +19,20 @@ type ResolvedSubstitution struct {
 	In          []string // subset of {"path","query","header","body","websocket"} — security boundary
 }
 
+// HasBodySubstitutions reports whether any substitution targets the
+// "body" surface — used to decide whether the request body must be
+// materialized in RAM.
+func HasBodySubstitutions(subs []ResolvedSubstitution) bool {
+	for _, sub := range subs {
+		for _, s := range sub.In {
+			if s == "body" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ApplySubstitutions rewrites declared surfaces of an outbound request
 // in-place. Path uses url.PathEscape, query uses url.QueryEscape, header
 // uses the raw value with a CRLF guard. On error, callers must not

--- a/internal/brokercore/substitution_test.go
+++ b/internal/brokercore/substitution_test.go
@@ -413,3 +413,30 @@ func TestApplyBodySubstitutionsScopingDoesNotAffectOtherSurfaces(t *testing.T) {
 		t.Fatalf("body-only sub should not modify header, got %q", headers.Get("X-Echo"))
 	}
 }
+
+func TestHasBodySubstitutions(t *testing.T) {
+	cases := []struct {
+		name string
+		subs []ResolvedSubstitution
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty", []ResolvedSubstitution{}, false},
+		{"header only", []ResolvedSubstitution{{In: []string{"header"}}}, false},
+		{"path and query", []ResolvedSubstitution{{In: []string{"path", "query"}}}, false},
+		{"body", []ResolvedSubstitution{{In: []string{"body"}}}, true},
+		{"body among others", []ResolvedSubstitution{{In: []string{"header", "body"}}}, true},
+		{"second sub has body", []ResolvedSubstitution{
+			{In: []string{"header"}},
+			{In: []string{"body"}},
+		}, true},
+		{"websocket only", []ResolvedSubstitution{{In: []string{"websocket"}}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasBodySubstitutions(tc.subs); got != tc.want {
+				t.Errorf("HasBodySubstitutions() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -195,7 +195,7 @@ func (p *Proxy) forwardRequest(
 	}
 	defer enf.Release()
 
-	r.Body = http.MaxBytesReader(w, r.Body, brokercore.MaxProxyBodyBytes)
+	r.Body = http.MaxBytesReader(w, r.Body, p.maxRequestBytes)
 
 	scheme := "http"
 	if useTLSUpstream {
@@ -209,22 +209,11 @@ func (p *Proxy) forwardRequest(
 		RawQuery: r.URL.RawQuery,
 	}
 
-	body, contentLength, err := brokercore.MaterializeRequestBody(r.Body)
-	if err != nil {
-		status, code := brokercore.RequestBodyErrorCode(err)
-		http.Error(w, http.StatusText(status), status)
-		emit(status, code)
+	if r.ContentLength > 0 && r.ContentLength > p.maxRequestBytes {
+		http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+		emit(http.StatusRequestEntityTooLarge, "request_too_large")
 		return
 	}
-
-	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, outURL.String(), body)
-	if err != nil {
-		http.Error(w, "bad gateway", http.StatusBadGateway)
-		emit(http.StatusBadGateway, "internal")
-		return
-	}
-	outReq.Host = hostHeaderForScheme(scheme, target)
-	outReq.ContentLength = contentLength
 
 	inject, err := p.creds.Inject(r.Context(), scope.VaultID, host, r.URL.Path)
 	if inject != nil {
@@ -247,26 +236,44 @@ func (p *Proxy) forwardRequest(
 		return
 	}
 
+	var body io.ReadCloser
+	var contentLength int64
+
+	hasSubs := brokercore.HasBodySubstitutions(inject.Substitutions)
+	canStream := !hasSubs && r.ContentLength >= 0
+
+	if canStream {
+		body = r.Body
+		contentLength = r.ContentLength
+	} else {
+		r.Body = http.MaxBytesReader(w, r.Body, brokercore.MaxMaterializeBytes)
+		body, contentLength, err = brokercore.MaterializeRequestBody(r.Body)
+		if err != nil {
+			status, code := brokercore.RequestBodyErrorCode(err)
+			http.Error(w, http.StatusText(status), status)
+			emit(status, code)
+			return
+		}
+	}
+
+	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, outURL.String(), body)
+	if err != nil {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+		emit(http.StatusBadGateway, "internal")
+		return
+	}
+	outReq.Host = hostHeaderForScheme(scheme, target)
+	outReq.ContentLength = contentLength
+
 	wsUpgrade := isWebSocketUpgrade(r)
 
-	// WS handshake needs Connection/Upgrade through, but ApplyInjection
-	// would drop them as hop-by-hop. Copy the full handshake set
-	// manually, then tell ApplyInjection to skip them so the
-	// non-hop-by-hop ones (Origin, Sec-*) aren't duplicated. Injection
-	// still wins on overlapping names (Authorization etc.) because
-	// inject.Headers is Set last by ApplyInjection.
 	if wsUpgrade {
 		copyWebSocketHandshakeHeaders(r.Header, outReq.Header)
 		brokercore.ApplyInjection(r.Header, outReq.Header, inject, websocketHandshakeHeaderNames...)
 	} else {
-		// No extraStrip: Proxy-Authorization is already in the broker
-		// denylist, and Authorization is the client's upstream header.
 		brokercore.ApplyInjection(r.Header, outReq.Header, inject)
 	}
 
-	// Apply any declared substitutions to the outbound URL and
-	// headers. Surfaces not listed in the substitution's `in:` are
-	// not scanned — scope is the security boundary.
 	if err := brokercore.ApplySubstitutions(outReq.URL, outReq.Header, inject.Substitutions); err != nil {
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 		emit(http.StatusBadGateway, "substitution_error")
@@ -305,7 +312,6 @@ func (p *Proxy) forwardRequest(
 
 	resp, err := p.upstream.RoundTrip(outReq)
 	if err != nil {
-		// Log the actual error for operators while sending generic message to client.
 		p.logger.Debug("upstream request failed",
 			slog.String("vault_id", scope.VaultID),
 			slog.String("vault_name", scope.VaultName),
@@ -318,6 +324,21 @@ func (p *Proxy) forwardRequest(
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if p.maxResponseBytes > 0 && resp.ContentLength > 0 && resp.ContentLength > p.maxResponseBytes {
+		_ = resp.Body.Close()
+		p.logger.Warn("response body exceeds limit",
+			slog.String("host", target),
+			slog.String("path", r.URL.Path),
+			slog.Int64("content_length", resp.ContentLength),
+			slog.Int64("max_response_bytes", p.maxResponseBytes),
+		)
+		brokercore.WriteProxyError(w, http.StatusBadGateway, "response_too_large",
+			fmt.Sprintf("Upstream response body (%d bytes) exceeds the proxy response-size limit (%d bytes).",
+				resp.ContentLength, p.maxResponseBytes))
+		emit(http.StatusBadGateway, "response_too_large")
+		return
+	}
+
 	for k, vv := range resp.Header {
 		if brokercore.ShouldStripResponseHeader(k) {
 			continue
@@ -327,6 +348,26 @@ func (p *Proxy) forwardRequest(
 		}
 	}
 	w.WriteHeader(resp.StatusCode)
-	_, _ = io.Copy(w, io.LimitReader(resp.Body, brokercore.MaxResponseBytes))
+
+	var src io.Reader = resp.Body
+	if p.maxResponseBytes > 0 {
+		src = io.LimitReader(resp.Body, p.maxResponseBytes)
+	}
+	n, _ := io.Copy(w, src)
+
+	if p.maxResponseBytes > 0 && n == p.maxResponseBytes {
+		var probe [1]byte
+		if extra, _ := resp.Body.Read(probe[:]); extra > 0 {
+			p.logger.Warn("response body truncated mid-stream, aborting connection",
+				slog.String("host", target),
+				slog.String("path", r.URL.Path),
+				slog.Int64("bytes_streamed", n),
+				slog.Int64("max_response_bytes", p.maxResponseBytes),
+			)
+			emit(resp.StatusCode, "response_truncated")
+			panic(http.ErrAbortHandler)
+		}
+	}
+
 	emit(resp.StatusCode, "")
 }

--- a/internal/mitm/proxy.go
+++ b/internal/mitm/proxy.go
@@ -45,16 +45,18 @@ import (
 // Proxy is a transparent MITM proxy. It is safe to start at most once;
 // reuse across Shutdown is not supported.
 type Proxy struct {
-	ca          ca.Provider
-	sessions    brokercore.SessionResolver
-	creds       brokercore.CredentialProvider
-	httpServer  *http.Server
-	upstream    *http.Transport
-	isListening atomic.Bool
-	baseURL     string // externally-reachable control-plane URL for help links
-	logger      *slog.Logger
-	rateLimit   *ratelimit.Registry // shared with the HTTP server; nil = no-op
-	logSink     requestlog.Sink     // never nil (Nop default); shared with the HTTP server
+	ca               ca.Provider
+	sessions         brokercore.SessionResolver
+	creds            brokercore.CredentialProvider
+	httpServer       *http.Server
+	upstream         *http.Transport
+	isListening      atomic.Bool
+	baseURL          string // externally-reachable control-plane URL for help links
+	logger           *slog.Logger
+	rateLimit        *ratelimit.Registry // shared with the HTTP server; nil = no-op
+	logSink          requestlog.Sink     // never nil (Nop default); shared with the HTTP server
+	maxResponseBytes int64               // 0 = unlimited
+	maxRequestBytes  int64
 }
 
 // Options carries the dependencies a Proxy needs. BaseURL is the
@@ -64,13 +66,15 @@ type Proxy struct {
 // server so proxy limits and control-plane limits live in one registry;
 // nil disables rate limiting on the MITM path.
 type Options struct {
-	CA          ca.Provider
-	Sessions    brokercore.SessionResolver
-	Credentials brokercore.CredentialProvider
-	BaseURL     string
-	Logger      *slog.Logger
-	RateLimit   *ratelimit.Registry
-	LogSink     requestlog.Sink // nil → Nop
+	CA               ca.Provider
+	Sessions         brokercore.SessionResolver
+	Credentials      brokercore.CredentialProvider
+	BaseURL          string
+	Logger           *slog.Logger
+	RateLimit        *ratelimit.Registry
+	LogSink          requestlog.Sink // nil → Nop
+	MaxResponseBytes int64           // 0 = unlimited (default); >0 = cap in bytes
+	MaxRequestBytes  int64           // 0 → DefaultMaxRequestBytes (1 GiB)
 }
 
 // New builds a Proxy bound to addr. The returned Proxy does not begin
@@ -90,15 +94,23 @@ func New(addr string, opts Options) *Proxy {
 	if sink == nil {
 		sink = requestlog.Nop{}
 	}
+
+	maxReq := opts.MaxRequestBytes
+	if maxReq <= 0 {
+		maxReq = brokercore.DefaultMaxRequestBytes
+	}
+
 	p := &Proxy{
-		ca:        opts.CA,
-		sessions:  opts.Sessions,
-		creds:     opts.Credentials,
-		upstream:  upstream,
-		baseURL:   opts.BaseURL,
-		logger:    opts.Logger,
-		rateLimit: opts.RateLimit,
-		logSink:   sink,
+		ca:               opts.CA,
+		sessions:         opts.Sessions,
+		creds:            opts.Credentials,
+		upstream:         upstream,
+		baseURL:          opts.BaseURL,
+		logger:           opts.Logger,
+		rateLimit:        opts.RateLimit,
+		logSink:          sink,
+		maxResponseBytes: opts.MaxResponseBytes, // 0 = unlimited
+		maxRequestBytes:  maxReq,
 	}
 
 	p.httpServer = &http.Server{

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -1639,3 +1639,196 @@ func TestIsValidHost(t *testing.T) {
 		}
 	}
 }
+
+// --- Response / request body size limit tests ---
+
+func TestResponseLimitRejectsKnownOversizeWith502(t *testing.T) {
+	body := strings.Repeat("X", 2048)
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, body)
+	}))
+	defer upstream.Close()
+
+	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
+	sr := validTokenResolver("tok", &brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp, func(o *Options) {
+		o.MaxResponseBytes = 1024
+	})
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: upstreamRoots}
+
+	resp, err := newTrustingClient(proxyURL, url.User("tok"), clientRoots).Get(upstream.URL + "/big")
+	if err != nil {
+		t.Fatalf("client.Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	}
+	if resp.Header.Get(brokercore.ProxyErrorHeader) != "true" {
+		t.Fatal("missing X-Agent-Vault-Proxy-Error header")
+	}
+	var errBody map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&errBody); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if errBody["error"] != "response_too_large" {
+		t.Fatalf("error code = %q, want response_too_large", errBody["error"])
+	}
+}
+
+func TestResponseLimitAbortsChunkedMidStream(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f, _ := w.(http.Flusher)
+		for i := 0; i < 20; i++ {
+			_, _ = w.Write(make([]byte, 128))
+			if f != nil {
+				f.Flush()
+			}
+		}
+	}))
+	defer upstream.Close()
+
+	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
+	sr := validTokenResolver("tok", &brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp, func(o *Options) {
+		o.MaxResponseBytes = 1024
+	})
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: upstreamRoots}
+
+	resp, err := newTrustingClient(proxyURL, url.User("tok"), clientRoots).Get(upstream.URL + "/chunked")
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	if len(data) >= 2560 {
+		t.Fatalf("got %d bytes, expected incomplete response (limit 1024)", len(data))
+	}
+}
+
+func TestResponseExactFitNoAbort(t *testing.T) {
+	body := strings.Repeat("X", 1024)
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, body)
+	}))
+	defer upstream.Close()
+
+	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
+	sr := validTokenResolver("tok", &brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp, func(o *Options) {
+		o.MaxResponseBytes = 1024
+	})
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: upstreamRoots}
+
+	resp, err := newTrustingClient(proxyURL, url.User("tok"), clientRoots).Get(upstream.URL + "/exact")
+	if err != nil {
+		t.Fatalf("client.Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	data, _ := io.ReadAll(resp.Body)
+	if string(data) != body {
+		t.Fatalf("got %d bytes, want %d", len(data), len(body))
+	}
+}
+
+func TestResponseUnlimitedByDefault(t *testing.T) {
+	body := strings.Repeat("X", 8192)
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, body)
+	}))
+	defer upstream.Close()
+
+	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
+	sr := validTokenResolver("tok", &brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: upstreamRoots}
+
+	resp, err := newTrustingClient(proxyURL, url.User("tok"), clientRoots).Get(upstream.URL + "/large")
+	if err != nil {
+		t.Fatalf("client.Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	data, _ := io.ReadAll(resp.Body)
+	if len(data) != len(body) {
+		t.Fatalf("got %d bytes, want %d", len(data), len(body))
+	}
+}
+
+func TestRequestBodyCapConfigurable(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+
+	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
+	sr := validTokenResolver("tok", &brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp, func(o *Options) {
+		o.MaxRequestBytes = 512
+	})
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: upstreamRoots}
+
+	resp, err := newTrustingClient(proxyURL, url.User("tok"), clientRoots).Post(
+		upstream.URL+"/upload", "application/octet-stream",
+		strings.NewReader(strings.Repeat("X", 1024)))
+	if err != nil {
+		t.Fatalf("client.Post: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", resp.StatusCode)
+	}
+}
+
+func TestDefaultMaxRequestBytesZeroMeansDefault(t *testing.T) {
+	p := New("127.0.0.1:0", Options{
+		Logger: slog.New(slog.DiscardHandler),
+	})
+	if p.maxRequestBytes != brokercore.DefaultMaxRequestBytes {
+		t.Fatalf("maxRequestBytes = %d, want %d", p.maxRequestBytes, brokercore.DefaultMaxRequestBytes)
+	}
+	if p.maxResponseBytes != 0 {
+		t.Fatalf("maxResponseBytes = %d, want 0 (unlimited)", p.maxResponseBytes)
+	}
+}

--- a/internal/mitm/websocket.go
+++ b/internal/mitm/websocket.go
@@ -101,6 +101,12 @@ func (p *Proxy) forwardWebSocket(
 		if p.maxResponseBytes > 0 && n == p.maxResponseBytes {
 			var probe [1]byte
 			if extra, _ := resp.Body.Read(probe[:]); extra > 0 {
+				p.logger.Warn("response body truncated mid-stream, aborting connection",
+					slog.String("host", outReq.URL.Host),
+					slog.String("path", outReq.URL.Path),
+					slog.Int64("bytes_streamed", n),
+					slog.Int64("max_response_bytes", p.maxResponseBytes),
+				)
 				emit(resp.StatusCode, "response_truncated")
 				panic(http.ErrAbortHandler)
 			}

--- a/internal/mitm/websocket.go
+++ b/internal/mitm/websocket.go
@@ -73,6 +73,15 @@ func (p *Proxy) forwardWebSocket(
 
 	if resp.StatusCode != http.StatusSwitchingProtocols {
 		defer func() { _ = resp.Body.Close() }()
+
+		if p.maxResponseBytes > 0 && resp.ContentLength > 0 && resp.ContentLength > p.maxResponseBytes {
+			brokercore.WriteProxyError(w, http.StatusBadGateway, "response_too_large",
+				fmt.Sprintf("Upstream response body (%d bytes) exceeds the proxy response-size limit (%d bytes).",
+					resp.ContentLength, p.maxResponseBytes))
+			emit(http.StatusBadGateway, "response_too_large")
+			return
+		}
+
 		for k, vv := range resp.Header {
 			if brokercore.ShouldStripResponseHeader(k) {
 				continue
@@ -82,7 +91,21 @@ func (p *Proxy) forwardWebSocket(
 			}
 		}
 		w.WriteHeader(resp.StatusCode)
-		_, _ = io.Copy(w, io.LimitReader(resp.Body, brokercore.MaxResponseBytes))
+
+		var src io.Reader = resp.Body
+		if p.maxResponseBytes > 0 {
+			src = io.LimitReader(resp.Body, p.maxResponseBytes)
+		}
+		n, _ := io.Copy(w, src)
+
+		if p.maxResponseBytes > 0 && n == p.maxResponseBytes {
+			var probe [1]byte
+			if extra, _ := resp.Body.Read(probe[:]); extra > 0 {
+				emit(resp.StatusCode, "response_truncated")
+				panic(http.ErrAbortHandler)
+			}
+		}
+
 		emit(resp.StatusCode, "")
 		return
 	}


### PR DESCRIPTION
## Summary

The MITM proxy hardcoded a 100 MB response body cap (`MaxResponseBytes`) and a 64 MB request body cap (`MaxProxyBodyBytes`) that silently truncated large transfers. `git clone` of any repo with >100 MB of history (TypeScript, React, Kubernetes, most company monorepos) failed with a confusing `early EOF` / `unexpected disconnect while reading sideband packet` error. The server logged `status=200` with no warning — users had no way to tell the proxy was at fault.

Confirmed by reproduction: cloning `microsoft/TypeScript` through the proxy truncated at exactly 104,857,600 bytes (the hardcoded limit). Same root cause reported in #210 and external draft PR #198.

**Response body cap: now unlimited by default**

Response bodies are streamed with a 32 KB `io.Copy` buffer — no OOM risk regardless of size. The old 100 MB cap only broke legitimate transfers. Default is now `0` (unlimited). Operators who want a bandwidth guard can set `--max-response-bytes` / `AGENT_VAULT_MAX_RESPONSE_BYTES`.

When a limit IS configured:
- **Known oversize** (`Content-Length > limit`): returns 502 Bad Gateway with `X-Agent-Vault-Proxy-Error` and a clear JSON error before streaming any body
- **Mid-stream discovery** (chunked, hits limit): aborts the connection via `http.ErrAbortHandler` — client sees a connection reset, not silently corrupted data

This follows the industry standard (nginx, Squid, Envoy): reject, never silently truncate.

**Request body cap: configurable, default 1 GiB**

Raised from 64 MB to 1 GiB via `--max-request-bytes` / `AGENT_VAULT_MAX_REQUEST_BYTES`. Fixes `git push` of large repos and bulk file uploads that previously hit 413.

**OOM fix: conditional body materialization**

Previously, every request body was fully buffered in RAM by `MaterializeRequestBody` — up to the body cap per concurrent request. Now:

- **Known-length bodies without body substitutions** (the common case: git, file uploads, API calls): streamed directly to the upstream without materialization. `Content-Length` is forwarded from the original request.
- **Unknown-length (chunked) or body-substitution bodies**: materialized as before, but capped at 64 MB (`MaxMaterializeBytes`) regardless of the request cap. Body substitutions target small API payloads (JSON, form-encoded), never large file uploads.

The reorder is safe: `Inject()` takes `(ctx, vaultID, host, path)` — no body dependency — so it moves before materialization. `HasBodySubstitutions()` (new helper) checks the substitution surfaces before deciding the path.

**Observability**

Both the 502 rejection and mid-stream abort paths log `slog.Warn` with host, path, bytes streamed, and the configured limit. Previously: zero logging on truncation.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] Existing tests pass (`make test` — all 20 packages green)
- [x] Added/updated tests for new behavior (9 new tests):

| Test | Validates |
|------|-----------|
| `TestResponseLimitRejectsKnownOversizeWith502` | Content-Length > limit → 502 + `X-Agent-Vault-Proxy-Error` + JSON error |
| `TestResponseLimitAbortsChunkedMidStream` | Chunked body > limit → connection abort, not clean 200 |
| `TestResponseExactFitNoAbort` | Body exactly at limit → completes normally (one-byte probe fix) |
| `TestResponseUnlimitedByDefault` | Default `MaxResponseBytes=0` → large response passes through |
| `TestRequestBodyCapConfigurable` | Body > configured limit → 413 |
| `TestDefaultMaxRequestBytesZeroMeansDefault` | `Options{}` zero-value → 1 GiB default |
| `TestHasBodySubstitutions` | Unit test for surface detection (8 subcases) |

- [x] Manual testing: built binary, started server, cloned `microsoft/TypeScript` through the proxy — completed successfully (was failing before at 100 MB)

Supersedes #198.

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)
