### PR TITLE
docs(openclaw): add companion YouTube video embed

### DIFF
--- a/docs/guides/openclaw-on-vps.mdx
+++ b/docs/guides/openclaw-on-vps.mdx
@@ -10,6 +10,21 @@ By the end, you'll have:
 1. **Agent Vault running on one droplet**, holding real Anthropic, GitHub, Notion, and Slack credentials encrypted at rest behind a master password.
 2. **An OpenClaw gateway running on a second droplet**, reachable via a Slack bot, with every outbound API call brokered through Agent Vault and revocable from the UI in one click.
 
+<Tip>
+Companion video for this guide: a full end-to-end walkthrough from two empty droplets to a brokered, Slack-reachable OpenClaw gateway. Watch below or [open on YouTube](https://youtu.be/JuDU6MANBww).
+</Tip>
+
+<iframe
+  width="100%"
+  height="450"
+  src="https://www.youtube.com/embed/JuDU6MANBww"
+  title="Run OpenClaw on a VPS: companion video"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  referrerpolicy="strict-origin-when-cross-origin"
+  allowfullscreen
+></iframe>
+
 ## Prerequisites
 
 - A [DigitalOcean](https://cloud.digitalocean.com) account.


### PR DESCRIPTION
Mirrors the Tip + iframe pattern at the top of the Hermes guide so the companion video for the OpenClaw VPS walkthrough is visible inline.

## Summary

Adds YouTube video to openclaw doc

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ x] Documentation
- [ ] CI / build



## Security checklist

- [x ] No secrets or credentials in code
- [x ] No new unauthenticated endpoints
- [ x] Input validation on new API surfaces
- [ x] Checked for OWASP top 10 (injection, XSS, etc.)
