### PR TITLE
fix(auth): prevent account takeover via unverified registration password overwrite

### DIFF
--- a/internal/ratelimit/config.go
+++ b/internal/ratelimit/config.go
@@ -53,7 +53,7 @@ func DefaultsFor(profile Profile) Config {
 	// Unauthenticated surface: login/register/forgot/reset/verify,
 	// invite/approval-token redemption, and proxy auth failures.
 	c.Tiers[TierAuth] = TierConfig{
-		Algorithm: AlgSliding, Window: 5 * time.Minute, Max: scaleMax(10, mul), MaxKeys: 10000,
+		Algorithm: AlgSliding, Window: 5 * time.Minute, Max: scaleMax(50, mul), MaxKeys: 10000,
 	}
 	// MITM proxy: token bucket smooths traffic; Concurrency caps
 	// in-flight slow upstream calls per (actor, vault). Defaults are

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -18,9 +18,9 @@ func testRegistry(t *testing.T) *Registry {
 
 func TestSlidingWindowAllowThenDeny(t *testing.T) {
 	r := testRegistry(t)
-	// Drive TierAuth to its ceiling (10 at default).
+	// Drive TierAuth to its ceiling (50 at default).
 	var lastAllowed bool
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 50; i++ {
 		d := r.Allow(TierAuth, "ip:1.2.3.4")
 		lastAllowed = d.Allow
 		if !d.Allow {
@@ -32,7 +32,7 @@ func TestSlidingWindowAllowThenDeny(t *testing.T) {
 	}
 	d := r.Allow(TierAuth, "ip:1.2.3.4")
 	if d.Allow {
-		t.Fatalf("11th attempt should be denied")
+		t.Fatalf("51st attempt should be denied")
 	}
 	if d.RetryAfter <= 0 {
 		t.Fatalf("retry-after should be positive on denial, got %v", d.RetryAfter)

--- a/internal/server/handle_auth.go
+++ b/internal/server/handle_auth.go
@@ -24,6 +24,8 @@ const emailVerificationTTL = 15 * time.Minute
 
 const maxPendingVerifications = 3
 
+const registerUniformMessage = "If this email is not already registered, a verification code has been sent."
+
 // generateAndSendVerificationCode creates a new 6-digit verification code for
 // the given email and sends it via email (or logs to stderr if SMTP is not configured).
 func (s *Server) generateAndSendVerificationCode(ctx context.Context, email string) (bool, error) {
@@ -105,25 +107,16 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 			"email":                 req.Email,
 			"requires_verification": true,
 			"email_sent":            s.notifier.Enabled(),
-			"message":               "If this email is not already registered, a verification code has been sent.",
+			"message":               registerUniformMessage,
 		})
 		return
 	}
 
-	hash, salt, kdfParams, err := auth.HashUserPassword([]byte(req.Password))
-	if err != nil {
-		jsonError(w, http.StatusInternalServerError, "Failed to hash password")
-		return
-	}
-
-	// If an inactive user exists, update their password and resend verification.
+	// If an inactive user exists, resend a verification code but do NOT
+	// overwrite their password — that would let an unauthenticated attacker
+	// silently replace the password before the legitimate user verifies.
 	if existing != nil && !existing.IsActive {
-		if err := s.store.UpdateUserPassword(ctx, existing.ID, hash, salt, kdfParams.Time, kdfParams.Memory, kdfParams.Threads); err != nil {
-			jsonError(w, http.StatusInternalServerError, "Failed to update account")
-			return
-		}
-
-		emailSent, err := s.generateAndSendVerificationCode(ctx, req.Email)
+		_, err := s.generateAndSendVerificationCode(ctx, req.Email)
 		if errors.Is(err, errTooManyPendingCodes) {
 			jsonError(w, http.StatusTooManyRequests, "Too many pending verification codes")
 			return
@@ -133,17 +126,18 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		msg := "Account updated. Ask your Agent Vault instance owner for the verification code."
-		if emailSent {
-			msg = "Account updated. Check your email for a new verification code."
-		}
-
 		jsonCreated(w, map[string]interface{}{
-			"email":                 existing.Email,
+			"email":                 req.Email,
 			"requires_verification": true,
-			"email_sent":            emailSent,
-			"message":               msg,
+			"email_sent":            s.notifier.Enabled(),
+			"message":               registerUniformMessage,
 		})
+		return
+	}
+
+	hash, salt, kdfParams, err := auth.HashUserPassword([]byte(req.Password))
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to hash password")
 		return
 	}
 
@@ -620,11 +614,12 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Rate limit by IP and by email (reject if either bucket is full).
+	// Rate limit by IP (read-only peek — the ipAuth middleware already
+	// recorded this request) and by email (reject if either is full).
 	// Normalize the email key so case/whitespace variations don't
 	// let an attacker bypass the email bucket for a legitimate user.
 	ip := clientIP(r)
-	ipDecision := s.rateLimit.Allow(ratelimit.TierAuth, "ip:"+ip)
+	ipDecision := s.rateLimit.Check(ratelimit.TierAuth, "ip:"+ip)
 	emailDecision := s.rateLimit.Allow(ratelimit.TierAuth, "email:"+strings.ToLower(strings.TrimSpace(req.Email)))
 	if !ipDecision.Allow || !emailDecision.Allow {
 		d := ipDecision

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5439,6 +5439,71 @@ func TestResendVerificationTooManyPending(t *testing.T) {
 	}
 }
 
+// --- Re-registration Security Tests ---
+
+func TestReRegisterInactiveUserDoesNotOverwritePassword(t *testing.T) {
+	ms := setupMockStoreWithInactiveUser(t, "victim@test.com", "original-password")
+	srv := newTestServer(withStore(ms))
+
+	// Attacker re-registers with the victim's email and a different password.
+	regBody := `{"email":"victim@test.com","password":"attacker-password"}`
+	regRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(regRec, httptest.NewRequest(http.MethodPost, "/v1/auth/register", strings.NewReader(regBody)))
+	if regRec.Code != http.StatusCreated {
+		t.Fatalf("re-register: expected 201, got %d: %s", regRec.Code, regRec.Body.String())
+	}
+
+	// A verification code should have been generated.
+	if len(ms.emailVerifications) != 1 {
+		t.Fatalf("expected 1 verification code, got %d", len(ms.emailVerifications))
+	}
+	code := ms.emailVerifications[0].Code
+
+	// Victim verifies with the code.
+	verifyBody := fmt.Sprintf(`{"email":"victim@test.com","code":"%s"}`, code)
+	verifyRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(verifyRec, httptest.NewRequest(http.MethodPost, "/v1/auth/verify", strings.NewReader(verifyBody)))
+	if verifyRec.Code != http.StatusOK {
+		t.Fatalf("verify: expected 200, got %d: %s", verifyRec.Code, verifyRec.Body.String())
+	}
+
+	// Login with original password should succeed.
+	loginOK := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(loginOK, httptest.NewRequest(http.MethodPost, "/v1/auth/login",
+		strings.NewReader(`{"email":"victim@test.com","password":"original-password"}`)))
+	if loginOK.Code != http.StatusOK {
+		t.Fatalf("login with original password: expected 200, got %d: %s", loginOK.Code, loginOK.Body.String())
+	}
+
+	// Login with attacker's password must fail.
+	loginFail := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(loginFail, httptest.NewRequest(http.MethodPost, "/v1/auth/login",
+		strings.NewReader(`{"email":"victim@test.com","password":"attacker-password"}`)))
+	if loginFail.Code != http.StatusUnauthorized {
+		t.Fatalf("login with attacker password: expected 401, got %d: %s", loginFail.Code, loginFail.Body.String())
+	}
+}
+
+func TestReRegisterInactiveUserUniformResponse(t *testing.T) {
+	ms := setupMockStoreWithInactiveUser(t, "existing@test.com", "password123")
+	srv := newTestServer(withStore(ms))
+
+	// Re-register an inactive account.
+	regBody := `{"email":"existing@test.com","password":"different-password"}`
+	regRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(regRec, httptest.NewRequest(http.MethodPost, "/v1/auth/register", strings.NewReader(regBody)))
+	if regRec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", regRec.Code, regRec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(regRec.Body).Decode(&resp)
+
+	if resp["message"] != registerUniformMessage {
+		t.Fatalf("expected uniform message %q, got %q", registerUniformMessage, resp["message"])
+	}
+}
+
 // --- Services Upsert Tests ---
 
 func TestServicesUpsertRejectsDeprecatedDescription(t *testing.T) {


### PR DESCRIPTION
## Summary

The registration handler was overwriting an inactive user's password when someone re-registered with the same email, while old verification codes remained valid. An attacker could replace a victim's password before they verified, then log in once the victim activated the account.

- Remove the `UpdateUserPassword` call on re-registration of inactive accounts — only resend a verification code
- Unify response messages and the `email_sent` field across all registration branches to prevent account-state enumeration
- Extract the uniform message to a `registerUniformMessage` const to prevent drift
- Bump `TierAuth` rate limit from 10 → 50 per 5 min — teams behind corporate NAT were hitting the ceiling during normal use
- Fix login handler double-counting the IP budget (`Allow` → `Check` for the IP key, since `ipAuth` middleware already recorded it — same pattern as the MITM proxy fix in #226)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] Existing tests pass (`make test`)
- [x] Added/updated tests for new behavior
- [x] Manual testing (describe below)

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)