### PR TITLE
feat: allow users to remove themselves from a vault

### DIFF
--- a/internal/server/handle_vaults.go
+++ b/internal/server/handle_vaults.go
@@ -1000,6 +1000,47 @@ func (s *Server) handleVaultSettingsPatch(w http.ResponseWriter, r *http.Request
 	jsonOK(w, map[string]interface{}{"unmatched_host_policy": string(policy)})
 }
 
+func (s *Server) handleVaultLeave(w http.ResponseWriter, r *http.Request) {
+	vaultName := r.PathValue("name")
+	ctx := r.Context()
+
+	vault, err := s.store.GetVault(ctx, vaultName)
+	if err != nil || vault == nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", vaultName))
+		return
+	}
+
+	actor, err := s.requireVaultAccess(w, r, vault.ID)
+	if err != nil {
+		return
+	}
+	if actor == nil {
+		jsonError(w, http.StatusForbidden, "Scoped sessions cannot leave a vault")
+		return
+	}
+
+	role, _ := s.store.GetVaultRole(ctx, actor.ID, vault.ID)
+	if role == "" {
+		jsonError(w, http.StatusConflict, "You do not have an explicit grant on this vault")
+		return
+	}
+
+	if role == "admin" {
+		adminCount, _ := s.store.CountVaultAdmins(ctx, vault.ID)
+		if adminCount <= 1 {
+			jsonError(w, http.StatusConflict, "Cannot leave as the last admin of this vault")
+			return
+		}
+	}
+
+	if err := s.store.RevokeVaultAccess(ctx, actor.ID, vault.ID); err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to leave vault")
+		return
+	}
+
+	jsonOK(w, map[string]string{"message": fmt.Sprintf("left vault %s", vaultName)})
+}
+
 func (s *Server) handleVaultJoin(w http.ResponseWriter, r *http.Request) {
 	actor, err := s.requireOwnerActor(w, r)
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -879,6 +879,7 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("DELETE /v1/vaults/{name}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultDelete))))
 	mux.HandleFunc("POST /v1/vaults/{name}/rename", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultRename)))))
 	mux.HandleFunc("POST /v1/vaults/{name}/join", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultJoin)))))
+	mux.HandleFunc("POST /v1/vaults/{name}/leave", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultLeave))))
 	mux.HandleFunc("GET /v1/vaults/{name}/settings", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultSettingsGet))))
 	mux.HandleFunc("PATCH /v1/vaults/{name}/settings", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultSettingsPatch)))))
 	mux.HandleFunc("PATCH /v1/vaults/{name}/credential-store", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultCredentialStorePatch)))))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -879,7 +879,7 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("DELETE /v1/vaults/{name}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultDelete))))
 	mux.HandleFunc("POST /v1/vaults/{name}/rename", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultRename)))))
 	mux.HandleFunc("POST /v1/vaults/{name}/join", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultJoin)))))
-	mux.HandleFunc("POST /v1/vaults/{name}/leave", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultLeave))))
+	mux.HandleFunc("POST /v1/vaults/{name}/leave", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultLeave)))))
 	mux.HandleFunc("GET /v1/vaults/{name}/settings", s.requireInitialized(s.requireAuth(actorAuthed(s.handleVaultSettingsGet))))
 	mux.HandleFunc("PATCH /v1/vaults/{name}/settings", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultSettingsPatch)))))
 	mux.HandleFunc("PATCH /v1/vaults/{name}/credential-store", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleVaultCredentialStorePatch)))))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7414,3 +7414,76 @@ func TestCredentialProvider_LateBindsDynamicResolver(t *testing.T) {
 		t.Fatalf("post-bind: expected ok=false err=nil, got ok=%v err=%v", ok, err)
 	}
 }
+
+func TestVaultLeaveMemberSuccess(t *testing.T) {
+	ms, _ := setupMockStoreWithSession(t)
+	memberToken := setupMemberSession(t, ms, "root-ns-id")
+	srv := newTestServer(withStore(ms))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/vaults/default/leave", nil)
+	req.Header.Set("Authorization", "Bearer "+memberToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	has, _ := ms.HasVaultAccess(context.Background(), "member-user-id", "root-ns-id")
+	if has {
+		t.Fatal("expected member to no longer have vault access after leaving")
+	}
+}
+
+func TestVaultLeaveLastAdminBlocked(t *testing.T) {
+	ms, ownerToken := setupMockStoreWithSession(t)
+	srv := newTestServer(withStore(ms))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/vaults/default/leave", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestVaultLeaveAdminWithOtherAdmins(t *testing.T) {
+	ms, ownerToken := setupMockStoreWithSession(t)
+	// Add a second admin so the owner can leave.
+	ms.users["admin2@test.com"] = &store.User{
+		ID: "admin2-user-id", Email: "admin2@test.com", Role: "member", IsActive: true,
+	}
+	ms.GrantVaultRole(context.Background(), "admin2-user-id", "user", "root-ns-id", "admin")
+	srv := newTestServer(withStore(ms))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/vaults/default/leave", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	has, _ := ms.HasVaultAccess(context.Background(), "owner-user-id", "root-ns-id")
+	if has {
+		t.Fatal("expected owner to no longer have vault access after leaving")
+	}
+}
+
+func TestVaultLeaveNoAccess(t *testing.T) {
+	ms, _ := setupMockStoreWithSession(t)
+	memberToken := setupMemberSession(t, ms) // no vault grants
+	srv := newTestServer(withStore(ms))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/vaults/default/leave", nil)
+	req.Header.Set("Authorization", "Bearer "+memberToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/web/src/pages/home/VaultsListTab.tsx
+++ b/web/src/pages/home/VaultsListTab.tsx
@@ -9,6 +9,7 @@ import VaultForm, {
   type VaultFormValues,
 } from "../../components/VaultForm";
 import Button from "../../components/Button";
+import Modal from "../../components/Modal";
 import ConfirmDeleteModal from "../../components/ConfirmDeleteModal";
 import { ErrorBanner, LoadingSpinner, timeAgo } from "../../components/shared";
 import { apiFetch } from "../../lib/api";
@@ -31,6 +32,8 @@ export default function VaultsListTab() {
   const [error, setError] = useState("");
   const [search, setSearch] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<Vault | null>(null);
+  const [leaveTarget, setLeaveTarget] = useState<Vault | null>(null);
+  const [leaveError, setLeaveError] = useState("");
 
   useEffect(() => {
     fetchVaults();
@@ -64,6 +67,22 @@ export default function VaultsListTab() {
       throw new Error(data.error || "Failed to delete vault");
     }
     setDeleteTarget(null);
+    fetchVaults();
+  }
+
+  async function handleLeaveVault() {
+    if (!leaveTarget) return;
+    setLeaveError("");
+    const resp = await apiFetch(
+      `/v1/vaults/${encodeURIComponent(leaveTarget.name)}/leave`,
+      { method: "POST" }
+    );
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({}));
+      setLeaveError(data.error || "Failed to leave vault");
+      return;
+    }
+    setLeaveTarget(null);
     fetchVaults();
   }
 
@@ -136,6 +155,7 @@ export default function VaultsListTab() {
                     key={vault.id}
                     vault={vault}
                     isOwner={auth.is_owner}
+                    onLeave={setLeaveTarget}
                     onDelete={setDeleteTarget}
                   />
                 ))}
@@ -171,6 +191,28 @@ export default function VaultsListTab() {
         confirmValue={deleteTarget?.name ?? ""}
         inputLabel="Vault name"
       />
+
+      <Modal
+        open={leaveTarget !== null}
+        onClose={() => { setLeaveTarget(null); setLeaveError(""); }}
+        title="Leave vault"
+        description={`You will lose access to "${leaveTarget?.name}" and its credentials. A vault admin can re-add you later.`}
+        footer={
+          <>
+            <Button variant="secondary" onClick={() => { setLeaveTarget(null); setLeaveError(""); }}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleLeaveVault}
+              className="!bg-danger !text-white hover:!bg-danger/90"
+            >
+              Leave vault
+            </Button>
+          </>
+        }
+      >
+        {leaveError && <ErrorBanner message={leaveError} />}
+      </Modal>
     </div>
   );
 }
@@ -179,11 +221,13 @@ function VaultCard({
   vault,
   isOwner,
   onJoined,
+  onLeave,
   onDelete,
 }: {
   vault: Vault;
   isOwner: boolean;
   onJoined?: () => void;
+  onLeave?: (vault: Vault) => void;
   onDelete: (vault: Vault) => void;
 }) {
   const [joining, setJoining] = useState(false);
@@ -209,6 +253,12 @@ function VaultCard({
     }
   }
 
+  function handleLeave(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    onLeave?.(vault);
+  }
+
   function handleDelete(e: React.MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
@@ -216,6 +266,7 @@ function VaultCard({
   }
 
   const isImplicit = vault.membership === "implicit";
+  const canLeave = !isImplicit && !vault.is_default;
   const canDelete = isOwner && !vault.is_default;
 
   const card = (
@@ -241,6 +292,19 @@ function VaultCard({
               {vault.pending_proposals === 1 ? "review needed" : "reviews needed"}
             </span>
           ) : null}
+          {canLeave && (
+            <button
+              onClick={handleLeave}
+              className="p-1 rounded text-text-dim hover:text-danger transition-colors"
+              title="Leave vault"
+            >
+              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                <polyline points="16 17 21 12 16 7" />
+                <line x1="21" y1="12" x2="9" y2="12" />
+              </svg>
+            </button>
+          )}
           {canDelete && (
             <button
               onClick={handleDelete}

--- a/web/src/pages/vault/UsersTab.tsx
+++ b/web/src/pages/vault/UsersTab.tsx
@@ -12,6 +12,7 @@ import Button from "../../components/Button";
 import Select from "../../components/Select";
 import FormField from "../../components/FormField";
 import { apiFetch } from "../../lib/api";
+import { useNavigate } from "@tanstack/react-router";
 
 interface VaultUser {
   email: string;
@@ -23,16 +24,29 @@ function RowActions({
   user,
   vaultName,
   currentEmail,
+  isAdmin,
   onDone,
+  onLeave,
   onError,
 }: {
   user: VaultUser;
   vaultName: string;
   currentEmail: string;
+  isAdmin: boolean;
   onDone: () => void;
+  onLeave: () => void;
   onError: (msg: string) => void;
 }) {
-  if (user.email === currentEmail) return null;
+  if (user.email === currentEmail) {
+    return (
+      <DropdownMenu
+        items={[{ label: "Leave vault", onClick: onLeave, variant: "danger" as const }]}
+        width={192}
+      />
+    );
+  }
+
+  if (!isAdmin) return null;
 
   const newRole = user.role === "admin" ? "member" : "admin";
 
@@ -79,9 +93,29 @@ function RowActions({
 
 export default function UsersTab() {
   const { vaultName, vaultRole, email: currentEmail } = useVaultParams();
+  const navigate = useNavigate();
   const [users, setUsers] = useState<VaultUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [leaveOpen, setLeaveOpen] = useState(false);
+  const [leaveError, setLeaveError] = useState("");
+
+  const isAdmin = vaultRole === "admin";
+
+  async function handleLeave() {
+    setLeaveError("");
+    const resp = await apiFetch(
+      `/v1/vaults/${encodeURIComponent(vaultName)}/leave`,
+      { method: "POST" }
+    );
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({}));
+      setLeaveError(data.error || "Failed to leave vault");
+      return;
+    }
+    setLeaveOpen(false);
+    navigate({ to: "/" });
+  }
 
   const columns: Column<VaultUser>[] = [
     {
@@ -101,24 +135,22 @@ export default function UsersTab() {
         <span className="text-sm text-text-muted capitalize">{u.role}</span>
       ),
     },
-    ...(vaultRole === "admin"
-      ? [
-          {
-            key: "actions" as const,
-            header: "",
-            align: "right" as const,
-            render: (u: VaultUser) => (
-              <RowActions
-                user={u}
-                vaultName={vaultName}
-                currentEmail={currentEmail}
-                onDone={fetchUsers}
-                onError={setError}
-              />
-            ),
-          },
-        ]
-      : []),
+    {
+      key: "actions" as const,
+      header: "",
+      align: "right" as const,
+      render: (u: VaultUser) => (
+        <RowActions
+          user={u}
+          vaultName={vaultName}
+          currentEmail={currentEmail}
+          isAdmin={isAdmin}
+          onDone={fetchUsers}
+          onLeave={() => setLeaveOpen(true)}
+          onError={setError}
+        />
+      ),
+    },
   ];
 
   useEffect(() => {
@@ -155,7 +187,7 @@ export default function UsersTab() {
             People with access to this vault.
           </p>
         </div>
-        {vaultRole === "admin" && (
+        {isAdmin && (
           <AddUserButton vaultName={vaultName} vaultUsers={users} onAdded={fetchUsers} />
         )}
       </div>
@@ -173,6 +205,28 @@ export default function UsersTab() {
           emptyDescription="Add existing instance users to give them access to this vault."
         />
       )}
+
+      <Modal
+        open={leaveOpen}
+        onClose={() => { setLeaveOpen(false); setLeaveError(""); }}
+        title="Leave vault"
+        description={`You will lose access to "${vaultName}" and its credentials. A vault admin can re-add you later.`}
+        footer={
+          <>
+            <Button variant="secondary" onClick={() => { setLeaveOpen(false); setLeaveError(""); }}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleLeave}
+              className="!bg-danger !text-white hover:!bg-danger/90"
+            >
+              Leave vault
+            </Button>
+          </>
+        }
+      >
+        {leaveError && <ErrorBanner message={leaveError} />}
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds `POST /v1/vaults/{name}/leave` endpoint and corresponding frontend UI so users can remove themselves from a vault. Previously the only way to lose vault access was for an admin to remove you or to delete the entire vault.

**Backend** - new `handleVaultLeave` handler that revokes the caller's own vault grant. Guards:
- Blocks the last admin from leaving (prevents orphaned vaults with no admin)
- Blocks scoped sessions (they can't modify their own access)
- Requires an explicit grant (implicit owner access can't be "left")

**Frontend** - two entry points:
- Vault list cards show a leave icon (door-arrow) for all explicit-membership vaults
- Users tab shows a "Leave vault" dropdown action on the current user's row (visible to all roles, not just admins)

Both surfaces open a confirmation modal before calling the API. Leaving from the Users tab redirects to the home page.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] Existing tests pass (`make test`)
- [x] Added/updated tests for new behavior
- [x] Manual testing (describe below)

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)