### PR TITLE
docs: move password rotation steps to CLI reference

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1044,6 +1044,8 @@ description: "Complete reference for all Agent Vault CLI commands."
 
 Manage the master password that wraps the data encryption key (DEK). All commands require the server to be stopped. When `DATABASE_URL` is set, these commands require `--force` because multiple instances may share the database -- stop all instances first.
 
+Password changes only re-wrap the encryption key (one database row). No credentials are re-encrypted and no data is lost. If an instance restarts before the secret store is updated, it will fail to start with "wrong password" -- update the secret and restart to resolve.
+
 <AccordionGroup>
   <Accordion title="agent-vault master-password set">
     ```bash

--- a/docs/self-hosting/postgres.mdx
+++ b/docs/self-hosting/postgres.mdx
@@ -38,9 +38,7 @@ For production, generate a strong random value:
 openssl rand -hex 32
 ```
 
-Save the output in your platform's secret store (Kubernetes Secrets, Docker secrets, `fly secrets set`, etc.) and set it as `AGENT_VAULT_MASTER_PASSWORD` on all instances.
-
-To rotate the master password: stop all instances, run `agent-vault master-password change --force` from any machine with `DATABASE_URL` set, update the value in your secret store, then restart all instances. This only re-wraps the encryption key (one row) -- no credentials are re-encrypted and no data is lost. If a pod restarts before the secret is updated, it will fail to start with "wrong password"; update the secret and restart to resolve.
+Save the output in your platform's secret store (Kubernetes Secrets, Docker secrets, `fly secrets set`, etc.) and set it as `AGENT_VAULT_MASTER_PASSWORD` on all instances. To rotate it later, see [`master-password change`](/reference/cli#master-password).
 
 <Warning>
   Never put `AGENT_VAULT_MASTER_PASSWORD` or `DATABASE_URL` in a Dockerfile or committed config file. Use your platform's secret store.
@@ -82,7 +80,7 @@ To rotate the master password: stop all instances, run `agent-vault master-passw
 `migrate-db` copies all data from an existing SQLite installation to Postgres in a single transaction. The source database is not modified.
 
 <Tip>
-  If your master password is weak, strengthen it by running `agent-vault master-password change` while still on SQLite, or after migration using `--force` (see rotation steps above).
+  If your master password is weak, strengthen it by running `agent-vault master-password change` while still on SQLite, or after migration using [`--force`](/reference/cli#master-password).
 </Tip>
 
 <Steps>


### PR DESCRIPTION
## Summary

Moves the master password rotation steps from the Postgres deployment guide to the CLI reference page where they belong. The Postgres guide now links to the CLI reference instead of inlining the steps.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / build

## Test plan

- [x] Existing tests pass (`make test`)

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)