### PR TITLE
feat: add agent delete, revoke, and token rotation to UI

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -119,8 +119,8 @@ var agentInfoCmd = &cobra.Command{
 }
 
 var agentRevokeCmd = &cobra.Command{
-	Use:   "delete <name>",
-	Short: "Delete an agent and all its tokens",
+	Use:   "revoke <name>",
+	Short: "Revoke an agent (invalidates tokens, keeps the record)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
@@ -131,6 +131,27 @@ var agentRevokeCmd = &cobra.Command{
 
 		reqURL := sess.Address + "/v1/agents/" + url.PathEscape(name)
 		if err := doAdminRequest("DELETE", reqURL, sess.Token, nil); err != nil {
+			return err
+		}
+
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Agent %q revoked.\n", successText("✓"), name)
+		return nil
+	},
+}
+
+var agentDeleteCmd = &cobra.Command{
+	Use:   "delete <name>",
+	Short: "Permanently delete an agent",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		sess, err := ensureSession()
+		if err != nil {
+			return err
+		}
+
+		reqURL := sess.Address + "/v1/agents/" + url.PathEscape(name) + "/delete"
+		if err := doAdminRequest("POST", reqURL, sess.Token, []byte("{}")); err != nil {
 			return err
 		}
 
@@ -386,10 +407,11 @@ func init() {
 	agentSetRoleCmd.Flags().String("role", "", "instance-level role (owner, member, or no-access)")
 	agentRotateCmd.Flags().Bool("token-only", false, "output only the raw agent token (for programmatic use)")
 
-	// Instance-level agent commands: agent-vault agent [list|info|revoke|rotate|rename|set-role]
+	// Instance-level agent commands: agent-vault agent [list|info|revoke|delete|rotate|rename|set-role]
 	topAgentCmd.AddCommand(agentListCmd)
 	topAgentCmd.AddCommand(agentInfoCmd)
 	topAgentCmd.AddCommand(agentRevokeCmd)
+	topAgentCmd.AddCommand(agentDeleteCmd)
 	topAgentCmd.AddCommand(agentRotateCmd)
 	topAgentCmd.AddCommand(agentRenameCmd)
 	topAgentCmd.AddCommand(agentSetRoleCmd)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -464,7 +464,7 @@ func TestAgentSubcommandsRegistered(t *testing.T) {
 }
 
 func TestTopAgentSubcommandsRegistered(t *testing.T) {
-	// Instance-level agent commands: list, info, delete, rotate, rename, create, set-role
+	// Instance-level agent commands: list, info, revoke, delete, rotate, rename, create, set-role
 	agCmd := findSubcommand(rootCmd, "agent")
 	if agCmd == nil {
 		t.Fatal("agent command not found")
@@ -475,7 +475,7 @@ func TestTopAgentSubcommandsRegistered(t *testing.T) {
 		registered[c.Name()] = true
 	}
 
-	expected := []string{"list", "info", "delete", "rotate", "rename", "create", "set-role"}
+	expected := []string{"list", "info", "revoke", "delete", "rotate", "rename", "create", "set-role"}
 	for _, name := range expected {
 		if !registered[name] {
 			t.Errorf("expected agent subcommand %q to be registered, but it was not", name)

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -784,12 +784,20 @@ description: "Complete reference for all Agent Vault CLI commands."
     Show agent details including vaults, status, and active session count.
   </Accordion>
 
+  <Accordion title="agent-vault agent revoke">
+    ```bash
+    agent-vault agent revoke <name>
+    ```
+
+    Revoke an agent and invalidate all its tokens. The agent remains visible with a "revoked" status but can no longer authenticate. Rotate its token to reactivate it.
+  </Accordion>
+
   <Accordion title="agent-vault agent delete">
     ```bash
     agent-vault agent delete <name>
     ```
 
-    Delete an agent and all its sessions across all vaults.
+    Permanently delete an agent, its tokens, and all vault grants. Works on both active and revoked agents.
   </Accordion>
 
   <Accordion title="agent-vault agent rotate">
@@ -797,7 +805,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault agent rotate <name> [flags]
     ```
 
-    Invalidate the agent's existing token and print a new one. Update `AGENT_VAULT_TOKEN` wherever the agent runs.
+    Invalidate the agent's existing token and print a new one. If the agent is revoked, rotation also reactivates it. Update `AGENT_VAULT_TOKEN` wherever the agent runs.
 
     | Flag | Default | Description |
     |------|---------|-------------|

--- a/internal/server/handle_agents.go
+++ b/internal/server/handle_agents.go
@@ -285,6 +285,42 @@ func (s *Server) handleAgentRevoke(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]string{"message": fmt.Sprintf("agent %q revoked", name)})
 }
 
+func (s *Server) handleAgentDelete(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	actor, err := s.requireInstanceMember(w, r)
+	if err != nil {
+		return
+	}
+
+	agent, err := s.store.GetAgentByName(ctx, name)
+	if err != nil {
+		jsonError(w, http.StatusNotFound, "Agent not found")
+		return
+	}
+
+	if !actor.IsOwner() && agent.Role == "owner" {
+		jsonError(w, http.StatusForbidden, "Only instance owners can manage owner-role agents")
+		return
+	}
+	if !actor.IsOwner() && agent.CreatedBy != actor.ID {
+		jsonError(w, http.StatusForbidden, "Only the owner or agent creator can delete agents")
+		return
+	}
+
+	if agent.Role == "owner" && s.guardLastOwner(ctx, w, "delete") {
+		return
+	}
+
+	if err := s.store.DeleteAgent(ctx, agent.ID); err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to delete agent")
+		return
+	}
+
+	jsonOK(w, map[string]string{"message": fmt.Sprintf("agent %q deleted", name)})
+}
+
 // handleAgentRotate invalidates the agent's existing tokens and mints a new one.
 func (s *Server) handleAgentRotate(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -307,10 +343,6 @@ func (s *Server) handleAgentRotate(w http.ResponseWriter, r *http.Request) {
 	}
 	if !actor.IsOwner() && agent.CreatedBy != actor.ID {
 		jsonError(w, http.StatusForbidden, "Only the owner or agent creator can rotate agents")
-		return
-	}
-	if agent.Status != "active" {
-		jsonError(w, http.StatusConflict, "Agent is revoked — cannot rotate")
 		return
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -764,7 +764,7 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("GET /v1/agents", s.requireInitialized(s.requireAuth(actorAuthed(s.handleAgentList))))
 	mux.HandleFunc("GET /v1/agents/{name}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleAgentGet))))
 	mux.HandleFunc("DELETE /v1/agents/{name}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleAgentRevoke))))
-	mux.HandleFunc("POST /v1/agents/{name}/delete", s.requireInitialized(s.requireAuth(actorAuthed(s.handleAgentDelete))))
+	mux.HandleFunc("POST /v1/agents/{name}/delete", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleAgentDelete)))))
 	mux.HandleFunc("POST /v1/agents/{name}/rotate", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleAgentRotate)))))
 	mux.HandleFunc("POST /v1/agents/{name}/rename", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleAgentRename)))))
 	mux.HandleFunc("POST /v1/agents/{name}/role", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleAgentSetRole)))))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -305,6 +305,7 @@ type Store interface {
 	ListAgents(ctx context.Context, vaultID string) ([]store.Agent, error)
 	ListAllAgents(ctx context.Context) ([]store.Agent, error)
 	RevokeAgent(ctx context.Context, id string) error
+	DeleteAgent(ctx context.Context, id string) error
 	RenameAgent(ctx context.Context, id string, newName string) error
 	UpdateAgentRole(ctx context.Context, agentID, role string) error
 	CountAgentTokens(ctx context.Context, agentID string) (int, error)
@@ -763,6 +764,7 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("GET /v1/agents", s.requireInitialized(s.requireAuth(actorAuthed(s.handleAgentList))))
 	mux.HandleFunc("GET /v1/agents/{name}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleAgentGet))))
 	mux.HandleFunc("DELETE /v1/agents/{name}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleAgentRevoke))))
+	mux.HandleFunc("POST /v1/agents/{name}/delete", s.requireInitialized(s.requireAuth(actorAuthed(s.handleAgentDelete))))
 	mux.HandleFunc("POST /v1/agents/{name}/rotate", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleAgentRotate)))))
 	mux.HandleFunc("POST /v1/agents/{name}/rename", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleAgentRename)))))
 	mux.HandleFunc("POST /v1/agents/{name}/role", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleAgentSetRole)))))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -986,6 +986,21 @@ func (m *mockStore) RevokeAgent(_ context.Context, id string) error {
 	return fmt.Errorf("agent not found")
 }
 
+func (m *mockStore) DeleteAgent(_ context.Context, id string) error {
+	for name, ag := range m.agents {
+		if ag.ID == id {
+			delete(m.agents, name)
+			for sid, sess := range m.sessions {
+				if sess.AgentID == id {
+					delete(m.sessions, sid)
+				}
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("agent not found")
+}
+
 func (m *mockStore) RenameAgent(_ context.Context, id string, newName string) error {
 	for name, ag := range m.agents {
 		if ag.ID == id {
@@ -1034,6 +1049,13 @@ func (m *mockStore) DeleteAgentTokens(_ context.Context, agentID string) error {
 func (m *mockStore) RotateAgentToken(ctx context.Context, agentID string, expiresAt *time.Time) (*store.Session, error) {
 	if err := m.DeleteAgentTokens(ctx, agentID); err != nil {
 		return nil, err
+	}
+	for _, ag := range m.agents {
+		if ag.ID == agentID {
+			ag.Status = "active"
+			ag.RevokedAt = nil
+			break
+		}
 	}
 	return m.CreateAgentToken(ctx, agentID, expiresAt)
 }
@@ -3996,6 +4018,31 @@ func TestAgentGet_NonOwnerCannotViewOthersAgent(t *testing.T) {
 	}
 }
 
+func TestAgentDelete(t *testing.T) {
+	srv, ms, sessID := setupAgentTest(t)
+
+	ms.agents["deletebot"] = &store.Agent{ID: "a1", Name: "deletebot", Status: "active"}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/deletebot/delete", nil)
+	req.Header.Set("Authorization", "Bearer "+sessID)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if _, exists := ms.agents["deletebot"]; exists {
+		t.Fatal("expected agent to be hard-deleted from store")
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+	if msg, ok := resp["message"].(string); !ok || !strings.Contains(msg, "deleted") {
+		t.Fatalf("expected 'deleted' in message, got: %v", resp["message"])
+	}
+}
+
 func TestAgentRevoke(t *testing.T) {
 	srv, ms, sessID := setupAgentTest(t)
 
@@ -4037,6 +4084,36 @@ func TestAgentRotate(t *testing.T) {
 	}
 	if resp["rotated_at"] == nil || resp["rotated_at"].(string) == "" {
 		t.Fatal("expected non-empty rotated_at")
+	}
+}
+
+func TestAgentRotate_ReactivatesRevokedAgent(t *testing.T) {
+	srv, ms, sessID := setupAgentTest(t)
+
+	now := time.Now()
+	ms.agents["deadbot"] = &store.Agent{ID: "a1", Name: "deadbot", Status: "revoked", RevokedAt: &now}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/agents/deadbot/rotate", nil)
+	req.Header.Set("Authorization", "Bearer "+sessID)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	ag := ms.agents["deadbot"]
+	if ag.Status != "active" {
+		t.Fatalf("expected active after rotate, got %s", ag.Status)
+	}
+	if ag.RevokedAt != nil {
+		t.Fatal("expected revoked_at to be cleared")
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+	if resp["av_agent_token"] == nil || resp["av_agent_token"].(string) == "" {
+		t.Fatal("expected non-empty av_agent_token")
 	}
 }
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -2739,6 +2739,37 @@ func (s *SQLiteStore) RevokeAgent(ctx context.Context, id string) error {
 	return tx.Commit()
 }
 
+func (s *SQLiteStore) DeleteAgent(ctx context.Context, id string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM sessions
+		 WHERE agent_id = ?
+		    OR (created_by_actor_id = ? AND created_by_actor_type = 'agent')`,
+		id, id); err != nil {
+		return fmt.Errorf("deleting agent sessions: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM vault_grants WHERE actor_id = ? AND actor_type = 'agent'`, id); err != nil {
+		return fmt.Errorf("deleting agent vault grants: %w", err)
+	}
+
+	res, err := tx.ExecContext(ctx, `DELETE FROM agents WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("deleting agent: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+
+	return tx.Commit()
+}
 
 func (s *SQLiteStore) RenameAgent(ctx context.Context, id string, newName string) error {
 	nowStr := nowUTC()
@@ -2813,6 +2844,14 @@ func (s *SQLiteStore) RotateAgentToken(ctx context.Context, agentID string, expi
 
 	if _, err := tx.ExecContext(ctx, "DELETE FROM sessions WHERE agent_id = ?", agentID); err != nil {
 		return nil, fmt.Errorf("deleting agent tokens: %w", err)
+	}
+
+	nowStr := nowUTC()
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE agents SET status = 'active', revoked_at = NULL, updated_at = ? WHERE id = ?`,
+		nowStr, agentID,
+	); err != nil {
+		return nil, fmt.Errorf("reactivating agent: %w", err)
 	}
 
 	rawToken := newAgentToken()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -523,6 +523,7 @@ type Store interface {
 	ListAgents(ctx context.Context, vaultID string) ([]Agent, error)
 	ListAllAgents(ctx context.Context) ([]Agent, error)
 	RevokeAgent(ctx context.Context, id string) error
+	DeleteAgent(ctx context.Context, id string) error
 	RenameAgent(ctx context.Context, id string, newName string) error
 	UpdateAgentRole(ctx context.Context, agentID, role string) error
 	CountAgentTokens(ctx context.Context, agentID string) (int, error)

--- a/web/src/pages/home/AllAgentsTab.tsx
+++ b/web/src/pages/home/AllAgentsTab.tsx
@@ -31,18 +31,20 @@ interface VaultOption {
 function RowActions({
   agent,
   isOwner,
+  onRotate,
   onRevoke,
+  onDelete,
   onDone,
   onError,
 }: {
   agent: AgentRow;
   isOwner: boolean;
+  onRotate: (agent: AgentRow) => void;
   onRevoke: (agent: AgentRow) => void;
+  onDelete: (agent: AgentRow) => void;
   onDone: () => void;
   onError: (msg: string) => void;
 }) {
-  if (agent.status === "revoked") return null;
-
   async function setRoleTo(newRole: InstanceRole) {
     const resp = await apiFetch(
       `/v1/agents/${encodeURIComponent(agent.name)}/role`,
@@ -58,7 +60,9 @@ function RowActions({
 
   const items: { label: string; onClick: () => void; variant?: "danger" }[] = [];
 
-  if (isOwner) {
+  items.push({ label: "Rotate token", onClick: () => onRotate(agent) });
+
+  if (isOwner && agent.status === "active") {
     for (const opt of INSTANCE_ROLE_OPTIONS) {
       if (opt.role === agent.role) continue;
       items.push({
@@ -68,7 +72,10 @@ function RowActions({
     }
   }
 
-  items.push({ label: "Revoke agent", onClick: () => onRevoke(agent), variant: "danger" });
+  if (agent.status === "active") {
+    items.push({ label: "Revoke agent", onClick: () => onRevoke(agent), variant: "danger" });
+  }
+  items.push({ label: "Delete agent", onClick: () => onDelete(agent), variant: "danger" });
 
   return (
     <DropdownMenu
@@ -83,7 +90,12 @@ export default function AllAgentsTab() {
   const [rows, setRows] = useState<AgentRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [rotateTarget, setRotateTarget] = useState<AgentRow | null>(null);
+  const [rotatedToken, setRotatedToken] = useState<string | null>(null);
+  const [rotateError, setRotateError] = useState("");
+  const [rotating, setRotating] = useState(false);
   const [revokeTarget, setRevokeTarget] = useState<AgentRow | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<AgentRow | null>(null);
 
   const fetchData = useCallback(async () => {
     try {
@@ -172,7 +184,7 @@ export default function AllAgentsTab() {
         header: "",
         align: "right" as const,
         render: (agent: AgentRow) => (
-          <RowActions agent={agent} isOwner={auth.is_owner} onRevoke={setRevokeTarget} onDone={fetchData} onError={setError} />
+          <RowActions agent={agent} isOwner={auth.is_owner} onRotate={setRotateTarget} onRevoke={setRevokeTarget} onDelete={setDeleteTarget} onDone={fetchData} onError={setError} />
         ),
       },
     ];
@@ -207,6 +219,72 @@ export default function AllAgentsTab() {
         />
       )}
 
+      <Modal
+        open={rotateTarget !== null}
+        onClose={() => { setRotateTarget(null); setRotatedToken(null); setRotateError(""); }}
+        title={rotatedToken ? "Token Rotated" : "Rotate Token"}
+        description={rotatedToken
+          ? `The agent "${rotateTarget?.name}" has a new token. The previous token is now invalid.`
+          : `This will invalidate the current token for "${rotateTarget?.name}" and generate a new one.${rotateTarget?.status === "revoked" ? " The agent will also be reactivated." : ""}`}
+        footer={
+          rotatedToken ? (
+            <Button onClick={() => { setRotateTarget(null); setRotatedToken(null); setRotateError(""); }}>Done</Button>
+          ) : (
+            <>
+              <Button variant="secondary" onClick={() => { setRotateTarget(null); setRotateError(""); }}>Cancel</Button>
+              <Button
+                loading={rotating}
+                onClick={async () => {
+                  if (!rotateTarget) return;
+                  setRotating(true);
+                  setRotateError("");
+                  try {
+                    const resp = await apiFetch(
+                      `/v1/agents/${encodeURIComponent(rotateTarget.name)}/rotate`,
+                      { method: "POST" }
+                    );
+                    const data = await resp.json().catch(() => ({}));
+                    if (!resp.ok) {
+                      setRotateError(data.error || "Failed to rotate token");
+                      return;
+                    }
+                    setRotatedToken(data.av_agent_token);
+                    fetchData();
+                  } catch {
+                    setRotateError("Network error.");
+                  } finally {
+                    setRotating(false);
+                  }
+                }}
+              >
+                Rotate
+              </Button>
+            </>
+          )
+        }
+      >
+        {rotatedToken ? (
+          <div className="space-y-3">
+            <FormField label="New agent token">
+              <div className="relative">
+                <pre className="pl-4 pr-20 py-3 bg-bg border border-border rounded-lg text-text text-sm font-mono overflow-x-auto whitespace-pre">{rotatedToken}</pre>
+                <CopyButton
+                  value={rotatedToken}
+                  className="absolute top-2 right-2 px-3 py-1.5 bg-primary text-primary-text rounded-md text-xs font-semibold hover:bg-primary-hover transition-colors"
+                />
+              </div>
+            </FormField>
+            <p className="text-xs text-text-muted">
+              Update <code className="text-text-muted">AGENT_VAULT_TOKEN</code> wherever the agent runs. This token will not be shown again.
+            </p>
+          </div>
+        ) : (
+          <>
+            {rotateError && <ErrorBanner message={rotateError} />}
+          </>
+        )}
+      </Modal>
+
       <ConfirmDeleteModal
         open={revokeTarget !== null}
         onClose={() => setRevokeTarget(null)}
@@ -224,9 +302,32 @@ export default function AllAgentsTab() {
           fetchData();
         }}
         title="Revoke agent"
-        description={`This will permanently revoke the agent "${revokeTarget?.name}" and invalidate all its sessions. This action cannot be undone.`}
+        description={`This will revoke the agent "${revokeTarget?.name}" and invalidate all its sessions. The agent will remain visible but inactive.`}
         confirmLabel="Revoke agent"
         confirmValue={revokeTarget?.name ?? ""}
+        inputLabel="Type the agent name to confirm"
+      />
+
+      <ConfirmDeleteModal
+        open={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={async () => {
+          if (!deleteTarget) return;
+          const resp = await apiFetch(
+            `/v1/agents/${encodeURIComponent(deleteTarget.name)}/delete`,
+            { method: "POST" }
+          );
+          if (!resp.ok) {
+            const data = await resp.json().catch(() => ({}));
+            throw new Error(data.error || "Failed to delete agent");
+          }
+          setDeleteTarget(null);
+          fetchData();
+        }}
+        title="Delete agent"
+        description={`This will permanently delete the agent "${deleteTarget?.name}", invalidate all its sessions, and remove it from all vaults. This action cannot be undone.`}
+        confirmLabel="Delete agent"
+        confirmValue={deleteTarget?.name ?? ""}
         inputLabel="Type the agent name to confirm"
       />
     </div>


### PR DESCRIPTION
## Summary

- **Delete agents**: new `POST /v1/agents/{name}/delete` endpoint and `agent delete` CLI command that hard-deletes an agent (row, vault grants, sessions). Works on both active and revoked agents.
- **Separate revoke from delete**: `DELETE /v1/agents/{name}` remains as revoke (soft-delete). CLI now has distinct `agent revoke` and `agent delete` commands.
- **Rotate reactivates revoked agents**: `RotateAgentToken` now sets `status='active'` and clears `revoked_at`, so rotating a revoked agent's token brings it back to life without needing to re-create it.
- **Frontend agent actions**: every agent row now has a dropdown with Rotate token, Set role (active only), Revoke (active only), and Delete. Rotate shows a modal with the new token and copy button. Revoke and delete each have typed-name confirmation modals.

## Test plan

- [x] `make test` passes (new tests: `TestAgentDelete`, `TestAgentRotate_ReactivatesRevokedAgent`, plus existing `TestAgentRevoke` preserved)
- [x] Frontend type-checks clean (`tsc --noEmit`)
- [x] Live API test: revoke, delete active, delete revoked, rotate active, rotate revoked (reactivates) all verified via curl against a running instance
- [ ] Manual UI test: log in, verify dropdown actions on active vs revoked agents, confirm rotate modal shows token, confirm delete/revoke modals work