### PR TITLE
feat: switch a vault's credential store in place

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -172,6 +172,9 @@ func TestVaultCredentialStoreSubcommandsRegistered(t *testing.T) {
 	}
 
 	setCmd := findSubcommand(csCmd, "set")
+	if setCmd == nil {
+		t.Fatal("set command not found under credential-store")
+	}
 	for _, flag := range []string{"kind", "infisical-project-id", "infisical-environment", "infisical-path", "poll-interval-seconds", "yes"} {
 		if setCmd.Flags().Lookup(flag) == nil {
 			t.Errorf("expected credential-store set to define --%s flag", flag)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -151,6 +151,42 @@ func TestVaultSubcommandsRegistered(t *testing.T) {
 	}
 }
 
+func TestVaultCredentialStoreSubcommandsRegistered(t *testing.T) {
+	vCmd := findSubcommand(rootCmd, "vault")
+	if vCmd == nil {
+		t.Fatal("vault command not found")
+	}
+	csCmd := findSubcommand(vCmd, "credential-store")
+	if csCmd == nil {
+		t.Fatal("credential-store command not found under vault")
+	}
+
+	registered := make(map[string]bool)
+	for _, c := range csCmd.Commands() {
+		registered[c.Name()] = true
+	}
+	for _, name := range []string{"show", "sync", "set"} {
+		if !registered[name] {
+			t.Errorf("expected credential-store subcommand %q to be registered", name)
+		}
+	}
+
+	setCmd := findSubcommand(csCmd, "set")
+	for _, flag := range []string{"kind", "infisical-project-id", "infisical-environment", "infisical-path", "poll-interval-seconds", "yes"} {
+		if setCmd.Flags().Lookup(flag) == nil {
+			t.Errorf("expected credential-store set to define --%s flag", flag)
+		}
+	}
+}
+
+func TestVaultCredentialStoreSetRequiresKind(t *testing.T) {
+	// Missing --kind should fail before any network call.
+	_, err := executeCommand("vault", "credential-store", "set", "my-app", "--yes")
+	if err == nil {
+		t.Fatal("expected error when --kind is omitted")
+	}
+}
+
 func TestOwnerVaultSubcommandsRegistered(t *testing.T) {
 	oCmd := findSubcommand(rootCmd, "owner")
 	if oCmd == nil {

--- a/cmd/vaults.go
+++ b/cmd/vaults.go
@@ -170,12 +170,14 @@ var vaultCredentialStoreSyncCmd = &cobra.Command{
 
 var vaultCredentialStoreSetCmd = &cobra.Command{
 	Use:   "set <name>",
-	Short: "Switch the credential store backing a vault (vault admin or instance owner)",
+	Short: "Switch the credential store backing a vault",
 	Long: "Switch a vault's credential store after creation.\n\n" +
 		"Switching to infisical OVERWRITES the vault's built-in credentials with the\n" +
-		"secrets fetched from the connected source and starts polling. Switching to\n" +
-		"builtin disconnects the external source (polling stops) but KEEPS the last\n" +
-		"synced secrets in place as editable built-in credentials.",
+		"secrets fetched from the connected source and starts polling. It requires\n" +
+		"instance-owner role, since the broker's machine identity authorizes the\n" +
+		"upstream fetch. Switching to builtin disconnects the external source\n" +
+		"(polling stops) but KEEPS the last synced secrets in place as editable\n" +
+		"built-in credentials, and is allowed for vault admins too.",
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]

--- a/cmd/vaults.go
+++ b/cmd/vaults.go
@@ -201,9 +201,11 @@ var vaultCredentialStoreSetCmd = &cobra.Command{
 
 		yes, _ := cmd.Flags().GetBool("yes")
 		if !yes {
-			warning := fmt.Sprintf("%s Switching vault %q to built-in disconnects Infisical; the synced secrets are kept as built-in credentials and stop updating.", warningText("WARNING"), name)
+			var warning string
 			if kind == store.CredentialStoreInfisical {
 				warning = fmt.Sprintf("%s Switching vault %q to Infisical will OVERWRITE its built-in credentials with the secrets from the connected source.", warningText("WARNING"), name)
+			} else {
+				warning = fmt.Sprintf("%s Switching vault %q to built-in disconnects Infisical; the synced secrets are kept as built-in credentials and stop updating.", warningText("WARNING"), name)
 			}
 			ok, err := confirmByName(cmd, warning, name)
 			if err != nil {

--- a/cmd/vaults.go
+++ b/cmd/vaults.go
@@ -199,19 +199,15 @@ var vaultCredentialStoreSetCmd = &cobra.Command{
 
 		yes, _ := cmd.Flags().GetBool("yes")
 		if !yes {
+			warning := fmt.Sprintf("%s Switching vault %q to built-in disconnects Infisical; the synced secrets are kept as built-in credentials and stop updating.", warningText("WARNING"), name)
 			if kind == store.CredentialStoreInfisical {
-				fmt.Fprintf(cmd.OutOrStderr(), "%s Switching vault %q to Infisical will OVERWRITE its built-in credentials with the secrets from the connected source.\n", warningText("WARNING"), name)
-			} else {
-				fmt.Fprintf(cmd.OutOrStderr(), "%s Switching vault %q to built-in disconnects Infisical; the synced secrets are kept as built-in credentials and stop updating.\n", warningText("WARNING"), name)
+				warning = fmt.Sprintf("%s Switching vault %q to Infisical will OVERWRITE its built-in credentials with the secrets from the connected source.", warningText("WARNING"), name)
 			}
-			fmt.Fprintf(cmd.OutOrStderr(), "Type %q to confirm: ", name)
-			reader := bufio.NewReader(os.Stdin)
-			answer, err := reader.ReadString('\n')
+			ok, err := confirmByName(cmd, warning, name)
 			if err != nil {
-				return fmt.Errorf("reading input: %w", err)
+				return err
 			}
-			if strings.TrimSpace(answer) != name {
-				fmt.Fprintln(cmd.OutOrStdout(), mutedText("Aborted."))
+			if !ok {
 				return nil
 			}
 		}
@@ -525,6 +521,22 @@ var vaultRenameCmd = &cobra.Command{
 	},
 }
 
+// confirmByName prints warning then requires the user to type name to proceed.
+// Returns false (after printing "Aborted.") if the typed value doesn't match.
+func confirmByName(cmd *cobra.Command, warning, name string) (bool, error) {
+	fmt.Fprintln(cmd.OutOrStderr(), warning)
+	fmt.Fprintf(cmd.OutOrStderr(), "Type %q to confirm: ", name)
+	answer, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return false, fmt.Errorf("reading input: %w", err)
+	}
+	if strings.TrimSpace(answer) != name {
+		fmt.Fprintln(cmd.OutOrStdout(), mutedText("Aborted."))
+		return false, nil
+	}
+	return true, nil
+}
+
 var vaultDeleteCmd = &cobra.Command{
 	Use:   "delete <name>",
 	Short: "Delete a vault (vault admin or instance owner)",
@@ -534,15 +546,12 @@ var vaultDeleteCmd = &cobra.Command{
 
 		yes, _ := cmd.Flags().GetBool("yes")
 		if !yes {
-			fmt.Fprintf(cmd.OutOrStderr(), "%s This will permanently delete vault %q and all its credentials, services, and proposals.\n", warningText("WARNING"), name)
-			fmt.Fprintf(cmd.OutOrStderr(), "Type %q to confirm: ", name)
-			reader := bufio.NewReader(os.Stdin)
-			answer, err := reader.ReadString('\n')
+			warning := fmt.Sprintf("%s This will permanently delete vault %q and all its credentials, services, and proposals.", warningText("WARNING"), name)
+			ok, err := confirmByName(cmd, warning, name)
 			if err != nil {
-				return fmt.Errorf("reading input: %w", err)
+				return err
 			}
-			if strings.TrimSpace(answer) != name {
-				fmt.Fprintln(cmd.OutOrStdout(), mutedText("Aborted."))
+			if !ok {
 				return nil
 			}
 		}

--- a/cmd/vaults.go
+++ b/cmd/vaults.go
@@ -41,29 +41,11 @@ var vaultCreateCmd = &cobra.Command{
 		case "", store.CredentialStoreBuiltin:
 			// no extra payload
 		case store.CredentialStoreInfisical:
-			projectID, _ := cmd.Flags().GetString("infisical-project-id")
-			environment, _ := cmd.Flags().GetString("infisical-environment")
-			secretPath, _ := cmd.Flags().GetString("infisical-path")
-			pollSecs, _ := cmd.Flags().GetInt("poll-interval-seconds")
-
-			if projectID == "" || environment == "" {
-				return fmt.Errorf("--infisical-project-id and --infisical-environment are required when --credential-store=%s", store.CredentialStoreInfisical)
+			cs, err := infisicalStorePayloadFromFlags(cmd)
+			if err != nil {
+				return err
 			}
-			if pollSecs < 10 {
-				return fmt.Errorf("--poll-interval-seconds must be at least 10")
-			}
-			if secretPath == "" {
-				secretPath = "/"
-			}
-			payload["credential_store"] = map[string]interface{}{
-				"kind": store.CredentialStoreInfisical,
-				"config": map[string]interface{}{
-					"project_id":  projectID,
-					"environment": environment,
-					"secret_path": secretPath,
-				},
-				"poll_interval_seconds": pollSecs,
-			}
+			payload["credential_store"] = cs
 		default:
 			return fmt.Errorf("unsupported --credential-store %q (use %s or %s)", credStore, store.CredentialStoreBuiltin, store.CredentialStoreInfisical)
 		}
@@ -97,6 +79,35 @@ var vaultCreateCmd = &cobra.Command{
 var vaultCredentialStoreCmd = &cobra.Command{
 	Use:   "credential-store",
 	Short: "Inspect the credential store backing a vault",
+}
+
+// infisicalStorePayloadFromFlags validates the shared Infisical flags and
+// returns the {kind, config, poll_interval_seconds} block used by both
+// `vault create` and `vault credential-store set`.
+func infisicalStorePayloadFromFlags(cmd *cobra.Command) (map[string]interface{}, error) {
+	projectID, _ := cmd.Flags().GetString("infisical-project-id")
+	environment, _ := cmd.Flags().GetString("infisical-environment")
+	secretPath, _ := cmd.Flags().GetString("infisical-path")
+	pollSecs, _ := cmd.Flags().GetInt("poll-interval-seconds")
+
+	if projectID == "" || environment == "" {
+		return nil, fmt.Errorf("--infisical-project-id and --infisical-environment are required for the %s credential store", store.CredentialStoreInfisical)
+	}
+	if pollSecs < 10 {
+		return nil, fmt.Errorf("--poll-interval-seconds must be at least 10")
+	}
+	if secretPath == "" {
+		secretPath = "/"
+	}
+	return map[string]interface{}{
+		"kind": store.CredentialStoreInfisical,
+		"config": map[string]interface{}{
+			"project_id":  projectID,
+			"environment": environment,
+			"secret_path": secretPath,
+		},
+		"poll_interval_seconds": pollSecs,
+	}, nil
 }
 
 var vaultCredentialStoreShowCmd = &cobra.Command{
@@ -152,6 +163,82 @@ var vaultCredentialStoreSyncCmd = &cobra.Command{
 		}
 		out := cmd.OutOrStdout()
 		fmt.Fprintf(out, "%s Synced vault %q\n", successText("✓"), name)
+		printCredentialStore(out, resp.CredentialStore)
+		return nil
+	},
+}
+
+var vaultCredentialStoreSetCmd = &cobra.Command{
+	Use:   "set <name>",
+	Short: "Switch the credential store backing a vault (vault admin or instance owner)",
+	Long: "Switch a vault's credential store after creation.\n\n" +
+		"Switching to infisical OVERWRITES the vault's built-in credentials with the\n" +
+		"secrets fetched from the connected source and starts polling. Switching to\n" +
+		"builtin disconnects the external source (polling stops) but KEEPS the last\n" +
+		"synced secrets in place as editable built-in credentials.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		kind, _ := cmd.Flags().GetString("kind")
+
+		var payload map[string]interface{}
+		switch kind {
+		case store.CredentialStoreBuiltin:
+			payload = map[string]interface{}{"kind": store.CredentialStoreBuiltin}
+		case store.CredentialStoreInfisical:
+			cs, err := infisicalStorePayloadFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+			payload = cs
+		case "":
+			return fmt.Errorf("--kind is required (%s or %s)", store.CredentialStoreBuiltin, store.CredentialStoreInfisical)
+		default:
+			return fmt.Errorf("unsupported --kind %q (use %s or %s)", kind, store.CredentialStoreBuiltin, store.CredentialStoreInfisical)
+		}
+
+		yes, _ := cmd.Flags().GetBool("yes")
+		if !yes {
+			if kind == store.CredentialStoreInfisical {
+				fmt.Fprintf(cmd.OutOrStderr(), "%s Switching vault %q to Infisical will OVERWRITE its built-in credentials with the secrets from the connected source.\n", warningText("WARNING"), name)
+			} else {
+				fmt.Fprintf(cmd.OutOrStderr(), "%s Switching vault %q to built-in disconnects Infisical; the synced secrets are kept as built-in credentials and stop updating.\n", warningText("WARNING"), name)
+			}
+			fmt.Fprintf(cmd.OutOrStderr(), "Type %q to confirm: ", name)
+			reader := bufio.NewReader(os.Stdin)
+			answer, err := reader.ReadString('\n')
+			if err != nil {
+				return fmt.Errorf("reading input: %w", err)
+			}
+			if strings.TrimSpace(answer) != name {
+				fmt.Fprintln(cmd.OutOrStdout(), mutedText("Aborted."))
+				return nil
+			}
+		}
+
+		sess, err := ensureSession()
+		if err != nil {
+			return err
+		}
+
+		body, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+
+		reqURL := fmt.Sprintf("%s/v1/vaults/%s/credential-store", sess.Address, url.PathEscape(name))
+		respBody, err := doAdminRequestWithBody("PATCH", reqURL, sess.Token, body)
+		if err != nil {
+			return err
+		}
+
+		var resp struct {
+			CredentialStore map[string]interface{} `json:"credential_store,omitempty"`
+		}
+		_ = json.Unmarshal(respBody, &resp)
+
+		out := cmd.OutOrStdout()
+		fmt.Fprintf(out, "%s Switched credential store for vault %q\n", successText("✓"), name)
 		printCredentialStore(out, resp.CredentialStore)
 		return nil
 	},
@@ -493,8 +580,16 @@ func init() {
 	vaultCmd.AddCommand(vaultUseCmd)
 	vaultCmd.AddCommand(vaultCurrentCmd)
 
+	vaultCredentialStoreSetCmd.Flags().String("kind", "", "target credential store kind: builtin or infisical")
+	vaultCredentialStoreSetCmd.Flags().String("infisical-project-id", "", "Infisical project ID (required when --kind=infisical)")
+	vaultCredentialStoreSetCmd.Flags().String("infisical-environment", "", "Infisical environment slug, e.g. dev/prod")
+	vaultCredentialStoreSetCmd.Flags().String("infisical-path", "/", "Infisical secret path (default /)")
+	vaultCredentialStoreSetCmd.Flags().Int("poll-interval-seconds", 60, "Sync cadence floor for the external store (min 10)")
+	vaultCredentialStoreSetCmd.Flags().Bool("yes", false, "Skip confirmation prompt")
+
 	vaultCredentialStoreCmd.AddCommand(vaultCredentialStoreShowCmd)
 	vaultCredentialStoreCmd.AddCommand(vaultCredentialStoreSyncCmd)
+	vaultCredentialStoreCmd.AddCommand(vaultCredentialStoreSetCmd)
 	vaultCmd.AddCommand(vaultCredentialStoreCmd)
 
 	vaultUserAddCmd.Flags().String("role", "member", "role to grant (admin or member)")

--- a/docs/learn/credential-stores.mdx
+++ b/docs/learn/credential-stores.mdx
@@ -3,7 +3,7 @@ title: "Credential stores"
 description: "Where a vault's credentials come from: Agent Vault's local DB, or an external system like Infisical."
 ---
 
-A **credential store** describes where a vault's [credentials](/learn/credentials) live. Every vault has exactly one credential store, chosen at create time. The kind is immutable; to move a vault between stores, create a new vault and update agents and services to point at it.
+A **credential store** describes where a vault's [credentials](/learn/credentials) live. Every vault has exactly one credential store, chosen at create time and switchable later (see [Switching a vault's credential store](#switching-a-vaults-credential-store)).
 
 There are two kinds:
 
@@ -37,6 +37,32 @@ To inspect a vault's credential store later:
 agent-vault vault credential-store show my-app
 ```
 
+## Switching a vault's credential store
+
+A vault admin or instance owner can switch the store backing an existing vault, keeping its services, grants, proposals, and logs. The two directions behave differently:
+
+- **Built-in → Infisical (connect):** Agent Vault probes Infisical first (same validation as create). On success it **overwrites** the vault's built-in credentials with the fetched snapshot and starts polling. Any credentials previously stored locally are replaced.
+- **Infisical → built-in (disconnect):** the external source is disconnected and polling stops. The last synced secrets are **kept** in place as ordinary built-in credentials, now editable through the CLI, API, and UI. Nothing is deleted.
+
+Because connecting overwrites local credentials and disconnecting changes the source of truth, both directions require a typed confirmation (the vault name) in the UI and CLI.
+
+```bash
+# Connect an existing vault to Infisical (overwrites built-in credentials)
+agent-vault vault credential-store set my-app \
+  --kind=infisical \
+  --infisical-project-id=abc123 \
+  --infisical-environment=dev \
+  --infisical-path=/stripe \
+  --poll-interval-seconds=60
+
+# Disconnect Infisical, keeping the synced secrets as built-in credentials
+agent-vault vault credential-store set my-app --kind=builtin
+```
+
+In the browser, open the vault's **Settings → Edit settings** and change the **Credential store** field in the drawer. The Infisical option is available only when the server has `INFISICAL_URL` configured.
+
+**HTTP**: `PATCH {AGENT_VAULT_ADDR}/v1/vaults/{name}/credential-store` with `{"kind":"builtin"}` or `{"kind":"infisical","config":{...},"poll_interval_seconds":N}` (vault admin or instance owner).
+
 ## Upstream key naming
 
 Agent Vault requires credential keys to match `^[A-Z][A-Z0-9_]*$` (UPPER_SNAKE_CASE). The same rule applies to keys fetched from Infisical: any non-conforming key (e.g., `database-url`, `stripeKey`) fails the whole sync with `external_store_invalid_key` and the vault keeps serving its previous snapshot until the key is renamed upstream. There is no partial sync. Rename the secret in Infisical, then retry.
@@ -49,7 +75,7 @@ The periodic syncer keeps the vault fresh on its own (default 60s; configured at
 - **Web UI**: click **Manual sync** on the vault's Credentials tab.
 - **HTTP**: `POST {AGENT_VAULT_ADDR}/v1/vaults/{name}/sync` (any vault member). Returns the post-refresh `credential_store` summary; a `409` means another refresh is already in flight.
 
-The poll interval itself is fixed at create time. To change cadence, create a new vault with the desired `--poll-interval-seconds` and migrate agents and services over.
+The poll interval is set at create time. To change cadence on an existing Infisical-backed vault, re-run `vault credential-store set <name> --kind=infisical` with the desired `--poll-interval-seconds` (this re-probes and re-syncs from the same source).
 
 ## Outage behavior
 

--- a/docs/learn/credential-stores.mdx
+++ b/docs/learn/credential-stores.mdx
@@ -41,8 +41,8 @@ agent-vault vault credential-store show my-app
 
 A vault admin or instance owner can switch the store backing an existing vault, keeping its services, grants, proposals, and logs. The two directions behave differently:
 
-- **Built-in → Infisical (connect):** Agent Vault probes Infisical first (same validation as create). On success it **overwrites** the vault's built-in credentials with the fetched snapshot and starts polling. Any credentials previously stored locally are replaced.
-- **Infisical → built-in (disconnect):** the external source is disconnected and polling stops. The last synced secrets are **kept** in place as ordinary built-in credentials, now editable through the CLI, API, and UI. Nothing is deleted.
+- **Built-in → Infisical (connect):** Agent Vault probes Infisical first (same validation as create). On success it **overwrites** the vault's built-in credentials with the fetched snapshot and starts polling. Any credentials previously stored locally are replaced. Like external-store vault creation, this direction is **instance-owner only** because the broker's machine identity, not the caller's, authorizes the upstream fetch.
+- **Infisical → built-in (disconnect):** the external source is disconnected and polling stops. The last synced secrets are **kept** in place as ordinary built-in credentials, now editable through the CLI, API, and UI. Nothing is deleted. A vault admin or instance owner can do this.
 
 Because connecting overwrites local credentials and disconnecting changes the source of truth, both directions require a typed confirmation (the vault name) in the UI and CLI.
 
@@ -61,7 +61,7 @@ agent-vault vault credential-store set my-app --kind=builtin
 
 In the browser, open the vault's **Settings → Edit settings** and change the **Credential store** field in the drawer. The Infisical option is available only when the server has `INFISICAL_URL` configured.
 
-**HTTP**: `PATCH {AGENT_VAULT_ADDR}/v1/vaults/{name}/credential-store` with `{"kind":"builtin"}` or `{"kind":"infisical","config":{...},"poll_interval_seconds":N}` (vault admin or instance owner).
+**HTTP**: `PATCH {AGENT_VAULT_ADDR}/v1/vaults/{name}/credential-store` with `{"kind":"builtin"}` or `{"kind":"infisical","config":{...},"poll_interval_seconds":N}`. Disconnecting (`builtin`) needs vault admin or instance owner; connecting (`infisical`) needs instance owner.
 
 ## Upstream key naming
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -205,7 +205,7 @@ description: "Complete reference for all Agent Vault CLI commands."
 
     | Flag | Default | Description |
     |------|---------|-------------|
-    | `--credential-store` | `builtin` | Credential store kind: `builtin` or `infisical`. Immutable after create. |
+    | `--credential-store` | `builtin` | Credential store kind: `builtin` or `infisical`. Switchable later with `vault credential-store set`. |
     | `--infisical-project-id` | | Infisical project ID. Required when `--credential-store=infisical`. |
     | `--infisical-environment` | | Infisical environment slug (e.g., `dev`, `prod`). Required when `--credential-store=infisical`. |
     | `--infisical-path` | `/` | Infisical secret path (must start with `/`). |
@@ -261,7 +261,26 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault credential-store show <name>
     ```
 
-    Print the vault's credential-store kind, full config, poll interval, and last sync health. Prints `Credential store: builtin` for vaults with no external source; otherwise the kind name plus the Infisical project, environment, path, poll cadence, and `last_sync_status` / `last_synced_at` / `last_sync_error`. The kind is fixed at create time; this command is read-only.
+    Print the vault's credential-store kind, full config, poll interval, and last sync health. Prints `Credential store: builtin` for vaults with no external source; otherwise the kind name plus the Infisical project, environment, path, poll cadence, and `last_sync_status` / `last_synced_at` / `last_sync_error`. This command is read-only; use `credential-store set` to change the kind.
+  </Accordion>
+
+  <Accordion title="agent-vault vault credential-store set">
+    ```bash
+    agent-vault vault credential-store set <name> --kind=<builtin|infisical> [flags]
+    ```
+
+    Switch the credential store backing an existing vault. Requires vault admin or instance owner role. Prompts for the vault name to confirm unless `--yes` is passed.
+
+    Switching to `infisical` probes the source (same validation as create), then **overwrites** the vault's built-in credentials with the fetched snapshot and starts polling. Switching to `builtin` disconnects the external source (polling stops) but **keeps** the last synced secrets in place as editable built-in credentials. See [Credential stores](/learn/credential-stores#switching-a-vaults-credential-store).
+
+    | Flag | Default | Description |
+    |------|---------|-------------|
+    | `--kind` | | Target credential store kind: `builtin` or `infisical`. Required. |
+    | `--infisical-project-id` | | Infisical project ID. Required when `--kind=infisical`. |
+    | `--infisical-environment` | | Infisical environment slug (e.g., `dev`, `prod`). Required when `--kind=infisical`. |
+    | `--infisical-path` | `/` | Infisical secret path (must start with `/`). |
+    | `--poll-interval-seconds` | `60` | Refresh cadence floor for the cached secrets. Minimum 10s. |
+    | `--yes` | `false` | Skip confirmation prompt |
   </Accordion>
 
   <Accordion title="agent-vault vault credential-store sync">

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -269,7 +269,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     agent-vault vault credential-store set <name> --kind=<builtin|infisical> [flags]
     ```
 
-    Switch the credential store backing an existing vault. Requires vault admin or instance owner role. Prompts for the vault name to confirm unless `--yes` is passed.
+    Switch the credential store backing an existing vault. Switching to `builtin` requires vault admin or instance owner role; switching to `infisical` requires instance-owner role (the broker's machine identity authorizes the upstream fetch). Prompts for the vault name to confirm unless `--yes` is passed.
 
     Switching to `infisical` probes the source (same validation as create), then **overwrites** the vault's built-in credentials with the fetched snapshot and starts polling. Switching to `builtin` disconnects the external source (polling stops) but **keeps** the last synced secrets in place as editable built-in credentials. See [Credential stores](/learn/credential-stores#switching-a-vaults-credential-store).
 

--- a/internal/infisical/sync.go
+++ b/internal/infisical/sync.go
@@ -16,7 +16,7 @@ import (
 
 type SyncerStore interface {
 	ListVaultCredentialStores(ctx context.Context) ([]store.VaultCredentialStore, error)
-	ReplaceVaultCredentials(ctx context.Context, vaultID string, items []store.EncryptedKV) error
+	ReplaceVaultCredentialsForSync(ctx context.Context, vaultID string, items []store.EncryptedKV) (applied bool, err error)
 	UpdateVaultCredentialStoreHealth(ctx context.Context, vaultID, status, errMsg string, syncedAt time.Time) error
 }
 
@@ -181,9 +181,18 @@ func (s *Syncer) refresh(ctx context.Context, cs store.VaultCredentialStore) err
 		return err
 	}
 
-	if err := s.store.ReplaceVaultCredentials(ctx, cs.VaultID, items); err != nil {
+	applied, err := s.store.ReplaceVaultCredentialsForSync(ctx, cs.VaultID, items)
+	if err != nil {
 		s.recordFailure(ctx, cs.VaultID, err)
 		return err
+	}
+	if !applied {
+		// The vault was disconnected (DeleteVaultCredentialStore) between the
+		// list scan and this write; the snapshot is dropped on purpose so the
+		// kept built-in credentials survive. Not a failure.
+		s.logger.Info("infisical sync skipped: vault disconnected mid-sync",
+			slog.String("vault_id", cs.VaultID))
+		return nil
 	}
 
 	// Replace + UpdateHealth are intentionally not in one transaction: a rare

--- a/internal/infisical/sync.go
+++ b/internal/infisical/sync.go
@@ -16,7 +16,7 @@ import (
 
 type SyncerStore interface {
 	ListVaultCredentialStores(ctx context.Context) ([]store.VaultCredentialStore, error)
-	ReplaceVaultCredentialsForSync(ctx context.Context, vaultID string, items []store.EncryptedKV) (applied bool, err error)
+	ReplaceVaultCredentialsForSync(ctx context.Context, vaultID, configJSON string, items []store.EncryptedKV) (applied bool, err error)
 	UpdateVaultCredentialStoreHealth(ctx context.Context, vaultID, status, errMsg string, syncedAt time.Time) error
 }
 
@@ -181,15 +181,15 @@ func (s *Syncer) refresh(ctx context.Context, cs store.VaultCredentialStore) err
 		return err
 	}
 
-	applied, err := s.store.ReplaceVaultCredentialsForSync(ctx, cs.VaultID, items)
+	applied, err := s.store.ReplaceVaultCredentialsForSync(ctx, cs.VaultID, cs.ConfigJSON, items)
 	if err != nil {
 		s.recordFailure(ctx, cs.VaultID, err)
 		return err
 	}
 	if !applied {
-		// Disconnected mid-sync: drop the snapshot so the kept credentials
-		// survive. Not a failure.
-		s.logger.Info("infisical sync skipped: vault disconnected mid-sync",
+		// Disconnected or reconfigured mid-sync: drop this snapshot so it can't
+		// clobber the current credentials. Not a failure.
+		s.logger.Info("infisical sync skipped: vault changed mid-sync",
 			slog.String("vault_id", cs.VaultID))
 		return nil
 	}

--- a/internal/infisical/sync.go
+++ b/internal/infisical/sync.go
@@ -187,9 +187,8 @@ func (s *Syncer) refresh(ctx context.Context, cs store.VaultCredentialStore) err
 		return err
 	}
 	if !applied {
-		// The vault was disconnected (DeleteVaultCredentialStore) between the
-		// list scan and this write; the snapshot is dropped on purpose so the
-		// kept built-in credentials survive. Not a failure.
+		// Disconnected mid-sync: drop the snapshot so the kept credentials
+		// survive. Not a failure.
 		s.logger.Info("infisical sync skipped: vault disconnected mid-sync",
 			slog.String("vault_id", cs.VaultID))
 		return nil

--- a/internal/infisical/sync_test.go
+++ b/internal/infisical/sync_test.go
@@ -66,16 +66,16 @@ func (f *fakeStore) ListVaultCredentialStores(_ context.Context) ([]store.VaultC
 	return out, nil
 }
 
-func (f *fakeStore) ReplaceVaultCredentialsForSync(_ context.Context, vaultID string, items []store.EncryptedKV) (bool, error) {
+func (f *fakeStore) ReplaceVaultCredentialsForSync(_ context.Context, vaultID, configJSON string, items []store.EncryptedKV) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.repErr != nil {
 		return false, f.repErr
 	}
-	// Mirror the store: a write only lands while the credential-store row exists.
+	// Mirror the store: a write only lands while a row with the same config exists.
 	found := false
 	for i := range f.rows {
-		if f.rows[i].VaultID == vaultID {
+		if f.rows[i].VaultID == vaultID && f.rows[i].ConfigJSON == configJSON {
 			found = true
 			break
 		}

--- a/internal/infisical/sync_test.go
+++ b/internal/infisical/sync_test.go
@@ -40,7 +40,7 @@ func (f *fakeFetcher) AuthMethod() AuthMethod { return AuthUniversal }
 type fakeStore struct {
 	mu        sync.Mutex
 	rows      []store.VaultCredentialStore
-	replaceCh chan map[string][]store.EncryptedKV // capture each ReplaceVaultCredentials per vault
+	replaceCh chan map[string][]store.EncryptedKV // capture each credential write per vault
 	health    map[string]healthRow
 	repErr    error
 }
@@ -66,14 +66,25 @@ func (f *fakeStore) ListVaultCredentialStores(_ context.Context) ([]store.VaultC
 	return out, nil
 }
 
-func (f *fakeStore) ReplaceVaultCredentials(_ context.Context, vaultID string, items []store.EncryptedKV) error {
+func (f *fakeStore) ReplaceVaultCredentialsForSync(_ context.Context, vaultID string, items []store.EncryptedKV) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.repErr != nil {
-		return f.repErr
+		return false, f.repErr
+	}
+	// Mirror the store: a write only lands while the credential-store row exists.
+	found := false
+	for i := range f.rows {
+		if f.rows[i].VaultID == vaultID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return false, nil
 	}
 	f.replaceCh <- map[string][]store.EncryptedKV{vaultID: append([]store.EncryptedKV(nil), items...)}
-	return nil
+	return true, nil
 }
 
 func (f *fakeStore) UpdateVaultCredentialStoreHealth(_ context.Context, vaultID, status, errMsg string, when time.Time) error {
@@ -156,6 +167,39 @@ func TestSyncerRefresh_SuccessReplacesCredentials(t *testing.T) {
 	}
 	if h := fs.getHealth("v1"); h.Status != "ok" || h.Error != "" {
 		t.Fatalf("expected ok health, got %+v", h)
+	}
+}
+
+// A refresh whose vault was disconnected (row removed) between the list scan
+// and the write must drop the snapshot, leaving the kept credentials and the
+// health row untouched — not record a failure.
+func TestSyncerRefresh_DisconnectedMidSyncSkipsWrite(t *testing.T) {
+	dek := makeDEK(t)
+	pastSynced := time.Now().Add(-time.Hour)
+	cs := store.VaultCredentialStore{
+		VaultID:             "v1",
+		Kind:                store.CredentialStoreInfisical,
+		ConfigJSON:          `{"project_id":"p","environment":"dev","secret_path":"/"}`,
+		PollIntervalSeconds: 60,
+		LastSyncedAt:        &pastSynced,
+		LastSyncStatus:      "ok",
+	}
+	// Empty store: the row is already gone, mimicking a disconnect that won the
+	// race after the syncer captured `cs`.
+	fs := newFakeStore()
+	ff := &fakeFetcher{secrets: []Secret{{Key: "ALPHA", Value: "a"}}}
+	s := &Syncer{store: fs, fetcher: ff, dek: dek, logger: newDiscardLogger(), clock: time.Now, inFlight: map[string]struct{}{}}
+
+	if err := s.refresh(context.Background(), cs); err != nil {
+		t.Fatalf("refresh should be a clean no-op, got %v", err)
+	}
+	select {
+	case got := <-fs.replaceCh:
+		t.Fatalf("expected no credential write after disconnect, got %+v", got)
+	default:
+	}
+	if h := fs.getHealth("v1"); h.Status != "" {
+		t.Fatalf("expected no health update after disconnect, got %+v", h)
 	}
 }
 

--- a/internal/server/handle_vaults.go
+++ b/internal/server/handle_vaults.go
@@ -535,29 +535,37 @@ func (s *Server) handleVaultCreate(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// createExternalVault validates + probes + commits the vault,
-// credential-store row, initial snapshot, and admin grant in one
-// transaction. Any failure leaves the DB untouched.
-func (s *Server) createExternalVault(w http.ResponseWriter, ctx context.Context, actor *Actor, req vaultCreateRequest) {
+// infisicalSnapshot is the validated, probed, and encrypted state needed to
+// back a vault with Infisical — shared by the create and switch paths.
+type infisicalSnapshot struct {
+	ConfigJSON          string
+	PollIntervalSeconds int
+	Credentials         []store.EncryptedKV
+}
+
+// prepareInfisicalSnapshot validates the requested config, probes Infisical to
+// catch auth/topology errors early, and encrypts the fetched secrets. On any
+// failure it writes the appropriate HTTP error response and returns ok=false;
+// callers should return immediately. logName is used only for log context.
+func (s *Server) prepareInfisicalSnapshot(w http.ResponseWriter, ctx context.Context, logName string, cs *vaultCreateCredentialStoreRequest) (infisicalSnapshot, bool) {
 	if s.infisicalClient == nil {
 		jsonCodedError(w, http.StatusServiceUnavailable, "infisical_not_configured",
 			"Infisical is not configured on this Agent Vault instance. Set INFISICAL_URL and a supported auth method's env vars.")
-		return
+		return infisicalSnapshot{}, false
 	}
-	cs := req.CredentialStore
 	if cs.Kind != store.CredentialStoreInfisical {
 		jsonError(w, http.StatusBadRequest, fmt.Sprintf("Unknown credential store kind %q", cs.Kind))
-		return
+		return infisicalSnapshot{}, false
 	}
 
 	cfg, err := infisical.ParseConfigJSON(string(cs.Config))
 	if err != nil {
 		jsonError(w, http.StatusBadRequest, "Invalid credential_store.config JSON")
-		return
+		return infisicalSnapshot{}, false
 	}
 	if err := cfg.Validate(); err != nil {
 		jsonError(w, http.StatusBadRequest, err.Error())
-		return
+		return infisicalSnapshot{}, false
 	}
 
 	pollInterval := cs.PollIntervalSeconds
@@ -565,41 +573,53 @@ func (s *Server) createExternalVault(w http.ResponseWriter, ctx context.Context,
 		pollInterval = infisical.DefaultPollIntervalSeconds
 	} else if pollInterval < infisical.MinPollIntervalSeconds {
 		jsonError(w, http.StatusBadRequest, fmt.Sprintf("poll_interval_seconds must be at least %d", infisical.MinPollIntervalSeconds))
-		return
+		return infisicalSnapshot{}, false
 	}
 
 	secs, err := s.infisicalClient.FetchSecrets(ctx, cfg)
 	if err != nil {
 		// SDK error embeds INFISICAL_URL + upstream rejection body; scrub it.
-		s.logger.Warn("infisical fetch failed during vault create",
-			slog.String("vault_name", req.Name),
+		s.logger.Warn("infisical fetch failed",
+			slog.String("vault", logName),
 			slog.String("err", err.Error()))
 		jsonCodedError(w, http.StatusBadGateway, "infisical_fetch_failed",
 			"Failed to fetch secrets from Infisical. See server logs for details.")
-		return
+		return infisicalSnapshot{}, false
 	}
 
 	items, err := infisical.EncryptSecrets(secs, s.encKey)
 	if err != nil {
 		if errors.Is(err, infisical.ErrInvalidKey) {
 			jsonCodedError(w, http.StatusBadRequest, "external_store_invalid_key", err.Error())
-			return
+			return infisicalSnapshot{}, false
 		}
 		jsonError(w, http.StatusInternalServerError, "Failed to encrypt fetched secrets")
-		return
+		return infisicalSnapshot{}, false
 	}
 
 	configJSON, err := infisical.MarshalConfigJSON(cfg)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to marshal credential store config")
+		return infisicalSnapshot{}, false
+	}
+	return infisicalSnapshot{ConfigJSON: configJSON, PollIntervalSeconds: pollInterval, Credentials: items}, true
+}
+
+// createExternalVault validates + probes + commits the vault,
+// credential-store row, initial snapshot, and admin grant in one
+// transaction. Any failure leaves the DB untouched.
+func (s *Server) createExternalVault(w http.ResponseWriter, ctx context.Context, actor *Actor, req vaultCreateRequest) {
+	snap, ok := s.prepareInfisicalSnapshot(w, ctx, req.Name, req.CredentialStore)
+	if !ok {
 		return
 	}
+
 	vault, err := s.store.CreateExternalVault(ctx, store.CreateExternalVaultParams{
 		Name:                req.Name,
 		Kind:                store.CredentialStoreInfisical,
-		ConfigJSON:          configJSON,
-		PollIntervalSeconds: pollInterval,
-		Credentials:         items,
+		ConfigJSON:          snap.ConfigJSON,
+		PollIntervalSeconds: snap.PollIntervalSeconds,
+		Credentials:         snap.Credentials,
 		CreatorActorID:      actor.ID,
 		CreatorActorType:    actor.Type,
 	})
@@ -619,12 +639,67 @@ func (s *Server) createExternalVault(w http.ResponseWriter, ctx context.Context,
 		"created_at": now.Format(time.RFC3339),
 		"credential_store": &credentialStoreSummary{
 			Kind:                store.CredentialStoreInfisical,
-			Config:              json.RawMessage(configJSON),
-			PollIntervalSeconds: pollInterval,
+			Config:              json.RawMessage(snap.ConfigJSON),
+			PollIntervalSeconds: snap.PollIntervalSeconds,
 			LastSyncStatus:      store.SyncStatusOK,
 			LastSyncedAt:        now.Format(time.RFC3339),
 		},
 	})
+}
+
+// handleVaultCredentialStorePatch switches the credential store backing an
+// existing vault (vault admin or instance owner). Switching to "infisical"
+// probes + fetches the upstream snapshot and OVERWRITES the vault's built-in
+// credentials. Switching to "builtin" disconnects the external store (polling
+// stops) but KEEPS the last synced credentials in place as built-in credentials.
+func (s *Server) handleVaultCredentialStorePatch(w http.ResponseWriter, r *http.Request) {
+	ns := s.resolveVaultForAdminOrOwner(w, r, r.PathValue("name"))
+	if ns == nil {
+		return
+	}
+	ctx := r.Context()
+
+	// The patch body has the same shape as the create credential_store block.
+	var req vaultCreateCredentialStoreRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	switch req.Kind {
+	case store.CredentialStoreBuiltin:
+		// Disconnect: drop the external-store row so polling stops; the last
+		// synced credentials remain as ordinary built-in credentials.
+		if err := s.store.DeleteVaultCredentialStore(ctx, ns.ID); err != nil {
+			jsonError(w, http.StatusInternalServerError, "Failed to switch credential store")
+			return
+		}
+		jsonOK(w, map[string]interface{}{
+			"credential_store": &credentialStoreSummary{Kind: store.CredentialStoreBuiltin},
+		})
+	case store.CredentialStoreInfisical:
+		// Connect: probe upstream, then overwrite the vault's credentials with
+		// the fetched snapshot and start polling.
+		snap, ok := s.prepareInfisicalSnapshot(w, ctx, ns.Name, &req)
+		if !ok {
+			return
+		}
+		cs, err := s.store.SetVaultExternalStore(ctx, store.SetVaultExternalStoreParams{
+			VaultID:             ns.ID,
+			Kind:                store.CredentialStoreInfisical,
+			ConfigJSON:          snap.ConfigJSON,
+			PollIntervalSeconds: snap.PollIntervalSeconds,
+			Credentials:         snap.Credentials,
+		})
+		if err != nil {
+			jsonError(w, http.StatusInternalServerError, "Failed to switch credential store")
+			return
+		}
+		// Caller is admin/owner (gated above), so full detail is permitted.
+		jsonOK(w, map[string]interface{}{"credential_store": credentialStoreDetailSummary(cs)})
+	default:
+		jsonError(w, http.StatusBadRequest, fmt.Sprintf("Unknown credential store kind %q (expected %q or %q)", req.Kind, store.CredentialStoreBuiltin, store.CredentialStoreInfisical))
+	}
 }
 
 func (s *Server) handleVaultList(w http.ResponseWriter, r *http.Request) {
@@ -835,7 +910,13 @@ func (s *Server) handleVaultSettingsGet(w http.ResponseWriter, r *http.Request) 
 		jsonError(w, http.StatusInternalServerError, "Failed to read vault settings")
 		return
 	}
-	jsonOK(w, map[string]interface{}{"unmatched_host_policy": string(policy)})
+	// infisical_available lets the settings UI enable the Infisical option in
+	// the credential-store switcher for vault admins (the instance-scoped
+	// /v1/instance/credential-stores endpoint only reports it to owners).
+	jsonOK(w, map[string]interface{}{
+		"unmatched_host_policy": string(policy),
+		"infisical_available":   s.infisicalClient != nil,
+	})
 }
 
 func (s *Server) handleVaultSettingsPatch(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handle_vaults.go
+++ b/internal/server/handle_vaults.go
@@ -648,10 +648,10 @@ func (s *Server) createExternalVault(w http.ResponseWriter, ctx context.Context,
 }
 
 // handleVaultCredentialStorePatch switches the credential store backing an
-// existing vault (vault admin or instance owner). Switching to "infisical"
-// probes + fetches the upstream snapshot and OVERWRITES the vault's built-in
-// credentials. Switching to "builtin" disconnects the external store (polling
-// stops) but KEEPS the last synced credentials in place as built-in credentials.
+// existing vault. Switching to "infisical" (owner-only) probes + fetches the
+// upstream snapshot and OVERWRITES the vault's built-in credentials. Switching
+// to "builtin" (vault admin or owner) disconnects the external store; polling
+// stops but the last synced credentials are KEPT as built-in credentials.
 func (s *Server) handleVaultCredentialStorePatch(w http.ResponseWriter, r *http.Request) {
 	ns := s.resolveVaultForAdminOrOwner(w, r, r.PathValue("name"))
 	if ns == nil {
@@ -678,11 +678,9 @@ func (s *Server) handleVaultCredentialStorePatch(w http.ResponseWriter, r *http.
 			"credential_store": &credentialStoreSummary{Kind: store.CredentialStoreBuiltin},
 		})
 	case store.CredentialStoreInfisical:
-		// Connect: probe upstream, then overwrite the vault's credentials with
-		// the fetched snapshot and start polling. Owner-only, mirroring
-		// handleVaultCreate — otherwise a vault admin could use the broker's
-		// machine identity to exfiltrate upstream secrets into a vault they
-		// control.
+		// Owner-only, mirroring handleVaultCreate: otherwise a vault admin could
+		// use the broker's machine identity to fetch upstream secrets into a
+		// vault they control.
 		actor, err := s.requireActor(w, r)
 		if err != nil {
 			return

--- a/internal/server/handle_vaults.go
+++ b/internal/server/handle_vaults.go
@@ -679,7 +679,18 @@ func (s *Server) handleVaultCredentialStorePatch(w http.ResponseWriter, r *http.
 		})
 	case store.CredentialStoreInfisical:
 		// Connect: probe upstream, then overwrite the vault's credentials with
-		// the fetched snapshot and start polling.
+		// the fetched snapshot and start polling. Owner-only, mirroring
+		// handleVaultCreate — otherwise a vault admin could use the broker's
+		// machine identity to exfiltrate upstream secrets into a vault they
+		// control.
+		actor, err := s.requireActor(w, r)
+		if err != nil {
+			return
+		}
+		if !actor.IsOwner() {
+			jsonError(w, http.StatusForbidden, "Owner role required to connect a vault to an external store")
+			return
+		}
 		snap, ok := s.prepareInfisicalSnapshot(w, ctx, ns.Name, &req)
 		if !ok {
 			return
@@ -902,7 +913,8 @@ func (s *Server) handleVaultSettingsGet(w http.ResponseWriter, r *http.Request) 
 		jsonError(w, http.StatusNotFound, "Vault not found")
 		return
 	}
-	if _, err := s.requireVaultAccess(w, r, ns.ID); err != nil {
+	actor, err := s.requireVaultAccess(w, r, ns.ID)
+	if err != nil {
 		return
 	}
 	policy, err := readUnmatchedHostPolicy(ctx, s.store, ns.ID)
@@ -910,12 +922,13 @@ func (s *Server) handleVaultSettingsGet(w http.ResponseWriter, r *http.Request) 
 		jsonError(w, http.StatusInternalServerError, "Failed to read vault settings")
 		return
 	}
-	// infisical_available lets the settings UI enable the Infisical option in
-	// the credential-store switcher for vault admins (the instance-scoped
-	// /v1/instance/credential-stores endpoint only reports it to owners).
+	// infisical_available enables the Infisical option in the credential-store
+	// switcher. Only owners can connect a vault to Infisical (see
+	// handleVaultCredentialStorePatch), so report it owner-gated — otherwise a
+	// non-owner admin would see an option that 403s on submit.
 	jsonOK(w, map[string]interface{}{
 		"unmatched_host_policy": string(policy),
-		"infisical_available":   s.infisicalClient != nil,
+		"infisical_available":   s.infisicalClient != nil && actor != nil && actor.IsOwner(),
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -296,6 +296,8 @@ type Store interface {
 	ListVaultCredentialStores(ctx context.Context) ([]store.VaultCredentialStore, error)
 	UpdateVaultCredentialStoreHealth(ctx context.Context, vaultID, status, errMsg string, syncedAt time.Time) error
 	ReplaceVaultCredentials(ctx context.Context, vaultID string, items []store.EncryptedKV) error
+	SetVaultExternalStore(ctx context.Context, p store.SetVaultExternalStoreParams) (*store.VaultCredentialStore, error)
+	DeleteVaultCredentialStore(ctx context.Context, vaultID string) error
 
 	// Agents
 	CreateAgent(ctx context.Context, name, createdBy, role string) (*store.Agent, error)
@@ -799,6 +801,7 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("POST /v1/vaults/{name}/join", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultJoin)))))
 	mux.HandleFunc("GET /v1/vaults/{name}/settings", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultSettingsGet))))
 	mux.HandleFunc("PATCH /v1/vaults/{name}/settings", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultSettingsPatch)))))
+	mux.HandleFunc("PATCH /v1/vaults/{name}/credential-store", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultCredentialStorePatch)))))
 
 	// Vault admin (owner-only)
 	mux.HandleFunc("GET /v1/admin/vaults", s.requireInitialized(s.requireAuth(actorAuthed(s.handleAdminVaultList))))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -296,6 +296,7 @@ type Store interface {
 	ListVaultCredentialStores(ctx context.Context) ([]store.VaultCredentialStore, error)
 	UpdateVaultCredentialStoreHealth(ctx context.Context, vaultID, status, errMsg string, syncedAt time.Time) error
 	ReplaceVaultCredentials(ctx context.Context, vaultID string, items []store.EncryptedKV) error
+	ReplaceVaultCredentialsForSync(ctx context.Context, vaultID string, items []store.EncryptedKV) (applied bool, err error)
 	SetVaultExternalStore(ctx context.Context, p store.SetVaultExternalStoreParams) (*store.VaultCredentialStore, error)
 	DeleteVaultCredentialStore(ctx context.Context, vaultID string) error
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -295,7 +295,7 @@ type Store interface {
 	GetVaultCredentialStore(ctx context.Context, vaultID string) (*store.VaultCredentialStore, error)
 	ListVaultCredentialStores(ctx context.Context) ([]store.VaultCredentialStore, error)
 	UpdateVaultCredentialStoreHealth(ctx context.Context, vaultID, status, errMsg string, syncedAt time.Time) error
-	ReplaceVaultCredentialsForSync(ctx context.Context, vaultID string, items []store.EncryptedKV) (applied bool, err error)
+	ReplaceVaultCredentialsForSync(ctx context.Context, vaultID, configJSON string, items []store.EncryptedKV) (applied bool, err error)
 	SetVaultExternalStore(ctx context.Context, p store.SetVaultExternalStoreParams) (*store.VaultCredentialStore, error)
 	DeleteVaultCredentialStore(ctx context.Context, vaultID string) error
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -295,7 +295,6 @@ type Store interface {
 	GetVaultCredentialStore(ctx context.Context, vaultID string) (*store.VaultCredentialStore, error)
 	ListVaultCredentialStores(ctx context.Context) ([]store.VaultCredentialStore, error)
 	UpdateVaultCredentialStoreHealth(ctx context.Context, vaultID, status, errMsg string, syncedAt time.Time) error
-	ReplaceVaultCredentials(ctx context.Context, vaultID string, items []store.EncryptedKV) error
 	ReplaceVaultCredentialsForSync(ctx context.Context, vaultID string, items []store.EncryptedKV) (applied bool, err error)
 	SetVaultExternalStore(ctx context.Context, p store.SetVaultExternalStoreParams) (*store.VaultCredentialStore, error)
 	DeleteVaultCredentialStore(ctx context.Context, vaultID string) error

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1148,9 +1148,6 @@ func (m *mockStore) UpdateVaultCredentialStoreHealth(_ context.Context, vaultID,
 	cs.LastSyncedAt = &t
 	return nil
 }
-func (m *mockStore) ReplaceVaultCredentials(_ context.Context, _ string, _ []store.EncryptedKV) error {
-	return nil
-}
 func (m *mockStore) ReplaceVaultCredentialsForSync(_ context.Context, _ string, _ []store.EncryptedKV) (bool, error) {
 	return true, nil
 }
@@ -3315,12 +3312,9 @@ func TestVaultCredentialStoreSwitchToInfisicalNoClient(t *testing.T) {
 	}
 }
 
-// Connecting a vault to Infisical is owner-only, mirroring vault create: a
-// vault admin who is not the instance owner must be rejected, otherwise they
-// could use the broker's machine identity to import arbitrary upstream secrets
-// into a vault they control (the gate handleVaultCreate enforces). The
-// Infisical client is attached so this proves the owner gate fires, not the
-// no-client 503.
+// Connecting to Infisical is owner-only, mirroring vault create. A non-owner
+// vault admin must be rejected. The client is attached so this proves the owner
+// gate fires (403), not the no-client 503.
 func TestVaultCredentialStoreSwitchToInfisicalRequiresOwner(t *testing.T) {
 	ms, _ := setupMockStoreWithSession(t)
 	adminToken := setupMemberSession(t, ms, "root-ns-id")

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1151,6 +1151,21 @@ func (m *mockStore) UpdateVaultCredentialStoreHealth(_ context.Context, vaultID,
 func (m *mockStore) ReplaceVaultCredentials(_ context.Context, _ string, _ []store.EncryptedKV) error {
 	return nil
 }
+func (m *mockStore) SetVaultExternalStore(_ context.Context, p store.SetVaultExternalStoreParams) (*store.VaultCredentialStore, error) {
+	cs := &store.VaultCredentialStore{
+		VaultID:             p.VaultID,
+		Kind:                p.Kind,
+		ConfigJSON:          p.ConfigJSON,
+		PollIntervalSeconds: p.PollIntervalSeconds,
+		LastSyncStatus:      store.SyncStatusOK,
+	}
+	m.credStores[p.VaultID] = cs
+	return cs, nil
+}
+func (m *mockStore) DeleteVaultCredentialStore(_ context.Context, vaultID string) error {
+	delete(m.credStores, vaultID)
+	return nil
+}
 
 func (m *mockStore) GetCredentialOAuth(_ context.Context, _, _ string) (*store.CredentialOAuth, error) {
 	return nil, nil
@@ -3221,6 +3236,79 @@ func TestVaultCreateExternalRequiresOwner(t *testing.T) {
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("expected 403 for member, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func patchCredentialStore(t *testing.T, srv *Server, token, vault, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPatch, "/v1/vaults/"+vault+"/credential-store", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// Switching an external vault to built-in drops the credential-store row so
+// polling stops; the synced credentials are left behind (kept by the store).
+func TestVaultCredentialStoreSwitchToBuiltin(t *testing.T) {
+	ms, ownerToken := setupMockStoreWithSession(t)
+	ms.credStores["root-ns-id"] = &store.VaultCredentialStore{
+		VaultID: "root-ns-id", Kind: "infisical",
+		ConfigJSON: `{"project_id":"p","environment":"dev","secret_path":"/"}`,
+	}
+	srv := newTestServer(withStore(ms))
+
+	rec := patchCredentialStore(t, srv, ownerToken, "default", `{"kind":"builtin"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if _, ok := ms.credStores["root-ns-id"]; ok {
+		t.Fatalf("expected credential-store row removed after switch to builtin")
+	}
+	var resp struct {
+		CredentialStore map[string]interface{} `json:"credential_store"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.CredentialStore["kind"] != store.CredentialStoreBuiltin {
+		t.Fatalf("want kind builtin, got %v", resp.CredentialStore)
+	}
+}
+
+// Only vault admins / instance owners may switch the store.
+func TestVaultCredentialStoreSwitchRequiresAdminOrOwner(t *testing.T) {
+	ms, _ := setupMockStoreWithSession(t)
+	memberToken := setupMemberSession(t, ms, "root-ns-id")
+	srv := newTestServer(withStore(ms))
+
+	rec := patchCredentialStore(t, srv, memberToken, "default", `{"kind":"builtin"}`)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin member, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestVaultCredentialStoreSwitchInvalidKind(t *testing.T) {
+	ms, ownerToken := setupMockStoreWithSession(t)
+	srv := newTestServer(withStore(ms))
+
+	rec := patchCredentialStore(t, srv, ownerToken, "default", `{"kind":"bogus"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown kind, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Switching to Infisical when the server has no Infisical client must 503,
+// mirroring the create gate.
+func TestVaultCredentialStoreSwitchToInfisicalNoClient(t *testing.T) {
+	ms, ownerToken := setupMockStoreWithSession(t)
+	srv := newTestServer(withStore(ms)) // no AttachInfisical → infisicalClient nil
+
+	body := `{"kind":"infisical","config":{"project_id":"p","environment":"dev","secret_path":"/"},"poll_interval_seconds":60}`
+	rec := patchCredentialStore(t, srv, ownerToken, "default", body)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 without infisical client, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1148,7 +1148,7 @@ func (m *mockStore) UpdateVaultCredentialStoreHealth(_ context.Context, vaultID,
 	cs.LastSyncedAt = &t
 	return nil
 }
-func (m *mockStore) ReplaceVaultCredentialsForSync(_ context.Context, _ string, _ []store.EncryptedKV) (bool, error) {
+func (m *mockStore) ReplaceVaultCredentialsForSync(_ context.Context, _, _ string, _ []store.EncryptedKV) (bool, error) {
 	return true, nil
 }
 func (m *mockStore) SetVaultExternalStore(_ context.Context, p store.SetVaultExternalStoreParams) (*store.VaultCredentialStore, error) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1151,6 +1151,9 @@ func (m *mockStore) UpdateVaultCredentialStoreHealth(_ context.Context, vaultID,
 func (m *mockStore) ReplaceVaultCredentials(_ context.Context, _ string, _ []store.EncryptedKV) error {
 	return nil
 }
+func (m *mockStore) ReplaceVaultCredentialsForSync(_ context.Context, _ string, _ []store.EncryptedKV) (bool, error) {
+	return true, nil
+}
 func (m *mockStore) SetVaultExternalStore(_ context.Context, p store.SetVaultExternalStoreParams) (*store.VaultCredentialStore, error) {
 	cs := &store.VaultCredentialStore{
 		VaultID:             p.VaultID,
@@ -3309,6 +3312,81 @@ func TestVaultCredentialStoreSwitchToInfisicalNoClient(t *testing.T) {
 	rec := patchCredentialStore(t, srv, ownerToken, "default", body)
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503 without infisical client, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Connecting a vault to Infisical is owner-only, mirroring vault create: a
+// vault admin who is not the instance owner must be rejected, otherwise they
+// could use the broker's machine identity to import arbitrary upstream secrets
+// into a vault they control (the gate handleVaultCreate enforces). The
+// Infisical client is attached so this proves the owner gate fires, not the
+// no-client 503.
+func TestVaultCredentialStoreSwitchToInfisicalRequiresOwner(t *testing.T) {
+	ms, _ := setupMockStoreWithSession(t)
+	adminToken := setupMemberSession(t, ms, "root-ns-id")
+	// Promote to vault admin while leaving the instance role at "member".
+	ms.GrantVaultRole(context.Background(), "member-user-id", "user", "root-ns-id", "admin")
+	srv := newTestServer(withStore(ms))
+	srv.AttachInfisical(&infisical.Client{})
+
+	body := `{"kind":"infisical","config":{"project_id":"p","environment":"dev","secret_path":"/"},"poll_interval_seconds":60}`
+	rec := patchCredentialStore(t, srv, adminToken, "default", body)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-owner vault admin, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Disconnecting (switch to builtin) stays allowed for a non-owner vault admin —
+// only the connect path is owner-gated.
+func TestVaultCredentialStoreSwitchToBuiltinAllowsAdmin(t *testing.T) {
+	ms, _ := setupMockStoreWithSession(t)
+	adminToken := setupMemberSession(t, ms, "root-ns-id")
+	ms.GrantVaultRole(context.Background(), "member-user-id", "user", "root-ns-id", "admin")
+	ms.credStores["root-ns-id"] = &store.VaultCredentialStore{
+		VaultID: "root-ns-id", Kind: "infisical",
+		ConfigJSON: `{"project_id":"p","environment":"dev","secret_path":"/"}`,
+	}
+	srv := newTestServer(withStore(ms))
+
+	rec := patchCredentialStore(t, srv, adminToken, "default", `{"kind":"builtin"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for non-owner admin disconnect, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// infisical_available drives the Infisical option in the credential-store
+// switcher. Since connecting is owner-only, it must be reported owner-gated:
+// true for an owner, false for a non-owner vault admin, even with a client.
+func TestVaultSettingsInfisicalAvailableOwnerGated(t *testing.T) {
+	settingsAvailable := func(t *testing.T, srv *Server, token string) bool {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/v1/vaults/default/settings", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		srv.httpServer.Handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("settings GET: expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp struct {
+			InfisicalAvailable bool `json:"infisical_available"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return resp.InfisicalAvailable
+	}
+
+	ms, ownerToken := setupMockStoreWithSession(t)
+	adminToken := setupMemberSession(t, ms, "root-ns-id")
+	ms.GrantVaultRole(context.Background(), "member-user-id", "user", "root-ns-id", "admin")
+	srv := newTestServer(withStore(ms))
+	srv.AttachInfisical(&infisical.Client{})
+
+	if !settingsAvailable(t, srv, ownerToken) {
+		t.Fatalf("expected infisical_available=true for owner")
+	}
+	if settingsAvailable(t, srv, adminToken) {
+		t.Fatalf("expected infisical_available=false for non-owner admin")
 	}
 }
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -330,27 +330,10 @@ func replaceCredentialsTx(ctx context.Context, tx *sql.Tx, vaultID, nowStr strin
 	return nil
 }
 
-// ReplaceVaultCredentials atomically wipes and rewrites the vault's credentials
-// in one transaction; empty items clears the vault.
-func (s *SQLiteStore) ReplaceVaultCredentials(ctx context.Context, vaultID string, items []EncryptedKV) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	if err := replaceCredentialsTx(ctx, tx, vaultID, nowUTC(), items); err != nil {
-		return err
-	}
-	return tx.Commit()
-}
-
-// ReplaceVaultCredentialsForSync is the syncer's write path. It rewrites the
-// vault's credentials only while the external-store row still exists, checking
-// and writing in one transaction. With a single DB connection that check+write
-// is atomic against DeleteVaultCredentialStore, so a disconnect racing an
-// in-flight sync can no longer have its "kept" snapshot clobbered after the row
-// is gone: a sync that loses the race reports applied=false and writes nothing.
+// ReplaceVaultCredentialsForSync is the syncer's write path: it rewrites the
+// vault's credentials in one transaction, but only while the external-store row
+// still exists. A sync that races a disconnect (the row is gone) reports
+// applied=false and writes nothing, leaving the kept credentials intact.
 func (s *SQLiteStore) ReplaceVaultCredentialsForSync(ctx context.Context, vaultID string, items []EncryptedKV) (applied bool, err error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -332,9 +332,11 @@ func replaceCredentialsTx(ctx context.Context, tx *sql.Tx, vaultID, nowStr strin
 
 // ReplaceVaultCredentialsForSync is the syncer's write path: it rewrites the
 // vault's credentials in one transaction, but only while the external-store row
-// still exists. A sync that races a disconnect (the row is gone) reports
-// applied=false and writes nothing, leaving the kept credentials intact.
-func (s *SQLiteStore) ReplaceVaultCredentialsForSync(ctx context.Context, vaultID string, items []EncryptedKV) (applied bool, err error) {
+// still matches the config the snapshot was fetched against. A sync that races
+// a disconnect (row gone) or a reconfigure (config_json changed) reports
+// applied=false and writes nothing, so a stale snapshot can never clobber the
+// credentials a switch just installed. configJSON is the fetched config.
+func (s *SQLiteStore) ReplaceVaultCredentialsForSync(ctx context.Context, vaultID, configJSON string, items []EncryptedKV) (applied bool, err error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return false, fmt.Errorf("begin tx: %w", err)
@@ -343,9 +345,9 @@ func (s *SQLiteStore) ReplaceVaultCredentialsForSync(ctx context.Context, vaultI
 
 	var dummy int
 	switch err := tx.QueryRowContext(ctx,
-		"SELECT 1 FROM vault_credential_stores WHERE vault_id = ?", vaultID).Scan(&dummy); {
+		"SELECT 1 FROM vault_credential_stores WHERE vault_id = ? AND config_json = ?", vaultID, configJSON).Scan(&dummy); {
 	case errors.Is(err, sql.ErrNoRows):
-		return false, nil // disconnected mid-sync; keep the existing credentials
+		return false, nil // disconnected or reconfigured mid-sync; keep current credentials
 	case err != nil:
 		return false, fmt.Errorf("checking credential store: %w", err)
 	}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -303,7 +303,8 @@ func (s *SQLiteStore) UpdateVaultCredentialStoreHealth(ctx context.Context, vaul
 
 // replaceCredentialsTx wipes and rewrites the vault's static credentials inside
 // an existing transaction; empty items just clears them. Shared by the
-// standalone replace and the external-store connect path.
+// standalone replace and the external-store connect path. Non-static (e.g.
+// oauth) credentials are deliberately left untouched.
 func replaceCredentialsTx(ctx context.Context, tx *sql.Tx, vaultID, nowStr string, items []EncryptedKV) error {
 	if _, err := tx.ExecContext(ctx, "DELETE FROM credentials WHERE vault_id = ? AND type = 'static'", vaultID); err != nil {
 		return fmt.Errorf("clearing credentials: %w", err)

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -301,38 +301,111 @@ func (s *SQLiteStore) UpdateVaultCredentialStoreHealth(ctx context.Context, vaul
 	return nil
 }
 
+// replaceCredentialsTx wipes and rewrites the vault's static credentials inside
+// an existing transaction; empty items just clears them. Shared by the
+// standalone replace and the external-store connect path.
+func replaceCredentialsTx(ctx context.Context, tx *sql.Tx, vaultID, nowStr string, items []EncryptedKV) error {
+	if _, err := tx.ExecContext(ctx, "DELETE FROM credentials WHERE vault_id = ? AND type = 'static'", vaultID); err != nil {
+		return fmt.Errorf("clearing credentials: %w", err)
+	}
+	if len(items) == 0 {
+		return nil
+	}
+	stmt, err := tx.PrepareContext(ctx,
+		`INSERT OR IGNORE INTO credentials (id, vault_id, key, type, ciphertext, nonce, created_at, updated_at)
+		   VALUES (?, ?, ?, 'static', ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("preparing credential insert: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+	for _, item := range items {
+		if _, err := stmt.ExecContext(ctx,
+			newUUID(), vaultID, item.Key, item.Ciphertext, item.Nonce, nowStr, nowStr,
+		); err != nil {
+			return fmt.Errorf("inserting credential %q: %w", item.Key, err)
+		}
+	}
+	return nil
+}
+
 // ReplaceVaultCredentials atomically wipes and rewrites the vault's credentials
 // in one transaction; empty items clears the vault.
 func (s *SQLiteStore) ReplaceVaultCredentials(ctx context.Context, vaultID string, items []EncryptedKV) error {
-	nowStr := nowUTC()
-
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if _, err := tx.ExecContext(ctx, "DELETE FROM credentials WHERE vault_id = ? AND type = 'static'", vaultID); err != nil {
-		return fmt.Errorf("clearing credentials: %w", err)
+	if err := replaceCredentialsTx(ctx, tx, vaultID, nowUTC(), items); err != nil {
+		return err
 	}
-	if len(items) > 0 {
-		stmt, err := tx.PrepareContext(ctx,
-			`INSERT OR IGNORE INTO credentials (id, vault_id, key, type, ciphertext, nonce, created_at, updated_at)
-			   VALUES (?, ?, ?, 'static', ?, ?, ?, ?)`)
-		if err != nil {
-			return fmt.Errorf("preparing credential insert: %w", err)
-		}
-		defer func() { _ = stmt.Close() }()
-		for _, item := range items {
-			if _, err := stmt.ExecContext(ctx,
-				newUUID(), vaultID, item.Key, item.Ciphertext, item.Nonce, nowStr, nowStr,
-			); err != nil {
-				return fmt.Errorf("inserting credential %q: %w", item.Key, err)
-			}
-		}
+	return tx.Commit()
+}
+
+// SetVaultExternalStore upserts the credential-store row and replaces the
+// vault's static credentials in one transaction — the connect path for an
+// existing built-in vault. The credential-store health is reset to a fresh
+// successful sync (the caller has just probed + fetched the snapshot). Returns
+// the resulting row so the caller can render it without a follow-up read.
+func (s *SQLiteStore) SetVaultExternalStore(ctx context.Context, p SetVaultExternalStoreParams) (*VaultCredentialStore, error) {
+	if p.VaultID == "" || p.Kind == "" || p.ConfigJSON == "" {
+		return nil, fmt.Errorf("SetVaultExternalStore: vault_id, kind, and config required")
+	}
+	now := time.Now().UTC()
+	nowStr := now.Format(time.DateTime)
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO vault_credential_stores
+		   (vault_id, kind, config_json, poll_interval_seconds, last_synced_at, last_sync_status, last_sync_error, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)
+		 ON CONFLICT(vault_id) DO UPDATE SET
+		   kind = excluded.kind,
+		   config_json = excluded.config_json,
+		   poll_interval_seconds = excluded.poll_interval_seconds,
+		   last_synced_at = excluded.last_synced_at,
+		   last_sync_status = excluded.last_sync_status,
+		   last_sync_error = NULL,
+		   updated_at = excluded.updated_at`,
+		p.VaultID, p.Kind, p.ConfigJSON, p.PollIntervalSeconds, nowStr, SyncStatusOK, nowStr, nowStr,
+	); err != nil {
+		return nil, fmt.Errorf("upserting credential store: %w", err)
 	}
 
-	return tx.Commit()
+	if err := replaceCredentialsTx(ctx, tx, p.VaultID, nowStr, p.Credentials); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+
+	return &VaultCredentialStore{
+		VaultID:             p.VaultID,
+		Kind:                p.Kind,
+		ConfigJSON:          p.ConfigJSON,
+		PollIntervalSeconds: p.PollIntervalSeconds,
+		LastSyncedAt:        &now,
+		LastSyncStatus:      SyncStatusOK,
+		UpdatedAt:           now,
+	}, nil
+}
+
+// DeleteVaultCredentialStore removes the external-store row so the syncer stops
+// polling the vault. The vault's credentials are intentionally left untouched —
+// the last synced snapshot becomes ordinary built-in credentials. Returns nil
+// when no row exists (the vault was already built-in).
+func (s *SQLiteStore) DeleteVaultCredentialStore(ctx context.Context, vaultID string) error {
+	if _, err := s.db.ExecContext(ctx,
+		`DELETE FROM vault_credential_stores WHERE vault_id = ?`, vaultID); err != nil {
+		return fmt.Errorf("deleting credential store: %w", err)
+	}
+	return nil
 }
 
 // rowScanner unifies *sql.Row and *sql.Rows so one scan func serves both.

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -342,6 +343,37 @@ func (s *SQLiteStore) ReplaceVaultCredentials(ctx context.Context, vaultID strin
 		return err
 	}
 	return tx.Commit()
+}
+
+// ReplaceVaultCredentialsForSync is the syncer's write path. It rewrites the
+// vault's credentials only while the external-store row still exists, checking
+// and writing in one transaction. With a single DB connection that check+write
+// is atomic against DeleteVaultCredentialStore, so a disconnect racing an
+// in-flight sync can no longer have its "kept" snapshot clobbered after the row
+// is gone: a sync that loses the race reports applied=false and writes nothing.
+func (s *SQLiteStore) ReplaceVaultCredentialsForSync(ctx context.Context, vaultID string, items []EncryptedKV) (applied bool, err error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var dummy int
+	switch err := tx.QueryRowContext(ctx,
+		"SELECT 1 FROM vault_credential_stores WHERE vault_id = ?", vaultID).Scan(&dummy); {
+	case errors.Is(err, sql.ErrNoRows):
+		return false, nil // disconnected mid-sync; keep the existing credentials
+	case err != nil:
+		return false, fmt.Errorf("checking credential store: %w", err)
+	}
+
+	if err := replaceCredentialsTx(ctx, tx, vaultID, nowUTC(), items); err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit: %w", err)
+	}
+	return true, nil
 }
 
 // SetVaultExternalStore upserts the credential-store row and replaces the

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -2321,7 +2321,7 @@ func TestReplaceVaultCredentialsForSyncRotates(t *testing.T) {
 	}
 
 	// Replace: keep A (rotated), drop B, add C.
-	applied, err := s.ReplaceVaultCredentialsForSync(ctx, v.ID, []EncryptedKV{
+	applied, err := s.ReplaceVaultCredentialsForSync(ctx, v.ID, `{}`, []EncryptedKV{
 		{Key: "A", Ciphertext: []byte("c1-new"), Nonce: []byte("n1-new")},
 		{Key: "C", Ciphertext: []byte("c3"), Nonce: []byte("n3")},
 	})
@@ -2363,7 +2363,7 @@ func TestReplaceVaultCredentialsForSyncEmptyWipes(t *testing.T) {
 		CreatorActorType:    "user",
 	})
 
-	if applied, err := s.ReplaceVaultCredentialsForSync(ctx, v.ID, nil); err != nil || !applied {
+	if applied, err := s.ReplaceVaultCredentialsForSync(ctx, v.ID, `{}`, nil); err != nil || !applied {
 		t.Fatalf("ReplaceVaultCredentialsForSync nil: applied=%v err=%v", applied, err)
 	}
 	creds, _ := s.ListCredentials(ctx, v.ID)
@@ -2544,18 +2544,20 @@ func TestDeleteVaultCredentialStoreKeepsCredentials(t *testing.T) {
 	}
 }
 
-// ReplaceVaultCredentialsForSync only writes while the external-store row
-// exists. This closes the race where an in-flight sync would clobber the
-// credentials a concurrent disconnect is meant to preserve.
+// ReplaceVaultCredentialsForSync writes only while the row still matches the
+// config the snapshot was fetched against. This closes two races where an
+// in-flight sync would clobber credentials: a concurrent disconnect, and a
+// concurrent switch to a different Infisical config.
 func TestReplaceVaultCredentialsForSyncGatedOnStoreRow(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
+	const cfgA = `{"project_id":"a","environment":"dev","secret_path":"/"}`
 	u, _ := s.CreateUser(ctx, "sync@test.com", []byte("h"), []byte("s"), "owner", 3, 65536, 4)
 	v, err := s.CreateExternalVault(ctx, CreateExternalVaultParams{
 		Name:                "sync-race",
 		Kind:                CredentialStoreInfisical,
-		ConfigJSON:          `{}`,
+		ConfigJSON:          cfgA,
 		PollIntervalSeconds: 60,
 		Credentials:         []EncryptedKV{{Key: "KEPT", Ciphertext: []byte("c"), Nonce: []byte("n")}},
 		CreatorActorID:      u.ID,
@@ -2565,8 +2567,8 @@ func TestReplaceVaultCredentialsForSyncGatedOnStoreRow(t *testing.T) {
 		t.Fatalf("CreateExternalVault: %v", err)
 	}
 
-	// While the store row exists the sync write lands.
-	applied, err := s.ReplaceVaultCredentialsForSync(ctx, v.ID, []EncryptedKV{
+	// Same config → the sync write lands.
+	applied, err := s.ReplaceVaultCredentialsForSync(ctx, v.ID, cfgA, []EncryptedKV{
 		{Key: "FRESH", Ciphertext: []byte("c2"), Nonce: []byte("n2")},
 	})
 	if err != nil || !applied {
@@ -2577,13 +2579,37 @@ func TestReplaceVaultCredentialsForSyncGatedOnStoreRow(t *testing.T) {
 		t.Fatalf("expected FRESH after applied sync, got %+v", creds)
 	}
 
-	// Simulate a disconnect, then a still-in-flight sync write: it must be a
-	// no-op so the kept credentials survive.
+	// Reconfigure to a different config, then a still-in-flight sync against the
+	// OLD config: it must be a no-op so the switched-in credentials survive.
+	if _, err := s.SetVaultExternalStore(ctx, SetVaultExternalStoreParams{
+		VaultID:             v.ID,
+		Kind:                CredentialStoreInfisical,
+		ConfigJSON:          `{"project_id":"b","environment":"prod","secret_path":"/x"}`,
+		PollIntervalSeconds: 60,
+		Credentials:         []EncryptedKV{{Key: "SWITCHED", Ciphertext: []byte("c4"), Nonce: []byte("n4")}},
+	}); err != nil {
+		t.Fatalf("SetVaultExternalStore: %v", err)
+	}
+	applied, err = s.ReplaceVaultCredentialsForSync(ctx, v.ID, cfgA, []EncryptedKV{
+		{Key: "STALE", Ciphertext: []byte("c3"), Nonce: []byte("n3")},
+	})
+	if err != nil {
+		t.Fatalf("ReplaceVaultCredentialsForSync after reconfigure: %v", err)
+	}
+	if applied {
+		t.Fatalf("expected applied=false after reconfigure")
+	}
+	creds, _ = s.ListCredentials(ctx, v.ID)
+	if len(creds) != 1 || creds[0].Key != "SWITCHED" {
+		t.Fatalf("expected SWITCHED credentials preserved after reconfigure, got %+v", creds)
+	}
+
+	// Disconnect entirely, then a still-in-flight sync: also a no-op.
 	if err := s.DeleteVaultCredentialStore(ctx, v.ID); err != nil {
 		t.Fatalf("DeleteVaultCredentialStore: %v", err)
 	}
-	applied, err = s.ReplaceVaultCredentialsForSync(ctx, v.ID, []EncryptedKV{
-		{Key: "STALE", Ciphertext: []byte("c3"), Nonce: []byte("n3")},
+	applied, err = s.ReplaceVaultCredentialsForSync(ctx, v.ID, cfgA, []EncryptedKV{
+		{Key: "STALE2", Ciphertext: []byte("c5"), Nonce: []byte("n5")},
 	})
 	if err != nil {
 		t.Fatalf("ReplaceVaultCredentialsForSync after disconnect: %v", err)
@@ -2592,8 +2618,8 @@ func TestReplaceVaultCredentialsForSyncGatedOnStoreRow(t *testing.T) {
 		t.Fatalf("expected applied=false after disconnect")
 	}
 	creds, _ = s.ListCredentials(ctx, v.ID)
-	if len(creds) != 1 || creds[0].Key != "FRESH" {
-		t.Fatalf("expected FRESH credentials preserved after disconnect, got %+v", creds)
+	if len(creds) != 1 || creds[0].Key != "SWITCHED" {
+		t.Fatalf("expected SWITCHED credentials preserved after disconnect, got %+v", creds)
 	}
 }
 

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -2299,7 +2299,7 @@ func TestCascadeDeleteVaultRemovesCredentialStore(t *testing.T) {
 	}
 }
 
-func TestReplaceVaultCredentials(t *testing.T) {
+func TestReplaceVaultCredentialsForSyncRotates(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
@@ -2321,12 +2321,12 @@ func TestReplaceVaultCredentials(t *testing.T) {
 	}
 
 	// Replace: keep A (rotated), drop B, add C.
-	err = s.ReplaceVaultCredentials(ctx, v.ID, []EncryptedKV{
+	applied, err := s.ReplaceVaultCredentialsForSync(ctx, v.ID, []EncryptedKV{
 		{Key: "A", Ciphertext: []byte("c1-new"), Nonce: []byte("n1-new")},
 		{Key: "C", Ciphertext: []byte("c3"), Nonce: []byte("n3")},
 	})
-	if err != nil {
-		t.Fatalf("ReplaceVaultCredentials: %v", err)
+	if err != nil || !applied {
+		t.Fatalf("ReplaceVaultCredentialsForSync: applied=%v err=%v", applied, err)
 	}
 
 	creds, _ := s.ListCredentials(ctx, v.ID)
@@ -2348,7 +2348,7 @@ func TestReplaceVaultCredentials(t *testing.T) {
 	}
 }
 
-func TestReplaceVaultCredentialsEmptyWipes(t *testing.T) {
+func TestReplaceVaultCredentialsForSyncEmptyWipes(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
@@ -2363,8 +2363,8 @@ func TestReplaceVaultCredentialsEmptyWipes(t *testing.T) {
 		CreatorActorType:    "user",
 	})
 
-	if err := s.ReplaceVaultCredentials(ctx, v.ID, nil); err != nil {
-		t.Fatalf("ReplaceVaultCredentials nil: %v", err)
+	if applied, err := s.ReplaceVaultCredentialsForSync(ctx, v.ID, nil); err != nil || !applied {
+		t.Fatalf("ReplaceVaultCredentialsForSync nil: applied=%v err=%v", applied, err)
 	}
 	creds, _ := s.ListCredentials(ctx, v.ID)
 	if len(creds) != 0 {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -2544,6 +2544,59 @@ func TestDeleteVaultCredentialStoreKeepsCredentials(t *testing.T) {
 	}
 }
 
+// ReplaceVaultCredentialsForSync only writes while the external-store row
+// exists. This closes the race where an in-flight sync would clobber the
+// credentials a concurrent disconnect is meant to preserve.
+func TestReplaceVaultCredentialsForSyncGatedOnStoreRow(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	u, _ := s.CreateUser(ctx, "sync@test.com", []byte("h"), []byte("s"), "owner", 3, 65536, 4)
+	v, err := s.CreateExternalVault(ctx, CreateExternalVaultParams{
+		Name:                "sync-race",
+		Kind:                CredentialStoreInfisical,
+		ConfigJSON:          `{}`,
+		PollIntervalSeconds: 60,
+		Credentials:         []EncryptedKV{{Key: "KEPT", Ciphertext: []byte("c"), Nonce: []byte("n")}},
+		CreatorActorID:      u.ID,
+		CreatorActorType:    "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateExternalVault: %v", err)
+	}
+
+	// While the store row exists the sync write lands.
+	applied, err := s.ReplaceVaultCredentialsForSync(ctx, v.ID, []EncryptedKV{
+		{Key: "FRESH", Ciphertext: []byte("c2"), Nonce: []byte("n2")},
+	})
+	if err != nil || !applied {
+		t.Fatalf("expected applied write, got applied=%v err=%v", applied, err)
+	}
+	creds, _ := s.ListCredentials(ctx, v.ID)
+	if len(creds) != 1 || creds[0].Key != "FRESH" {
+		t.Fatalf("expected FRESH after applied sync, got %+v", creds)
+	}
+
+	// Simulate a disconnect, then a still-in-flight sync write: it must be a
+	// no-op so the kept credentials survive.
+	if err := s.DeleteVaultCredentialStore(ctx, v.ID); err != nil {
+		t.Fatalf("DeleteVaultCredentialStore: %v", err)
+	}
+	applied, err = s.ReplaceVaultCredentialsForSync(ctx, v.ID, []EncryptedKV{
+		{Key: "STALE", Ciphertext: []byte("c3"), Nonce: []byte("n3")},
+	})
+	if err != nil {
+		t.Fatalf("ReplaceVaultCredentialsForSync after disconnect: %v", err)
+	}
+	if applied {
+		t.Fatalf("expected applied=false after disconnect")
+	}
+	creds, _ = s.ListCredentials(ctx, v.ID)
+	if len(creds) != 1 || creds[0].Key != "FRESH" {
+		t.Fatalf("expected FRESH credentials preserved after disconnect, got %+v", creds)
+	}
+}
+
 func TestListUnmatchedHosts(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -2436,6 +2436,114 @@ func TestListVaultCredentialStoresFiltersBuiltin(t *testing.T) {
 	}
 }
 
+func TestSetVaultExternalStoreOverwritesBuiltin(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	v, err := s.CreateVault(ctx, "switch-up")
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+	// Seed built-in credentials that the connect should overwrite.
+	if _, err := s.SetCredential(ctx, v.ID, "OLD_KEY", []byte("c-old"), []byte("n-old")); err != nil {
+		t.Fatalf("SetCredential: %v", err)
+	}
+
+	cs, err := s.SetVaultExternalStore(ctx, SetVaultExternalStoreParams{
+		VaultID:             v.ID,
+		Kind:                CredentialStoreInfisical,
+		ConfigJSON:          `{"project_id":"p","environment":"dev","secret_path":"/"}`,
+		PollIntervalSeconds: 30,
+		Credentials: []EncryptedKV{
+			{Key: "NEW_KEY", Ciphertext: []byte("c-new"), Nonce: []byte("n-new")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SetVaultExternalStore: %v", err)
+	}
+	// The returned row reflects the write without a follow-up read.
+	if cs == nil || cs.Kind != CredentialStoreInfisical || cs.PollIntervalSeconds != 30 || cs.LastSyncStatus != SyncStatusOK {
+		t.Fatalf("unexpected returned row: %+v", cs)
+	}
+
+	cs, err = s.GetVaultCredentialStore(ctx, v.ID)
+	if err != nil || cs == nil {
+		t.Fatalf("GetVaultCredentialStore: %v cs=%+v", err, cs)
+	}
+	if cs.Kind != CredentialStoreInfisical || cs.PollIntervalSeconds != 30 || cs.LastSyncStatus != SyncStatusOK {
+		t.Fatalf("unexpected store row: %+v", cs)
+	}
+
+	creds, _ := s.ListCredentials(ctx, v.ID)
+	if len(creds) != 1 || creds[0].Key != "NEW_KEY" {
+		t.Fatalf("expected only NEW_KEY after overwrite, got %+v", creds)
+	}
+
+	// Calling again upserts the row (reconfigure) without duplicating.
+	if _, err = s.SetVaultExternalStore(ctx, SetVaultExternalStoreParams{
+		VaultID:             v.ID,
+		Kind:                CredentialStoreInfisical,
+		ConfigJSON:          `{"project_id":"p2","environment":"prod","secret_path":"/x"}`,
+		PollIntervalSeconds: 60,
+		Credentials:         []EncryptedKV{{Key: "K2", Ciphertext: []byte("c"), Nonce: []byte("n")}},
+	}); err != nil {
+		t.Fatalf("SetVaultExternalStore re-run: %v", err)
+	}
+	cs, _ = s.GetVaultCredentialStore(ctx, v.ID)
+	if cs.PollIntervalSeconds != 60 || cs.ConfigJSON != `{"project_id":"p2","environment":"prod","secret_path":"/x"}` {
+		t.Fatalf("upsert did not update row: %+v", cs)
+	}
+	list, _ := s.ListVaultCredentialStores(ctx)
+	if len(list) != 1 {
+		t.Fatalf("expected single store row after upsert, got %d", len(list))
+	}
+}
+
+func TestDeleteVaultCredentialStoreKeepsCredentials(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	u, _ := s.CreateUser(ctx, "disconnect@test.com", []byte("h"), []byte("s"), "owner", 3, 65536, 4)
+	v, err := s.CreateExternalVault(ctx, CreateExternalVaultParams{
+		Name:                "switch-down",
+		Kind:                CredentialStoreInfisical,
+		ConfigJSON:          `{}`,
+		PollIntervalSeconds: 60,
+		Credentials: []EncryptedKV{
+			{Key: "SYNCED_KEY", Ciphertext: []byte("c"), Nonce: []byte("n")},
+		},
+		CreatorActorID:   u.ID,
+		CreatorActorType: "user",
+	})
+	if err != nil {
+		t.Fatalf("CreateExternalVault: %v", err)
+	}
+
+	if err := s.DeleteVaultCredentialStore(ctx, v.ID); err != nil {
+		t.Fatalf("DeleteVaultCredentialStore: %v", err)
+	}
+
+	// Row is gone (vault is now built-in).
+	if _, err := s.GetVaultCredentialStore(ctx, v.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows after delete, got %v", err)
+	}
+	list, _ := s.ListVaultCredentialStores(ctx)
+	if len(list) != 0 {
+		t.Fatalf("expected no external stores, got %d", len(list))
+	}
+
+	// Credentials are kept as built-in credentials.
+	creds, _ := s.ListCredentials(ctx, v.ID)
+	if len(creds) != 1 || creds[0].Key != "SYNCED_KEY" {
+		t.Fatalf("expected SYNCED_KEY kept, got %+v", creds)
+	}
+
+	// Deleting again is a no-op (no row to remove).
+	if err := s.DeleteVaultCredentialStore(ctx, v.ID); err != nil {
+		t.Fatalf("DeleteVaultCredentialStore second call: %v", err)
+	}
+}
+
 func TestListUnmatchedHosts(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -560,8 +560,6 @@ type Store interface {
 	GetVaultCredentialStore(ctx context.Context, vaultID string) (*VaultCredentialStore, error)
 	ListVaultCredentialStores(ctx context.Context) ([]VaultCredentialStore, error)
 	UpdateVaultCredentialStoreHealth(ctx context.Context, vaultID, status, errMsg string, syncedAt time.Time) error
-	// ReplaceVaultCredentials atomically wipes and rewrites the vault's credentials.
-	ReplaceVaultCredentials(ctx context.Context, vaultID string, items []EncryptedKV) error
 	// ReplaceVaultCredentialsForSync rewrites credentials only while the
 	// external-store row still exists; applied=false means the vault was
 	// disconnected mid-sync and nothing was written.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -279,6 +279,16 @@ type CreateExternalVaultParams struct {
 	CreatorActorType    string // "user" or "agent"
 }
 
+// SetVaultExternalStoreParams carries inputs to SetVaultExternalStore, used to
+// connect an existing vault to an external store (built-in → external switch).
+type SetVaultExternalStoreParams struct {
+	VaultID             string
+	Kind                string
+	ConfigJSON          string
+	PollIntervalSeconds int
+	Credentials         []EncryptedKV
+}
+
 // RequestLog is a persisted record of a single proxied request. Secret-free
 // by construction: no header values, no bodies, no query strings — only
 // metadata already safe to log (see internal/brokercore/logging.go).
@@ -552,6 +562,14 @@ type Store interface {
 	UpdateVaultCredentialStoreHealth(ctx context.Context, vaultID, status, errMsg string, syncedAt time.Time) error
 	// ReplaceVaultCredentials atomically wipes and rewrites the vault's credentials.
 	ReplaceVaultCredentials(ctx context.Context, vaultID string, items []EncryptedKV) error
+	// SetVaultExternalStore connects an existing vault to an external store:
+	// it upserts the credential-store row and replaces the vault's credentials
+	// in one transaction (built-in → external switch), returning the new row.
+	SetVaultExternalStore(ctx context.Context, p SetVaultExternalStoreParams) (*VaultCredentialStore, error)
+	// DeleteVaultCredentialStore removes the external-store row so polling stops;
+	// the vault's already-synced credentials are left in place as built-in
+	// credentials (external → built-in switch).
+	DeleteVaultCredentialStore(ctx context.Context, vaultID string) error
 
 	// Request logs
 	InsertRequestLogs(ctx context.Context, rows []RequestLog) error

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -562,6 +562,10 @@ type Store interface {
 	UpdateVaultCredentialStoreHealth(ctx context.Context, vaultID, status, errMsg string, syncedAt time.Time) error
 	// ReplaceVaultCredentials atomically wipes and rewrites the vault's credentials.
 	ReplaceVaultCredentials(ctx context.Context, vaultID string, items []EncryptedKV) error
+	// ReplaceVaultCredentialsForSync rewrites credentials only while the
+	// external-store row still exists; applied=false means the vault was
+	// disconnected mid-sync and nothing was written.
+	ReplaceVaultCredentialsForSync(ctx context.Context, vaultID string, items []EncryptedKV) (applied bool, err error)
 	// SetVaultExternalStore connects an existing vault to an external store:
 	// it upserts the credential-store row and replaces the vault's credentials
 	// in one transaction (built-in → external switch), returning the new row.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -561,9 +561,9 @@ type Store interface {
 	ListVaultCredentialStores(ctx context.Context) ([]VaultCredentialStore, error)
 	UpdateVaultCredentialStoreHealth(ctx context.Context, vaultID, status, errMsg string, syncedAt time.Time) error
 	// ReplaceVaultCredentialsForSync rewrites credentials only while the
-	// external-store row still exists; applied=false means the vault was
-	// disconnected mid-sync and nothing was written.
-	ReplaceVaultCredentialsForSync(ctx context.Context, vaultID string, items []EncryptedKV) (applied bool, err error)
+	// external-store row still matches configJSON; applied=false means the vault
+	// was disconnected or reconfigured mid-sync and nothing was written.
+	ReplaceVaultCredentialsForSync(ctx context.Context, vaultID, configJSON string, items []EncryptedKV) (applied bool, err error)
 	// SetVaultExternalStore connects an existing vault to an external store:
 	// it upserts the credential-store row and replaces the vault's credentials
 	// in one transaction (built-in → external switch), returning the new row.


### PR DESCRIPTION
## Summary

Adds the backend, CLI, and docs for switching the credential store backing an **existing** vault (built-in ↔ Infisical) without recreating it. This is the backend half of the credential-store switching feature; the UI shipped in #259 and already calls these endpoints.

- **New endpoint:** `PATCH /v1/vaults/{name}/credential-store` (vault admin or instance owner). Body is `{"kind":"builtin"}` or `{"kind":"infisical","config":{...},"poll_interval_seconds":N}`.
  - **builtin → infisical (connect):** probes the source (same validation as create), then **overwrites** the vault's built-in credentials with the fetched snapshot and starts polling.
  - **infisical → builtin (disconnect):** stops polling and **keeps** the last synced secrets in place as ordinary built-in credentials. Nothing is deleted.
- **Store layer:** `SetVaultExternalStore` (upserts the store row and replaces credentials in one transaction) and `DeleteVaultCredentialStore` (idempotent disconnect), plus a shared `replaceCredentialsTx` helper extracted from `ReplaceVaultCredentials`.
- **Settings GET** now returns `infisical_available` so vault admins see the Infisical option in the UI (the instance-scoped credential-stores endpoint only reports availability to owners).
- **CLI:** `agent-vault vault credential-store set <name> --kind=...` with a type-the-vault-name confirmation (`--yes` to skip) and directional warnings.
- **Docs:** learn/credential-stores and reference/cli updated. Also corrected the browser-flow line to point at the new **Settings → Edit settings** drawer that #259 introduced (it previously referenced the removed inline "Switch credential store" section).

## Sequencing

#259 (the UI) is already merged to main and calls `PATCH /credential-store` + reads `infisical_available`. Until this PR lands, that UI path 404s, so this should merge promptly.

## Testing

- `go build ./...` passes
- `go test ./...` passes (including new tests in `cmd`, `internal/server`, `internal/store`)
- `go vet` clean on the touched packages