### PR TITLE
fix(isolation): block mounts that are ancestors of protected paths

### DIFF
--- a/docs/guides/container-isolation.mdx
+++ b/docs/guides/container-isolation.mdx
@@ -41,7 +41,7 @@ First run takes ~60s while the isolation image builds. Subsequent runs reuse the
 |------|---------|-------------|
 | `--isolation` | `host` | `host` (default) or `container`. Also read from `AGENT_VAULT_ISOLATION`. |
 | `--image` | | Override the bundled image. Use for your own base (different agent, pinned versions). |
-| `--mount` | | Extra bind mount `src:dst[:ro]`; repeatable. Host paths are symlink-resolved before validation; binds into `~/.agent-vault/` or `/var/run/docker.sock` are rejected. |
+| `--mount` | | Extra bind mount `src:dst[:ro]`; repeatable. Host paths are symlink-resolved before validation; binds into, containing, or pointing at `~/.agent-vault/` or `/var/run/docker.sock` are rejected. |
 | `--keep` | `false` | Omit `--rm` so the container is available for `docker inspect` / `docker logs` after exit. |
 | `--no-firewall` | `false` | **Debug only.** Skip `init-firewall.sh`; container has unrestricted egress. Prints a loud warning. |
 | `--home-volume-shared` | `false` | Share `/home/claude/.claude` across invocations via a persistent docker volume. Default is per-invocation (auth doesn't persist, but concurrent runs can't corrupt each other). |

--- a/internal/isolation/docker.go
+++ b/internal/isolation/docker.go
@@ -246,7 +246,8 @@ func validateHostSrc(resolved, homeDir string) error {
 			canonicalHome = c
 		}
 		vaultDir := filepath.Join(canonicalHome, ".agent-vault")
-		if resolved == vaultDir || strings.HasPrefix(resolved, vaultDir+string(os.PathSeparator)) {
+		sep := string(os.PathSeparator)
+		if resolved == vaultDir || strings.HasPrefix(resolved, vaultDir+sep) || strings.HasPrefix(vaultDir, resolved+sep) {
 			return fmt.Errorf("--mount: refusing to bind inside %s (contains master-key-encrypted vault data)", filepath.Join(homeDir, ".agent-vault"))
 		}
 	}
@@ -259,7 +260,7 @@ func validateHostSrc(resolved, homeDir string) error {
 // setups.
 func isDockerSocket(resolved string) bool {
 	for _, p := range []string{"/var/run/docker.sock", "/private/var/run/docker.sock"} {
-		if resolved == p {
+		if resolved == p || strings.HasPrefix(p, resolved+string(os.PathSeparator)) {
 			return true
 		}
 	}

--- a/internal/isolation/docker.go
+++ b/internal/isolation/docker.go
@@ -233,6 +233,9 @@ func parseAndValidateMount(raw, homeDir string) (parsedMount, error) {
 }
 
 func validateHostSrc(resolved, homeDir string) error {
+	if resolved == "/" {
+		return errors.New("--mount: refusing to bind the host root filesystem")
+	}
 	if isDockerSocket(resolved) {
 		return errors.New("--mount: refusing to bind the docker socket (would undo every isolation guarantee)")
 	}

--- a/internal/isolation/docker_test.go
+++ b/internal/isolation/docker_test.go
@@ -430,6 +430,16 @@ func TestBuildRunArgs_RejectsCWDAncestorOfAgentVaultDir(t *testing.T) {
 	}
 }
 
+func TestValidateHostSrc_RejectsRootFilesystem(t *testing.T) {
+	err := validateHostSrc("/", t.TempDir())
+	if err == nil {
+		t.Fatal("expected validateHostSrc to reject /")
+	}
+	if !strings.Contains(err.Error(), "root filesystem") {
+		t.Errorf("err = %q, want to mention root filesystem", err.Error())
+	}
+}
+
 func TestIsDockerSocket_RejectsAncestorDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("docker socket path is POSIX-specific")

--- a/internal/isolation/docker_test.go
+++ b/internal/isolation/docker_test.go
@@ -391,6 +391,57 @@ func TestParseAndValidateMount_SymlinkLaunderingRejected(t *testing.T) {
 	}
 }
 
+func TestBuildRunArgs_RejectsAncestorOfAgentVaultDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	vaultDir := filepath.Join(home, ".agent-vault")
+	if err := os.MkdirAll(vaultDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	cfg := baseConfig(t)
+	// Mount the home directory itself — an ancestor of ~/.agent-vault.
+	cfg.Mounts = []string{home + ":/data"}
+	_, err := BuildRunArgs(cfg)
+	if err == nil {
+		t.Fatal("expected BuildRunArgs to reject mounting a parent of ~/.agent-vault")
+	}
+	if !strings.Contains(err.Error(), ".agent-vault") {
+		t.Errorf("err = %q, want to mention .agent-vault", err.Error())
+	}
+}
+
+func TestBuildRunArgs_RejectsCWDAncestorOfAgentVaultDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	vaultDir := filepath.Join(home, ".agent-vault")
+	if err := os.MkdirAll(vaultDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	cfg := baseConfig(t)
+	cfg.WorkDir = home
+	_, err := BuildRunArgs(cfg)
+	if err == nil {
+		t.Fatal("expected BuildRunArgs to reject CWD that is a parent of ~/.agent-vault")
+	}
+	if !strings.Contains(err.Error(), ".agent-vault") {
+		t.Errorf("err = %q, want to mention .agent-vault", err.Error())
+	}
+}
+
+func TestIsDockerSocket_RejectsAncestorDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("docker socket path is POSIX-specific")
+	}
+	// /var/run is a parent of /var/run/docker.sock
+	for _, ancestor := range []string{"/var/run", "/private/var/run"} {
+		if !isDockerSocket(ancestor) {
+			t.Errorf("expected isDockerSocket(%q) = true (ancestor of docker.sock)", ancestor)
+		}
+	}
+}
+
 func TestParseAndValidateMount_MalformedSpec(t *testing.T) {
 	tmp := t.TempDir()
 	for _, raw := range []string{


### PR DESCRIPTION
## Summary

`validateHostSrc` checked whether a mount path was `~/.agent-vault` or inside it, but not whether `~/.agent-vault` was inside the mount path. Same gap in `isDockerSocket` for `/var/run/docker.sock`. Mounting a parent directory (e.g. `$HOME` or `/var/run`) passed validation and exposed protected paths to the container.

- Add the symmetric ancestor check to `validateHostSrc` and `isDockerSocket`, matching the pattern already used in `validateContainerDst`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] Existing tests pass (`make test`)
- [x] Added/updated tests for new behavior
- [ ] Manual testing (describe below)

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)