### PR TITLE
docs(openclaw): add VPS guide callout to quickstart

### DIFF
--- a/docs/guides/openclaw-on-vps.mdx
+++ b/docs/guides/openclaw-on-vps.mdx
@@ -555,7 +555,7 @@ cat > /root/.config/systemd/user/openclaw-gateway.service.d/override.conf <<'EOF
 [Service]
 EnvironmentFile=/etc/openclaw/agent-vault.env
 ExecStart=
-ExecStart=/usr/local/bin/agent-vault run -- /usr/bin/openclaw gateway --port 18789
+ExecStart=/usr/local/bin/agent-vault run -- /usr/bin/openclaw gateway run --port 18789
 EOF
 ```
 

--- a/docs/quickstart/openclaw.mdx
+++ b/docs/quickstart/openclaw.mdx
@@ -5,6 +5,10 @@ description: "Learn how to connect OpenClaw to Agent Vault so it can make authen
 
 import InstallCommand from "/snippets/install-command.mdx";
 
+<Tip>
+Running OpenClaw on a remote VPS instead of your laptop? Follow [Run OpenClaw on a VPS](/guides/openclaw-on-vps). It covers the same brokering pattern as a two-VPS deployment with systemd, a Slack bot, and an optional egress firewall.
+</Tip>
+
 ## Prerequisites
 
 - A running Agent Vault instance on a separate host from where OpenClaw runs ([see installation guide](/installation)).
@@ -120,7 +124,10 @@ Install the Agent Vault CLI on the host or in the container image where OpenClaw
 
 ## Next steps
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
+  <Card title="Run OpenClaw on a VPS" icon="server" href="/guides/openclaw-on-vps">
+    Production pattern with brokered credentials on a separate host.
+  </Card>
   <Card title="Agent protocol" icon="code" href="/agents/protocol">
     Full request lifecycle end-to-end.
   </Card>


### PR DESCRIPTION

Mirror the Hermes quickstart: add a top Tip and a Next-steps card linking to the Run OpenClaw on a VPS guide.

Standardize on the explicit foreground subcommand `openclaw gateway run` (verified against OpenClaw 2026.5.27 CLI) in both the quickstart and the VPS guide's systemd ExecStart, replacing the bare `gateway` form.

## Summary

Adds more visibility to the openclaw on VPS doc by adding it to the Quickstart doc as well.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ x] Documentation
- [ ] CI / build

## Test plan

n/a

- [x ] Existing tests pass (`make test`)
- [ x] Added/updated tests for new behavior
- [ x] Manual testing (describe below)

## Security checklist

- [x ] No secrets or credentials in code
- [x ] No new unauthenticated endpoints
- [ x] Input validation on new API surfaces
- [ x] Checked for OWASP top 10 (injection, XSS, etc.)
