### PR TITLE
feat(oauth): add scope selection with provider-specific suggestions

### DIFF
--- a/docs/learn/credentials.mdx
+++ b/docs/learn/credentials.mdx
@@ -40,7 +40,7 @@ There are two ways to set up an OAuth credential:
 
 You register an OAuth app with the provider (e.g., GitHub, Google), enter the client ID and secret in Agent Vault, and click "Connect." Agent Vault handles the browser redirect, consent flow, and token exchange using Authorization Code + PKCE.
 
-The URL fields suggest popular providers (GitHub, Google, Slack, Microsoft, and others) as you type; picking one prefills the authorization URL, token URL, and token auth method. Any other provider works too: just paste its URLs directly.
+The URL fields suggest popular providers (GitHub, Google, Slack, Microsoft, and others) as you type; picking one prefills the authorization URL, token URL, and token auth method. Any other provider works too: just paste its URLs directly. The scopes field shows provider-specific suggestions when a provider is selected; you can also type custom scopes.
 
 After connecting, Agent Vault stores the access token, refresh token, and expiry. When the access token nears expiry (within 5 minutes), the proxy automatically refreshes it before injecting.
 

--- a/web/src/components/CreatableSelect.tsx
+++ b/web/src/components/CreatableSelect.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+export interface CreatableSelectOption {
+  value: string;
+  label?: string;
+  description?: string;
+}
+
+interface CreatableSelectProps {
+  values: string[];
+  onChange: (values: string[]) => void;
+  options?: CreatableSelectOption[];
+  placeholder?: string;
+}
+
+export default function CreatableSelect({ values, onChange, options = [], placeholder }: CreatableSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [highlighted, setHighlighted] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ top: 0, left: 0, width: 0 });
+
+  const q = query.trim().toLowerCase();
+  const available = options.filter((o) => !values.includes(o.value));
+  const filtered = q
+    ? available.filter((o) => o.value.toLowerCase().includes(q) || o.label?.toLowerCase().includes(q) || o.description?.toLowerCase().includes(q))
+    : available;
+  const exactMatch = options.some((o) => o.value.toLowerCase() === q) || values.some((v) => v.toLowerCase() === q);
+  const showCreate = q && !exactMatch;
+
+  const items: { type: "option" | "create"; option?: CreatableSelectOption; createValue?: string }[] = [
+    ...filtered.map((o) => ({ type: "option" as const, option: o })),
+    ...(showCreate ? [{ type: "create" as const, createValue: query.trim() }] : []),
+  ];
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e: MouseEvent) {
+      if (
+        listRef.current && !listRef.current.contains(e.target as Node) &&
+        wrapperRef.current && !wrapperRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  function show() {
+    if (wrapperRef.current) {
+      const rect = wrapperRef.current.getBoundingClientRect();
+      setPos({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+    }
+    setHighlighted(0);
+    setOpen(true);
+  }
+
+  function addValue(v: string) {
+    if (!v || values.includes(v)) return;
+    onChange([...values, v]);
+    setQuery("");
+    setHighlighted(0);
+  }
+
+  function removeValue(v: string) {
+    onChange(values.filter((x) => x !== v));
+  }
+
+  function toggleOption(v: string) {
+    if (values.includes(v)) {
+      removeValue(v);
+    } else {
+      addValue(v);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Backspace" && !query && values.length > 0) {
+      onChange(values.slice(0, -1));
+      return;
+    }
+    if (!open || items.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlighted((h) => (h + 1) % items.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlighted((h) => (h - 1 + items.length) % items.length);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const item = items[Math.min(highlighted, items.length - 1)];
+      if (item.type === "create" && item.createValue) {
+        addValue(item.createValue);
+      } else if (item.type === "option" && item.option) {
+        toggleOption(item.option.value);
+      }
+    } else if (e.key === "Escape") {
+      e.stopPropagation();
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <div
+        className={`flex items-center gap-1.5 w-full min-h-[46px] px-3 py-2 bg-surface-raised border rounded-lg text-sm transition-colors cursor-text ${open ? "border-border-focus shadow-[0_0_0_3px_var(--color-primary-ring)]" : "border-border"}`}
+        onClick={() => { inputRef.current?.focus(); }}
+      >
+        <div className="flex flex-wrap items-center gap-1.5 flex-1 min-w-0">
+          {values.map((v) => {
+            const opt = options.find((o) => o.value === v);
+            return (
+              <span key={v} className="inline-flex items-center gap-1 bg-primary/10 text-primary border border-primary/20 text-xs font-medium rounded-md px-2 py-1 max-w-[200px]">
+                <span className="truncate">{opt?.label || v}</span>
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  onClick={(e) => { e.stopPropagation(); removeValue(v); }}
+                  className="flex-shrink-0 text-text-dim hover:text-text transition-colors"
+                >
+                  <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
+                </button>
+              </span>
+            );
+          })}
+          <input
+            ref={inputRef}
+            value={query}
+            placeholder={values.length === 0 ? placeholder : undefined}
+            onChange={(e) => { setQuery(e.target.value); setHighlighted(0); show(); }}
+            onFocus={show}
+            onKeyDown={handleKeyDown}
+            autoComplete="off"
+            className="flex-1 min-w-[80px] bg-transparent outline-none text-text text-sm py-1"
+          />
+        </div>
+        <div className="flex items-center gap-1 flex-shrink-0 self-start mt-2">
+          {values.length > 0 && (
+            <button
+              type="button"
+              tabIndex={-1}
+              aria-label="Clear all"
+              onMouseDown={(e) => { e.preventDefault(); onChange([]); setQuery(""); }}
+              className="text-text-dim hover:text-text transition-colors"
+            >
+              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
+            </button>
+          )}
+          <button
+            type="button"
+            tabIndex={-1}
+            aria-label="Show suggestions"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              if (open) { setOpen(false); } else { inputRef.current?.focus(); show(); }
+            }}
+            className="w-4 h-4 text-text-muted hover:text-text transition-colors"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      {open && items.length > 0 &&
+        createPortal(
+          <div
+            ref={listRef}
+            className="fixed z-50 bg-surface border border-border rounded-lg shadow-[0_4px_16px_rgba(0,0,0,0.12)] py-1 max-h-64 overflow-y-auto"
+            style={{ top: pos.top, left: pos.left, width: pos.width, scrollbarWidth: "thin", scrollbarColor: "var(--color-border) var(--color-surface)" }}
+          >
+            {items.map((item, i) => {
+              if (item.type === "create") {
+                return (
+                  <button
+                    key="__create__"
+                    type="button"
+                    onMouseDown={(e) => { e.preventDefault(); addValue(item.createValue!); }}
+                    onMouseEnter={() => setHighlighted(i)}
+                    className={`w-full text-left px-4 py-2.5 transition-colors border-t border-border ${i === highlighted ? "bg-bg" : ""}`}
+                  >
+                    <span className="text-sm text-primary">Add "{item.createValue}"</span>
+                  </button>
+                );
+              }
+              const opt = item.option!;
+              const selected = values.includes(opt.value);
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onMouseDown={(e) => { e.preventDefault(); toggleOption(opt.value); }}
+                  onMouseEnter={() => setHighlighted(i)}
+                  className={`w-full text-left px-4 py-2.5 transition-colors flex items-center justify-between ${i === highlighted ? "bg-bg" : ""}`}
+                >
+                  <div className="min-w-0">
+                    <span className="block text-sm text-text truncate">{opt.label || opt.value}</span>
+                    {opt.description && <span className="block text-xs text-text-dim truncate">{opt.description}</span>}
+                  </div>
+                  {selected && (
+                    <svg className="w-4 h-4 flex-shrink-0 text-primary ml-2" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+                  )}
+                </button>
+              );
+            })}
+          </div>,
+          document.body
+        )}
+    </div>
+  );
+}

--- a/web/src/lib/oauthProviders.ts
+++ b/web/src/lib/oauthProviders.ts
@@ -1,5 +1,10 @@
 // Built-in OAuth provider presets for the credential form. Selecting one
 // prefills the endpoint fields; users always supply their own client ID/secret.
+export interface ScopePreset {
+  value: string;
+  description: string;
+}
+
 export interface OAuthProviderPreset {
   id: string;
   name: string;
@@ -7,6 +12,7 @@ export interface OAuthProviderPreset {
   tokenUrl: string;
   tokenAuthMethod: "client_secret_post" | "client_secret_basic";
   suggestedKey: string;
+  scopes?: ScopePreset[];
 }
 
 export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
@@ -17,6 +23,14 @@ export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
     tokenUrl: "https://github.com/login/oauth/access_token",
     tokenAuthMethod: "client_secret_post",
     suggestedKey: "GITHUB",
+    scopes: [
+      { value: "repo", description: "Full access to private repositories" },
+      { value: "read:user", description: "Read user profile data" },
+      { value: "user:email", description: "Read user email addresses" },
+      { value: "read:org", description: "Read organization membership" },
+      { value: "workflow", description: "Update GitHub Actions workflows" },
+      { value: "gist", description: "Create and read gists" },
+    ],
   },
   {
     id: "google",
@@ -25,6 +39,15 @@ export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
     tokenUrl: "https://oauth2.googleapis.com/token",
     tokenAuthMethod: "client_secret_post",
     suggestedKey: "GOOGLE",
+    scopes: [
+      { value: "openid", description: "OpenID Connect authentication" },
+      { value: "email", description: "View user email address" },
+      { value: "profile", description: "View basic profile info" },
+      { value: "https://www.googleapis.com/auth/calendar", description: "Manage Google Calendar" },
+      { value: "https://www.googleapis.com/auth/drive", description: "Full access to Google Drive" },
+      { value: "https://www.googleapis.com/auth/gmail.readonly", description: "Read Gmail messages" },
+      { value: "https://www.googleapis.com/auth/spreadsheets", description: "Read and write Google Sheets" },
+    ],
   },
   {
     id: "gitlab",
@@ -33,6 +56,14 @@ export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
     tokenUrl: "https://gitlab.com/oauth/token",
     tokenAuthMethod: "client_secret_post",
     suggestedKey: "GITLAB",
+    scopes: [
+      { value: "api", description: "Full API access" },
+      { value: "read_api", description: "Read-only API access" },
+      { value: "read_user", description: "Read user profile info" },
+      { value: "read_repository", description: "Read repository files" },
+      { value: "write_repository", description: "Write to repositories" },
+      { value: "openid", description: "OpenID Connect authentication" },
+    ],
   },
   {
     id: "discord",
@@ -41,6 +72,13 @@ export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
     tokenUrl: "https://discord.com/api/oauth2/token",
     tokenAuthMethod: "client_secret_post",
     suggestedKey: "DISCORD",
+    scopes: [
+      { value: "identify", description: "Read user profile info" },
+      { value: "email", description: "Read user email address" },
+      { value: "guilds", description: "List user's guilds/servers" },
+      { value: "bot", description: "Add a bot to a guild" },
+      { value: "messages.read", description: "Read messages in channels" },
+    ],
   },
   {
     id: "spotify",
@@ -49,6 +87,14 @@ export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
     tokenUrl: "https://accounts.spotify.com/api/token",
     tokenAuthMethod: "client_secret_basic",
     suggestedKey: "SPOTIFY",
+    scopes: [
+      { value: "user-read-email", description: "Read user email address" },
+      { value: "user-read-private", description: "Read user subscription details" },
+      { value: "playlist-read-private", description: "Read private playlists" },
+      { value: "playlist-modify-public", description: "Create and edit public playlists" },
+      { value: "user-library-read", description: "Read saved tracks and albums" },
+      { value: "streaming", description: "Control playback on devices" },
+    ],
   },
   {
     id: "slack",
@@ -57,6 +103,14 @@ export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
     tokenUrl: "https://slack.com/api/oauth.v2.access",
     tokenAuthMethod: "client_secret_post",
     suggestedKey: "SLACK",
+    scopes: [
+      { value: "channels:read", description: "View basic channel info" },
+      { value: "channels:history", description: "View messages in public channels" },
+      { value: "chat:write", description: "Post messages to channels" },
+      { value: "users:read", description: "View user profiles" },
+      { value: "users:read.email", description: "View user email addresses" },
+      { value: "files:read", description: "View files shared in channels" },
+    ],
   },
   {
     id: "microsoft",
@@ -65,6 +119,16 @@ export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
     tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
     tokenAuthMethod: "client_secret_post",
     suggestedKey: "MICROSOFT",
+    scopes: [
+      { value: "openid", description: "OpenID Connect authentication" },
+      { value: "profile", description: "Read user basic profile" },
+      { value: "email", description: "Read user email address" },
+      { value: "User.Read", description: "Read signed-in user profile" },
+      { value: "Mail.Read", description: "Read user mail" },
+      { value: "Calendars.ReadWrite", description: "Read and write calendar events" },
+      { value: "Files.ReadWrite", description: "Read and write OneDrive files" },
+      { value: "offline_access", description: "Maintain access via refresh tokens" },
+    ],
   },
   {
     id: "notion",
@@ -81,6 +145,12 @@ export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
     tokenUrl: "https://api.linear.app/oauth/token",
     tokenAuthMethod: "client_secret_post",
     suggestedKey: "LINEAR",
+    scopes: [
+      { value: "read", description: "Read access to Linear data" },
+      { value: "write", description: "Write access to Linear data" },
+      { value: "issues:create", description: "Create new issues" },
+      { value: "admin", description: "Admin access to workspace settings" },
+    ],
   },
   {
     id: "bitbucket",
@@ -89,6 +159,13 @@ export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
     tokenUrl: "https://bitbucket.org/site/oauth2/access_token",
     tokenAuthMethod: "client_secret_basic",
     suggestedKey: "BITBUCKET",
+    scopes: [
+      { value: "repository", description: "Read repositories" },
+      { value: "repository:write", description: "Write to repositories" },
+      { value: "pullrequest", description: "Read pull requests" },
+      { value: "pullrequest:write", description: "Create and update pull requests" },
+      { value: "account", description: "Read user account info" },
+    ],
   },
   {
     id: "dropbox",
@@ -97,6 +174,13 @@ export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
     tokenUrl: "https://api.dropboxapi.com/oauth2/token",
     tokenAuthMethod: "client_secret_post",
     suggestedKey: "DROPBOX",
+    scopes: [
+      { value: "files.metadata.read", description: "Read file and folder metadata" },
+      { value: "files.content.read", description: "Read file contents" },
+      { value: "files.content.write", description: "Create and write files" },
+      { value: "sharing.read", description: "Read shared files and folders" },
+      { value: "account_info.read", description: "Read basic account info" },
+    ],
   },
   {
     id: "twitch",
@@ -105,6 +189,13 @@ export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
     tokenUrl: "https://id.twitch.tv/oauth2/token",
     tokenAuthMethod: "client_secret_post",
     suggestedKey: "TWITCH",
+    scopes: [
+      { value: "user:read:email", description: "Read user email address" },
+      { value: "channel:read:subscriptions", description: "List channel subscribers" },
+      { value: "channel:manage:broadcast", description: "Update channel stream settings" },
+      { value: "chat:read", description: "View live chat messages" },
+      { value: "chat:edit", description: "Send live chat messages" },
+    ],
   },
   {
     id: "zoom",
@@ -113,6 +204,12 @@ export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
     tokenUrl: "https://zoom.us/oauth/token",
     tokenAuthMethod: "client_secret_basic",
     suggestedKey: "ZOOM",
+    scopes: [
+      { value: "user:read", description: "Read user profile info" },
+      { value: "meeting:read", description: "Read meeting details" },
+      { value: "meeting:write", description: "Create and update meetings" },
+      { value: "recording:read", description: "Read cloud recordings" },
+    ],
   },
   {
     id: "hubspot",
@@ -121,5 +218,13 @@ export const OAUTH_PROVIDERS: OAuthProviderPreset[] = [
     tokenUrl: "https://api.hubapi.com/oauth/v1/token",
     tokenAuthMethod: "client_secret_post",
     suggestedKey: "HUBSPOT",
+    scopes: [
+      { value: "crm.objects.contacts.read", description: "Read contact records" },
+      { value: "crm.objects.contacts.write", description: "Create and update contacts" },
+      { value: "crm.objects.companies.read", description: "Read company records" },
+      { value: "crm.objects.deals.read", description: "Read deal records" },
+      { value: "crm.objects.deals.write", description: "Create and update deals" },
+      { value: "content", description: "Manage website content and blogs" },
+    ],
   },
 ];

--- a/web/src/pages/vault/CredentialsTab.tsx
+++ b/web/src/pages/vault/CredentialsTab.tsx
@@ -10,6 +10,7 @@ import Input from "../../components/Input";
 import FormField from "../../components/FormField";
 import Select from "../../components/Select";
 import Combobox from "../../components/Combobox";
+import CreatableSelect from "../../components/CreatableSelect";
 import { apiFetch } from "../../lib/api";
 import { OAUTH_PROVIDERS } from "../../lib/oauthProviders";
 
@@ -436,7 +437,7 @@ function CredentialModal({ vaultName, editingKey, editingCred, onClose, onSaved 
   const [oauthClientId, setOauthClientId] = useState(editingCred?.client_id ?? "");
   const [oauthClientSecret, setOauthClientSecret] = useState(editingCred?.client_secret ?? "");
   const [oauthTokenAuthMethod, setOauthTokenAuthMethod] = useState(editingCred?.token_auth_method ?? (editingCred?.client_secret ? "client_secret_post" : "none"));
-  const [oauthScopes, setOauthScopes] = useState(editingCred?.scopes ?? "");
+  const [oauthScopes, setOauthScopes] = useState<string[]>(editingCred?.scopes ? editingCred.scopes.split(" ").filter(Boolean) : []);
   const [oauthAccessToken, setOauthAccessToken] = useState(editingCred?.access_token ?? "");
   const [oauthRefreshToken, setOauthRefreshToken] = useState(editingCred?.refresh_token ?? "");
   const [oauthConnecting, setOauthConnecting] = useState(false);
@@ -449,7 +450,7 @@ function CredentialModal({ vaultName, editingKey, editingCred, onClose, onSaved 
   function removeEntry(i: number) { setEntries((p) => p.filter((_, j) => j !== i)); }
   function addEntry() { setEntries((p) => [...p, { key: "", value: "" }]); }
 
-  const [oauthMode, setOauthMode] = useState<"connect" | "upload">(editingCred?.authorization_url ? "connect" : "upload");
+  const [oauthMode, setOauthMode] = useState<"connect" | "upload">(!isEdit || editingCred?.authorization_url ? "connect" : "upload");
   const isTokenUpload = oauthMode === "upload";
   const canSubmitStatic = entries.every((e) => e.key.trim() && e.value.trim());
   const canSubmitOAuthConnect = !!(oauthKey.trim() && oauthTokenUrl.trim() && oauthClientId.trim() && oauthAuthUrl.trim());
@@ -483,6 +484,9 @@ function CredentialModal({ vaultName, editingKey, editingCred, onClose, onSaved 
   // selecting it just closes the list and leaves all fields free-form.
   const customOption = { id: "custom", label: "Custom Provider", sublabel: "Enter provider manually", pinned: true };
 
+  const currentProvider = OAUTH_PROVIDERS.find((p) => p.authorizationUrl === oauthAuthUrl || p.tokenUrl === oauthTokenUrl);
+  const scopeOptions = (currentProvider?.scopes ?? []).map((s) => ({ value: s.value, description: s.description }));
+
   function applyProvider(id: string) {
     const p = OAUTH_PROVIDERS.find((p) => p.id === id);
     if (!p) return;
@@ -490,6 +494,7 @@ function CredentialModal({ vaultName, editingKey, editingCred, onClose, onSaved 
     setOauthTokenUrl(p.tokenUrl);
     setOauthTokenAuthMethod(p.tokenAuthMethod);
     if (!isEdit) setOauthKey(p.suggestedKey);
+    setOauthScopes([]);
   }
 
   async function handleOAuthConnect() {
@@ -497,7 +502,7 @@ function CredentialModal({ vaultName, editingKey, editingCred, onClose, onSaved 
     try {
       const resp = await apiFetch("/v1/credentials/oauth/connect", {
         method: "POST",
-        body: JSON.stringify({ vault: vaultName, key: oauthKey.trim(), authorization_url: oauthAuthUrl.trim(), token_url: oauthTokenUrl.trim(), client_id: oauthClientId.trim(), client_secret: oauthClientSecret.trim() || undefined, scopes: oauthScopes.trim() || undefined, token_auth_method: oauthTokenAuthMethod === "none" ? undefined : oauthTokenAuthMethod }),
+        body: JSON.stringify({ vault: vaultName, key: oauthKey.trim(), authorization_url: oauthAuthUrl.trim(), token_url: oauthTokenUrl.trim(), client_id: oauthClientId.trim(), client_secret: oauthClientSecret.trim() || undefined, scopes: oauthScopes.join(" ") || undefined, token_auth_method: oauthTokenAuthMethod === "none" ? undefined : oauthTokenAuthMethod }),
       });
       if (!resp.ok) { const d = await resp.json(); throw new Error(d.error || "Failed to start OAuth."); }
       const data = await resp.json();
@@ -624,7 +629,14 @@ function CredentialModal({ vaultName, editingKey, editingCred, onClose, onSaved 
                   </Select>
                 </FormField></div>
               </div>
-              <FormField label="Scopes" helperText="Space-separated"><Input placeholder="e.g. repo user" value={oauthScopes} onChange={(e) => setOauthScopes(e.target.value)} /></FormField>
+              <FormField label="Scopes" helperText="Space-separated">
+                <CreatableSelect
+                  values={oauthScopes}
+                  onChange={setOauthScopes}
+                  options={scopeOptions}
+                  placeholder="Add scopes"
+                />
+              </FormField>
             </>
           ) : (
             <>

--- a/web/src/pages/vault/CredentialsTab.tsx
+++ b/web/src/pages/vault/CredentialsTab.tsx
@@ -629,7 +629,7 @@ function CredentialModal({ vaultName, editingKey, editingCred, onClose, onSaved 
                   </Select>
                 </FormField></div>
               </div>
-              <FormField label="Scopes" helperText="Space-separated">
+              <FormField label="Scopes">
                 <CreatableSelect
                   values={oauthScopes}
                   onChange={setOauthScopes}


### PR DESCRIPTION
## Summary

Replaces the free-text scopes input with a creatable multi-select. Picking a provider from the URL combobox populates scope suggestions with descriptions; users can pick from the list or type custom scopes. Scopes clear when switching providers. New credentials now default to Connect mode.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] Existing tests pass (`make test`)
- [ ] Added/updated tests for new behavior
- [x] Manual testing (describe below)

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)