### PR TITLE
feat: auto-detect and recommend hostnames from proxy traffic

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -578,6 +578,19 @@ func matchHostPattern(pattern, host string) (tier int, ok bool) {
 	return 0, false
 }
 
+// AnyHostMatches reports whether any service's host pattern matches
+// host, ignoring paths. Used to filter discovered hosts against the
+// current service list so hosts that are already covered by a
+// configured service (even path-scoped or disabled) are excluded.
+func AnyHostMatches(host string, services []Service) bool {
+	for i := range services {
+		if _, ok := matchHostPattern(services[i].Host, host); ok {
+			return true
+		}
+	}
+	return false
+}
+
 // matchPathGlob reports whether pattern matches path and returns the
 // literal-prefix length. Empty pattern is a catch-all. '*' is greedy
 // across '/'.

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -1042,3 +1042,36 @@ func TestServiceCredentialKeysOnlyAuth(t *testing.T) {
 		t.Fatalf("expected [MY_KEY], got %v", keys)
 	}
 }
+
+func TestAnyHostMatches(t *testing.T) {
+	services := []Service{
+		{Host: "api.stripe.com", Auth: Auth{Type: "bearer", Token: "K"}},
+		{Host: "*.github.com", Auth: Auth{Type: "bearer", Token: "K"}},
+		{Host: "slack.com", Path: "/api/*", Auth: Auth{Type: "bearer", Token: "K"}},
+	}
+
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"api.stripe.com", true},
+		{"api.github.com", true},
+		{"raw.github.com", true},
+		{"github.com", false},
+		{"a.b.github.com", false},
+		{"slack.com", true},
+		{"api.unknown.com", false},
+		{"example.com", false},
+	}
+	for _, tt := range tests {
+		got := AnyHostMatches(tt.host, services)
+		if got != tt.want {
+			t.Errorf("AnyHostMatches(%q) = %v, want %v", tt.host, got, tt.want)
+		}
+	}
+
+	// Nil services: nothing matches.
+	if AnyHostMatches("anything.com", nil) {
+		t.Error("AnyHostMatches with nil services should return false")
+	}
+}

--- a/internal/brokercore/logging.go
+++ b/internal/brokercore/logging.go
@@ -41,6 +41,8 @@ type ProxyEvent struct {
 	TotalMs        int64    // handler entry → emit, in milliseconds
 	Err            string   // short error code, or "" on success
 	Passthrough    bool     // see InjectResult.Passthrough
+	AuthScheme     string   // best-effort detected auth scheme: "bearer", "basic", "api-key", or ""
+	AuthHeader     string   // header name carrying auth (e.g. "Authorization", "X-API-KEY"), or ""
 }
 
 // Emit fills in the terminal fields (Status, Err, TotalMs measured from

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -188,11 +188,14 @@ func (p *Proxy) forwardRequest(
 	scope *brokercore.ProxyScope,
 ) {
 	start := time.Now()
+	authScheme, authHeader := detectAuthFromHeaders(r.Header)
 	event := brokercore.ProxyEvent{
-		Ingress: brokercore.IngressMITM,
-		Method:  r.Method,
-		Host:    target,
-		Path:    r.URL.Path,
+		Ingress:    brokercore.IngressMITM,
+		Method:     r.Method,
+		Host:       target,
+		Path:       r.URL.Path,
+		AuthScheme: authScheme,
+		AuthHeader: authHeader,
 	}
 	actorType, actorID := actorFromScope(scope)
 	emit := func(status int, errCode string) {
@@ -413,4 +416,30 @@ func (p *Proxy) forwardRequest(
 	}
 
 	emit(resp.StatusCode, "")
+}
+
+// knownAPIKeyHeaders are non-Authorization headers that commonly carry
+// API keys. Checked by exact canonical match -- no heuristic scanning.
+var knownAPIKeyHeaders = []string{"X-Api-Key", "Api-Key"}
+
+// detectAuthFromHeaders inspects request headers to determine the auth
+// scheme and header name. Returns ("", "") when no recognizable auth
+// pattern is found.
+func detectAuthFromHeaders(h http.Header) (scheme, header string) {
+	if auth := h.Get("Authorization"); auth != "" {
+		switch {
+		case strings.HasPrefix(auth, "Bearer ") || strings.HasPrefix(auth, "bearer "):
+			return "bearer", "Authorization"
+		case strings.HasPrefix(auth, "Basic ") || strings.HasPrefix(auth, "basic "):
+			return "basic", "Authorization"
+		default:
+			return "api-key", "Authorization"
+		}
+	}
+	for _, name := range knownAPIKeyHeaders {
+		if h.Get(name) != "" {
+			return "api-key", http.CanonicalHeaderKey(name)
+		}
+	}
+	return "", ""
 }

--- a/internal/mitm/forward_test.go
+++ b/internal/mitm/forward_test.go
@@ -731,3 +731,78 @@ func TestMITMForwardAuthRateLimitCountsFailures(t *testing.T) {
 		t.Fatalf("forward 4 got %d, want 429 after budget exhausted", resp.StatusCode)
 	}
 }
+
+func TestDetectAuthFromHeaders(t *testing.T) {
+	tests := []struct {
+		name       string
+		headers    http.Header
+		wantScheme string
+		wantHeader string
+	}{
+		{
+			name:       "bearer",
+			headers:    http.Header{"Authorization": {"Bearer sk-xxx"}},
+			wantScheme: "bearer",
+			wantHeader: "Authorization",
+		},
+		{
+			name:       "bearer_lowercase",
+			headers:    http.Header{"Authorization": {"bearer sk-xxx"}},
+			wantScheme: "bearer",
+			wantHeader: "Authorization",
+		},
+		{
+			name:       "basic",
+			headers:    http.Header{"Authorization": {"Basic dXNlcjpwYXNz"}},
+			wantScheme: "basic",
+			wantHeader: "Authorization",
+		},
+		{
+			name:       "api_key_via_authorization",
+			headers:    http.Header{"Authorization": {"Token abc123"}},
+			wantScheme: "api-key",
+			wantHeader: "Authorization",
+		},
+		{
+			name:       "x_api_key",
+			headers:    http.Header{"X-Api-Key": {"key123"}},
+			wantScheme: "api-key",
+			wantHeader: "X-Api-Key",
+		},
+		{
+			name:       "api_key_header",
+			headers:    http.Header{"Api-Key": {"key123"}},
+			wantScheme: "api-key",
+			wantHeader: "Api-Key",
+		},
+		{
+			name:       "no_auth",
+			headers:    http.Header{"Content-Type": {"application/json"}},
+			wantScheme: "",
+			wantHeader: "",
+		},
+		{
+			name:       "empty_headers",
+			headers:    http.Header{},
+			wantScheme: "",
+			wantHeader: "",
+		},
+		{
+			name:       "authorization_takes_precedence",
+			headers:    http.Header{"Authorization": {"Bearer tok"}, "X-Api-Key": {"key"}},
+			wantScheme: "bearer",
+			wantHeader: "Authorization",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme, header := detectAuthFromHeaders(tt.headers)
+			if scheme != tt.wantScheme {
+				t.Errorf("scheme = %q, want %q", scheme, tt.wantScheme)
+			}
+			if header != tt.wantHeader {
+				t.Errorf("header = %q, want %q", header, tt.wantHeader)
+			}
+		})
+	}
+}

--- a/internal/requestlog/sink.go
+++ b/internal/requestlog/sink.go
@@ -33,6 +33,8 @@ type Record struct {
 	Status         int
 	LatencyMs      int64
 	ErrorCode      string
+	AuthScheme     string
+	AuthHeader     string
 }
 
 // Sink accepts records on the hot proxy path. Implementations MUST NOT
@@ -84,6 +86,8 @@ func FromEvent(ev brokercore.ProxyEvent, vaultID, actorType, actorID string) Rec
 		Status:         ev.Status,
 		LatencyMs:      ev.TotalMs,
 		ErrorCode:      ev.Err,
+		AuthScheme:     ev.AuthScheme,
+		AuthHeader:     ev.AuthHeader,
 	}
 }
 
@@ -104,5 +108,7 @@ func toStoreRow(r Record) store.RequestLog {
 		Status:         r.Status,
 		LatencyMs:      r.LatencyMs,
 		ErrorCode:      r.ErrorCode,
+		AuthScheme:     r.AuthScheme,
+		AuthHeader:     r.AuthHeader,
 	}
 }

--- a/internal/server/handle_host_discovery.go
+++ b/internal/server/handle_host_discovery.go
@@ -20,6 +20,8 @@ type discoveredHost struct {
 	Host         string `json:"host"`
 	RequestCount int    `json:"request_count"`
 	LastSeen     string `json:"last_seen"`
+	AuthScheme   string `json:"auth_scheme,omitempty"`
+	AuthHeader   string `json:"auth_header,omitempty"`
 
 	lastSeenTime time.Time
 }
@@ -79,12 +81,16 @@ func (s *Server) handleDiscoveredHosts(w http.ResponseWriter, r *http.Request) {
 			if uh.LastSeen.After(existing.lastSeenTime) {
 				existing.lastSeenTime = uh.LastSeen
 				existing.LastSeen = uh.LastSeen.Format(time.RFC3339)
+				existing.AuthScheme = uh.AuthScheme
+				existing.AuthHeader = uh.AuthHeader
 			}
 		} else {
 			deduped[h] = &discoveredHost{
 				Host:         h,
 				RequestCount: uh.RequestCount,
 				LastSeen:     uh.LastSeen.Format(time.RFC3339),
+				AuthScheme:   uh.AuthScheme,
+				AuthHeader:   uh.AuthHeader,
 				lastSeenTime: uh.LastSeen,
 			}
 		}

--- a/internal/server/handle_host_discovery.go
+++ b/internal/server/handle_host_discovery.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/Infisical/agent-vault/internal/broker"
+)
+
+const (
+	discoveredHostsDefaultLimit = 5
+	discoveredHostsMaxLimit     = 100
+)
+
+type discoveredHost struct {
+	Host         string `json:"host"`
+	RequestCount int    `json:"request_count"`
+	LastSeen     string `json:"last_seen"`
+
+	lastSeenTime time.Time
+}
+
+func (s *Server) handleDiscoveredHosts(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	ns, err := s.store.GetVault(ctx, name)
+	if err != nil || ns == nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", name))
+		return
+	}
+
+	if _, err := s.requireVaultMember(w, r, ns.ID); err != nil {
+		return
+	}
+
+	// Parse limit: absent/error = default, negative = default, 0 = count-only, >max = clamp.
+	limit := discoveredHostsDefaultLimit
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil {
+			if v == 0 {
+				limit = 0
+			} else if v > 0 {
+				limit = v
+			}
+		}
+	}
+	if limit > discoveredHostsMaxLimit {
+		limit = discoveredHostsMaxLimit
+	}
+
+	unmatched, err := s.store.ListUnmatchedHosts(ctx, ns.ID)
+	if err != nil {
+		s.logger.Warn("discovered-hosts: store query failed", "vault", name, "err", err.Error())
+		jsonError(w, http.StatusInternalServerError, "Failed to list discovered hosts")
+		return
+	}
+
+	services, err := s.loadServices(ctx, ns.ID)
+	if err != nil {
+		s.logger.Warn("discovered-hosts: loadServices failed", "vault", name, "err", err.Error())
+		jsonError(w, http.StatusInternalServerError, "Failed to load services")
+		return
+	}
+
+	// Port-strip and deduplicate: merge entries that differ only by port.
+	deduped := make(map[string]*discoveredHost)
+	for _, uh := range unmatched {
+		h := uh.Host
+		if stripped, _, err := net.SplitHostPort(h); err == nil {
+			h = stripped
+		}
+		if existing, ok := deduped[h]; ok {
+			existing.RequestCount += uh.RequestCount
+			if uh.LastSeen.After(existing.lastSeenTime) {
+				existing.lastSeenTime = uh.LastSeen
+				existing.LastSeen = uh.LastSeen.Format(time.RFC3339)
+			}
+		} else {
+			deduped[h] = &discoveredHost{
+				Host:         h,
+				RequestCount: uh.RequestCount,
+				LastSeen:     uh.LastSeen.Format(time.RFC3339),
+				lastSeenTime: uh.LastSeen,
+			}
+		}
+	}
+
+	// Filter out hosts that match a currently configured service (host-only matching).
+	var filtered []*discoveredHost
+	for _, dh := range deduped {
+		if broker.AnyHostMatches(dh.Host, services) {
+			continue
+		}
+		filtered = append(filtered, dh)
+	}
+
+	// Re-sort by last_seen DESC, hostname ASC as tiebreaker for stable ordering.
+	sort.Slice(filtered, func(i, j int) bool {
+		if !filtered[i].lastSeenTime.Equal(filtered[j].lastSeenTime) {
+			return filtered[i].lastSeenTime.After(filtered[j].lastSeenTime)
+		}
+		return filtered[i].Host < filtered[j].Host
+	})
+
+	total := len(filtered)
+
+	// limit=0: count-only mode for sidebar badge polling.
+	if limit == 0 {
+		jsonOK(w, map[string]any{
+			"hosts": []discoveredHost{},
+			"total": total,
+		})
+		return
+	}
+
+	if limit < len(filtered) {
+		filtered = filtered[:limit]
+	}
+
+	hosts := make([]discoveredHost, len(filtered))
+	for i, dh := range filtered {
+		hosts[i] = *dh
+	}
+
+	jsonOK(w, map[string]any{
+		"hosts": hosts,
+		"total": total,
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -317,6 +317,7 @@ type Store interface {
 	// Request logs
 	InsertRequestLogs(ctx context.Context, rows []store.RequestLog) error
 	ListRequestLogs(ctx context.Context, opts store.ListRequestLogsOpts) ([]store.RequestLog, error)
+	ListUnmatchedHosts(ctx context.Context, vaultID string) ([]store.UnmatchedHost, error)
 	DeleteOldRequestLogs(ctx context.Context, before time.Time) (int64, error)
 	TrimRequestLogsToCap(ctx context.Context, vaultID string, cap int64) (int64, error)
 	VaultIDsWithLogs(ctx context.Context) ([]string, error)
@@ -807,6 +808,7 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("DELETE /v1/vaults/{name}/services", s.requireInitialized(s.requireAuth(actorAuthed(s.handleServicesClear))))
 	mux.HandleFunc("GET /v1/vaults/{name}/services/credential-usage", s.requireInitialized(s.requireAuth(actorAuthed(s.handleServicesCredentialUsage))))
 	mux.HandleFunc("GET /v1/vaults/{name}/logs", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultLogsList))))
+	mux.HandleFunc("GET /v1/vaults/{name}/discovered-hosts", s.requireInitialized(s.requireAuth(actorAuthed(s.handleDiscoveredHosts))))
 	// Public static reads — immutable payloads with no credentials on
 	// the wire. TierGlobal is the only useful backstop; TierAuth would
 	// punish `vault run` (CA fetch per invocation) and the dashboard

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -45,6 +45,7 @@ type mockStore struct {
 	settings           map[string]string                     // instance settings
 	vaultSettings      map[string]map[string]string          // per-vault: vaultID -> key -> value
 	credStores         map[string]*store.VaultCredentialStore // per-vault external credential store config
+	unmatchedHosts     map[string][]store.UnmatchedHost      // keyed by vaultID
 	sessionCounter     int
 }
 
@@ -398,6 +399,10 @@ func (m *mockStore) InsertRequestLogs(_ context.Context, _ []store.RequestLog) e
 
 func (m *mockStore) ListRequestLogs(_ context.Context, _ store.ListRequestLogsOpts) ([]store.RequestLog, error) {
 	return nil, nil
+}
+
+func (m *mockStore) ListUnmatchedHosts(_ context.Context, vaultID string) ([]store.UnmatchedHost, error) {
+	return m.unmatchedHosts[vaultID], nil
 }
 
 func (m *mockStore) DeleteOldRequestLogs(_ context.Context, _ time.Time) (int64, error) {
@@ -6843,4 +6848,277 @@ func TestSPACatchAllRoutes(t *testing.T) {
 			t.Fatalf("expected 404 for unregistered path, got %d: %s", rec.Code, rec.Body.String())
 		}
 	})
+}
+
+// --- Discovered Hosts Tests ---
+
+func setupDiscoveredHostsTest(t *testing.T, servicesJSON string, hosts []store.UnmatchedHost) (*mockStore, string) {
+	t.Helper()
+	ms := newMockStore()
+
+	sess, err := ms.CreateScopedSession(context.Background(), store.CreateScopedSessionParams{
+		VaultID:   "root-ns-id",
+		VaultRole: "member",
+		ExpiresAt: tp(time.Now().Add(time.Hour)),
+	})
+	if err != nil {
+		t.Fatalf("CreateScopedSession: %v", err)
+	}
+
+	if servicesJSON != "" {
+		ms.brokerConfigs["root-ns-id"] = &store.BrokerConfig{
+			ID: "bc-1", VaultID: "root-ns-id", ServicesJSON: servicesJSON,
+		}
+	}
+
+	if ms.unmatchedHosts == nil {
+		ms.unmatchedHosts = make(map[string][]store.UnmatchedHost)
+	}
+	ms.unmatchedHosts["root-ns-id"] = hosts
+
+	return ms, sess.ID
+}
+
+func TestDiscoveredHostsBasic(t *testing.T) {
+	now := time.Now().UTC()
+	hosts := []store.UnmatchedHost{
+		{Host: "api.stripe.com:443", RequestCount: 10, LastSeen: now},
+		{Host: "api.openai.com:443", RequestCount: 5, LastSeen: now.Add(-1 * time.Minute)},
+		{Host: "hooks.slack.com:443", RequestCount: 2, LastSeen: now.Add(-5 * time.Minute)},
+	}
+
+	ms, token := setupDiscoveredHostsTest(t, "", hosts)
+	srv := newTestServer(withStore(ms))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/vaults/default/discovered-hosts", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Hosts []struct {
+			Host         string `json:"host"`
+			RequestCount int    `json:"request_count"`
+			LastSeen     string `json:"last_seen"`
+		} `json:"hosts"`
+		Total int `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Total != 3 {
+		t.Fatalf("expected total=3, got %d", resp.Total)
+	}
+	if len(resp.Hosts) != 3 {
+		t.Fatalf("expected 3 hosts, got %d", len(resp.Hosts))
+	}
+	// Port-stripped hostnames
+	if resp.Hosts[0].Host != "api.stripe.com" {
+		t.Errorf("expected first host api.stripe.com, got %q", resp.Hosts[0].Host)
+	}
+	if resp.Hosts[0].RequestCount != 10 {
+		t.Errorf("expected 10 requests, got %d", resp.Hosts[0].RequestCount)
+	}
+}
+
+func TestDiscoveredHostsFilterConfiguredService(t *testing.T) {
+	now := time.Now().UTC()
+	hosts := []store.UnmatchedHost{
+		{Host: "api.stripe.com:443", RequestCount: 10, LastSeen: now},
+		{Host: "api.github.com:443", RequestCount: 5, LastSeen: now.Add(-1 * time.Minute)},
+		{Host: "raw.github.com:443", RequestCount: 3, LastSeen: now.Add(-2 * time.Minute)},
+		{Host: "hooks.slack.com:443", RequestCount: 2, LastSeen: now.Add(-3 * time.Minute)},
+	}
+
+	servicesJSON := `[{"name":"github","host":"*.github.com","auth":{"type":"bearer","token":"GH_TOKEN"}},{"name":"stripe","host":"api.stripe.com/v1/*","auth":{"type":"bearer","token":"STRIPE_KEY"}}]`
+	ms, token := setupDiscoveredHostsTest(t, servicesJSON, hosts)
+	srv := newTestServer(withStore(ms))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/vaults/default/discovered-hosts?limit=100", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Hosts []struct{ Host string `json:"host"` } `json:"hosts"`
+		Total int                                    `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// api.stripe.com filtered (host-only match against api.stripe.com/v1/*),
+	// api.github.com and raw.github.com filtered (wildcard *.github.com),
+	// only hooks.slack.com remains
+	if resp.Total != 1 {
+		t.Fatalf("expected total=1, got %d (hosts: %+v)", resp.Total, resp.Hosts)
+	}
+	if resp.Hosts[0].Host != "hooks.slack.com" {
+		t.Errorf("expected hooks.slack.com, got %q", resp.Hosts[0].Host)
+	}
+}
+
+func TestDiscoveredHostsPortDedup(t *testing.T) {
+	now := time.Now().UTC()
+	hosts := []store.UnmatchedHost{
+		{Host: "api.stripe.com:443", RequestCount: 10, LastSeen: now},
+		{Host: "api.stripe.com:80", RequestCount: 3, LastSeen: now.Add(-1 * time.Minute)},
+	}
+
+	ms, token := setupDiscoveredHostsTest(t, "", hosts)
+	srv := newTestServer(withStore(ms))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/vaults/default/discovered-hosts", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	var resp struct {
+		Hosts []struct {
+			Host         string `json:"host"`
+			RequestCount int    `json:"request_count"`
+		} `json:"hosts"`
+		Total int `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Total != 1 {
+		t.Fatalf("expected total=1 (deduped), got %d", resp.Total)
+	}
+	if resp.Hosts[0].Host != "api.stripe.com" {
+		t.Errorf("expected api.stripe.com, got %q", resp.Hosts[0].Host)
+	}
+	if resp.Hosts[0].RequestCount != 13 {
+		t.Errorf("expected 13 (10+3 merged), got %d", resp.Hosts[0].RequestCount)
+	}
+}
+
+func TestDiscoveredHostsLimitZeroCountOnly(t *testing.T) {
+	now := time.Now().UTC()
+	hosts := []store.UnmatchedHost{
+		{Host: "a.com:443", RequestCount: 1, LastSeen: now},
+		{Host: "b.com:443", RequestCount: 1, LastSeen: now},
+	}
+
+	ms, token := setupDiscoveredHostsTest(t, "", hosts)
+	srv := newTestServer(withStore(ms))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/vaults/default/discovered-hosts?limit=0", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	var resp struct {
+		Hosts []struct{ Host string } `json:"hosts"`
+		Total int                     `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Total != 2 {
+		t.Fatalf("expected total=2, got %d", resp.Total)
+	}
+	if len(resp.Hosts) != 0 {
+		t.Fatalf("expected empty hosts array for limit=0, got %d", len(resp.Hosts))
+	}
+}
+
+func TestDiscoveredHostsLimitPagination(t *testing.T) {
+	now := time.Now().UTC()
+	var hosts []store.UnmatchedHost
+	for i := 0; i < 8; i++ {
+		hosts = append(hosts, store.UnmatchedHost{
+			Host: fmt.Sprintf("host-%d.com:443", i), RequestCount: 1,
+			LastSeen: now.Add(-time.Duration(i) * time.Minute),
+		})
+	}
+
+	ms, token := setupDiscoveredHostsTest(t, "", hosts)
+	srv := newTestServer(withStore(ms))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/vaults/default/discovered-hosts?limit=5", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	var resp struct {
+		Hosts []struct{ Host string } `json:"hosts"`
+		Total int                     `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Total != 8 {
+		t.Fatalf("expected total=8, got %d", resp.Total)
+	}
+	if len(resp.Hosts) != 5 {
+		t.Fatalf("expected 5 hosts with limit=5, got %d", len(resp.Hosts))
+	}
+}
+
+func TestDiscoveredHostsProxyRoleRejected(t *testing.T) {
+	ms := newMockStore()
+	sess, err := ms.CreateScopedSession(context.Background(), store.CreateScopedSessionParams{
+		VaultID:   "root-ns-id",
+		VaultRole: "proxy",
+		ExpiresAt: tp(time.Now().Add(time.Hour)),
+	})
+	if err != nil {
+		t.Fatalf("CreateScopedSession: %v", err)
+	}
+	srv := newTestServer(withStore(ms))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/vaults/default/discovered-hosts", nil)
+	req.Header.Set("Authorization", "Bearer "+sess.ID)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for proxy role, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDiscoveredHostsNoBrokerConfig(t *testing.T) {
+	now := time.Now().UTC()
+	hosts := []store.UnmatchedHost{
+		{Host: "api.stripe.com:443", RequestCount: 5, LastSeen: now},
+	}
+
+	ms, token := setupDiscoveredHostsTest(t, "", hosts)
+	srv := newTestServer(withStore(ms))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/vaults/default/discovered-hosts", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Hosts []struct{ Host string } `json:"hosts"`
+		Total int                     `json:"total"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// No broker config = no services to filter against, all hosts pass through
+	if resp.Total != 1 {
+		t.Fatalf("expected total=1, got %d", resp.Total)
+	}
 }

--- a/internal/store/migrations/049_request_logs_auth_detection.sql
+++ b/internal/store/migrations/049_request_logs_auth_detection.sql
@@ -1,0 +1,2 @@
+ALTER TABLE request_logs ADD COLUMN auth_scheme TEXT NOT NULL DEFAULT '';
+ALTER TABLE request_logs ADD COLUMN auth_header TEXT NOT NULL DEFAULT '';

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -3124,6 +3124,39 @@ func (s *SQLiteStore) ListRequestLogs(ctx context.Context, opts ListRequestLogsO
 	return out, rows.Err()
 }
 
+// ListUnmatchedHosts returns distinct hostnames from request_logs that did
+// not match any configured service and resulted in an auth failure (401/403)
+// or proxy denial (error_code 'no_match'). Results are ordered by most
+// recent failure first. Capped at 500 rows as a defense-in-depth limit.
+func (s *SQLiteStore) ListUnmatchedHosts(ctx context.Context, vaultID string) ([]UnmatchedHost, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT host, COUNT(*) AS request_count, MAX(created_at) AS last_seen
+		FROM request_logs
+		WHERE vault_id = ?
+		  AND matched_service = ''
+		  AND host != ''
+		  AND (error_code = 'no_match' OR status IN (401, 403))
+		GROUP BY host
+		ORDER BY MAX(created_at) DESC, host ASC
+		LIMIT 500`, vaultID)
+	if err != nil {
+		return nil, fmt.Errorf("listing unmatched hosts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []UnmatchedHost
+	for rows.Next() {
+		var uh UnmatchedHost
+		var lastSeen string
+		if err := rows.Scan(&uh.Host, &uh.RequestCount, &lastSeen); err != nil {
+			return nil, fmt.Errorf("scanning unmatched host: %w", err)
+		}
+		uh.LastSeen, _ = time.Parse(time.DateTime, lastSeen)
+		out = append(out, uh)
+	}
+	return out, rows.Err()
+}
+
 // DeleteOldRequestLogs deletes rows older than before across all vaults.
 // Returns the number of rows affected.
 func (s *SQLiteStore) DeleteOldRequestLogs(ctx context.Context, before time.Time) (int64, error) {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -3001,8 +3001,9 @@ func (s *SQLiteStore) InsertRequestLogs(ctx context.Context, rows []RequestLog) 
 	stmt, err := tx.PrepareContext(ctx, `
 		INSERT INTO request_logs
 		  (vault_id, actor_type, actor_id, ingress, method, host, path,
-		   matched_service, credential_keys, status, latency_ms, error_code, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		   matched_service, credential_keys, status, latency_ms, error_code,
+		   auth_scheme, auth_header, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("preparing request_logs insert: %w", err)
 	}
@@ -3024,6 +3025,7 @@ func (s *SQLiteStore) InsertRequestLogs(ctx context.Context, rows []RequestLog) 
 		if _, err := stmt.ExecContext(ctx,
 			r.VaultID, r.ActorType, r.ActorID, r.Ingress, r.Method, r.Host, r.Path,
 			r.MatchedService, string(keysJSON), r.Status, r.LatencyMs, r.ErrorCode,
+			r.AuthScheme, r.AuthHeader,
 			createdAt.UTC().Format(time.DateTime),
 		); err != nil {
 			return fmt.Errorf("inserting request_log: %w", err)
@@ -3129,8 +3131,13 @@ func (s *SQLiteStore) ListRequestLogs(ctx context.Context, opts ListRequestLogsO
 // or proxy denial (error_code 'no_match'). Results are ordered by most
 // recent failure first. Capped at 500 rows as a defense-in-depth limit.
 func (s *SQLiteStore) ListUnmatchedHosts(ctx context.Context, vaultID string) ([]UnmatchedHost, error) {
+	// auth_scheme and auth_header are bare columns in a GROUP BY with
+	// MAX(created_at). SQLite guarantees these come from the row that
+	// produced the MAX, giving us the auth detection from the most
+	// recent request per host.
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT host, COUNT(*) AS request_count, MAX(created_at) AS last_seen
+		SELECT host, COUNT(*) AS request_count, MAX(created_at) AS last_seen,
+		       auth_scheme, auth_header
 		FROM request_logs
 		WHERE vault_id = ?
 		  AND matched_service = ''
@@ -3148,7 +3155,7 @@ func (s *SQLiteStore) ListUnmatchedHosts(ctx context.Context, vaultID string) ([
 	for rows.Next() {
 		var uh UnmatchedHost
 		var lastSeen string
-		if err := rows.Scan(&uh.Host, &uh.RequestCount, &lastSeen); err != nil {
+		if err := rows.Scan(&uh.Host, &uh.RequestCount, &lastSeen, &uh.AuthScheme, &uh.AuthHeader); err != nil {
 			return nil, fmt.Errorf("scanning unmatched host: %w", err)
 		}
 		uh.LastSeen, _ = time.Parse(time.DateTime, lastSeen)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -2435,3 +2435,93 @@ func TestListVaultCredentialStoresFiltersBuiltin(t *testing.T) {
 		t.Fatalf("expected 2 external stores, got %d (%+v)", len(list), list)
 	}
 }
+
+func TestListUnmatchedHosts(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	vA, err := s.CreateVault(ctx, "vault-a")
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	vB, err := s.CreateVault(ctx, "vault-b")
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+
+	now := time.Now().UTC()
+	rows := []RequestLog{
+		// Unmatched, denied by proxy (error_code=no_match) -- should appear
+		{VaultID: vA.ID, Ingress: "mitm", Method: "GET", Host: "api.stripe.com:443", Path: "/", MatchedService: "", Status: 403, ErrorCode: "no_match", CreatedAt: now.Add(-1 * time.Minute)},
+		{VaultID: vA.ID, Ingress: "mitm", Method: "POST", Host: "api.stripe.com:443", Path: "/v1/charges", MatchedService: "", Status: 403, ErrorCode: "no_match", CreatedAt: now},
+
+		// Unmatched, passthrough with upstream 401 -- should appear
+		{VaultID: vA.ID, Ingress: "mitm", Method: "GET", Host: "api.openai.com:443", Path: "/v1/models", MatchedService: "", Status: 401, ErrorCode: "", CreatedAt: now.Add(-30 * time.Second)},
+
+		// Unmatched, passthrough with upstream 403 -- should appear
+		{VaultID: vA.ID, Ingress: "mitm", Method: "GET", Host: "hooks.slack.com:443", Path: "/", MatchedService: "", Status: 403, ErrorCode: "", CreatedAt: now.Add(-2 * time.Minute)},
+
+		// Matched service -- should NOT appear (matched_service != '')
+		{VaultID: vA.ID, Ingress: "mitm", Method: "GET", Host: "api.github.com:443", Path: "/", MatchedService: "github", Status: 200, ErrorCode: "", CreatedAt: now},
+
+		// Unmatched, passthrough success (200) -- should NOT appear
+		{VaultID: vA.ID, Ingress: "mitm", Method: "GET", Host: "public-api.example.com:443", Path: "/", MatchedService: "", Status: 200, ErrorCode: "", CreatedAt: now},
+
+		// Unmatched, passthrough 500 (server error, not auth) -- should NOT appear
+		{VaultID: vA.ID, Ingress: "mitm", Method: "GET", Host: "buggy.example.com:443", Path: "/", MatchedService: "", Status: 500, ErrorCode: "", CreatedAt: now},
+
+		// Vault B: unmatched denied -- should NOT appear in vault A query
+		{VaultID: vB.ID, Ingress: "mitm", Method: "GET", Host: "vault-b-only.com:443", Path: "/", MatchedService: "", Status: 403, ErrorCode: "no_match", CreatedAt: now},
+
+		// Disabled service produces matched_service='' and error_code=no_match -- should appear at store level
+		{VaultID: vA.ID, Ingress: "mitm", Method: "GET", Host: "disabled.example.com:443", Path: "/", MatchedService: "", Status: 403, ErrorCode: "no_match", CreatedAt: now.Add(-5 * time.Minute)},
+	}
+	if err := s.InsertRequestLogs(ctx, rows); err != nil {
+		t.Fatalf("InsertRequestLogs: %v", err)
+	}
+
+	hosts, err := s.ListUnmatchedHosts(ctx, vA.ID)
+	if err != nil {
+		t.Fatalf("ListUnmatchedHosts: %v", err)
+	}
+
+	// Expected: api.stripe.com:443 (2 requests), api.openai.com:443 (1), hooks.slack.com:443 (1), disabled.example.com:443 (1)
+	if len(hosts) != 4 {
+		t.Fatalf("expected 4 unmatched hosts, got %d: %+v", len(hosts), hosts)
+	}
+
+	// Sorted by last_seen DESC: stripe (now), openai (now-30s), slack (now-2m), disabled (now-5m)
+	if hosts[0].Host != "api.stripe.com:443" {
+		t.Errorf("expected first host to be api.stripe.com:443, got %q", hosts[0].Host)
+	}
+	if hosts[0].RequestCount != 2 {
+		t.Errorf("expected api.stripe.com to have 2 requests, got %d", hosts[0].RequestCount)
+	}
+	if hosts[1].Host != "api.openai.com:443" {
+		t.Errorf("expected second host to be api.openai.com:443, got %q", hosts[1].Host)
+	}
+	if hosts[2].Host != "hooks.slack.com:443" {
+		t.Errorf("expected third host to be hooks.slack.com:443, got %q", hosts[2].Host)
+	}
+	if hosts[3].Host != "disabled.example.com:443" {
+		t.Errorf("expected fourth host to be disabled.example.com:443, got %q", hosts[3].Host)
+	}
+
+	// Vault B query should only return its own host
+	hostsB, err := s.ListUnmatchedHosts(ctx, vB.ID)
+	if err != nil {
+		t.Fatalf("ListUnmatchedHosts vault B: %v", err)
+	}
+	if len(hostsB) != 1 || hostsB[0].Host != "vault-b-only.com:443" {
+		t.Fatalf("vault B expected 1 host (vault-b-only.com:443), got %+v", hostsB)
+	}
+
+	// Empty vault should return nothing
+	empty, err := s.ListUnmatchedHosts(ctx, "nonexistent-vault-id")
+	if err != nil {
+		t.Fatalf("ListUnmatchedHosts empty: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected 0 hosts for nonexistent vault, got %d", len(empty))
+	}
+}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -29,8 +29,8 @@ func TestOpenAndMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("querying schema_migrations: %v", err)
 	}
-	if version != 48 {
-		t.Fatalf("expected migration version 48, got %d", version)
+	if version != 49 {
+		t.Fatalf("expected migration version 49, got %d", version)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -296,6 +296,8 @@ type RequestLog struct {
 	Status         int
 	LatencyMs      int64
 	ErrorCode      string
+	AuthScheme     string
+	AuthHeader     string
 	CreatedAt      time.Time
 }
 
@@ -319,6 +321,8 @@ type UnmatchedHost struct {
 	Host         string
 	RequestCount int
 	LastSeen     time.Time
+	AuthScheme   string
+	AuthHeader   string
 }
 
 // Agent represents a named, instance-level agent entity.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -312,6 +312,15 @@ type ListRequestLogsOpts struct {
 	Limit          int   // capped at 200 by handler; store trusts caller
 }
 
+// UnmatchedHost is a hostname seen in proxy traffic that did not match
+// any configured service and resulted in an auth failure (401/403) or
+// proxy denial (no_match). Returned by ListUnmatchedHosts.
+type UnmatchedHost struct {
+	Host         string
+	RequestCount int
+	LastSeen     time.Time
+}
+
 // Agent represents a named, instance-level agent entity.
 // Agents have multi-vault access via VaultGrant records and an instance-level role.
 type Agent struct {
@@ -542,6 +551,7 @@ type Store interface {
 	// Request logs
 	InsertRequestLogs(ctx context.Context, rows []RequestLog) error
 	ListRequestLogs(ctx context.Context, opts ListRequestLogsOpts) ([]RequestLog, error)
+	ListUnmatchedHosts(ctx context.Context, vaultID string) ([]UnmatchedHost, error)
 	DeleteOldRequestLogs(ctx context.Context, before time.Time) (int64, error)
 	TrimRequestLogsToCap(ctx context.Context, vaultID string, cap int64) (int64, error)
 	VaultIDsWithLogs(ctx context.Context) ([]string, error)

--- a/web/src/components/VaultLayout.tsx
+++ b/web/src/components/VaultLayout.tsx
@@ -20,6 +20,7 @@ export default function VaultLayout() {
   const [isExiting, setIsExiting] = useState(false);
   const sidebarRef = useRef<HTMLElement>(null);
   const [pendingCount, setPendingCount] = useState(0);
+  const [discoveredCount, setDiscoveredCount] = useState(0);
 
   // The Members section (Users / Agents / Tokens) is only meaningful at
   // vault `member` or higher: a `proxy`-role caller can only proxy
@@ -47,6 +48,26 @@ export default function VaultLayout() {
     return () => clearInterval(interval);
   }, [vaultContext.vault_name]);
 
+  useEffect(() => {
+    if (vaultContext.vault_role === "proxy") return;
+    async function fetchDiscoveredCount() {
+      try {
+        const resp = await fetch(
+          `/v1/vaults/${encodeURIComponent(vaultContext.vault_name)}/discovered-hosts?limit=0`
+        );
+        if (resp.ok) {
+          const data = await resp.json();
+          setDiscoveredCount(data.total ?? 0);
+        }
+      } catch {
+        // ignore
+      }
+    }
+    fetchDiscoveredCount();
+    const interval = setInterval(fetchDiscoveredCount, 30_000);
+    return () => clearInterval(interval);
+  }, [vaultContext.vault_name, vaultContext.vault_role]);
+
   // Derive active tab from current URL path
   const pathSegments = location.pathname.split("/");
   const lastSegment = pathSegments[pathSegments.length - 1] as VaultTab;
@@ -58,6 +79,7 @@ export default function VaultLayout() {
     {
       id: "services",
       label: "Services",
+      badge: discoveredCount > 0 ? discoveredCount : undefined,
       icon: (
         <svg className="w-[18px] h-[18px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />

--- a/web/src/pages/vault/CredentialsTab.tsx
+++ b/web/src/pages/vault/CredentialsTab.tsx
@@ -11,7 +11,8 @@ import FormField from "../../components/FormField";
 import Select from "../../components/Select";
 import Combobox from "../../components/Combobox";
 import CreatableSelect from "../../components/CreatableSelect";
-import { apiFetch } from "../../lib/api";
+import { Link } from "@tanstack/react-router";
+import { apiFetch, apiRequest } from "../../lib/api";
 import { OAUTH_PROVIDERS } from "../../lib/oauthProviders";
 
 export default function CredentialsTab() {
@@ -51,9 +52,55 @@ export default function CredentialsTab() {
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState("");
 
+  // Service suggestions: credentials matching catalog entries that aren't used by any service
+  interface CatalogTemplate { id: string; name: string; host: string; suggested_credential_key: string; }
+  interface ServiceInfo { name: string; host: string; auth: { type: string; token?: string; username?: string; password?: string; key?: string; headers?: Record<string, string> }; }
+  const [catalog, setCatalog] = useState<CatalogTemplate[]>([]);
+  const [usedCredentialKeys, setUsedCredentialKeys] = useState<Set<string>>(new Set());
+
   useEffect(() => {
     fetchKeys();
+    fetchCatalogAndServices();
   }, []);
+
+  async function fetchCatalogAndServices() {
+    try {
+      const [catalogResp, servicesResp] = await Promise.all([
+        apiRequest<{ services: CatalogTemplate[] }>("/v1/service-catalog"),
+        apiFetch(`/v1/vaults/${encodeURIComponent(vaultName)}/services`),
+      ]);
+      setCatalog(catalogResp.services ?? []);
+      if (servicesResp.ok) {
+        const data = await servicesResp.json();
+        const services: ServiceInfo[] = data.services ?? [];
+        const keys = new Set<string>();
+        for (const svc of services) {
+          if (svc.auth.token) keys.add(svc.auth.token);
+          if (svc.auth.username) keys.add(svc.auth.username);
+          if (svc.auth.password) keys.add(svc.auth.password);
+          if (svc.auth.key) keys.add(svc.auth.key);
+          if (svc.auth.headers) {
+            for (const v of Object.values(svc.auth.headers)) {
+              const matches = v.matchAll(/\{\{\s*(\w+)\s*\}\}/g);
+              for (const m of matches) keys.add(m[1]);
+            }
+          }
+        }
+        setUsedCredentialKeys(keys);
+      }
+    } catch {
+      // Supplementary -- degrade silently.
+    }
+  }
+
+  const suggestions = credentials
+    .map((cred) => {
+      const template = catalog.find((t) => t.suggested_credential_key === cred.key);
+      if (!template) return null;
+      if (usedCredentialKeys.has(cred.key)) return null;
+      return { credKey: cred.key, template };
+    })
+    .filter(Boolean) as { credKey: string; template: CatalogTemplate }[];
 
   async function fetchKeys() {
     try {
@@ -307,6 +354,23 @@ export default function CredentialsTab() {
           </Button>
         )}
       </div>
+
+      {suggestions.map((s) => (
+        <div key={s.credKey} className="mb-4 flex items-center justify-between rounded-lg border border-warning/20 bg-warning-bg px-4 py-3">
+          <span className="text-sm text-text">
+            <span className="font-mono text-warning">{s.credKey}</span>
+            {" "}is unused. Add <span className="font-medium">{s.template.name}</span> ({s.template.host}) as a service?
+          </span>
+          <Link
+            to="/vaults/$name/services"
+            params={{ name: vaultName }}
+            search={{ preset: s.template.id }}
+            className="rounded border border-border bg-surface px-2.5 py-1 text-xs text-text-muted hover:bg-surface-hover hover:text-text transition-colors whitespace-nowrap"
+          >
+            Add as service
+          </Link>
+        </div>
+      ))}
 
       {isExternal && (
         <>

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -855,7 +855,7 @@ function ServiceModal({
                   onClick={() =>
                     setCustomHeaders((prev) => [...prev, { _id: nextRowId(), name: "", value: "" }])
                   }
-                  className="text-sm font-medium text-warning hover:text-primary-hover transition-colors"
+                  className="text-sm font-medium text-primary hover:text-primary-hover transition-colors"
                 >
                   + Add another
                 </button>
@@ -959,7 +959,7 @@ function ServiceModal({
                   { _id: nextRowId(), key: "", placeholder: "", in: [...DEFAULT_SUBSTITUTION_SURFACES] },
                 ])
               }
-              className="text-sm font-medium text-warning hover:text-primary-hover transition-colors"
+              className="text-sm font-medium text-primary hover:text-primary-hover transition-colors"
             >
               + Add substitution
             </button>

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -294,13 +294,13 @@ export default function ServicesTab() {
       </div>
 
       {discoveredTotal > 0 && !loading && (
-        <div className="mb-6 rounded-lg border border-purple-500/20 bg-purple-500/5">
+        <div className="mb-6 rounded-lg border border-warning/20 bg-warning-bg">
           <button
             type="button"
             className="flex w-full items-center justify-between px-4 py-3 text-left"
             onClick={() => setDiscoveredCollapsed((c) => !c)}
           >
-            <span className="flex items-center gap-2 text-sm font-medium text-purple-300">
+            <span className="flex items-center gap-2 text-sm font-medium text-warning">
               <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5"/><path d="M8 5v3M8 10h.01" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
               {discoveredTotal} {discoveredTotal === 1 ? "host" : "hosts"} detected in recent traffic
             </span>
@@ -312,14 +312,14 @@ export default function ServicesTab() {
             </svg>
           </button>
           {!discoveredCollapsed && (
-            <div className="border-t border-purple-500/20 px-4 pb-3">
+            <div className="border-t border-info/20 px-4 pb-3">
               {discoveredHosts.map((dh) => (
                 <div key={dh.host} className="flex items-center justify-between py-2.5 border-b border-border last:border-b-0">
                   <div>
-                    <span className="font-mono text-sm text-text">{dh.host}</span>
-                    <span className="ml-3 text-xs text-text-muted">
+                    <div className="font-mono text-sm text-text">{dh.host}</div>
+                    <div className="text-xs text-text-muted mt-0.5">
                       {dh.request_count} {dh.request_count === 1 ? "request" : "requests"} &middot; {timeAgo(dh.last_seen)}
-                    </span>
+                    </div>
                   </div>
                   {isAdmin && (
                     <button
@@ -338,7 +338,7 @@ export default function ServicesTab() {
               {discoveredTotal > 5 && !discoveredExpanded && (
                 <button
                   type="button"
-                  className="mt-2 text-xs text-purple-400 hover:text-purple-300"
+                  className="mt-2 text-xs text-warning hover:text-warning/80"
                   onClick={() => {
                     setDiscoveredExpanded(true);
                     fetchDiscoveredHosts(100);
@@ -831,7 +831,7 @@ function ServiceModal({
                   onClick={() =>
                     setCustomHeaders((prev) => [...prev, { _id: nextRowId(), name: "", value: "" }])
                   }
-                  className="text-sm font-medium text-primary hover:text-primary-hover transition-colors"
+                  className="text-sm font-medium text-warning hover:text-primary-hover transition-colors"
                 >
                   + Add another
                 </button>
@@ -935,7 +935,7 @@ function ServiceModal({
                   { _id: nextRowId(), key: "", placeholder: "", in: [...DEFAULT_SUBSTITUTION_SURFACES] },
                 ])
               }
-              className="text-sm font-medium text-primary hover:text-primary-hover transition-colors"
+              className="text-sm font-medium text-warning hover:text-primary-hover transition-colors"
             >
               + Add substitution
             </button>

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useSearch } from "@tanstack/react-router";
 import {
   useVaultParams,
   LoadingSpinner,
@@ -71,10 +72,12 @@ function slugifyHost(host: string): string {
 
 export default function ServicesTab() {
   const { vaultName, vaultRole } = useVaultParams();
+  const { preset: presetParam } = useSearch({ strict: false }) as { preset?: string };
   const [services, setServices] = useState<Service[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [catalog, setCatalog] = useState<CatalogTemplate[]>([]);
+  const presetApplied = useRef(false);
 
   // Add/Edit modal state: null = closed, -1 = add, 0+ = edit index
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
@@ -98,6 +101,16 @@ export default function ServicesTab() {
     fetchCatalog();
     fetchDiscoveredHosts();
   }, []);
+
+  useEffect(() => {
+    if (presetParam && catalog.length > 0 && !presetApplied.current) {
+      const match = catalog.find((t) => t.id === presetParam);
+      if (match) {
+        presetApplied.current = true;
+        setEditingIndex(-1);
+      }
+    }
+  }, [presetParam, catalog]);
 
   async function fetchCatalog() {
     try {
@@ -405,6 +418,7 @@ export default function ServicesTab() {
           defaultName={editingIndex === -1 && addWithHost ? slugifyHost(addWithHost.host) : undefined}
           defaultAuthScheme={editingIndex === -1 ? addWithHost?.authScheme : undefined}
           defaultAuthHeader={editingIndex === -1 ? addWithHost?.authHeader : undefined}
+          defaultPreset={editingIndex === -1 && !addWithHost ? presetParam : undefined}
           catalog={catalog}
           onClose={() => {
             setEditingIndex(null);
@@ -436,6 +450,7 @@ function ServiceModal({
   defaultName,
   defaultAuthScheme,
   defaultAuthHeader,
+  defaultPreset,
   catalog,
   onClose,
   onSave,
@@ -446,6 +461,7 @@ function ServiceModal({
   defaultName?: string;
   defaultAuthScheme?: string;
   defaultAuthHeader?: string;
+  defaultPreset?: string;
   catalog: CatalogTemplate[];
   onClose: () => void;
   onSave: (service: Service) => Promise<void>;
@@ -502,6 +518,7 @@ function ServiceModal({
   const [catalogSnapshot] = useState<CatalogTemplate[]>(() => catalog);
   const [selectedPreset, setSelectedPreset] = useState("");
   const showPresets = !initial && catalogSnapshot.length > 0;
+  const presetInitialized = useRef(false);
 
   function resetFields() {
     setName("");
@@ -535,6 +552,13 @@ function ServiceModal({
       setApiKeyPrefix(tpl.prefix ?? "");
     }
   }
+
+  useEffect(() => {
+    if (defaultPreset && !presetInitialized.current) {
+      presetInitialized.current = true;
+      applyPreset(defaultPreset);
+    }
+  }, [defaultPreset]);
 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -86,12 +86,12 @@ export default function ServicesTab() {
 
   // Discovered hosts state
   const [discoveredHosts, setDiscoveredHosts] = useState<
-    { host: string; request_count: number; last_seen: string }[]
+    { host: string; request_count: number; last_seen: string; auth_scheme?: string; auth_header?: string }[]
   >([]);
   const [discoveredTotal, setDiscoveredTotal] = useState(0);
   const [discoveredExpanded, setDiscoveredExpanded] = useState(false);
   const [discoveredCollapsed, setDiscoveredCollapsed] = useState(false);
-  const [addWithHost, setAddWithHost] = useState<string | null>(null);
+  const [addWithHost, setAddWithHost] = useState<{ host: string; authScheme?: string; authHeader?: string } | null>(null);
 
   useEffect(() => {
     fetchServices();
@@ -326,7 +326,7 @@ export default function ServicesTab() {
                       type="button"
                       className="rounded border border-border bg-surface px-2.5 py-1 text-xs text-text-muted hover:bg-surface-hover hover:text-text transition-colors"
                       onClick={() => {
-                        setAddWithHost(dh.host);
+                        setAddWithHost({ host: dh.host, authScheme: dh.auth_scheme, authHeader: dh.auth_header });
                         setEditingIndex(-1);
                       }}
                     >
@@ -401,8 +401,10 @@ export default function ServicesTab() {
         <ServiceModal
           title={editingIndex === -1 ? "Add Service" : "Edit Service"}
           initial={editingIndex >= 0 ? services[editingIndex] : undefined}
-          defaultHost={editingIndex === -1 ? addWithHost ?? undefined : undefined}
-          defaultName={editingIndex === -1 && addWithHost ? slugifyHost(addWithHost) : undefined}
+          defaultHost={editingIndex === -1 ? addWithHost?.host : undefined}
+          defaultName={editingIndex === -1 && addWithHost ? slugifyHost(addWithHost.host) : undefined}
+          defaultAuthScheme={editingIndex === -1 ? addWithHost?.authScheme : undefined}
+          defaultAuthHeader={editingIndex === -1 ? addWithHost?.authHeader : undefined}
           catalog={catalog}
           onClose={() => {
             setEditingIndex(null);
@@ -432,6 +434,8 @@ function ServiceModal({
   initial,
   defaultHost,
   defaultName,
+  defaultAuthScheme,
+  defaultAuthHeader,
   catalog,
   onClose,
   onSave,
@@ -440,6 +444,8 @@ function ServiceModal({
   initial?: Service;
   defaultHost?: string;
   defaultName?: string;
+  defaultAuthScheme?: string;
+  defaultAuthHeader?: string;
   catalog: CatalogTemplate[];
   onClose: () => void;
   onSave: (service: Service) => Promise<void>;
@@ -447,7 +453,7 @@ function ServiceModal({
   const [name, setName] = useState(initial?.name ?? defaultName ?? "");
   const [pattern, setPattern] = useState(initial?.host ?? defaultHost ?? "");
   const [enabled, setEnabled] = useState(initial ? initial.enabled !== false : true);
-  const [authType, setAuthType] = useState<AuthType>((initial?.auth?.type as AuthType) ?? "passthrough");
+  const [authType, setAuthType] = useState<AuthType>((initial?.auth?.type as AuthType) ?? (defaultAuthScheme as AuthType) ?? "passthrough");
 
   // Bearer fields
   const [token, setToken] = useState(initial?.auth?.token ?? "");
@@ -458,7 +464,7 @@ function ServiceModal({
 
   // API key fields
   const [apiKey, setApiKey] = useState(initial?.auth?.key ?? "");
-  const [apiKeyHeader, setApiKeyHeader] = useState(initial?.auth?.header ?? "");
+  const [apiKeyHeader, setApiKeyHeader] = useState(initial?.auth?.header ?? (defaultAuthScheme === "api-key" ? defaultAuthHeader ?? "" : ""));
   const [apiKeyPrefix, setApiKeyPrefix] = useState(initial?.auth?.prefix ?? "");
 
   // Stable row IDs so React reconciliation keys editable rows by identity

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -3,6 +3,7 @@ import {
   useVaultParams,
   LoadingSpinner,
   ErrorBanner,
+  timeAgo,
 } from "./shared";
 import DropdownMenu from "../../components/DropdownMenu";
 import DataTable, { type Column } from "../../components/DataTable";
@@ -57,6 +58,17 @@ const AUTH_TYPE_OPTIONS: { value: AuthType; label: string }[] = [
   { value: "custom", label: "Custom" },
 ];
 
+function slugifyHost(host: string): string {
+  let slug = host
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "");
+  if (slug.length > 64) slug = slug.slice(0, 64).replace(/-$/, "");
+  if (slug.length < 3) slug = slug || "svc";
+  return slug;
+}
+
 export default function ServicesTab() {
   const { vaultName, vaultRole } = useVaultParams();
   const [services, setServices] = useState<Service[]>([]);
@@ -72,9 +84,19 @@ export default function ServicesTab() {
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState("");
 
+  // Discovered hosts state
+  const [discoveredHosts, setDiscoveredHosts] = useState<
+    { host: string; request_count: number; last_seen: string }[]
+  >([]);
+  const [discoveredTotal, setDiscoveredTotal] = useState(0);
+  const [discoveredExpanded, setDiscoveredExpanded] = useState(false);
+  const [discoveredCollapsed, setDiscoveredCollapsed] = useState(false);
+  const [addWithHost, setAddWithHost] = useState<string | null>(null);
+
   useEffect(() => {
     fetchServices();
     fetchCatalog();
+    fetchDiscoveredHosts();
   }, []);
 
   async function fetchCatalog() {
@@ -107,6 +129,21 @@ export default function ServicesTab() {
     }
   }
 
+  async function fetchDiscoveredHosts(limit = 5) {
+    try {
+      const resp = await apiFetch(
+        `/v1/vaults/${encodeURIComponent(vaultName)}/discovered-hosts?limit=${limit}`
+      );
+      if (resp.ok) {
+        const data = await resp.json();
+        setDiscoveredHosts(data.hosts ?? []);
+        setDiscoveredTotal(data.total ?? 0);
+      }
+    } catch {
+      // Discovered hosts are supplementary; degrade silently.
+    }
+  }
+
   async function saveServices(updatedServices: Service[]) {
     const resp = await apiFetch(
       `/v1/vaults/${encodeURIComponent(vaultName)}/services`,
@@ -122,6 +159,7 @@ export default function ServicesTab() {
     // Re-fetch so the local copy always reflects exactly what the
     // server stored (e.g. inline-host re-joining for the read surface).
     await fetchServices();
+    fetchDiscoveredHosts(discoveredExpanded ? 100 : 5);
   }
 
   async function toggleEnabled(index: number, next: boolean) {
@@ -255,6 +293,65 @@ export default function ServicesTab() {
         )}
       </div>
 
+      {discoveredTotal > 0 && !loading && (
+        <div className="mb-6 rounded-lg border border-purple-500/20 bg-purple-500/5">
+          <button
+            type="button"
+            className="flex w-full items-center justify-between px-4 py-3 text-left"
+            onClick={() => setDiscoveredCollapsed((c) => !c)}
+          >
+            <span className="flex items-center gap-2 text-sm font-medium text-purple-300">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="7" stroke="currentColor" strokeWidth="1.5"/><path d="M8 5v3M8 10h.01" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
+              {discoveredTotal} {discoveredTotal === 1 ? "host" : "hosts"} detected in recent traffic
+            </span>
+            <svg
+              className={`w-4 h-4 text-text-muted transition-transform ${discoveredCollapsed ? "" : "rotate-180"}`}
+              viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+            >
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </button>
+          {!discoveredCollapsed && (
+            <div className="border-t border-purple-500/20 px-4 pb-3">
+              {discoveredHosts.map((dh) => (
+                <div key={dh.host} className="flex items-center justify-between py-2.5 border-b border-border last:border-b-0">
+                  <div>
+                    <span className="font-mono text-sm text-text">{dh.host}</span>
+                    <span className="ml-3 text-xs text-text-muted">
+                      {dh.request_count} {dh.request_count === 1 ? "request" : "requests"} &middot; {timeAgo(dh.last_seen)}
+                    </span>
+                  </div>
+                  {isAdmin && (
+                    <button
+                      type="button"
+                      className="rounded border border-border bg-surface px-2.5 py-1 text-xs text-text-muted hover:bg-surface-hover hover:text-text transition-colors"
+                      onClick={() => {
+                        setAddWithHost(dh.host);
+                        setEditingIndex(-1);
+                      }}
+                    >
+                      Add as service
+                    </button>
+                  )}
+                </div>
+              ))}
+              {discoveredTotal > 5 && !discoveredExpanded && (
+                <button
+                  type="button"
+                  className="mt-2 text-xs text-purple-400 hover:text-purple-300"
+                  onClick={() => {
+                    setDiscoveredExpanded(true);
+                    fetchDiscoveredHosts(100);
+                  }}
+                >
+                  Show all ({discoveredTotal})
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
       {loading ? (
         <LoadingSpinner />
       ) : error ? (
@@ -304,8 +401,13 @@ export default function ServicesTab() {
         <ServiceModal
           title={editingIndex === -1 ? "Add Service" : "Edit Service"}
           initial={editingIndex >= 0 ? services[editingIndex] : undefined}
+          defaultHost={editingIndex === -1 ? addWithHost ?? undefined : undefined}
+          defaultName={editingIndex === -1 && addWithHost ? slugifyHost(addWithHost) : undefined}
           catalog={catalog}
-          onClose={() => setEditingIndex(null)}
+          onClose={() => {
+            setEditingIndex(null);
+            setAddWithHost(null);
+          }}
           onSave={async (service) => {
             const updated = [...services];
             if (editingIndex === -1) {
@@ -315,6 +417,7 @@ export default function ServicesTab() {
             }
             await saveServices(updated);
             setEditingIndex(null);
+            setAddWithHost(null);
           }}
         />
       )}
@@ -327,18 +430,22 @@ export default function ServicesTab() {
 function ServiceModal({
   title,
   initial,
+  defaultHost,
+  defaultName,
   catalog,
   onClose,
   onSave,
 }: {
   title: string;
   initial?: Service;
+  defaultHost?: string;
+  defaultName?: string;
   catalog: CatalogTemplate[];
   onClose: () => void;
   onSave: (service: Service) => Promise<void>;
 }) {
-  const [name, setName] = useState(initial?.name ?? "");
-  const [pattern, setPattern] = useState(initial?.host ?? "");
+  const [name, setName] = useState(initial?.name ?? defaultName ?? "");
+  const [pattern, setPattern] = useState(initial?.host ?? defaultHost ?? "");
   const [enabled, setEnabled] = useState(initial ? initial.enabled !== false : true);
   const [authType, setAuthType] = useState<AuthType>((initial?.auth?.type as AuthType) ?? "passthrough");
 

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -318,6 +318,11 @@ const servicesTabRoute = createRoute({
   getParentRoute: () => vaultLayoutRoute,
   path: "/services",
   component: ServicesTab,
+  validateSearch: (search: Record<string, unknown>) => {
+    const result: { preset?: string } = {};
+    if (search.preset) result.preset = search.preset as string;
+    return result;
+  },
 });
 
 const credentialsTabRoute = createRoute({


### PR DESCRIPTION
## Summary

Surfaces unmatched hostnames from recent failing proxy traffic so operators can quickly configure them as services, instead of manually figuring out hostnames.

Three pieces:

- **Hostname discovery**: new `GET /v1/vaults/{name}/discovered-hosts` endpoint queries `request_logs` for hosts that hit 401/403 or got proxy-denied (`no_match`), filters out hosts already covered by configured services (including wildcards), deduplicates ports, and ranks by most recent failure. Shows on the Services tab as a collapsible section with "Add as service" buttons, plus a count badge on the sidebar nav. Capped at 5 visible with "Show all (N)".

- **Auth detection**: best-effort detection of auth scheme (bearer, basic, api-key) from request headers in the MITM forward handler. Stored as `auth_scheme` + `auth_header` columns on `request_logs` (new migration). When adding a service from discovered hosts, the auth type tab and header field are pre-selected.

- **Credential-to-service suggestions**: on the Credentials tab, any credential matching a catalog template's `suggested_credential_key` that isn't used by any service shows a suggestion banner linking to the Services tab with the preset auto-applied.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] Existing tests pass (`make test`)
- [x] Added/updated tests for new behavior
- [x] Manual testing (describe below)

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)