### PR TITLE
feat: add Helm chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,12 +175,28 @@ jobs:
       - name: Build
         run: npm run build
 
+  helm-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v4.2.2
+
+      - name: Lint and render chart security scenarios
+        run: charts/agent-vault/ci/test-chart.sh
+
   # Single required status check. `if: always()` is mandatory — without it,
   # a skipped upstream job would mark this job as skipped, and a skipped
   # required check blocks merging.
   ci-summary:
     if: always()
-    needs: [changes, frontend-build, go-test, go-lint, go-mod-tidy, sdk-ts]
+    needs: [changes, frontend-build, go-test, go-lint, go-mod-tidy, sdk-ts, helm-chart]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs
@@ -191,6 +207,7 @@ jobs:
           GO_LINT: ${{ needs.go-lint.result }}
           GO_MOD_TIDY: ${{ needs.go-mod-tidy.result }}
           SDK_TS: ${{ needs.sdk-ts.result }}
+          HELM_CHART: ${{ needs.helm-chart.result }}
         run: |
           fail=0
           check() {
@@ -209,4 +226,5 @@ jobs:
           check go-lint        "$GO_LINT"
           check go-mod-tidy    "$GO_MOD_TIDY"
           check sdk-ts         "$SDK_TS"
+          check helm-chart     "$HELM_CHART"
           exit $fail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,11 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v4.2.2
+
       - name: Install syft (SBOM generator)
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
@@ -62,9 +67,26 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.GO_RELEASER_GITHUB_TOKEN }}
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
 
+      - name: Package and publish Helm chart
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          helm package charts/agent-vault \
+            --version "$version" \
+            --app-version "$version" \
+            --destination dist
+          printf '%s' "$GITHUB_TOKEN" | helm registry login ghcr.io \
+            --username "$GITHUB_ACTOR" \
+            --password-stdin
+          helm push "dist/agent-vault-${version}.tgz" \
+            oci://ghcr.io/infisical/charts
+          cosign sign --yes "ghcr.io/infisical/charts/agent-vault:${version}"
+
       - name: Generate build provenance attestations
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |
             dist/*.tar.gz
+            dist/agent-vault-*.tgz
             dist/checksums.txt

--- a/README.md
+++ b/README.md
@@ -100,9 +100,19 @@ You can also deploy Agent Vault with Docker:
 
 ```bash
 docker run -it -p 14321:14321 -p 14322:14322 \
-  -e AGENT_VAULT_MASTER_PASSWORD=your-password \
+  -e AGENT_VAULT_MASTER_PASSWORD=REPLACE_ME \
   -v agent-vault-data:/data infisical/agent-vault
 ```
+
+Or deploy it to Kubernetes with the bundled Helm chart:
+
+```bash
+helm install agent-vault ./charts/agent-vault \
+  --set env.AGENT_VAULT_ADDR=http://agent-vault.example.internal:14321 \
+  --set secretEnv.AGENT_VAULT_MASTER_PASSWORD=REPLACE_ME
+```
+
+See [charts/agent-vault](charts/agent-vault) for PostgreSQL, ingress, and Infisical-backed credential store examples.
 
 The server starts the HTTP API on port `14321` and a transparent HTTP/HTTPS proxy on port `14322`; the same listener handles `CONNECT` for `https://` upstreams and absolute-form forward-proxy requests for `http://` upstreams.
 

--- a/charts/agent-vault/Chart.yaml
+++ b/charts/agent-vault/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: agent-vault
+description: HTTP credential proxy and vault for AI agents
+type: application
+version: 0.1.0
+appVersion: "0.39.0"
+home: https://github.com/Infisical/agent-vault
+sources:
+  - https://github.com/Infisical/agent-vault
+keywords:
+  - agent-vault
+  - credentials
+  - proxy
+  - infisical
+  - ai-agents
+maintainers:
+  - name: Infisical
+    url: https://infisical.com

--- a/charts/agent-vault/README.md
+++ b/charts/agent-vault/README.md
@@ -1,0 +1,108 @@
+# Agent Vault Helm Chart
+
+This chart deploys [Agent Vault](https://github.com/Infisical/agent-vault), an HTTP credential proxy and vault for AI agents.
+
+Agent Vault exposes two listeners:
+
+- Management UI/API: port `14321`
+- MITM proxy: port `14322`
+
+Keep the MITM proxy private to trusted agent networks. The chart only creates an ingress for the management UI/API, and ingress is disabled by default.
+
+## Install
+
+```bash
+helm install agent-vault ./charts/agent-vault \
+  --set env.AGENT_VAULT_ADDR=http://agent-vault.example.internal:14321 \
+  --set secretEnv.AGENT_VAULT_MASTER_PASSWORD=change-me
+```
+
+For a local UI session:
+
+```bash
+kubectl port-forward svc/agent-vault 14321:14321
+open http://127.0.0.1:14321/register
+```
+
+The first registered user becomes the instance owner.
+
+## Production with PostgreSQL
+
+By default, Agent Vault uses SQLite under `/data/.agent-vault/agent-vault.db` and this chart enables a PVC. For production, set `DATABASE_URL` to use PostgreSQL. You may disable persistence when all durable state is in PostgreSQL.
+
+```yaml
+env:
+  AGENT_VAULT_ADDR: https://agent-vault.example.com
+  AGENT_VAULT_TELEMETRY: "false"
+
+existingSecret: agent-vault-env
+existingSecretKeys:
+  - AGENT_VAULT_MASTER_PASSWORD
+  - DATABASE_URL
+
+persistence:
+  enabled: false
+```
+
+The referenced secret should contain:
+
+```text
+AGENT_VAULT_MASTER_PASSWORD
+DATABASE_URL
+```
+
+## Infisical-backed credential stores
+
+Set `INFISICAL_URL` and one supported Infisical machine identity auth group to enable Infisical-backed vaults. For Universal Auth:
+
+```yaml
+env:
+  INFISICAL_URL: https://app.infisical.com
+
+existingSecret: agent-vault-env
+existingSecretKeys:
+  - AGENT_VAULT_MASTER_PASSWORD
+  - DATABASE_URL
+  - INFISICAL_UNIVERSAL_AUTH_CLIENT_ID
+  - INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET
+```
+
+Then create an Infisical-backed vault from the Agent Vault CLI or UI:
+
+```bash
+agent-vault vault create hermes \
+  --credential-store=infisical \
+  --infisical-project-id=<project-id> \
+  --infisical-environment=prod \
+  --infisical-path=/hermes \
+  --poll-interval-seconds=60
+```
+
+The Infisical machine identity should be read-only and scoped to the smallest project/path that Agent Vault needs.
+
+## Values
+
+| Value | Default | Description |
+| --- | --- | --- |
+| `replicaCount` | `1` | Number of Agent Vault pods. Use PostgreSQL before increasing. |
+| `image.repository` | `infisical/agent-vault` | Container image repository. |
+| `image.tag` | chart appVersion | Container image tag. |
+| `server.port` | `14321` | Management UI/API port. |
+| `server.mitmPort` | `14322` | MITM proxy port. |
+| `env` | `{}` | Non-secret env vars. |
+| `secretEnv` | `{}` | Secret env vars for chart-created Secret. |
+| `existingSecret` | `""` | Existing Secret containing sensitive env vars. |
+| `existingSecretKeys` | common Agent Vault secret keys | Keys to expose from `existingSecret`. |
+| `service.api.type` | `ClusterIP` | Service type for the management UI/API. |
+| `service.proxy.type` | `ClusterIP` | Service type for the MITM proxy. Keep private. |
+| `ingress.enabled` | `false` | Whether to expose the management UI/API with Ingress. |
+| `persistence.enabled` | `true` | PVC for SQLite/data storage. |
+| `resources` | `{}` | Pod resource requests/limits. |
+
+## Security notes
+
+- Deploy Agent Vault separately from untrusted agent execution environments.
+- Keep `14322` reachable only from trusted agent hosts/sandboxes.
+- Prefer PostgreSQL and a strong `AGENT_VAULT_MASTER_PASSWORD` for production.
+- Store real credentials in Agent Vault or in an Infisical-backed vault; agents should receive only placeholders and Agent Vault tokens.
+- Do not put production secrets directly into `values.yaml`. Use `existingSecret` or your platform secret manager.

--- a/charts/agent-vault/README.md
+++ b/charts/agent-vault/README.md
@@ -2,72 +2,90 @@
 
 This chart deploys [Agent Vault](https://github.com/Infisical/agent-vault), an HTTP credential proxy and vault for AI agents.
 
-Agent Vault exposes two listeners:
+Agent Vault exposes two listeners through one Kubernetes Service because clients derive the proxy hostname from `AGENT_VAULT_ADDR` and change only the port:
 
 - Management UI/API: port `14321`
-- MITM proxy: port `14322`
+- Credential proxy: port `14322`
 
-Keep the MITM proxy private to trusted agent networks. The chart only creates an ingress for the management UI/API, and ingress is disabled by default.
+The optional Ingress routes only the management UI/API. It never exposes the proxy listener and is intended for human access. Agents must use a private address that reaches both ports on the Service.
 
-## Install
+## Install from OCI
+
+Release tags publish a signed chart to GHCR. Strip the leading `v` from the application tag when selecting the chart version:
 
 ```bash
-helm install agent-vault ./charts/agent-vault \
-  --set env.AGENT_VAULT_ADDR=http://agent-vault.example.internal:14321 \
-  --set secretEnv.AGENT_VAULT_MASTER_PASSWORD=change-me
+helm install agent-vault \
+  oci://ghcr.io/infisical/charts/agent-vault \
+  --version 0.40.0 \
+  --set-string secretEnv.AGENT_VAULT_MASTER_PASSWORD='replace-me'
 ```
 
-For a local UI session:
+For production, do not put the master password on the command line or in a values file. Sync it into a Kubernetes Secret and use `existingSecret`.
+
+Verify the chart artifact before deployment:
 
 ```bash
-kubectl port-forward svc/agent-vault 14321:14321
+cosign verify \
+  --certificate-identity-regexp='^https://github.com/Infisical/agent-vault/.github/workflows/release.yml@refs/tags/v' \
+  --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+  ghcr.io/infisical/charts/agent-vault:0.40.0
+```
+
+## Local access
+
+Port-forward both listeners from the same Service so the CLI's derived proxy address remains valid:
+
+```bash
+kubectl port-forward svc/agent-vault 14321:14321 14322:14322
+export AGENT_VAULT_ADDR=http://127.0.0.1:14321
 open http://127.0.0.1:14321/register
 ```
 
-The first registered user becomes the instance owner.
+The first registered user becomes the instance owner. A local deployment keeps both cleartext Agent Vault tokens and proxied credentials on the loopback interface. A shared cluster deployment centralizes persistence and operations, but it must place both listeners behind a private network because `Proxy-Authorization` is not end-to-end encrypted between the client and Agent Vault.
 
-## Production with PostgreSQL
+## PostgreSQL and scaling
 
-By default, Agent Vault uses SQLite under `/data/.agent-vault/agent-vault.db` and this chart enables a PVC. For production, set `DATABASE_URL` to use PostgreSQL. You may disable persistence when all durable state is in PostgreSQL.
+The default configuration uses SQLite under `/data/.agent-vault/agent-vault.db`, enables a PVC, forces a `Recreate` deployment strategy, and rejects `replicaCount > 1`.
+
+Use PostgreSQL before scaling above one replica. Set `DATABASE_URL` from a database-managed Kubernetes Secret, then disable local persistence:
 
 ```yaml
-env:
-  AGENT_VAULT_ADDR: https://agent-vault.example.com
-  AGENT_VAULT_TELEMETRY: "false"
+replicaCount: 2
 
-existingSecret: agent-vault-env
+existingSecret: agent-vault-runtime
 existingSecretKeys:
-  - AGENT_VAULT_MASTER_PASSWORD
-  - DATABASE_URL
+  required:
+    - AGENT_VAULT_MASTER_PASSWORD
+  optional: []
+
+extraEnv:
+  - name: DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: agent-vault-db-app
+        key: uri
 
 persistence:
   enabled: false
 ```
 
-The referenced secret should contain:
-
-```text
-AGENT_VAULT_MASTER_PASSWORD
-DATABASE_URL
-```
+All replicas must share the same PostgreSQL database and master password. Validate one replica, migrations, CA persistence, and client sessions before increasing the replica count.
 
 ## Infisical-backed credential stores
 
-Set `INFISICAL_URL` and one supported Infisical machine identity auth group to enable Infisical-backed vaults. For Universal Auth:
+Agent Vault supports Infisical Kubernetes Auth without a static client secret. Enable service-account token mounting only for this workload and bind the corresponding Infisical identity to the narrowest project and path it needs:
 
 ```yaml
+serviceAccount:
+  automount: true
+
 env:
   INFISICAL_URL: https://app.infisical.com
-
-existingSecret: agent-vault-env
-existingSecretKeys:
-  - AGENT_VAULT_MASTER_PASSWORD
-  - DATABASE_URL
-  - INFISICAL_UNIVERSAL_AUTH_CLIENT_ID
-  - INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET
+  INFISICAL_KUBERNETES_IDENTITY_ID: identity-id
+  INFISICAL_KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH: /var/run/secrets/kubernetes.io/serviceaccount/token
 ```
 
-Then create an Infisical-backed vault from the Agent Vault CLI or UI:
+Then create an Infisical-backed vault from the CLI or UI:
 
 ```bash
 agent-vault vault create hermes \
@@ -78,31 +96,42 @@ agent-vault vault create hermes \
   --poll-interval-seconds=60
 ```
 
-The Infisical machine identity should be read-only and scoped to the smallest project/path that Agent Vault needs.
+## Network boundaries
 
-## Values
+The chart enables an ingress-only `NetworkPolicy` by default:
+
+- API port `14321` accepts all otherwise-routable sources by default.
+- Proxy port `14322` accepts pods in the release namespace by default.
+- `networkPolicy.api.from` and `networkPolicy.proxy.from` accept standard Kubernetes NetworkPolicy peers, including namespace selectors, pod selectors, and IP blocks.
+- The chart deliberately does not add an egress policy. Agent Vault's netguard independently rejects loopback, private, link-local, and cloud metadata destinations.
+
+For a NodePort or private-overlay bridge, add only the node or bridge source CIDRs to `networkPolicy.proxy.from`. Never publish `14322` through a public Ingress or load balancer.
+
+Agent Vault passes unmatched destinations through by default. Use strict-deny vault policy for agents that should only reach registered services; the Kubernetes policy protects who can reach the proxy, while vault policy controls what the proxy will authorize.
+
+## Important values
 
 | Value | Default | Description |
 | --- | --- | --- |
-| `replicaCount` | `1` | Number of Agent Vault pods. Use PostgreSQL before increasing. |
+| `replicaCount` | `1` | Agent Vault pods; values above one require PostgreSQL and `persistence.enabled=false`. |
 | `image.repository` | `infisical/agent-vault` | Container image repository. |
 | `image.tag` | chart appVersion | Container image tag. |
-| `server.port` | `14321` | Management UI/API port. |
-| `server.mitmPort` | `14322` | MITM proxy port. |
-| `env` | `{}` | Non-secret env vars. |
-| `secretEnv` | `{}` | Secret env vars for chart-created Secret. |
-| `existingSecret` | `""` | Existing Secret containing sensitive env vars. |
-| `existingSecretKeys` | common Agent Vault secret keys | Keys to expose from `existingSecret`. |
-| `service.api.type` | `ClusterIP` | Service type for the management UI/API. |
-| `service.proxy.type` | `ClusterIP` | Service type for the MITM proxy. Keep private. |
-| `ingress.enabled` | `false` | Whether to expose the management UI/API with Ingress. |
+| `image.digest` | `""` | Optional `sha256:` digest; takes precedence over the tag. |
+| `serviceAccount.automount` | `false` | Mount a Kubernetes token only for workload identity. |
+| `existingSecret` | `""` | Existing Secret containing sensitive environment variables. |
+| `existingSecretKeys.required` | master password | Keys that must exist in `existingSecret`. |
+| `existingSecretKeys.optional` | supported integrations | Keys ignored when absent. |
+| `service.type` | `ClusterIP` | Type of the single dual-port Service. |
+| `service.api.nodePort` | `0` | Optional explicit API NodePort. |
+| `service.proxy.nodePort` | `0` | Optional explicit private proxy NodePort. |
+| `networkPolicy.enabled` | `true` | Restrict inbound API/proxy access. |
+| `ingress.enabled` | `false` | Expose only the management UI/API with Ingress. |
 | `persistence.enabled` | `true` | PVC for SQLite/data storage. |
-| `resources` | `{}` | Pod resource requests/limits. |
 
 ## Security notes
 
 - Deploy Agent Vault separately from untrusted agent execution environments.
-- Keep `14322` reachable only from trusted agent hosts/sandboxes.
-- Prefer PostgreSQL and a strong `AGENT_VAULT_MASTER_PASSWORD` for production.
-- Store real credentials in Agent Vault or in an Infisical-backed vault; agents should receive only placeholders and Agent Vault tokens.
-- Do not put production secrets directly into `values.yaml`. Use `existingSecret` or your platform secret manager.
+- Use a strong `AGENT_VAULT_MASTER_PASSWORD`; the chart refuses to render without one supplied through a generated or existing Secret.
+- Pin both the chart version and image digest in production.
+- Store real provider credentials in Agent Vault or a supported external credential store. Agents should receive only placeholders and scoped Agent Vault tokens.
+- Keep the API and proxy on a private network unless the API is separately protected by a trusted access layer.

--- a/charts/agent-vault/ci/test-chart.sh
+++ b/charts/agent-vault/ci/test-chart.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="${1:-charts/agent-vault}"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+test_master="$(openssl rand -hex 32)"
+master=(--set-string "secretEnv.AGENT_VAULT_MASTER_PASSWORD=$test_master")
+
+helm lint "$chart_dir" --strict "${master[@]}"
+
+helm template test "$chart_dir" "${master[@]}" \
+  --show-only templates/service.yaml > "$work_dir/service.yaml"
+test "$(grep -c '^kind: Service$' "$work_dir/service.yaml")" -eq 1
+grep -q 'name: api' "$work_dir/service.yaml"
+grep -q 'name: proxy' "$work_dir/service.yaml"
+
+helm template test "$chart_dir" "${master[@]}" \
+  --show-only templates/deployment.yaml > "$work_dir/deployment.yaml"
+grep -q 'type: RuntimeDefault' "$work_dir/deployment.yaml"
+
+helm template test "$chart_dir" "${master[@]}" \
+  --set ingress.enabled=true \
+  --show-only templates/ingress.yaml > "$work_dir/ingress.yaml"
+grep -q 'name: api' "$work_dir/ingress.yaml"
+if grep -Eq '14322|name: proxy' "$work_dir/ingress.yaml"; then
+  echo "proxy listener must not be exposed through Ingress" >&2
+  exit 1
+fi
+
+helm template test "$chart_dir" "${master[@]}" \
+  --set replicaCount=2 \
+  --set persistence.enabled=false \
+  --set image.digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  > "$work_dir/postgres-ha.yaml"
+grep -q 'infisical/agent-vault@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' "$work_dir/postgres-ha.yaml"
+if grep -Eq '^ *volume(Mount)?s: *$' "$work_dir/postgres-ha.yaml"; then
+  echo "disabled persistence must not render null volume fields" >&2
+  exit 1
+fi
+
+if helm template invalid "$chart_dir" "${master[@]}" --set replicaCount=2 > /dev/null 2>&1; then
+  echo "SQLite with multiple replicas must fail to render" >&2
+  exit 1
+fi
+
+if helm template invalid "$chart_dir" > /dev/null 2>&1; then
+  echo "missing AGENT_VAULT_MASTER_PASSWORD must fail to render" >&2
+  exit 1
+fi
+
+if helm template invalid "$chart_dir" --set-string secretEnv.AGENT_VAULT_MASTER_PASSWORD= > /dev/null 2>&1; then
+  echo "empty AGENT_VAULT_MASTER_PASSWORD must fail to render" >&2
+  exit 1
+fi
+
+if helm template invalid "$chart_dir" \
+  --set existingSecret=runtime \
+  --set 'existingSecretKeys.required={AGENT_VAULT_MASTER_PASSWORD}' \
+  --set 'existingSecretKeys.optional={AGENT_VAULT_MASTER_PASSWORD}' > /dev/null 2>&1; then
+  echo "a secret key cannot be both required and optional" >&2
+  exit 1
+fi

--- a/charts/agent-vault/templates/NOTES.txt
+++ b/charts/agent-vault/templates/NOTES.txt
@@ -1,0 +1,20 @@
+Agent Vault has been installed.
+
+Management API/UI service:
+  {{ include "agent-vault.fullname" . }}:{{ .Values.service.api.port }}
+
+MITM proxy service:
+  {{ include "agent-vault.fullname" . }}-proxy:{{ .Values.service.proxy.port }}
+
+{{- if .Values.ingress.enabled }}
+Management UI ingress:
+{{- range .Values.ingress.hosts }}
+  https://{{ .host }}
+{{- end }}
+{{- else }}
+To access the management UI locally:
+  kubectl port-forward svc/{{ include "agent-vault.fullname" . }} {{ .Values.service.api.port }}:{{ .Values.service.api.port }}
+  open http://127.0.0.1:{{ .Values.service.api.port }}/register
+{{- end }}
+
+Keep the proxy service private to trusted agent networks. Do not expose {{ include "agent-vault.fullname" . }}-proxy publicly.

--- a/charts/agent-vault/templates/NOTES.txt
+++ b/charts/agent-vault/templates/NOTES.txt
@@ -4,7 +4,7 @@ Management API/UI service:
   {{ include "agent-vault.fullname" . }}:{{ .Values.service.api.port }}
 
 MITM proxy service:
-  {{ include "agent-vault.fullname" . }}-proxy:{{ .Values.service.proxy.port }}
+  {{ include "agent-vault.fullname" . }}:{{ .Values.service.proxy.port }}
 
 {{- if .Values.ingress.enabled }}
 Management UI ingress:
@@ -13,8 +13,8 @@ Management UI ingress:
 {{- end }}
 {{- else }}
 To access the management UI locally:
-  kubectl port-forward svc/{{ include "agent-vault.fullname" . }} {{ .Values.service.api.port }}:{{ .Values.service.api.port }}
+  kubectl port-forward svc/{{ include "agent-vault.fullname" . }} {{ .Values.service.api.port }}:{{ .Values.service.api.port }} {{ .Values.service.proxy.port }}:{{ .Values.service.proxy.port }}
   open http://127.0.0.1:{{ .Values.service.api.port }}/register
 {{- end }}
 
-Keep the proxy service private to trusted agent networks. Do not expose {{ include "agent-vault.fullname" . }}-proxy publicly.
+Keep the proxy port private to trusted agent networks. Do not expose port {{ .Values.service.proxy.port }} publicly.

--- a/charts/agent-vault/templates/_helpers.tpl
+++ b/charts/agent-vault/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "agent-vault.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "agent-vault.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "agent-vault.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "agent-vault.labels" -}}
+helm.sh/chart: {{ include "agent-vault.chart" . }}
+{{ include "agent-vault.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "agent-vault.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agent-vault.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "agent-vault.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "agent-vault.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image tag defaults to appVersion.
+*/}}
+{{- define "agent-vault.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}
+
+{{/*
+Secret name for generated or existing env secret.
+*/}}
+{{- define "agent-vault.secretName" -}}
+{{- default (printf "%s-env" (include "agent-vault.fullname" .)) .Values.existingSecret }}
+{{- end }}

--- a/charts/agent-vault/templates/_helpers.tpl
+++ b/charts/agent-vault/templates/_helpers.tpl
@@ -61,8 +61,12 @@ Create the name of the service account to use.
 Image tag defaults to appVersion.
 */}}
 {{- define "agent-vault.image" -}}
+{{- if .Values.image.digest }}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest }}
+{{- else }}
 {{- $tag := default .Chart.AppVersion .Values.image.tag }}
 {{- printf "%s:%s" .Values.image.repository $tag }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/agent-vault/templates/deployment.yaml
+++ b/charts/agent-vault/templates/deployment.yaml
@@ -1,0 +1,132 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent-vault.fullname" . }}
+  labels:
+    {{- include "agent-vault.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "agent-vault.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "agent-vault.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "agent-vault.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: {{ include "agent-vault.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - server
+            - --host
+            - {{ .Values.server.host | quote }}
+            - --port
+            - {{ .Values.server.port | quote }}
+            - --mitm-port
+            - {{ .Values.server.mitmPort | quote }}
+            - --log-level
+            - {{ .Values.server.logLevel | quote }}
+          ports:
+            - name: api
+              containerPort: {{ .Values.server.port }}
+              protocol: TCP
+            - name: proxy
+              containerPort: {{ .Values.server.mitmPort }}
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- $secretName := include "agent-vault.secretName" . }}
+            {{- if .Values.existingSecret }}
+            {{- range .Values.existingSecretKeys }}
+            - name: {{ . }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ . }}
+                  optional: true
+            {{- end }}
+            {{- else if .Values.secretEnv }}
+            {{- range $key, $_ := .Values.secretEnv }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ $key }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /data
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ default (include "agent-vault.fullname" .) .Values.persistence.existingClaim }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}

--- a/charts/agent-vault/templates/deployment.yaml
+++ b/charts/agent-vault/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "agent-vault.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ ternary "Recreate" "RollingUpdate" .Values.persistence.enabled }}
   selector:
     matchLabels:
       {{- include "agent-vault.selectorLabels" . | nindent 6 }}
@@ -26,6 +28,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "agent-vault.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -62,7 +65,15 @@ spec:
             {{- end }}
             {{- $secretName := include "agent-vault.secretName" . }}
             {{- if .Values.existingSecret }}
-            {{- range .Values.existingSecretKeys }}
+            {{- range .Values.existingSecretKeys.required }}
+            - name: {{ . }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ . }}
+                  optional: false
+            {{- end }}
+            {{- range .Values.existingSecretKeys.optional }}
             - name: {{ . }}
               valueFrom:
                 secretKeyRef:
@@ -98,6 +109,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if or .Values.persistence.enabled .Values.extraVolumeMounts }}
           volumeMounts:
             {{- if .Values.persistence.enabled }}
             - name: data
@@ -106,6 +118,8 @@ spec:
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
+      {{- if or .Values.persistence.enabled .Values.extraVolumes }}
       volumes:
         {{- if .Values.persistence.enabled }}
         - name: data
@@ -115,6 +129,7 @@ spec:
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/agent-vault/templates/ingress.yaml
+++ b/charts/agent-vault/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ .secretName | quote }}
     {{- end }}
   {{- end }}
   rules:

--- a/charts/agent-vault/templates/ingress.yaml
+++ b/charts/agent-vault/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agent-vault.fullname" . }}
+  labels:
+    {{- include "agent-vault.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "agent-vault.fullname" $ }}
+                port:
+                  name: api
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/agent-vault/templates/networkpolicy.yaml
+++ b/charts/agent-vault/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "agent-vault.fullname" . }}
+  labels:
+    {{- include "agent-vault.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "agent-vault.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: api
+          protocol: TCP
+      {{- with .Values.networkPolicy.api.from }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    - ports:
+        - port: proxy
+          protocol: TCP
+      from:
+        {{- toYaml .Values.networkPolicy.proxy.from | nindent 8 }}
+{{- end }}

--- a/charts/agent-vault/templates/pvc.yaml
+++ b/charts/agent-vault/templates/pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "agent-vault.fullname" . }}
+  labels:
+    {{- include "agent-vault.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/agent-vault/templates/secret.yaml
+++ b/charts/agent-vault/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if and (not .Values.existingSecret) .Values.secretEnv }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agent-vault.secretName" . }}
+  labels:
+    {{- include "agent-vault.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.secretEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/agent-vault/templates/service.yaml
+++ b/charts/agent-vault/templates/service.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agent-vault.fullname" . }}
+  labels:
+    {{- include "agent-vault.labels" . | nindent 4 }}
+  {{- with .Values.service.api.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.api.type }}
+  ports:
+    - port: {{ .Values.service.api.port }}
+      targetPort: api
+      protocol: TCP
+      name: api
+  selector:
+    {{- include "agent-vault.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agent-vault.fullname" . }}-proxy
+  labels:
+    {{- include "agent-vault.labels" . | nindent 4 }}
+  {{- with .Values.service.proxy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.proxy.type }}
+  ports:
+    - port: {{ .Values.service.proxy.port }}
+      targetPort: proxy
+      protocol: TCP
+      name: proxy
+  selector:
+    {{- include "agent-vault.selectorLabels" . | nindent 4 }}

--- a/charts/agent-vault/templates/service.yaml
+++ b/charts/agent-vault/templates/service.yaml
@@ -4,36 +4,35 @@ metadata:
   name: {{ include "agent-vault.fullname" . }}
   labels:
     {{- include "agent-vault.labels" . | nindent 4 }}
-  {{- with .Values.service.api.annotations }}
+  {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.api.type }}
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP | quote }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass | quote }}
+  {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.api.port }}
       targetPort: api
       protocol: TCP
       name: api
-  selector:
-    {{- include "agent-vault.selectorLabels" . | nindent 4 }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "agent-vault.fullname" . }}-proxy
-  labels:
-    {{- include "agent-vault.labels" . | nindent 4 }}
-  {{- with .Values.service.proxy.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  type: {{ .Values.service.proxy.type }}
-  ports:
+      {{- if .Values.service.api.nodePort }}
+      nodePort: {{ .Values.service.api.nodePort }}
+      {{- end }}
     - port: {{ .Values.service.proxy.port }}
       targetPort: proxy
       protocol: TCP
       name: proxy
+      {{- if .Values.service.proxy.nodePort }}
+      nodePort: {{ .Values.service.proxy.nodePort }}
+      {{- end }}
   selector:
     {{- include "agent-vault.selectorLabels" . | nindent 4 }}

--- a/charts/agent-vault/templates/serviceaccount.yaml
+++ b/charts/agent-vault/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent-vault.serviceAccountName" . }}
+  labels:
+    {{- include "agent-vault.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/agent-vault/templates/validate.yaml
+++ b/charts/agent-vault/templates/validate.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.persistence.enabled (gt (int .Values.replicaCount) 1) -}}
+{{- fail "replicaCount must be 1 while persistence.enabled=true; use PostgreSQL and disable persistence before scaling Agent Vault" -}}
+{{- end -}}
+{{- $masterInGeneratedSecret := and (hasKey .Values.secretEnv "AGENT_VAULT_MASTER_PASSWORD") (ne (toString (get .Values.secretEnv "AGENT_VAULT_MASTER_PASSWORD")) "") -}}
+{{- $masterInExistingSecret := and (ne .Values.existingSecret "") (has "AGENT_VAULT_MASTER_PASSWORD" .Values.existingSecretKeys.required) -}}
+{{- $hasMaster := ternary $masterInExistingSecret $masterInGeneratedSecret (ne .Values.existingSecret "") -}}
+{{- if not $hasMaster -}}
+{{- fail "AGENT_VAULT_MASTER_PASSWORD is required: set secretEnv.AGENT_VAULT_MASTER_PASSWORD or include it in existingSecretKeys.required" -}}
+{{- end -}}
+{{- range .Values.existingSecretKeys.required -}}
+{{- if has . $.Values.existingSecretKeys.optional -}}
+{{- fail (printf "%s cannot appear in both existingSecretKeys.required and existingSecretKeys.optional" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/agent-vault/values.schema.json
+++ b/charts/agent-vault/values.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": {"type": "integer", "minimum": 1},
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {"type": "string"},
+        "pullPolicy": {"type": "string"},
+        "tag": {"type": "string"}
+      }
+    },
+    "server": {
+      "type": "object",
+      "properties": {
+        "host": {"type": "string"},
+        "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+        "mitmPort": {"type": "integer", "minimum": 0, "maximum": 65535},
+        "logLevel": {"type": "string", "enum": ["debug", "info"]}
+      }
+    },
+    "env": {"type": "object", "additionalProperties": {"type": ["string", "number", "boolean"]}},
+    "secretEnv": {"type": "object", "additionalProperties": {"type": ["string", "number", "boolean"]}},
+    "existingSecret": {"type": "string"},
+    "existingSecretKeys": {"type": "array", "items": {"type": "string"}},
+    "service": {
+      "type": "object",
+      "properties": {
+        "api": {"type": "object"},
+        "proxy": {"type": "object"}
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"}
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "size": {"type": "string"},
+        "existingClaim": {"type": "string"}
+      }
+    }
+  }
+}

--- a/charts/agent-vault/values.schema.json
+++ b/charts/agent-vault/values.schema.json
@@ -1,48 +1,140 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": true,
   "properties": {
     "replicaCount": {"type": "integer", "minimum": 1},
     "image": {
       "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "pullPolicy", "tag", "digest"],
       "properties": {
-        "repository": {"type": "string"},
-        "pullPolicy": {"type": "string"},
-        "tag": {"type": "string"}
+        "repository": {"type": "string", "minLength": 1},
+        "pullPolicy": {"type": "string", "enum": ["Always", "IfNotPresent", "Never"]},
+        "tag": {"type": "string"},
+        "digest": {"type": "string", "pattern": "^(|sha256:[a-fA-F0-9]{64})$"}
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["create", "automount", "annotations", "name"],
+      "properties": {
+        "create": {"type": "boolean"},
+        "automount": {"type": "boolean"},
+        "annotations": {"type": "object", "additionalProperties": {"type": "string"}},
+        "name": {"type": "string"}
       }
     },
     "server": {
       "type": "object",
+      "additionalProperties": false,
+      "required": ["host", "port", "mitmPort", "logLevel"],
       "properties": {
-        "host": {"type": "string"},
+        "host": {"type": "string", "minLength": 1},
         "port": {"type": "integer", "minimum": 1, "maximum": 65535},
-        "mitmPort": {"type": "integer", "minimum": 0, "maximum": 65535},
+        "mitmPort": {"type": "integer", "minimum": 1, "maximum": 65535},
         "logLevel": {"type": "string", "enum": ["debug", "info"]}
       }
     },
     "env": {"type": "object", "additionalProperties": {"type": ["string", "number", "boolean"]}},
     "secretEnv": {"type": "object", "additionalProperties": {"type": ["string", "number", "boolean"]}},
     "existingSecret": {"type": "string"},
-    "existingSecretKeys": {"type": "array", "items": {"type": "string"}},
+    "existingSecretKeys": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "optional"],
+      "properties": {
+        "required": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+        "optional": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true}
+      }
+    },
+    "extraEnv": {"type": "array"},
+    "extraEnvFrom": {"type": "array"},
     "service": {
       "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "annotations", "clusterIP", "loadBalancerClass", "externalTrafficPolicy", "api", "proxy"],
       "properties": {
-        "api": {"type": "object"},
-        "proxy": {"type": "object"}
+        "type": {"type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"]},
+        "annotations": {"type": "object", "additionalProperties": {"type": "string"}},
+        "clusterIP": {"type": "string"},
+        "loadBalancerClass": {"type": "string"},
+        "externalTrafficPolicy": {"type": "string", "enum": ["", "Cluster", "Local"]},
+        "api": {"$ref": "#/definitions/servicePort"},
+        "proxy": {"$ref": "#/definitions/servicePort"}
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "api", "proxy"],
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "api": {"$ref": "#/definitions/networkPolicyListener"},
+        "proxy": {"$ref": "#/definitions/networkPolicyListener"}
       }
     },
     "ingress": {
       "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "className", "annotations", "hosts", "tls"],
       "properties": {
-        "enabled": {"type": "boolean"}
+        "enabled": {"type": "boolean"},
+        "className": {"type": "string"},
+        "annotations": {"type": "object", "additionalProperties": {"type": "string"}},
+        "hosts": {"type": "array"},
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["secretName", "hosts"],
+            "properties": {
+              "secretName": {"type": "string", "minLength": 1},
+              "hosts": {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 1}
+            }
+          }
+        }
       }
     },
     "persistence": {
       "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "accessMode", "size", "storageClass", "annotations", "existingClaim"],
       "properties": {
         "enabled": {"type": "boolean"},
-        "size": {"type": "string"},
+        "accessMode": {"type": "string", "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany", "ReadWriteOncePod"]},
+        "size": {"type": "string", "minLength": 1},
+        "storageClass": {"type": "string"},
+        "annotations": {"type": "object", "additionalProperties": {"type": "string"}},
         "existingClaim": {"type": "string"}
+      }
+    },
+    "extraVolumes": {"type": "array"},
+    "extraVolumeMounts": {"type": "array"}
+  },
+  "definitions": {
+    "servicePort": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["port", "nodePort"],
+      "properties": {
+        "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+        "nodePort": {
+          "anyOf": [
+            {"const": 0},
+            {"type": "integer", "minimum": 30000, "maximum": 32767}
+          ]
+        }
+      }
+    },
+    "networkPolicyListener": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from"],
+      "properties": {
+        "from": {"type": "array"}
       }
     }
   }

--- a/charts/agent-vault/values.yaml
+++ b/charts/agent-vault/values.yaml
@@ -1,0 +1,155 @@
+# Default values for agent-vault.
+
+replicaCount: 1
+
+image:
+  repository: infisical/agent-vault
+  pullPolicy: IfNotPresent
+  # Defaults to Chart.appVersion when empty.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  fsGroup: 65532
+  fsGroupChangePolicy: OnRootMismatch
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+
+server:
+  host: 0.0.0.0
+  port: 14321
+  mitmPort: 14322
+  logLevel: info
+
+# Non-secret environment variables passed directly to the container.
+env: {}
+  # AGENT_VAULT_ADDR: https://agent-vault.example.com
+  # AGENT_VAULT_TELEMETRY: "false"
+  # INFISICAL_URL: https://app.infisical.com
+
+# Secret environment variables. When non-empty and existingSecret is unset, this
+# chart creates a Secret and wires these keys into the container env.
+secretEnv: {}
+  # AGENT_VAULT_MASTER_PASSWORD: change-me
+  # DATABASE_URL: postgres://user:password@postgres:5432/agentvault?sslmode=require
+  # INFISICAL_UNIVERSAL_AUTH_CLIENT_ID: ...
+  # INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET: ...
+
+# Use an existing Secret for sensitive env vars. All keys in existingSecretKeys
+# are exposed as env vars with matching names.
+existingSecret: ""
+existingSecretKeys:
+  - AGENT_VAULT_MASTER_PASSWORD
+  - DATABASE_URL
+  - INFISICAL_UNIVERSAL_AUTH_CLIENT_ID
+  - INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET
+  - INFISICAL_KUBERNETES_IDENTITY_ID
+  - INFISICAL_KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH
+  - INFISICAL_AWS_IAM_AUTH_IDENTITY_ID
+  - INFISICAL_GCP_AUTH_IDENTITY_ID
+  - INFISICAL_GCP_IAM_SERVICE_ACCOUNT_KEY_FILE_PATH
+  - INFISICAL_LDAP_AUTH_IDENTITY_ID
+  - INFISICAL_LDAP_AUTH_USERNAME
+  - INFISICAL_LDAP_AUTH_PASSWORD
+  - AGENT_VAULT_SMTP_HOST
+  - AGENT_VAULT_SMTP_PORT
+  - AGENT_VAULT_SMTP_USERNAME
+  - AGENT_VAULT_SMTP_PASSWORD
+  - AGENT_VAULT_SMTP_FROM
+  - AGENT_VAULT_SMTP_FROM_NAME
+
+extraEnv: []
+# - name: AGENT_VAULT_NETWORK_ALLOWLIST
+#   value: 10.0.0.0/8
+
+extraEnvFrom: []
+# - secretRef:
+#     name: agent-vault-extra
+
+service:
+  api:
+    type: ClusterIP
+    port: 14321
+    annotations: {}
+  proxy:
+    type: ClusterIP
+    port: 14322
+    annotations: {}
+
+# Management UI/API ingress. The MITM proxy port is intentionally not exposed by
+# ingress; keep it reachable only from trusted agent networks.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: agent-vault.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources: {}
+# requests:
+#   cpu: 100m
+#   memory: 256Mi
+# limits:
+#   memory: 1Gi
+
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /health
+    port: api
+  initialDelaySeconds: 10
+  periodSeconds: 30
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /health
+    port: api
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+persistence:
+  enabled: true
+  accessMode: ReadWriteOnce
+  size: 5Gi
+  storageClass: ""
+  annotations: {}
+  existingClaim: ""
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+priorityClassName: ""
+
+# Additional volumes and mounts.
+extraVolumes: []
+extraVolumeMounts: []

--- a/charts/agent-vault/values.yaml
+++ b/charts/agent-vault/values.yaml
@@ -7,6 +7,8 @@ image:
   pullPolicy: IfNotPresent
   # Defaults to Chart.appVersion when empty.
   tag: ""
+  # When set, the digest takes precedence over tag (repository@digest).
+  digest: ""
 
 imagePullSecrets: []
 nameOverride: ""
@@ -14,7 +16,9 @@ fullnameOverride: ""
 
 serviceAccount:
   create: true
-  automount: true
+  # Enable only when Agent Vault uses Kubernetes workload identity (for
+  # example, Infisical Kubernetes Auth).
+  automount: false
   annotations: {}
   name: ""
 
@@ -24,6 +28,8 @@ podLabels: {}
 podSecurityContext:
   fsGroup: 65532
   fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   allowPrivilegeEscalation: false
@@ -55,28 +61,30 @@ secretEnv: {}
   # INFISICAL_UNIVERSAL_AUTH_CLIENT_ID: ...
   # INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET: ...
 
-# Use an existing Secret for sensitive env vars. All keys in existingSecretKeys
-# are exposed as env vars with matching names.
+# Use an existing Secret for sensitive env vars. Required keys fail pod startup
+# if absent; optional keys are ignored when absent.
 existingSecret: ""
 existingSecretKeys:
-  - AGENT_VAULT_MASTER_PASSWORD
-  - DATABASE_URL
-  - INFISICAL_UNIVERSAL_AUTH_CLIENT_ID
-  - INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET
-  - INFISICAL_KUBERNETES_IDENTITY_ID
-  - INFISICAL_KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH
-  - INFISICAL_AWS_IAM_AUTH_IDENTITY_ID
-  - INFISICAL_GCP_AUTH_IDENTITY_ID
-  - INFISICAL_GCP_IAM_SERVICE_ACCOUNT_KEY_FILE_PATH
-  - INFISICAL_LDAP_AUTH_IDENTITY_ID
-  - INFISICAL_LDAP_AUTH_USERNAME
-  - INFISICAL_LDAP_AUTH_PASSWORD
-  - AGENT_VAULT_SMTP_HOST
-  - AGENT_VAULT_SMTP_PORT
-  - AGENT_VAULT_SMTP_USERNAME
-  - AGENT_VAULT_SMTP_PASSWORD
-  - AGENT_VAULT_SMTP_FROM
-  - AGENT_VAULT_SMTP_FROM_NAME
+  required:
+    - AGENT_VAULT_MASTER_PASSWORD
+  optional:
+    - DATABASE_URL
+    - INFISICAL_UNIVERSAL_AUTH_CLIENT_ID
+    - INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET
+    - INFISICAL_KUBERNETES_IDENTITY_ID
+    - INFISICAL_KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH
+    - INFISICAL_AWS_IAM_AUTH_IDENTITY_ID
+    - INFISICAL_GCP_AUTH_IDENTITY_ID
+    - INFISICAL_GCP_IAM_SERVICE_ACCOUNT_KEY_FILE_PATH
+    - INFISICAL_LDAP_AUTH_IDENTITY_ID
+    - INFISICAL_LDAP_AUTH_USERNAME
+    - INFISICAL_LDAP_AUTH_PASSWORD
+    - AGENT_VAULT_SMTP_HOST
+    - AGENT_VAULT_SMTP_PORT
+    - AGENT_VAULT_SMTP_USERNAME
+    - AGENT_VAULT_SMTP_PASSWORD
+    - AGENT_VAULT_SMTP_FROM
+    - AGENT_VAULT_SMTP_FROM_NAME
 
 extraEnv: []
 # - name: AGENT_VAULT_NETWORK_ALLOWLIST
@@ -87,14 +95,29 @@ extraEnvFrom: []
 #     name: agent-vault-extra
 
 service:
+  type: ClusterIP
+  annotations: {}
+  clusterIP: ""
+  loadBalancerClass: ""
+  externalTrafficPolicy: ""
   api:
-    type: ClusterIP
     port: 14321
-    annotations: {}
+    nodePort: 0
   proxy:
-    type: ClusterIP
     port: 14322
-    annotations: {}
+    nodePort: 0
+
+# Ingress policy only. Agent Vault's own netguard separately blocks private,
+# loopback, link-local, and metadata destinations from proxied requests.
+networkPolicy:
+  enabled: true
+  api:
+    # Empty means all sources that can otherwise route to the Service.
+    from: []
+  proxy:
+    # podSelector: {} means all pods in this release namespace.
+    from:
+      - podSelector: {}
 
 # Management UI/API ingress. The MITM proxy port is intentionally not exposed by
 # ingress; keep it reachable only from trusted agent networks.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -34,6 +34,18 @@ Each install method below configures a master password at startup. Store it some
     See [Docker deployment](/self-hosting/docker) for Compose, volumes, and full configuration.
 
   </Tab>
+  <Tab title="Helm">
+    Deploy Agent Vault to Kubernetes with the bundled Helm chart:
+
+    ```bash
+    helm install agent-vault ./charts/agent-vault \
+      --set env.AGENT_VAULT_ADDR="http://<your-host>:14321" \
+      --set secretEnv.AGENT_VAULT_MASTER_PASSWORD=REPLACE_ME
+    ```
+
+    The chart keeps the proxy service as an internal `ClusterIP` by default. See [`charts/agent-vault/README.md`](https://github.com/Infisical/agent-vault/tree/main/charts/agent-vault) for PostgreSQL, ingress, and Infisical-backed credential store examples.
+
+  </Tab>
   <Tab title="From source">
     **Prerequisites**: [Go 1.25+](https://go.dev/dl/), [Node.js 22+](https://nodejs.org/)
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -43,7 +43,7 @@ Each install method below configures a master password at startup. Store it some
       --set secretEnv.AGENT_VAULT_MASTER_PASSWORD=REPLACE_ME
     ```
 
-    The chart keeps the proxy service as an internal `ClusterIP` by default. See [`charts/agent-vault/README.md`](https://github.com/Infisical/agent-vault/tree/main/charts/agent-vault) for PostgreSQL, ingress, and Infisical-backed credential store examples.
+    The chart exposes both listeners on one internal `ClusterIP` Service by default because clients derive the proxy hostname from `AGENT_VAULT_ADDR`. See [`charts/agent-vault/README.md`](https://github.com/Infisical/agent-vault/tree/main/charts/agent-vault) for PostgreSQL, private-network access, ingress, and Infisical-backed credential store examples.
 
   </Tab>
   <Tab title="From source">

--- a/docs/self-hosting/postgres.mdx
+++ b/docs/self-hosting/postgres.mdx
@@ -129,7 +129,7 @@ Save the output in your platform's secret store (Kubernetes Secrets, Docker secr
 
 ## Example: Kubernetes
 
-A minimal setup with two replicas. The MITM proxy terminates TLS itself, so it needs a Layer-4 (TCP) load balancer. The API/UI can sit behind a standard HTTP Ingress.
+A minimal setup with two replicas. The API and MITM proxy must share a hostname because clients derive the proxy address from `AGENT_VAULT_ADDR` and change only the port. Put both listeners on one private Layer-4 load balancer or overlay-network address. If you add a public HTTP Ingress, use it only for human UI/API access; agents still need the private dual-port address.
 
 ```yaml agent-vault-deployment.yaml
 apiVersion: apps/v1
@@ -180,29 +180,20 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
 ---
-# L7 Service for the API/UI (works behind a standard Ingress)
+# One private service for both listeners. A standard Ingress may route the API
+# port for human access, but must never route the proxy port.
 apiVersion: v1
 kind: Service
 metadata:
-  name: agent-vault-api
+  name: agent-vault
 spec:
+  type: LoadBalancer
   selector:
     app: agent-vault
   ports:
     - name: api
       port: 14321
       targetPort: api
----
-# L4 Service for the MITM proxy (TCP passthrough, no HTTP termination)
-apiVersion: v1
-kind: Service
-metadata:
-  name: agent-vault-proxy
-spec:
-  type: LoadBalancer
-  selector:
-    app: agent-vault
-  ports:
     - name: proxy
       port: 14322
       targetPort: proxy


### PR DESCRIPTION
## Summary
- Add a generic Helm chart under `charts/agent-vault`
- Support SQLite persistence by default and PostgreSQL via `DATABASE_URL`
- Support Kubernetes Secret wiring for `AGENT_VAULT_MASTER_PASSWORD`, `DATABASE_URL`, SMTP, and Infisical credential-store auth variables
- Keep the MITM proxy service internal by default while optionally exposing the management UI/API via Ingress
- Document Helm installation in the root README and installation docs

## Security notes
- The chart does not expose the proxy port via Ingress
- Production secrets should be passed through `existingSecret`; examples use placeholders only
- The chart README documents keeping `14322` private and using read-only Infisical machine identities

## Test plan
- `helm lint charts/agent-vault`
- `helm template agent-vault charts/agent-vault > /tmp/agent-vault-rendered-default.yaml`
- `helm template agent-vault charts/agent-vault --set env.AGENT_VAULT_ADDR=http://agent-vault.local:14321 --set secretEnv.AGENT_VAULT_MASTER_PASSWORD=REPLACE_ME --set persistence.enabled=false --set ingress.enabled=true --set ingress.hosts[0].host=agent-vault.local > /tmp/agent-vault-rendered-custom.yaml`
