### PR TITLE
feat(web): move vault settings editing into a side drawer

### DIFF
--- a/web/src/components/FormField.tsx
+++ b/web/src/components/FormField.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import InfoTooltip from "./InfoTooltip";
 
 interface FormFieldProps {
   label: string;
@@ -17,23 +18,7 @@ export default function FormField({ label, helperText, tooltip, required, error,
           {label}
           {required && <span aria-hidden="true" className="ml-0.5 text-danger">*</span>}
         </span>
-        {tooltip && (
-          <span className="relative group inline-flex">
-            <span
-              tabIndex={0}
-              aria-label="More info"
-              className="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full border border-text-dim text-text-dim cursor-help normal-case font-normal text-[10px] leading-none focus:outline-none focus:border-text-muted focus:text-text-muted hover:border-text-muted hover:text-text-muted"
-            >
-              ?
-            </span>
-            <span
-              role="tooltip"
-              className="pointer-events-none absolute left-0 top-full mt-1.5 z-20 w-72 px-3 py-2 rounded-md bg-surface-raised border border-border text-xs text-text-muted leading-snug shadow-lg opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-100 normal-case tracking-normal font-normal"
-            >
-              {tooltip}
-            </span>
-          </span>
-        )}
+        {tooltip && <InfoTooltip>{tooltip}</InfoTooltip>}
       </label>
       {children}
       {helperText && !error && (

--- a/web/src/components/InfoTooltip.tsx
+++ b/web/src/components/InfoTooltip.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+/** A "?" chip that reveals its content on hover/focus. */
+export default function InfoTooltip({ children }: { children: ReactNode }) {
+  return (
+    <span className="relative group inline-flex">
+      <span
+        tabIndex={0}
+        aria-label="More info"
+        className="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full border border-text-dim text-text-dim cursor-help normal-case font-normal text-[10px] leading-none focus:outline-none focus:border-text-muted focus:text-text-muted hover:border-text-muted hover:text-text-muted"
+      >
+        ?
+      </span>
+      <span
+        role="tooltip"
+        className="pointer-events-none absolute left-0 top-full mt-1.5 z-20 w-72 px-3 py-2 rounded-md bg-surface-raised border border-border text-xs text-text-muted leading-snug shadow-lg opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-100 normal-case tracking-normal font-normal"
+      >
+        {children}
+      </span>
+    </span>
+  );
+}

--- a/web/src/components/VaultForm.tsx
+++ b/web/src/components/VaultForm.tsx
@@ -1,0 +1,151 @@
+import type { ReactNode } from "react";
+import Input from "./Input";
+import Select from "./Select";
+import FormField from "./FormField";
+import Toggle from "./Toggle";
+import { ErrorBanner } from "./shared";
+
+// The fields a vault create/edit form edits. The same shape backs both flows;
+// each parent decides what submitting it means (POST vs PATCH/rename).
+export type VaultFormValues = {
+  name: string;
+  policy: "passthrough" | "deny";
+  kind: "builtin" | "infisical";
+  projectID: string;
+  environment: string;
+  secretPath: string;
+};
+
+export const emptyVaultForm: VaultFormValues = {
+  name: "",
+  policy: "passthrough",
+  kind: "builtin",
+  projectID: "",
+  environment: "",
+  secretPath: "/",
+};
+
+// Infisical needs a project + environment; everything else may be blank.
+export function infisicalFieldsValid(v: VaultFormValues): boolean {
+  return (
+    v.kind !== "infisical" || (!!v.projectID.trim() && !!v.environment.trim())
+  );
+}
+
+// Trimmed, validated Infisical config block. Throws on a bad secret path.
+export function buildInfisicalConfig(v: VaultFormValues) {
+  const secretPath = v.secretPath.trim() || "/";
+  if (!secretPath.startsWith("/")) {
+    throw new Error('Secret path must start with "/".');
+  }
+  return {
+    project_id: v.projectID.trim(),
+    environment: v.environment.trim(),
+    secret_path: secretPath,
+  };
+}
+
+export default function VaultForm({
+  values,
+  onChange,
+  infisicalOptionDisabled,
+  storeTooltip,
+  showPolicy = false,
+  policyDisabled = false,
+  nameDisabled = false,
+  namePlaceholder = "vault-name",
+  autoFocusName = false,
+  onEnter,
+  error,
+  header,
+}: {
+  values: VaultFormValues;
+  onChange: (patch: Partial<VaultFormValues>) => void;
+  infisicalOptionDisabled: boolean;
+  storeTooltip: ReactNode;
+  showPolicy?: boolean;
+  policyDisabled?: boolean;
+  nameDisabled?: boolean;
+  namePlaceholder?: string;
+  autoFocusName?: boolean;
+  onEnter?: () => void;
+  error?: string;
+  header?: ReactNode;
+}) {
+  const isInfisical = values.kind === "infisical";
+
+  return (
+    <div className="space-y-5">
+      {header}
+
+      <FormField label="Vault Name">
+        <Input
+          value={values.name}
+          onChange={(e) => onChange({ name: e.target.value })}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && onEnter) onEnter();
+          }}
+          disabled={nameDisabled}
+          placeholder={namePlaceholder}
+          autoFocus={autoFocusName}
+        />
+      </FormField>
+
+      {showPolicy && (
+        <FormField
+          label="Strict deny mode"
+          tooltip="Reject unmatched hosts with HTTP 403 instead of forwarding them upstream unauthenticated."
+        >
+          <Toggle
+            checked={values.policy === "deny"}
+            onChange={(v) => onChange({ policy: v ? "deny" : "passthrough" })}
+            disabled={policyDisabled}
+            ariaLabel="Strict deny mode"
+          />
+        </FormField>
+      )}
+
+      <FormField label="Credential store" tooltip={storeTooltip}>
+        <Select
+          value={values.kind}
+          onChange={(e) =>
+            onChange({ kind: e.target.value as VaultFormValues["kind"] })
+          }
+        >
+          <option value="builtin">Built In</option>
+          <option value="infisical" disabled={infisicalOptionDisabled}>
+            Infisical
+          </option>
+        </Select>
+      </FormField>
+
+      {isInfisical && (
+        <div className="space-y-3">
+          <FormField label="Project ID" required>
+            <Input
+              placeholder="abcdef..."
+              value={values.projectID}
+              onChange={(e) => onChange({ projectID: e.target.value })}
+            />
+          </FormField>
+          <FormField label="Environment Slug" required>
+            <Input
+              placeholder="dev"
+              value={values.environment}
+              onChange={(e) => onChange({ environment: e.target.value })}
+            />
+          </FormField>
+          <FormField label="Secret path">
+            <Input
+              placeholder="/"
+              value={values.secretPath}
+              onChange={(e) => onChange({ secretPath: e.target.value })}
+            />
+          </FormField>
+        </div>
+      )}
+
+      {error && <ErrorBanner message={error} />}
+    </div>
+  );
+}

--- a/web/src/pages/home/VaultsListTab.tsx
+++ b/web/src/pages/home/VaultsListTab.tsx
@@ -2,9 +2,12 @@ import { useState, useEffect, useMemo } from "react";
 import { Link, useNavigate, useRouteContext } from "@tanstack/react-router";
 import type { AuthContext } from "../../router";
 import Sheet from "../../components/Sheet";
-import FormField from "../../components/FormField";
-import Input from "../../components/Input";
-import Select from "../../components/Select";
+import VaultForm, {
+  emptyVaultForm,
+  infisicalFieldsValid,
+  buildInfisicalConfig,
+  type VaultFormValues,
+} from "../../components/VaultForm";
 import Button from "../../components/Button";
 import ConfirmDeleteModal from "../../components/ConfirmDeleteModal";
 import { ErrorBanner, LoadingSpinner, timeAgo } from "../../components/shared";
@@ -291,17 +294,10 @@ function VaultCard({
 
 function CreateVaultButton({ onCreated }: { onCreated: (name: string) => void }) {
   const [open, setOpen] = useState(false);
-  const [name, setName] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
-
+  const [values, setValues] = useState<VaultFormValues>(emptyVaultForm);
   const [availableStores, setAvailableStores] = useState<string[]>(["builtin"]);
-  const [kind, setKind] = useState<string>("builtin");
-
-  // Infisical-only fields.
-  const [projectID, setProjectID] = useState("");
-  const [environment, setEnvironment] = useState("");
-  const [secretPath, setSecretPath] = useState("/");
 
   useEffect(() => {
     apiFetch("/v1/instance/credential-stores")
@@ -314,42 +310,33 @@ function CreateVaultButton({ onCreated }: { onCreated: (name: string) => void })
 
   function close() {
     setOpen(false);
-    setName("");
+    setValues(emptyVaultForm);
     setError("");
-    setKind("builtin");
-    setProjectID("");
-    setEnvironment("");
-    setSecretPath("/");
   }
 
   async function handleCreate() {
-    if (!name.trim()) return;
+    const trimmed = values.name.trim();
+    if (!trimmed) return;
     setSubmitting(true);
     setError("");
-    const trimmed = name.trim();
-    try {
-      const body: Record<string, unknown> = { name: trimmed };
-      if (kind === "infisical") {
-        if (!projectID.trim() || !environment.trim()) {
-          setError("Project ID and environment are required for Infisical.");
-          setSubmitting(false);
-          return;
-        }
-        const trimmedPath = secretPath.trim() || "/";
-        if (!trimmedPath.startsWith("/")) {
-          setError('Secret path must start with "/".');
-          setSubmitting(false);
-          return;
-        }
-        body.credential_store = {
-          kind: "infisical",
-          config: {
-            project_id: projectID.trim(),
-            environment: environment.trim(),
-            secret_path: trimmedPath,
-          },
-        };
+
+    const body: Record<string, unknown> = { name: trimmed };
+    if (values.kind === "infisical") {
+      if (!infisicalFieldsValid(values)) {
+        setError("Project ID and environment are required for Infisical.");
+        setSubmitting(false);
+        return;
       }
+      try {
+        body.credential_store = { kind: "infisical", config: buildInfisicalConfig(values) };
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Invalid Infisical config.");
+        setSubmitting(false);
+        return;
+      }
+    }
+
+    try {
       const resp = await apiFetch("/v1/vaults", {
         method: "POST",
         body: JSON.stringify(body),
@@ -401,39 +388,25 @@ function CreateVaultButton({ onCreated }: { onCreated: (name: string) => void })
             <Button
               onClick={handleCreate}
               loading={submitting}
-              disabled={
-                !name.trim() ||
-                (kind === "infisical" && (!projectID.trim() || !environment.trim()))
-              }
+              disabled={!values.name.trim() || !infisicalFieldsValid(values)}
             >
               Create
             </Button>
           </>
         }
       >
-        <div className="space-y-4">
-        <p className="text-sm text-text-muted">
-          Create an isolated environment with its own credentials and proxy rules.
-        </p>
-        <FormField
-          label="Vault Name"
-          error={error && kind === "builtin" ? error : undefined}
-        >
-          <Input
-            placeholder="e.g. my-project"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleCreate();
-            }}
-            error={!!error && kind === "builtin"}
-            autoFocus
-          />
-        </FormField>
-
-        <FormField
-          label="Credential store"
-          tooltip={
+        <VaultForm
+          values={values}
+          onChange={(patch) => {
+            setValues((v) => ({ ...v, ...patch }));
+            setError("");
+          }}
+          infisicalOptionDisabled={!infisicalAvailable}
+          namePlaceholder="e.g. my-project"
+          autoFocusName
+          onEnter={handleCreate}
+          error={error}
+          storeTooltip={
             <>
               Built-in keeps credentials in Agent Vault. Infisical syncs read-only from your Infisical instance.
               {!infisicalAvailable && (
@@ -441,45 +414,12 @@ function CreateVaultButton({ onCreated }: { onCreated: (name: string) => void })
               )}
             </>
           }
-        >
-          <Select
-            value={kind}
-            onChange={(e) => setKind(e.target.value)}
-          >
-            <option value="builtin">Built In</option>
-            <option value="infisical" disabled={!infisicalAvailable}>
-              Infisical
-            </option>
-          </Select>
-        </FormField>
-
-        {kind === "infisical" && (
-          <div className="space-y-3">
-            <FormField label="Project ID" required>
-              <Input
-                placeholder="abcdef..."
-                value={projectID}
-                onChange={(e) => setProjectID(e.target.value)}
-              />
-            </FormField>
-            <FormField label="Environment Slug" required>
-              <Input
-                placeholder="dev"
-                value={environment}
-                onChange={(e) => setEnvironment(e.target.value)}
-              />
-            </FormField>
-            <FormField label="Secret path">
-              <Input
-                placeholder="/"
-                value={secretPath}
-                onChange={(e) => setSecretPath(e.target.value)}
-              />
-            </FormField>
-            {error && <ErrorBanner message={error} />}
-          </div>
-        )}
-        </div>
+          header={
+            <p className="text-sm text-text-muted">
+              Create an isolated environment with its own credentials and proxy rules.
+            </p>
+          }
+        />
       </Sheet>
     </>
   );

--- a/web/src/pages/vault/SettingsTab.tsx
+++ b/web/src/pages/vault/SettingsTab.tsx
@@ -14,6 +14,13 @@ import { apiFetch } from "../../lib/api";
 
 type UnmatchedHostPolicy = "passthrough" | "deny";
 
+// Shape of an Infisical credential store's config (server stores it untyped).
+type InfisicalConfig = {
+  project_id?: string;
+  environment?: string;
+  secret_path?: string;
+};
+
 export default function SettingsTab() {
   const { vaultName, vaultRole, isOwner, credentialStore } = useVaultParams();
   const navigate = useNavigate();
@@ -169,11 +176,7 @@ export default function SettingsTab() {
 }
 
 function CredentialStoreDisplay({ store }: { store?: CredentialStoreInfo }) {
-  const config = (store?.config ?? {}) as {
-    project_id?: string;
-    environment?: string;
-    secret_path?: string;
-  };
+  const config = (store?.config ?? {}) as InfisicalConfig;
   const isInfisical = store?.kind === "infisical";
   const kindLabel = !store ? "Built-in" : isInfisical ? "Infisical" : store.kind;
 
@@ -236,11 +239,7 @@ function EditSettingsSheet({
   const navigate = useNavigate();
   const router = useRouter();
 
-  const config = (store?.config ?? {}) as {
-    project_id?: string;
-    environment?: string;
-    secret_path?: string;
-  };
+  const config = (store?.config ?? {}) as InfisicalConfig;
   const currentKind: "builtin" | "infisical" =
     store?.kind === "infisical" ? "infisical" : "builtin";
 

--- a/web/src/pages/vault/SettingsTab.tsx
+++ b/web/src/pages/vault/SettingsTab.tsx
@@ -329,6 +329,9 @@ function EditSettingsSheet({
           const data = await resp.json().catch(() => ({}));
           throw new Error(data.error || "Failed to rename vault");
         }
+        // Close the drawer before navigating; the route change re-renders this
+        // component in place rather than unmounting it, so it won't close itself.
+        onClose();
         // The URL carries the old name; jump to the new one (reloads context).
         navigate({ to: "/vaults/$name/settings", params: { name: trimmedName } });
         return;

--- a/web/src/pages/vault/SettingsTab.tsx
+++ b/web/src/pages/vault/SettingsTab.tsx
@@ -1,11 +1,14 @@
-import { useEffect, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import { useEffect, useState, type ReactNode } from "react";
+import { useNavigate, useRouter } from "@tanstack/react-router";
 import { useVaultParams, ErrorBanner, timeAgo } from "./shared";
 import type { CredentialStoreInfo } from "../../router";
 import Button from "../../components/Button";
 import Input from "../../components/Input";
+import Select from "../../components/Select";
 import FormField from "../../components/FormField";
 import ConfirmDeleteModal from "../../components/ConfirmDeleteModal";
+import InfoTooltip from "../../components/InfoTooltip";
+import Sheet from "../../components/Sheet";
 import Toggle from "../../components/Toggle";
 import { apiFetch } from "../../lib/api";
 
@@ -17,19 +20,18 @@ export default function SettingsTab() {
   const canManage = vaultRole === "admin" || isOwner;
   const isDefault = vaultName === "default";
 
-  // Rename state
-  const [newName, setNewName] = useState(vaultName);
-  const [renaming, setRenaming] = useState(false);
-  const [renameError, setRenameError] = useState("");
-  const [renameSuccess, setRenameSuccess] = useState("");
-
   // Delete state
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
-  // null until the initial fetch lands; disables the toggle on first paint.
+  // Edit-settings drawer.
+  const [editing, setEditing] = useState(false);
+
+  // null until the initial fetch lands; keeps the displayed policy blank on
+  // first paint and gates the drawer toggle.
   const [policy, setPolicy] = useState<UnmatchedHostPolicy | null>(null);
-  const [policySaving, setPolicySaving] = useState(false);
-  const [policyError, setPolicyError] = useState("");
+
+  // Whether the server can back vaults with Infisical (controls the switcher).
+  const [infisicalAvailable, setInfisicalAvailable] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -45,11 +47,13 @@ export default function SettingsTab() {
         }
         const data = (await resp.json()) as {
           unmatched_host_policy?: UnmatchedHostPolicy;
+          infisical_available?: boolean;
         };
         if (cancelled) return;
         setPolicy(
           data.unmatched_host_policy === "deny" ? "deny" : "passthrough"
         );
+        setInfisicalAvailable(!!data.infisical_available);
       } catch {
         if (!cancelled) setPolicy("passthrough");
       }
@@ -58,69 +62,6 @@ export default function SettingsTab() {
       cancelled = true;
     };
   }, [vaultName]);
-
-  async function handlePolicyToggle(strictDeny: boolean) {
-    const next: UnmatchedHostPolicy = strictDeny ? "deny" : "passthrough";
-    const previous = policy;
-    setPolicy(next);
-    setPolicySaving(true);
-    setPolicyError("");
-    try {
-      const resp = await apiFetch(
-        `/v1/vaults/${encodeURIComponent(vaultName)}/settings`,
-        {
-          method: "PATCH",
-          body: JSON.stringify({ unmatched_host_policy: next }),
-        }
-      );
-      if (!resp.ok) {
-        const data = await resp.json().catch(() => ({}));
-        setPolicy(previous);
-        setPolicyError(data.error || "Failed to update policy");
-      }
-    } catch {
-      setPolicy(previous);
-      setPolicyError("Network error");
-    } finally {
-      setPolicySaving(false);
-    }
-  }
-
-  async function handleRename(e: React.FormEvent) {
-    e.preventDefault();
-    if (!newName || newName === vaultName) return;
-
-    setRenaming(true);
-    setRenameError("");
-    setRenameSuccess("");
-
-    try {
-      const resp = await apiFetch(
-        `/v1/vaults/${encodeURIComponent(vaultName)}/rename`,
-        {
-          method: "POST",
-          body: JSON.stringify({ name: newName }),
-        }
-      );
-      if (!resp.ok) {
-        const data = await resp.json().catch(() => ({}));
-        setRenameError(data.error || "Failed to rename vault");
-        return;
-      }
-      setRenameSuccess(`Vault renamed to "${newName}"`);
-      // Navigate to the new vault URL after a brief pause
-      setTimeout(() => {
-        navigate({
-          to: "/vaults/$name/settings",
-          params: { name: newName },
-        });
-      }, 500);
-    } catch {
-      setRenameError("Network error");
-    } finally {
-      setRenaming(false);
-    }
-  }
 
   async function handleDelete() {
     const resp = await apiFetch(
@@ -145,69 +86,39 @@ export default function SettingsTab() {
         </p>
       </div>
 
-      {/* Vault config (rename + unmatched-host policy + credential store) */}
+      {/* Read-only vault config; editing happens in the side drawer. */}
       <section className="mb-8">
-        <div className="border border-border rounded-xl bg-surface">
+        <div className="relative border border-border rounded-xl bg-surface">
+          {canManage && (
+            <Button
+              variant="secondary"
+              onClick={() => setEditing(true)}
+              className="absolute top-4 right-4 !px-3 !py-1.5"
+            >
+              Edit settings
+            </Button>
+          )}
           <div className="p-5">
-            <div className="max-w-md">
-              <form onSubmit={handleRename} className="flex items-end gap-3">
-                <div className="flex-1 min-w-0">
-                  <FormField label="Vault Name">
-                    <Input
-                      value={newName}
-                      onChange={(e) => {
-                        setNewName(e.target.value);
-                        setRenameError("");
-                        setRenameSuccess("");
-                      }}
-                      disabled={!canManage || isDefault}
-                      placeholder="vault-name"
-                    />
-                  </FormField>
-                </div>
-                <Button
-                  type="submit"
-                  disabled={!canManage || isDefault || !newName || newName === vaultName}
-                  loading={renaming}
-                >
-                  Rename
-                </Button>
-              </form>
-
-              {renameError && <ErrorBanner message={renameError} className="mt-3" />}
-              {renameSuccess && (
-                <div className="mt-3 bg-success-bg border border-success/20 rounded-lg p-4 text-sm text-success">
-                  {renameSuccess}
-                </div>
-              )}
-            </div>
+            <StoreField label="Vault Name" value={vaultName} />
           </div>
 
           <div className="border-t border-border mx-5" />
 
           <div className="p-5">
-            <div className="max-w-md">
-              <label className="block text-xs font-semibold uppercase tracking-wider text-text-muted mb-2">
-                Strict deny mode
-              </label>
-              <div className="flex items-center justify-between gap-3">
-                <p className="text-sm text-text-muted flex-1 min-w-0">
-                  Reject unmatched hosts with HTTP 403 instead of forwarding them upstream unauthenticated.
-                </p>
-                <Toggle
-                  checked={policy === "deny"}
-                  onChange={handlePolicyToggle}
-                  disabled={!canManage || policy === null || policySaving}
-                  ariaLabel="Strict deny mode"
-                />
-              </div>
-              {policyError && (
-                <ErrorBanner message={policyError} className="mt-3" />
-              )}
-            </div>
+            <StoreField
+              label="Strict deny mode"
+              tooltip="Reject unmatched hosts with HTTP 403 instead of forwarding them upstream unauthenticated."
+              value={
+                policy === null
+                  ? "—"
+                  : policy === "deny"
+                    ? "Enabled"
+                    : "Disabled"
+              }
+            />
           </div>
 
-          <CredentialStoreSection store={credentialStore} />
+          <CredentialStoreDisplay store={credentialStore} />
         </div>
       </section>
 
@@ -242,11 +153,22 @@ export default function SettingsTab() {
         confirmValue={vaultName}
         inputLabel="Vault name"
       />
+
+      <EditSettingsSheet
+        open={editing}
+        onClose={() => setEditing(false)}
+        vaultName={vaultName}
+        isDefault={isDefault}
+        policy={policy}
+        onPolicySaved={setPolicy}
+        store={credentialStore}
+        infisicalAvailable={infisicalAvailable}
+      />
     </div>
   );
 }
 
-function CredentialStoreSection({ store }: { store?: CredentialStoreInfo }) {
+function CredentialStoreDisplay({ store }: { store?: CredentialStoreInfo }) {
   const config = (store?.config ?? {}) as {
     project_id?: string;
     environment?: string;
@@ -260,7 +182,11 @@ function CredentialStoreSection({ store }: { store?: CredentialStoreInfo }) {
       <div className="border-t border-border mx-5" />
       <div className="p-5 grid grid-cols-2 gap-x-6 gap-y-4">
         <div className="col-span-2">
-          <StoreField label="Credential store" value={kindLabel} />
+          <StoreField
+            label="Credential store"
+            tooltip="Built-in keeps credentials in Agent Vault. Infisical syncs read-only from your Infisical instance, overwriting the built-in credentials."
+            value={kindLabel}
+          />
         </div>
         {/* Config is redacted server-side for non-admin viewers; sync status
             stays populated for everyone. */}
@@ -288,14 +214,286 @@ function CredentialStoreSection({ store }: { store?: CredentialStoreInfo }) {
   );
 }
 
-function StoreField({ label, value }: { label: string; value: string }) {
+function EditSettingsSheet({
+  open,
+  onClose,
+  vaultName,
+  isDefault,
+  policy,
+  onPolicySaved,
+  store,
+  infisicalAvailable,
+}: {
+  open: boolean;
+  onClose: () => void;
+  vaultName: string;
+  isDefault: boolean;
+  policy: UnmatchedHostPolicy | null;
+  onPolicySaved: (p: UnmatchedHostPolicy) => void;
+  store?: CredentialStoreInfo;
+  infisicalAvailable: boolean;
+}) {
+  const navigate = useNavigate();
+  const router = useRouter();
+
+  const config = (store?.config ?? {}) as {
+    project_id?: string;
+    environment?: string;
+    secret_path?: string;
+  };
+  const currentKind: "builtin" | "infisical" =
+    store?.kind === "infisical" ? "infisical" : "builtin";
+
+  // Draft state, seeded from the live values each time the drawer opens.
+  const [name, setName] = useState(vaultName);
+  const [draftPolicy, setDraftPolicy] = useState<UnmatchedHostPolicy>(
+    policy ?? "passthrough"
+  );
+  const [target, setTarget] = useState<"builtin" | "infisical">(currentKind);
+  const [projectID, setProjectID] = useState(config.project_id ?? "");
+  const [environment, setEnvironment] = useState(config.environment ?? "");
+  const [secretPath, setSecretPath] = useState(config.secret_path || "/");
+
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setName(vaultName);
+    setDraftPolicy(policy ?? "passthrough");
+    setTarget(currentKind);
+    setProjectID(config.project_id ?? "");
+    setEnvironment(config.environment ?? "");
+    setSecretPath(config.secret_path || "/");
+    setError("");
+    setShowConfirm(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const switchToInfisical = target === "infisical";
+  const trimmedName = name.trim();
+
+  const nameChanged = !isDefault && !!trimmedName && trimmedName !== vaultName;
+  const policyChanged = policy !== null && draftPolicy !== policy;
+  const configChanged =
+    switchToInfisical &&
+    (projectID.trim() !== (config.project_id ?? "") ||
+      environment.trim() !== (config.environment ?? "") ||
+      (secretPath.trim() || "/") !== (config.secret_path || "/"));
+  const storeChanged = target !== currentKind || configChanged;
+
+  const infisicalFieldsValid =
+    !switchToInfisical || (!!projectID.trim() && !!environment.trim());
+  // nameChanged already implies a non-empty trimmed name, so no extra guard.
+  const canSave =
+    (nameChanged || policyChanged || storeChanged) && infisicalFieldsValid;
+
+  // Runs every pending change in a safe order: non-destructive first, then the
+  // credential-store overwrite, then rename last (it changes the vault URL).
+  async function applyChanges() {
+    setSaving(true);
+    setError("");
+    try {
+      if (policyChanged) {
+        const resp = await apiFetch(
+          `/v1/vaults/${encodeURIComponent(vaultName)}/settings`,
+          {
+            method: "PATCH",
+            body: JSON.stringify({ unmatched_host_policy: draftPolicy }),
+          }
+        );
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          throw new Error(data.error || "Failed to update policy");
+        }
+        onPolicySaved(draftPolicy);
+      }
+
+      if (storeChanged) {
+        const body: Record<string, unknown> = { kind: target };
+        if (switchToInfisical) {
+          const trimmedPath = secretPath.trim() || "/";
+          if (!trimmedPath.startsWith("/")) {
+            throw new Error('Secret path must start with "/".');
+          }
+          body.config = {
+            project_id: projectID.trim(),
+            environment: environment.trim(),
+            secret_path: trimmedPath,
+          };
+        }
+        const resp = await apiFetch(
+          `/v1/vaults/${encodeURIComponent(vaultName)}/credential-store`,
+          { method: "PATCH", body: JSON.stringify(body) }
+        );
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          throw new Error(data.error || "Failed to switch credential store");
+        }
+      }
+
+      if (nameChanged) {
+        const resp = await apiFetch(
+          `/v1/vaults/${encodeURIComponent(vaultName)}/rename`,
+          { method: "POST", body: JSON.stringify({ name: trimmedName }) }
+        );
+        if (!resp.ok) {
+          const data = await resp.json().catch(() => ({}));
+          throw new Error(data.error || "Failed to rename vault");
+        }
+        // The URL carries the old name; jump to the new one (reloads context).
+        navigate({ to: "/vaults/$name/settings", params: { name: trimmedName } });
+        return;
+      }
+
+      // Refresh the vault context so the read-only display reflects the change.
+      await router.invalidate();
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // The credential-store change is destructive (it overwrites credentials), so
+  // gate it behind the type-the-vault-name confirmation. Other edits save directly.
+  function handleSave() {
+    if (storeChanged) {
+      setShowConfirm(true);
+      return;
+    }
+    applyChanges().catch((err) =>
+      setError(err instanceof Error ? err.message : "Something went wrong")
+    );
+  }
+
+  return (
+    <>
+      <Sheet
+        open={open}
+        onClose={onClose}
+        eyebrow="Vault"
+        title="Edit settings"
+        footer={
+          <>
+            <Button variant="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} loading={saving} disabled={!canSave}>
+              Save
+            </Button>
+          </>
+        }
+      >
+        <div className="space-y-5">
+          <FormField label="Vault Name">
+            <Input
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setError("");
+              }}
+              disabled={isDefault}
+              placeholder="vault-name"
+            />
+          </FormField>
+
+          <FormField
+            label="Strict deny mode"
+            tooltip="Reject unmatched hosts with HTTP 403 instead of forwarding them upstream unauthenticated."
+          >
+            <Toggle
+              checked={draftPolicy === "deny"}
+              onChange={(v) => setDraftPolicy(v ? "deny" : "passthrough")}
+              disabled={policy === null}
+              ariaLabel="Strict deny mode"
+            />
+          </FormField>
+
+          <FormField
+            label="Credential store"
+            tooltip="Built-in keeps credentials in Agent Vault. Infisical syncs read-only from your Infisical instance, overwriting the built-in credentials."
+          >
+            <Select
+              value={target}
+              onChange={(e) =>
+                setTarget(e.target.value as "builtin" | "infisical")
+              }
+            >
+              <option value="builtin">Built In</option>
+              <option value="infisical" disabled={!infisicalAvailable}>
+                Infisical
+              </option>
+            </Select>
+          </FormField>
+
+          {switchToInfisical && (
+            <div className="space-y-3">
+              <FormField label="Project ID" required>
+                <Input
+                  placeholder="abcdef..."
+                  value={projectID}
+                  onChange={(e) => setProjectID(e.target.value)}
+                />
+              </FormField>
+              <FormField label="Environment Slug" required>
+                <Input
+                  placeholder="dev"
+                  value={environment}
+                  onChange={(e) => setEnvironment(e.target.value)}
+                />
+              </FormField>
+              <FormField label="Secret path">
+                <Input
+                  placeholder="/"
+                  value={secretPath}
+                  onChange={(e) => setSecretPath(e.target.value)}
+                />
+              </FormField>
+            </div>
+          )}
+
+          {error && <ErrorBanner message={error} />}
+        </div>
+      </Sheet>
+
+      <ConfirmDeleteModal
+        open={showConfirm}
+        onClose={() => setShowConfirm(false)}
+        onConfirm={async () => {
+          await applyChanges();
+          setShowConfirm(false);
+        }}
+        title="Switch credential store"
+        description={
+          switchToInfisical
+            ? `Switching to Infisical will OVERWRITE all current built-in credentials in "${vaultName}" with the secrets from the connected Infisical source. Type the vault name to confirm.`
+            : `Switching to the built-in store disconnects Infisical from "${vaultName}". The secrets currently synced are kept as built-in credentials and stop updating from Infisical. Type the vault name to confirm.`
+        }
+        confirmLabel="Save changes"
+        confirmValue={vaultName}
+        inputLabel="Vault name"
+      />
+    </>
+  );
+}
+
+function StoreField({
+  label,
+  value,
+  tooltip,
+}: {
+  label: string;
+  value: string;
+  tooltip?: ReactNode;
+}) {
   return (
     <div className="min-w-0">
-      <div className="text-xs font-semibold uppercase tracking-wider text-text-muted mb-2">
-        {label}
+      <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-text-muted mb-2">
+        <span>{label}</span>
+        {tooltip && <InfoTooltip>{tooltip}</InfoTooltip>}
       </div>
       <div className="text-sm font-mono text-text break-all">{value}</div>
     </div>
   );
 }
-

--- a/web/src/pages/vault/SettingsTab.tsx
+++ b/web/src/pages/vault/SettingsTab.tsx
@@ -421,7 +421,13 @@ function EditSettingsSheet({
               }
             >
               <option value="builtin">Built In</option>
-              <option value="infisical" disabled={!infisicalAvailable}>
+              {/* Keep the current store selectable even when the server can no
+                  longer make new Infisical connections, so toggling to Built In
+                  and back restores the pre-filled config. */}
+              <option
+                value="infisical"
+                disabled={!infisicalAvailable && currentKind !== "infisical"}
+              >
                 Infisical
               </option>
             </Select>

--- a/web/src/pages/vault/SettingsTab.tsx
+++ b/web/src/pages/vault/SettingsTab.tsx
@@ -3,13 +3,14 @@ import { useNavigate, useRouter } from "@tanstack/react-router";
 import { useVaultParams, ErrorBanner, timeAgo } from "./shared";
 import type { CredentialStoreInfo } from "../../router";
 import Button from "../../components/Button";
-import Input from "../../components/Input";
-import Select from "../../components/Select";
-import FormField from "../../components/FormField";
 import ConfirmDeleteModal from "../../components/ConfirmDeleteModal";
 import InfoTooltip from "../../components/InfoTooltip";
 import Sheet from "../../components/Sheet";
-import Toggle from "../../components/Toggle";
+import VaultForm, {
+  infisicalFieldsValid,
+  buildInfisicalConfig,
+  type VaultFormValues,
+} from "../../components/VaultForm";
 import { apiFetch } from "../../lib/api";
 
 type UnmatchedHostPolicy = "passthrough" | "deny";
@@ -243,50 +244,45 @@ function EditSettingsSheet({
   const currentKind: "builtin" | "infisical" =
     store?.kind === "infisical" ? "infisical" : "builtin";
 
-  // Draft state, seeded from the live values each time the drawer opens.
-  const [name, setName] = useState(vaultName);
-  const [draftPolicy, setDraftPolicy] = useState<UnmatchedHostPolicy>(
-    policy ?? "passthrough"
-  );
-  const [target, setTarget] = useState<"builtin" | "infisical">(currentKind);
-  const [projectID, setProjectID] = useState(config.project_id ?? "");
-  const [environment, setEnvironment] = useState(config.environment ?? "");
-  const [secretPath, setSecretPath] = useState(config.secret_path || "/");
+  const initialValues: VaultFormValues = {
+    name: vaultName,
+    policy: policy ?? "passthrough",
+    kind: currentKind,
+    projectID: config.project_id ?? "",
+    environment: config.environment ?? "",
+    secretPath: config.secret_path || "/",
+  };
 
+  // Draft state, re-seeded from the live values each time the drawer opens.
+  const [values, setValues] = useState<VaultFormValues>(initialValues);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [showConfirm, setShowConfirm] = useState(false);
 
   useEffect(() => {
     if (!open) return;
-    setName(vaultName);
-    setDraftPolicy(policy ?? "passthrough");
-    setTarget(currentKind);
-    setProjectID(config.project_id ?? "");
-    setEnvironment(config.environment ?? "");
-    setSecretPath(config.secret_path || "/");
+    setValues(initialValues);
     setError("");
     setShowConfirm(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  const switchToInfisical = target === "infisical";
-  const trimmedName = name.trim();
+  const switchToInfisical = values.kind === "infisical";
+  const trimmedName = values.name.trim();
 
   const nameChanged = !isDefault && !!trimmedName && trimmedName !== vaultName;
-  const policyChanged = policy !== null && draftPolicy !== policy;
+  const policyChanged = policy !== null && values.policy !== policy;
   const configChanged =
     switchToInfisical &&
-    (projectID.trim() !== (config.project_id ?? "") ||
-      environment.trim() !== (config.environment ?? "") ||
-      (secretPath.trim() || "/") !== (config.secret_path || "/"));
-  const storeChanged = target !== currentKind || configChanged;
+    (values.projectID.trim() !== (config.project_id ?? "") ||
+      values.environment.trim() !== (config.environment ?? "") ||
+      (values.secretPath.trim() || "/") !== (config.secret_path || "/"));
+  const storeChanged = values.kind !== currentKind || configChanged;
 
-  const infisicalFieldsValid =
-    !switchToInfisical || (!!projectID.trim() && !!environment.trim());
   // nameChanged already implies a non-empty trimmed name, so no extra guard.
   const canSave =
-    (nameChanged || policyChanged || storeChanged) && infisicalFieldsValid;
+    (nameChanged || policyChanged || storeChanged) &&
+    infisicalFieldsValid(values);
 
   // Runs every pending change in a safe order: non-destructive first, then the
   // credential-store overwrite, then rename last (it changes the vault URL).
@@ -299,28 +295,20 @@ function EditSettingsSheet({
           `/v1/vaults/${encodeURIComponent(vaultName)}/settings`,
           {
             method: "PATCH",
-            body: JSON.stringify({ unmatched_host_policy: draftPolicy }),
+            body: JSON.stringify({ unmatched_host_policy: values.policy }),
           }
         );
         if (!resp.ok) {
           const data = await resp.json().catch(() => ({}));
           throw new Error(data.error || "Failed to update policy");
         }
-        onPolicySaved(draftPolicy);
+        onPolicySaved(values.policy);
       }
 
       if (storeChanged) {
-        const body: Record<string, unknown> = { kind: target };
+        const body: Record<string, unknown> = { kind: values.kind };
         if (switchToInfisical) {
-          const trimmedPath = secretPath.trim() || "/";
-          if (!trimmedPath.startsWith("/")) {
-            throw new Error('Secret path must start with "/".');
-          }
-          body.config = {
-            project_id: projectID.trim(),
-            environment: environment.trim(),
-            secret_path: trimmedPath,
-          };
+          body.config = buildInfisicalConfig(values);
         }
         const resp = await apiFetch(
           `/v1/vaults/${encodeURIComponent(vaultName)}/credential-store`,
@@ -384,82 +372,19 @@ function EditSettingsSheet({
           </>
         }
       >
-        <div className="space-y-5">
-          <FormField label="Vault Name">
-            <Input
-              value={name}
-              onChange={(e) => {
-                setName(e.target.value);
-                setError("");
-              }}
-              disabled={isDefault}
-              placeholder="vault-name"
-            />
-          </FormField>
-
-          <FormField
-            label="Strict deny mode"
-            tooltip="Reject unmatched hosts with HTTP 403 instead of forwarding them upstream unauthenticated."
-          >
-            <Toggle
-              checked={draftPolicy === "deny"}
-              onChange={(v) => setDraftPolicy(v ? "deny" : "passthrough")}
-              disabled={policy === null}
-              ariaLabel="Strict deny mode"
-            />
-          </FormField>
-
-          <FormField
-            label="Credential store"
-            tooltip="Built-in keeps credentials in Agent Vault. Infisical syncs read-only from your Infisical instance, overwriting the built-in credentials."
-          >
-            <Select
-              value={target}
-              onChange={(e) =>
-                setTarget(e.target.value as "builtin" | "infisical")
-              }
-            >
-              <option value="builtin">Built In</option>
-              {/* Keep the current store selectable even when the server can no
-                  longer make new Infisical connections, so toggling to Built In
-                  and back restores the pre-filled config. */}
-              <option
-                value="infisical"
-                disabled={!infisicalAvailable && currentKind !== "infisical"}
-              >
-                Infisical
-              </option>
-            </Select>
-          </FormField>
-
-          {switchToInfisical && (
-            <div className="space-y-3">
-              <FormField label="Project ID" required>
-                <Input
-                  placeholder="abcdef..."
-                  value={projectID}
-                  onChange={(e) => setProjectID(e.target.value)}
-                />
-              </FormField>
-              <FormField label="Environment Slug" required>
-                <Input
-                  placeholder="dev"
-                  value={environment}
-                  onChange={(e) => setEnvironment(e.target.value)}
-                />
-              </FormField>
-              <FormField label="Secret path">
-                <Input
-                  placeholder="/"
-                  value={secretPath}
-                  onChange={(e) => setSecretPath(e.target.value)}
-                />
-              </FormField>
-            </div>
-          )}
-
-          {error && <ErrorBanner message={error} />}
-        </div>
+        <VaultForm
+          values={values}
+          onChange={(patch) => {
+            setValues((v) => ({ ...v, ...patch }));
+            setError("");
+          }}
+          showPolicy
+          policyDisabled={policy === null}
+          nameDisabled={isDefault}
+          infisicalOptionDisabled={!infisicalAvailable && currentKind !== "infisical"}
+          error={error}
+          storeTooltip="Built-in keeps credentials in Agent Vault. Infisical syncs read-only from your Infisical instance, overwriting the built-in credentials."
+        />
       </Sheet>
 
       <ConfirmDeleteModal


### PR DESCRIPTION
## Summary

Reworks the vault Settings tab so the config card is read-only and editing happens in a right-side drawer.

- The settings card now shows **Vault Name**, **Strict deny mode**, and **Credential store** as read-only label-over-value fields (matching the existing credential-store display style).
- An **Edit settings** button is anchored to the card's top-right corner (the natural edit affordance for a read-only card).
- The button opens a right-side drawer (reusing the shared `Sheet` component used by "create vault") with pre-populated, editable fields and Cancel/Save in the footer.
- **Save** applies only what changed, in a safe order: policy, then credential store, then rename last (rename changes the vault URL, so it must go last). Save is disabled when there are no changes or required Infisical fields are blank.
- A **credential-store change is destructive** (switching overwrites credentials), so it routes through the existing type-the-vault-name confirmation modal before applying. Name/policy-only edits save directly.
- Added hoverable **`?` tooltips** to the strict-deny and credential-store fields in both the card and the drawer. The tooltip chip markup, previously duplicated in `FormField`, was extracted into a shared `InfoTooltip` component now used by both.

The old inline rename form, inline policy toggle, and inline "Switch credential store" section are removed; their behavior moves into the drawer.

## Notes

- The `/rename`, `/settings`, and `/credential-store` endpoints are unchanged; this is a frontend-only refactor.
- Followup worth considering: the Infisical credential-store form + validation is duplicated between this drawer and `CreateVaultButton` in `VaultsListTab.tsx`, and has begun to drift. Extracting a shared `CredentialStoreForm` (or at least a shared validation helper) was left out of scope here since it touches code outside this change.

## Testing

- `npx tsc --noEmit` passes.
- `npm run build` (production Vite build) succeeds.
- Not manually exercised in a running app; worth a quick visual check of the drawer layout and the destructive-confirm flow.