### PR TITLE
fix: include substitution keys in credential-usage checks

### DIFF
--- a/internal/server/handle_services.go
+++ b/internal/server/handle_services.go
@@ -322,7 +322,7 @@ func (s *Server) handleServicesCredentialUsage(w http.ResponseWriter, r *http.Re
 	}
 	var refs []serviceRef
 	for _, svc := range services {
-		for _, sk := range svc.Auth.CredentialKeys() {
+		for _, sk := range svc.CredentialKeys() {
 			if sk == key {
 				refs = append(refs, serviceRef{Name: svc.Name, Host: svc.MatcherPattern()})
 				break

--- a/web/src/pages/vault/CredentialsTab.tsx
+++ b/web/src/pages/vault/CredentialsTab.tsx
@@ -55,7 +55,37 @@ export default function CredentialsTab() {
 
   // Service suggestions: credentials matching catalog entries that aren't used by any service
   interface CatalogTemplate { id: string; name: string; host: string; suggested_credential_key: string; }
-  interface ServiceInfo { name: string; host: string; auth: { type: string; token?: string; username?: string; password?: string; key?: string; headers?: Record<string, string> }; }
+  interface ServiceInfo { name: string; host: string; auth: { type: string; token?: string; username?: string; password?: string; key?: string; headers?: Record<string, string> }; substitutions?: { key: string; placeholder: string; in?: string[] }[]; }
+
+  // Mirrors Service.CredentialKeys() in broker.go: auth keys + substitution keys.
+  function serviceCredentialKeys(svc: ServiceInfo): string[] {
+    const keys: string[] = [];
+    switch (svc.auth.type) {
+      case "bearer":
+        if (svc.auth.token) keys.push(svc.auth.token);
+        break;
+      case "basic":
+        if (svc.auth.username) keys.push(svc.auth.username);
+        if (svc.auth.password) keys.push(svc.auth.password);
+        break;
+      case "api-key":
+        if (svc.auth.key) keys.push(svc.auth.key);
+        break;
+      case "custom":
+        if (svc.auth.headers) {
+          for (const v of Object.values(svc.auth.headers)) {
+            for (const m of v.matchAll(/\{\{\s*(\w+)\s*\}\}/g)) keys.push(m[1]);
+          }
+        }
+        break;
+    }
+    if (svc.substitutions) {
+      for (const sub of svc.substitutions) {
+        if (sub.key) keys.push(sub.key);
+      }
+    }
+    return keys;
+  }
   const [catalog, setCatalog] = useState<CatalogTemplate[]>([]);
   const [usedCredentialKeys, setUsedCredentialKeys] = useState<Set<string>>(new Set());
 
@@ -76,16 +106,7 @@ export default function CredentialsTab() {
         const services: ServiceInfo[] = data.services ?? [];
         const keys = new Set<string>();
         for (const svc of services) {
-          if (svc.auth.token) keys.add(svc.auth.token);
-          if (svc.auth.username) keys.add(svc.auth.username);
-          if (svc.auth.password) keys.add(svc.auth.password);
-          if (svc.auth.key) keys.add(svc.auth.key);
-          if (svc.auth.headers) {
-            for (const v of Object.values(svc.auth.headers)) {
-              const matches = v.matchAll(/\{\{\s*(\w+)\s*\}\}/g);
-              for (const m of matches) keys.add(m[1]);
-            }
-          }
+          for (const k of serviceCredentialKeys(svc)) keys.add(k);
         }
         setUsedCredentialKeys(keys);
       }


### PR DESCRIPTION
## Summary

The "unused credential" suggestion and the credential-usage endpoint only inspected auth fields (token, username, password, key, custom headers), missing credentials referenced via URL substitutions. Services using passthrough auth with substitutions (e.g. `ANTHROPIC_API_KEY` on `api.anthropic.com`) appeared unused even though the proxy was actively injecting them.

- Frontend: extracted a `serviceCredentialKeys()` helper mirroring `Service.CredentialKeys()` from `broker.go` (switch on auth type + substitution rollup) so the used-keys set stays in sync with the proxy's injection logic
- Backend: credential-usage endpoint now calls `svc.CredentialKeys()` instead of `svc.Auth.CredentialKeys()`, so the delete-confirmation dialog also warns about substitution references

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

<!-- How did you verify this works? -->

- [x] Existing tests pass (`make test`)
- [ ] Added/updated tests for new behavior
- [x] Manual testing (describe below)

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)