### PR TITLE
feat(oauth): add provider presets combobox to credential form

### DIFF
--- a/docs/learn/credentials.mdx
+++ b/docs/learn/credentials.mdx
@@ -40,6 +40,8 @@ There are two ways to set up an OAuth credential:
 
 You register an OAuth app with the provider (e.g., GitHub, Google), enter the client ID and secret in Agent Vault, and click "Connect." Agent Vault handles the browser redirect, consent flow, and token exchange using Authorization Code + PKCE.
 
+The URL fields suggest popular providers (GitHub, Google, Slack, Microsoft, and others) as you type; picking one prefills the authorization URL, token URL, and token auth method. Any other provider works too: just paste its URLs directly.
+
 After connecting, Agent Vault stores the access token, refresh token, and expiry. When the access token nears expiry (within 5 minutes), the proxy automatically refreshes it before injecting.
 
 ### Paste tokens

--- a/web/src/components/Combobox.tsx
+++ b/web/src/components/Combobox.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+export interface ComboboxOption {
+  id: string;
+  label: string;
+  sublabel?: string;
+  /** Pinned options always render at the end of the list, exempt from filtering. */
+  pinned?: boolean;
+}
+
+interface ComboboxProps {
+  value: string;
+  /** Called on free typing, like a normal Input. */
+  onChange: (text: string) => void;
+  options: ComboboxOption[];
+  /** Called when an option is explicitly picked from the list. */
+  onSelect: (id: string) => void;
+  placeholder?: string;
+}
+
+/**
+ * A text input with a suggestion popover. Typing filters the options;
+ * text that matches nothing behaves exactly like a plain Input.
+ */
+export default function Combobox({ value, onChange, options, onSelect, placeholder }: ComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [highlighted, setHighlighted] = useState(0);
+  const [typing, setTyping] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ top: 0, left: 0, width: 0 });
+
+  const query = value.trim().toLowerCase();
+  const matches = typing
+    ? options.filter((o) => !o.pinned && (!query || o.label.toLowerCase().includes(query) || o.sublabel?.toLowerCase().includes(query)))
+    : options.filter((o) => !o.pinned);
+  const filtered = [...matches, ...options.filter((o) => o.pinned)];
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (
+        listRef.current &&
+        !listRef.current.contains(e.target as Node) &&
+        wrapperRef.current &&
+        !wrapperRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  function show() {
+    if (inputRef.current) {
+      const rect = inputRef.current.getBoundingClientRect();
+      setPos({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+    }
+    setHighlighted(0);
+    setOpen(true);
+  }
+
+  function select(id: string) {
+    setOpen(false);
+    setTyping(false);
+    onSelect(id);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (!open || filtered.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlighted((h) => (h + 1) % filtered.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlighted((h) => (h - 1 + filtered.length) % filtered.length);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      select(filtered[Math.min(highlighted, filtered.length - 1)].id);
+    } else if (e.key === "Escape") {
+      e.stopPropagation();
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <input
+        ref={inputRef}
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setHighlighted(0);
+          setTyping(true);
+          show();
+        }}
+        onFocus={() => { setTyping(false); show(); }}
+        onKeyDown={handleKeyDown}
+        role="combobox"
+        aria-expanded={open && filtered.length > 0}
+        autoComplete="off"
+        className="w-full px-4 py-3 pr-10 bg-surface-raised border border-border rounded-lg text-text text-sm outline-none transition-colors focus:border-border-focus focus:shadow-[0_0_0_3px_var(--color-primary-ring)]"
+      />
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-label="Show suggestions"
+        // mousedown so the toggle wins over the input's focus/outside-click handling
+        onMouseDown={(e) => {
+          e.preventDefault();
+          setTyping(false);
+          if (open) {
+            setOpen(false);
+          } else {
+            inputRef.current?.focus();
+            show();
+          }
+        }}
+        className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted hover:text-text transition-colors"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+      {open && filtered.length > 0 &&
+        createPortal(
+          <div
+            ref={listRef}
+            className="fixed z-50 bg-surface border border-border rounded-lg shadow-[0_4px_16px_rgba(0,0,0,0.12)] py-1 max-h-64 overflow-y-auto"
+            style={{ top: pos.top, left: pos.left, width: pos.width, scrollbarWidth: "thin", scrollbarColor: "var(--color-border) var(--color-surface)" }}
+          >
+            {filtered.map((option, i) => (
+              <button
+                key={option.id}
+                type="button"
+                // mousedown so selection wins over the input's blur/outside-click handling
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  select(option.id);
+                }}
+                onMouseEnter={() => setHighlighted(i)}
+                className={`w-full text-left px-4 py-2.5 transition-colors ${i === highlighted ? "bg-bg" : ""} ${option.pinned && i > 0 ? "border-t border-border" : ""}`}
+              >
+                <span className="block text-sm text-text">{option.label}</span>
+                {option.sublabel && <span className="block text-xs text-text-dim truncate">{option.sublabel}</span>}
+              </button>
+            ))}
+          </div>,
+          document.body
+        )}
+    </div>
+  );
+}

--- a/web/src/lib/oauthProviders.ts
+++ b/web/src/lib/oauthProviders.ts
@@ -1,0 +1,125 @@
+// Built-in OAuth provider presets for the credential form. Selecting one
+// prefills the endpoint fields; users always supply their own client ID/secret.
+export interface OAuthProviderPreset {
+  id: string;
+  name: string;
+  authorizationUrl: string;
+  tokenUrl: string;
+  tokenAuthMethod: "client_secret_post" | "client_secret_basic";
+  suggestedKey: string;
+}
+
+export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
+  {
+    id: "github",
+    name: "GitHub",
+    authorizationUrl: "https://github.com/login/oauth/authorize",
+    tokenUrl: "https://github.com/login/oauth/access_token",
+    tokenAuthMethod: "client_secret_post",
+    suggestedKey: "GITHUB",
+  },
+  {
+    id: "google",
+    name: "Google",
+    authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+    tokenUrl: "https://oauth2.googleapis.com/token",
+    tokenAuthMethod: "client_secret_post",
+    suggestedKey: "GOOGLE",
+  },
+  {
+    id: "gitlab",
+    name: "GitLab",
+    authorizationUrl: "https://gitlab.com/oauth/authorize",
+    tokenUrl: "https://gitlab.com/oauth/token",
+    tokenAuthMethod: "client_secret_post",
+    suggestedKey: "GITLAB",
+  },
+  {
+    id: "discord",
+    name: "Discord",
+    authorizationUrl: "https://discord.com/oauth2/authorize",
+    tokenUrl: "https://discord.com/api/oauth2/token",
+    tokenAuthMethod: "client_secret_post",
+    suggestedKey: "DISCORD",
+  },
+  {
+    id: "spotify",
+    name: "Spotify",
+    authorizationUrl: "https://accounts.spotify.com/authorize",
+    tokenUrl: "https://accounts.spotify.com/api/token",
+    tokenAuthMethod: "client_secret_basic",
+    suggestedKey: "SPOTIFY",
+  },
+  {
+    id: "slack",
+    name: "Slack",
+    authorizationUrl: "https://slack.com/oauth/v2/authorize",
+    tokenUrl: "https://slack.com/api/oauth.v2.access",
+    tokenAuthMethod: "client_secret_post",
+    suggestedKey: "SLACK",
+  },
+  {
+    id: "microsoft",
+    name: "Microsoft",
+    authorizationUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    tokenAuthMethod: "client_secret_post",
+    suggestedKey: "MICROSOFT",
+  },
+  {
+    id: "notion",
+    name: "Notion",
+    authorizationUrl: "https://api.notion.com/v1/oauth/authorize",
+    tokenUrl: "https://api.notion.com/v1/oauth/token",
+    tokenAuthMethod: "client_secret_basic",
+    suggestedKey: "NOTION",
+  },
+  {
+    id: "linear",
+    name: "Linear",
+    authorizationUrl: "https://linear.app/oauth/authorize",
+    tokenUrl: "https://api.linear.app/oauth/token",
+    tokenAuthMethod: "client_secret_post",
+    suggestedKey: "LINEAR",
+  },
+  {
+    id: "bitbucket",
+    name: "Bitbucket",
+    authorizationUrl: "https://bitbucket.org/site/oauth2/authorize",
+    tokenUrl: "https://bitbucket.org/site/oauth2/access_token",
+    tokenAuthMethod: "client_secret_basic",
+    suggestedKey: "BITBUCKET",
+  },
+  {
+    id: "dropbox",
+    name: "Dropbox",
+    authorizationUrl: "https://www.dropbox.com/oauth2/authorize",
+    tokenUrl: "https://api.dropboxapi.com/oauth2/token",
+    tokenAuthMethod: "client_secret_post",
+    suggestedKey: "DROPBOX",
+  },
+  {
+    id: "twitch",
+    name: "Twitch",
+    authorizationUrl: "https://id.twitch.tv/oauth2/authorize",
+    tokenUrl: "https://id.twitch.tv/oauth2/token",
+    tokenAuthMethod: "client_secret_post",
+    suggestedKey: "TWITCH",
+  },
+  {
+    id: "zoom",
+    name: "Zoom",
+    authorizationUrl: "https://zoom.us/oauth/authorize",
+    tokenUrl: "https://zoom.us/oauth/token",
+    tokenAuthMethod: "client_secret_basic",
+    suggestedKey: "ZOOM",
+  },
+  {
+    id: "hubspot",
+    name: "HubSpot",
+    authorizationUrl: "https://app.hubspot.com/oauth/authorize",
+    tokenUrl: "https://api.hubapi.com/oauth/v1/token",
+    tokenAuthMethod: "client_secret_post",
+    suggestedKey: "HUBSPOT",
+  },
+];

--- a/web/src/pages/vault/CredentialsTab.tsx
+++ b/web/src/pages/vault/CredentialsTab.tsx
@@ -9,7 +9,9 @@ import Button from "../../components/Button";
 import Input from "../../components/Input";
 import FormField from "../../components/FormField";
 import Select from "../../components/Select";
+import Combobox from "../../components/Combobox";
 import { apiFetch } from "../../lib/api";
+import { OAUTH_PROVIDERS } from "../../lib/oauthProviders";
 
 export default function CredentialsTab() {
   const router = useRouter();
@@ -477,6 +479,19 @@ function CredentialModal({ vaultName, editingKey, editingCred, onClose, onSaved 
     } catch (err: unknown) { setError(err instanceof Error ? err.message : "An error occurred."); } finally { setSaving(false); }
   }
 
+  // The "custom" pinned option intentionally falls through the guard below:
+  // selecting it just closes the list and leaves all fields free-form.
+  const customOption = { id: "custom", label: "Custom Provider", sublabel: "Enter provider manually", pinned: true };
+
+  function applyProvider(id: string) {
+    const p = OAUTH_PROVIDERS.find((p) => p.id === id);
+    if (!p) return;
+    setOauthAuthUrl(p.authorizationUrl);
+    setOauthTokenUrl(p.tokenUrl);
+    setOauthTokenAuthMethod(p.tokenAuthMethod);
+    setOauthKey(p.suggestedKey);
+  }
+
   async function handleOAuthConnect() {
     setOauthConnecting(true); setError("");
     try {
@@ -588,7 +603,15 @@ function CredentialModal({ vaultName, editingKey, editingCred, onClose, onSaved 
 
           {!isTokenUpload ? (
             <>
-              <FormField label="Authorization URL"><Input placeholder="e.g. https://accounts.google.com/o/oauth2/v2/auth" value={oauthAuthUrl} onChange={(e) => setOauthAuthUrl(e.target.value)} /></FormField>
+              <FormField label="Authorization URL" helperText="Pick a provider or paste any URL">
+                <Combobox
+                  placeholder="e.g. https://accounts.google.com/o/oauth2/v2/auth"
+                  value={oauthAuthUrl}
+                  onChange={setOauthAuthUrl}
+                  options={[...OAUTH_PROVIDERS.map((p) => ({ id: p.id, label: p.name, sublabel: p.authorizationUrl })), customOption]}
+                  onSelect={applyProvider}
+                />
+              </FormField>
               <FormField label="Token URL"><Input placeholder="e.g. https://oauth2.googleapis.com/token" value={oauthTokenUrl} onChange={(e) => setOauthTokenUrl(e.target.value)} /></FormField>
               <div className="flex gap-3">
                 <div className="flex-1"><FormField label="Client ID"><Input placeholder="OAuth app client ID" value={oauthClientId} onChange={(e) => setOauthClientId(e.target.value)} /></FormField></div>
@@ -609,7 +632,15 @@ function CredentialModal({ vaultName, editingKey, editingCred, onClose, onSaved 
                 <div className="flex-1"><FormField label="Access Token" helperText="Optional when refresh token is provided"><Input placeholder="Access token" value={oauthAccessToken} onChange={(e) => setOauthAccessToken(e.target.value)} type="password" /></FormField></div>
                 <div className="flex-1"><FormField label="Refresh Token" helperText="Validated immediately on save"><Input placeholder="Refresh token" value={oauthRefreshToken} onChange={(e) => setOauthRefreshToken(e.target.value)} type="password" /></FormField></div>
               </div>
-              <FormField label="Token URL" helperText="Required for refresh"><Input placeholder="e.g. https://oauth2.googleapis.com/token" value={oauthTokenUrl} onChange={(e) => setOauthTokenUrl(e.target.value)} /></FormField>
+              <FormField label="Token URL" helperText="Required for refresh. Pick a provider or paste any URL.">
+                <Combobox
+                  placeholder="e.g. https://oauth2.googleapis.com/token"
+                  value={oauthTokenUrl}
+                  onChange={setOauthTokenUrl}
+                  options={[...OAUTH_PROVIDERS.map((p) => ({ id: p.id, label: p.name, sublabel: p.tokenUrl })), customOption]}
+                  onSelect={applyProvider}
+                />
+              </FormField>
               <div className="flex gap-3">
                 <div className="flex-1"><FormField label="Client ID" helperText="Required for refresh"><Input placeholder="OAuth app client ID" value={oauthClientId} onChange={(e) => setOauthClientId(e.target.value)} /></FormField></div>
                 <div className="flex-1"><FormField label="Client Secret" helperText="Optional"><Input placeholder="OAuth app client secret" value={oauthClientSecret} onChange={(e) => setOauthClientSecret(e.target.value)} type="password" /></FormField></div>

--- a/web/src/pages/vault/CredentialsTab.tsx
+++ b/web/src/pages/vault/CredentialsTab.tsx
@@ -489,7 +489,7 @@ function CredentialModal({ vaultName, editingKey, editingCred, onClose, onSaved 
     setOauthAuthUrl(p.authorizationUrl);
     setOauthTokenUrl(p.tokenUrl);
     setOauthTokenAuthMethod(p.tokenAuthMethod);
-    setOauthKey(p.suggestedKey);
+    if (!isEdit) setOauthKey(p.suggestedKey);
   }
 
   async function handleOAuthConnect() {


### PR DESCRIPTION
## Summary

Adds a provider presets combobox to the OAuth credential form. The URL fields now suggest popular providers (GitHub, Google, Slack, Microsoft, etc.); selecting one prefills the authorization URL, token URL, auth method, and credential key. Custom providers still work by typing any URL directly.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] Existing tests pass (`make test`)
- [ ] Added/updated tests for new behavior
- [x] Manual testing (describe below)

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)