### PR TITLE
feat: flush MITM responses per-chunk for live streaming (git clone, SSE)

### DIFF
--- a/internal/mitm/connect.go
+++ b/internal/mitm/connect.go
@@ -132,6 +132,11 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	listener := newOneShotListener(tlsConn)
 	srv := &http.Server{
 		Handler: p.forwardHandler(target, host, scope),
+		// ReadHeaderTimeout and ReadTimeout bound the request side
+		// (slow-loris defense). IdleTimeout caps keep-alives between
+		// requests. The upstream transport's ResponseHeaderTimeout
+		// (5 min) prevents stalled upstreams. WriteTimeout is 30 min
+		// to allow long-running streaming transfers (git clone, SSE).
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       60 * time.Second,
 		WriteTimeout:      30 * time.Minute,

--- a/internal/mitm/connect.go
+++ b/internal/mitm/connect.go
@@ -132,11 +132,9 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	listener := newOneShotListener(tlsConn)
 	srv := &http.Server{
 		Handler: p.forwardHandler(target, host, scope),
-		// Slow-loris defense: without these the tunnel can drip bytes
-		// forever and pin a proxy concurrency slot.
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       60 * time.Second,
-		WriteTimeout:      5 * time.Minute, // upstream streaming can be legit
+		WriteTimeout:      30 * time.Minute,
 		IdleTimeout:       2 * time.Minute,
 		ConnState: func(c net.Conn, state http.ConnState) {
 			// Either terminal state means Serve should return. The

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -16,6 +16,19 @@ import (
 	"github.com/Infisical/agent-vault/internal/requestlog"
 )
 
+type flushingWriter struct {
+	w io.Writer
+	f http.Flusher
+}
+
+func (fw *flushingWriter) Write(p []byte) (int, error) {
+	n, err := fw.w.Write(p)
+	if n > 0 {
+		fw.f.Flush()
+	}
+	return n, err
+}
+
 // actorFromScope returns the (type, id) pair used in request log rows.
 // Empty strings when neither principal is set on the scope.
 func actorFromScope(scope *brokercore.ProxyScope) (string, string) {
@@ -353,7 +366,11 @@ func (p *Proxy) forwardRequest(
 	if p.maxResponseBytes > 0 {
 		src = io.LimitReader(resp.Body, p.maxResponseBytes)
 	}
-	n, _ := io.Copy(w, src)
+	var dst io.Writer = w
+	if f, ok := w.(http.Flusher); ok {
+		dst = &flushingWriter{w: w, f: f}
+	}
+	n, _ := io.Copy(dst, src)
 
 	if p.maxResponseBytes > 0 && n == p.maxResponseBytes {
 		var probe [1]byte

--- a/internal/mitm/proxy_test.go
+++ b/internal/mitm/proxy_test.go
@@ -1832,3 +1832,67 @@ func TestDefaultMaxRequestBytesZeroMeansDefault(t *testing.T) {
 		t.Fatalf("maxResponseBytes = %d, want 0 (unlimited)", p.maxResponseBytes)
 	}
 }
+
+func TestMITMForwardStreamsChunksPromptly(t *testing.T) {
+	const chunkCount = 5
+	const chunkDelay = 80 * time.Millisecond
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "no flusher", 500)
+			return
+		}
+		for i := 0; i < chunkCount; i++ {
+			_, _ = fmt.Fprintf(w, "chunk-%d\n", i)
+			f.Flush()
+			if i < chunkCount-1 {
+				time.Sleep(chunkDelay)
+			}
+		}
+	}))
+	defer upstream.Close()
+
+	upstreamHost, _, _ := net.SplitHostPort(strings.TrimPrefix(upstream.URL, "https://"))
+	sr := validTokenResolver("tok", &brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: upstreamRoots}
+
+	resp, err := newTrustingClient(proxyURL, url.User("tok"), clientRoots).Get(upstream.URL + "/stream")
+	if err != nil {
+		t.Fatalf("client.Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var arrivals []time.Time
+	buf := make([]byte, 256)
+	for {
+		n, readErr := resp.Body.Read(buf)
+		if n > 0 {
+			arrivals = append(arrivals, time.Now())
+		}
+		if readErr != nil {
+			break
+		}
+	}
+
+	if len(arrivals) < 3 {
+		t.Fatalf("got %d reads, want ≥3 (chunks should arrive incrementally)", len(arrivals))
+	}
+	var hasGap bool
+	for i := 1; i < len(arrivals); i++ {
+		if arrivals[i].Sub(arrivals[i-1]) >= chunkDelay/2 {
+			hasGap = true
+			break
+		}
+	}
+	if !hasGap {
+		t.Fatal("no inter-chunk gap ≥40ms detected; proxy is buffering instead of flushing per-chunk")
+	}
+}

--- a/internal/mitm/websocket.go
+++ b/internal/mitm/websocket.go
@@ -96,7 +96,11 @@ func (p *Proxy) forwardWebSocket(
 		if p.maxResponseBytes > 0 {
 			src = io.LimitReader(resp.Body, p.maxResponseBytes)
 		}
-		n, _ := io.Copy(w, src)
+		var dst io.Writer = w
+		if f, ok := w.(http.Flusher); ok {
+			dst = &flushingWriter{w: w, f: f}
+		}
+		n, _ := io.Copy(dst, src)
 
 		if p.maxResponseBytes > 0 && n == p.maxResponseBytes {
 			var probe [1]byte
@@ -426,6 +430,10 @@ func copyWSFramesWithSubstitution(dst io.Writer, src io.Reader, srcConn net.Conn
 		if !canSubstitute {
 			if opcode == wsOpText && !fin {
 				slog.Default().Warn("fragmented WebSocket text frame on connection with substitutions; passing through without substitution")
+			} else if opcode == wsOpText && payloadLen > maxWSSubstitutionPayload {
+				slog.Default().Warn("WebSocket text frame exceeds substitution size limit; passing through without substitution",
+					slog.Uint64("payload_len", payloadLen),
+					slog.Int("max_substitution_payload", maxWSSubstitutionPayload))
 			}
 			// Stream the frame through: write the already-read header bytes,
 			// then copy the payload with io.CopyN.


### PR DESCRIPTION
## Summary

Streaming responses (git clone pack data, SSE event streams) were buffered by Go's `ResponseWriter` until the internal 4 KB buffer filled or the handler returned. Upstream chunk boundaries collapsed into a single blob — git's sideband parser stalled, SSE events arrived late, and any chunk-boundary-sensitive protocol broke. On top of that, the CONNECT tunnel's `WriteTimeout: 5 * time.Minute` killed any transfer that took longer than 5 minutes to stream.

Concrete failure: `git clone` of `microsoft/TypeScript` through the proxy died with `fatal: early EOF` / `fetch-pack: unexpected disconnect while reading sideband packet`. Same root cause as external draft PR #197.

**Per-chunk flushing**

Wraps the `ResponseWriter` in a `flushingWriter` that calls `http.Flusher.Flush()` after every successful `Write`. `io.Copy` uses a 32 KB buffer, so this flushes every ≤32 KB — upstream chunk boundaries reach the client immediately instead of coalescing. Applied to both the HTTP forward path (`forward.go`) and the WebSocket non-101 fallback path (`websocket.go`).

For non-streaming responses (single JSON body with `Content-Length`), this is effectively a no-op — `io.Copy` does one `Write` and one `Flush`, same as before.

**CONNECT tunnel WriteTimeout raised to 30 minutes**

The previous 5-minute `WriteTimeout` on the CONNECT tunnel's `http.Server` was an absolute deadline from request-header-read to response-complete. Any streaming response >5 minutes was killed. Raised to 30 minutes to cover realistic long-running transfers. Slow-loris defense is preserved by `ReadHeaderTimeout` (10s) and `ReadTimeout` (60s) on the request side, `IdleTimeout` (2 min) between requests, and the upstream transport's `ResponseHeaderTimeout` (5 min) for stalled upstreams.

**WebSocket oversized-frame substitution warning**

Added `slog.Warn` when a WebSocket text frame exceeds the 1 MB substitution buffer (`maxWSSubstitutionPayload`) and substitutions are configured. The existing fragmentation case already warned; the size case silently passed through.

Supersedes #197.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] Existing tests pass (`go test ./...` — all 20 packages green)
- [x] Added/updated tests for new behavior:

| Test | Validates |
|------|-----------|
| `TestMITMForwardStreamsChunksPromptly` | Upstream sends 5 chunks with 80ms delays; asserts inter-chunk arrival gaps ≥40ms at the client (proves per-chunk flushing, not batch delivery) |

- [x] Manual testing:

| Scenario | Result |
|----------|--------|
| Full `git clone` of `microsoft/TypeScript` through proxy | Completed: 3.4 GB, 81K files, ~6 min. Previously failed at 100 MB (body cap, fixed in #227) and at 5 min (WriteTimeout, fixed here). |
| SSE drip test (`httpbin.org/drip?duration=5&numbytes=5`) through proxy | 5 bytes arrived 1/sec — same cadence as direct, no buffering. |

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)