### PR TITLE
fix(auth): prevent non-owners from managing owner-role agents

### DIFF
--- a/internal/server/handle_agents.go
+++ b/internal/server/handle_agents.go
@@ -260,7 +260,11 @@ func (s *Server) handleAgentRevoke(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !actor.IsOwner() && (agent.CreatedBy != actor.ID || agent.Role == "owner") {
+	if !actor.IsOwner() && agent.Role == "owner" {
+		jsonError(w, http.StatusForbidden, "Only instance owners can manage owner-role agents")
+		return
+	}
+	if !actor.IsOwner() && agent.CreatedBy != actor.ID {
 		jsonError(w, http.StatusForbidden, "Only the owner or agent creator can revoke agents")
 		return
 	}
@@ -297,7 +301,11 @@ func (s *Server) handleAgentRotate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !actor.IsOwner() && (agent.CreatedBy != actor.ID || agent.Role == "owner") {
+	if !actor.IsOwner() && agent.Role == "owner" {
+		jsonError(w, http.StatusForbidden, "Only instance owners can manage owner-role agents")
+		return
+	}
+	if !actor.IsOwner() && agent.CreatedBy != actor.ID {
 		jsonError(w, http.StatusForbidden, "Only the owner or agent creator can rotate agents")
 		return
 	}
@@ -334,7 +342,11 @@ func (s *Server) handleAgentRename(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !actor.IsOwner() && (agent.CreatedBy != actor.ID || agent.Role == "owner") {
+	if !actor.IsOwner() && agent.Role == "owner" {
+		jsonError(w, http.StatusForbidden, "Only instance owners can manage owner-role agents")
+		return
+	}
+	if !actor.IsOwner() && agent.CreatedBy != actor.ID {
 		jsonError(w, http.StatusForbidden, "Only the owner or agent creator can rename agents")
 		return
 	}

--- a/internal/server/handle_agents.go
+++ b/internal/server/handle_agents.go
@@ -260,7 +260,7 @@ func (s *Server) handleAgentRevoke(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !actor.IsOwner() && agent.CreatedBy != actor.ID {
+	if !actor.IsOwner() && (agent.CreatedBy != actor.ID || agent.Role == "owner") {
 		jsonError(w, http.StatusForbidden, "Only the owner or agent creator can revoke agents")
 		return
 	}
@@ -297,7 +297,7 @@ func (s *Server) handleAgentRotate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !actor.IsOwner() && agent.CreatedBy != actor.ID {
+	if !actor.IsOwner() && (agent.CreatedBy != actor.ID || agent.Role == "owner") {
 		jsonError(w, http.StatusForbidden, "Only the owner or agent creator can rotate agents")
 		return
 	}
@@ -334,7 +334,7 @@ func (s *Server) handleAgentRename(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !actor.IsOwner() && agent.CreatedBy != actor.ID {
+	if !actor.IsOwner() && (agent.CreatedBy != actor.ID || agent.Role == "owner") {
 		jsonError(w, http.StatusForbidden, "Only the owner or agent creator can rename agents")
 		return
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4026,6 +4026,9 @@ func TestAgentRotate_MemberCannotRotateOwnerRoleAgent(t *testing.T) {
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
 	}
+	if !strings.Contains(rec.Body.String(), "owner-role agents") {
+		t.Errorf("expected owner-role error message, got: %s", rec.Body.String())
+	}
 }
 
 func TestAgentRename(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4007,6 +4007,27 @@ func TestAgentRotate(t *testing.T) {
 	}
 }
 
+func TestAgentRotate_MemberCannotRotateOwnerRoleAgent(t *testing.T) {
+	ms, _ := setupMockStoreWithSession(t)
+	memberToken := setupMemberSession(t, ms)
+	srv := newTestServer(withStore(ms))
+
+	// Agent created by the member but promoted to owner role.
+	ms.agents["admin-bot"] = &store.Agent{
+		ID: "a1", Name: "admin-bot", Status: "active",
+		Role: "owner", CreatedBy: "member-user-id",
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/admin-bot/rotate", nil)
+	req.Header.Set("Authorization", "Bearer "+memberToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestAgentRename(t *testing.T) {
 	srv, ms, sessID := setupAgentTest(t)
 


### PR DESCRIPTION
## Summary

The rotate, revoke, and rename handlers allowed the original creator of an agent to manage it regardless of their current privilege level. A user demoted from owner to member could rotate an owner-role agent they previously created and obtain an owner-level session token.

- Add `agent.Role == "owner"` guard to all three handlers so non-owners cannot manage owner-role agents, even if they are the original creator

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] Existing tests pass (`make test`)
- [x] Added/updated tests for new behavior
- [x] Manual testing (describe below)

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)