### PR TITLE
fix: harden CI npm installs with --ignore-scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           cache-dependency-path: web/package-lock.json
 
       - name: Build frontend (tsc + vite)
-        run: cd web && npm ci && npm run build
+        run: cd web && npm ci --ignore-scripts && npm rebuild esbuild && npm run build
 
   # Security-critical: always run on every PR. Path-gating these would mean
   # a missed filter entry (e.g. a new //go:embed target) silently turns the
@@ -164,7 +164,7 @@ jobs:
           cache-dependency-path: sdks/sdk-typescript/package-lock.json
 
       - name: Install
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/release-node-sdk.yml
+++ b/.github/workflows/release-node-sdk.yml
@@ -34,7 +34,7 @@ jobs:
                 registry-url: "https://registry.npmjs.org"
 
             - name: Install dependencies
-              run: npm ci
+              run: npm ci --ignore-scripts
 
             - name: Set NPM version
               run: npm version ${GITHUB_REF_NAME#node-sdk/v} --allow-same-version --no-git-tag-version


### PR DESCRIPTION
## Summary

CI and the node-sdk release workflow now run `npm ci --ignore-scripts`, so lifecycle scripts from transitive dependencies cannot execute during installs. The frontend build keeps working by explicitly rebuilding the one dependency that needs its install script (`npm rebuild esbuild`) before `vite build`. This is item 3 of the hardening list in #108; the remaining items there are separate concerns and untouched.

## Type of change

- [x] CI / build

## Test plan

- [x] Existing tests pass (`make test`)
- [x] Manual testing (describe below)

Both workflow files parse as valid YAML. The typecheck/test/publish steps that follow each modified install only need declared dependencies, not lifecycle scripts; esbuild is the only install-script dependency the frontend build requires, and it is explicitly rebuilt. No new tests are needed for a workflow-only change.

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)

Refs #108
