### PR TITLE
Redact brokered credentials from response bodies

### DIFF
--- a/cmd/proposal.go
+++ b/cmd/proposal.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/huh"
 	"github.com/Infisical/agent-vault/internal/proposal"
 	"github.com/Infisical/agent-vault/internal/session"
 	"github.com/Infisical/agent-vault/internal/store"
+	"github.com/charmbracelet/huh"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -56,6 +56,13 @@ func printServices(w io.Writer, servicesJSON string) {
 			}
 			if r.Action == proposal.ActionSet && r.Auth != nil {
 				fmt.Fprintf(w, "      %s: %s\n", mutedText("auth"), r.Auth.Type)
+			}
+			if r.Action == proposal.ActionSet && r.ResponseRedaction != nil {
+				state := "disabled"
+				if r.ResponseRedaction.Enabled {
+					state = "enabled"
+				}
+				fmt.Fprintf(w, "      %s: %s\n", mutedText("response redaction"), state)
 			}
 			if r.Action == proposal.ActionSet && len(r.Substitutions) > 0 {
 				fmt.Fprintf(w, "      %s:\n", mutedText("substitutions"))
@@ -173,8 +180,8 @@ func sendApproveRequest(sess *session.ClientSession, vault string, id int, crede
 // sendRejectRequest sends a proposal rejection to the running server via HTTP.
 func sendRejectRequest(sess *session.ClientSession, vault string, id int, reason string) error {
 	body, err := json.Marshal(map[string]interface{}{
-		"vault": vault,
-		"reason":    reason,
+		"vault":  vault,
+		"reason": reason,
 	})
 	if err != nil {
 		return fmt.Errorf("marshalling request: %w", err)
@@ -209,15 +216,15 @@ func fetchProposal(sess *session.ClientSession, vault string, id int) (*store.Pr
 // parseProposalJSON parses the admin proposal API response into a store.Proposal.
 func parseProposalJSON(data []byte) (*store.Proposal, error) {
 	var resp struct {
-		ID          int     `json:"id"`
-		Status      string  `json:"status"`
-		Message     string  `json:"message"`
-		UserMessage string  `json:"user_message"`
-		ServicesJSON string  `json:"services_json"`
+		ID              int     `json:"id"`
+		Status          string  `json:"status"`
+		Message         string  `json:"message"`
+		UserMessage     string  `json:"user_message"`
+		ServicesJSON    string  `json:"services_json"`
 		CredentialsJSON string  `json:"credentials_json"`
-		ReviewNote  string  `json:"review_note"`
-		ReviewedAt  *string `json:"reviewed_at"`
-		CreatedAt   string  `json:"created_at"`
+		ReviewNote      string  `json:"review_note"`
+		ReviewedAt      *string `json:"reviewed_at"`
+		CreatedAt       string  `json:"created_at"`
 	}
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return nil, fmt.Errorf("parsing proposal: %w", err)
@@ -226,18 +233,17 @@ func parseProposalJSON(data []byte) (*store.Proposal, error) {
 	createdAt, _ := time.Parse(time.RFC3339, resp.CreatedAt)
 
 	return &store.Proposal{
-		ID:          resp.ID,
-		Status:      resp.Status,
-		Message:     resp.Message,
-		UserMessage: resp.UserMessage,
-		ServicesJSON: resp.ServicesJSON,
+		ID:              resp.ID,
+		Status:          resp.Status,
+		Message:         resp.Message,
+		UserMessage:     resp.UserMessage,
+		ServicesJSON:    resp.ServicesJSON,
 		CredentialsJSON: resp.CredentialsJSON,
-		ReviewNote:  resp.ReviewNote,
-		ReviewedAt:  resp.ReviewedAt,
-		CreatedAt:   createdAt,
+		ReviewNote:      resp.ReviewNote,
+		ReviewedAt:      resp.ReviewedAt,
+		CreatedAt:       createdAt,
 	}, nil
 }
-
 
 // ---------------------------------------------------------------------------
 // Commands

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -95,6 +95,20 @@ Some APIs put credentials in the URL path, query string, or request body instead
 
 The proxy finds the placeholder string and replaces it with the real credential. Supported surfaces: `path`, `query`, `header`, `body`, `websocket`. Defaults to `["path", "query"]` if omitted.
 
+## Response redaction
+
+For services that may echo a brokered secret back in an API response, JSON mode
+can request response-body redaction:
+
+```json
+"response_redaction": {"enabled": true}
+```
+
+When enabled, the proxy removes exact credential values it injected for that
+request from text-like upstream response bodies before returning them to the
+agent. If a response cannot be safely inspected, such as compressed, streaming,
+or oversized bodies, the proxy fails closed with `502`.
+
 ## OAuth credentials
 
 Some services use OAuth 2.0 instead of static API keys. Use `type: "oauth"` when the service requires OAuth authorization (e.g., Google APIs, services without long-lived API keys). Use the default (static) when the service provides API keys or personal access tokens.

--- a/docs/learn/services.mdx
+++ b/docs/learn/services.mdx
@@ -10,6 +10,7 @@ Each service contains:
 - **Name**: A canonical per-vault identifier (slug, 3–64 lowercase alphanumeric/hyphen chars, no leading/trailing hyphen, no consecutive hyphens). **Required on write** for new services — pick a deliberate name like `stripe`, `slack-bot`, or `internal-billing`. `name` may be omitted only when `host` + `path` uniquely matches an existing service (the server adopts that service's name, the same pattern as host-based delete). Legacy services persisted without a name before this contract are auto-slugified from `host` + `path` on read so they remain addressable; the slug becomes durable on the next write.
 - **Host**: The single matcher field. Accepts a bare hostname (`api.stripe.com`), a one-level wildcard (`*.github.com`), an inline path-scoped form (`slack.com/api/*`), or a port-scoped form (`internal.corp.com:3000` or `internal.corp.com:3000/api/*`). When a port is included, the service matches only traffic to that port; without a port, the service matches any port. Reads and writes use the same shape: writes accept any of those forms; reads return the joined inline form so you see exactly what you wrote.
 - **Auth config**: How Agent Vault authenticates. Five types are supported: `bearer`, `basic`, `api-key`, `custom`, and `passthrough` (opt out of injection).
+- **Response redaction**: Optional defense-in-depth for services that may echo brokered credential values in upstream response bodies.
 
 <Tip>
   The `/discover` endpoint returns each service's `name` and `host` (joined
@@ -255,6 +256,35 @@ Substitutions and auth are independent. A service can use either, both, or neith
   Auth-only or enable/disable-only `set` proposals preserve existing
   substitutions; to clear them, delete and recreate the service.
 </Warning>
+
+## Response redaction
+
+Some upstream APIs can return a credential value in a response body, even when
+the agent never had that credential in its own environment. Enable response
+redaction on a service when that upstream has routes that may echo tokens,
+API keys, account secrets, or credential-bearing substitution values.
+
+```yaml
+services:
+  - name: internal-api
+    host: api.internal.example
+    auth:
+      type: bearer
+      token: INTERNAL_API_TOKEN
+    response_redaction:
+      enabled: true
+```
+
+When enabled, Agent Vault removes exact credential values that it injected for
+that request from eligible upstream response bodies before returning them to
+the agent. This includes raw credential values, rendered auth header values
+such as `Bearer <token>`, and resolved substitution values.
+
+Response redaction is off by default. It only applies to text-like response
+bodies such as JSON, XML, form-encoded, and `text/*` content. If redaction is
+enabled but the response cannot be safely materialized or inspected, such as a
+compressed, streaming, or oversized body, Agent Vault fails the proxied request
+with `502` instead of passing a potentially secret-bearing body through.
 
 ## Matching rules
 

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -28,13 +28,20 @@ type Config struct {
 // existed stay live after upgrade — use IsEnabled() rather than
 // dereferencing the pointer.
 type Service struct {
-	Name          string         `yaml:"name" json:"name"`
-	Host          string         `yaml:"host" json:"host"`
-	Path          string         `yaml:"path,omitempty" json:"path,omitempty"`
-	Port          *int           `yaml:"port,omitempty" json:"-"`
-	Enabled       *bool          `yaml:"enabled,omitempty" json:"enabled,omitempty"`
-	Auth          Auth           `yaml:"auth" json:"auth"`
-	Substitutions []Substitution `yaml:"substitutions,omitempty" json:"substitutions,omitempty"`
+	Name              string                   `yaml:"name" json:"name"`
+	Host              string                   `yaml:"host" json:"host"`
+	Path              string                   `yaml:"path,omitempty" json:"path,omitempty"`
+	Port              *int                     `yaml:"port,omitempty" json:"-"`
+	Enabled           *bool                    `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Auth              Auth                     `yaml:"auth" json:"auth"`
+	Substitutions     []Substitution           `yaml:"substitutions,omitempty" json:"substitutions,omitempty"`
+	ResponseRedaction *ResponseRedactionConfig `yaml:"response_redaction,omitempty" json:"response_redaction,omitempty"`
+}
+
+// ResponseRedactionConfig controls whether injected credential values should
+// also be considered secret on upstream response bodies.
+type ResponseRedactionConfig struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`
 }
 
 // MatcherPattern returns the joined inline form (`slack.com/api/*`),
@@ -73,6 +80,10 @@ type Substitution struct {
 // so services persisted before this field existed stay live after upgrade.
 func (s *Service) IsEnabled() bool {
 	return s.Enabled == nil || *s.Enabled
+}
+
+func (s *Service) ResponseRedactionEnabled() bool {
+	return s.ResponseRedaction != nil && s.ResponseRedaction.Enabled
 }
 
 // Auth describes how credentials are attached for a broker service.

--- a/internal/brokercore/credential.go
+++ b/internal/brokercore/credential.go
@@ -54,6 +54,10 @@ type InjectResult struct {
 	// carries a SECRET Value — never log placeholder values.
 	Substitutions []ResolvedSubstitution
 
+	// Redactions are exact secret values to remove from eligible upstream
+	// response bodies. Each Value is SECRET — never log.
+	Redactions []ResolvedRedaction
+
 	// Passthrough is set when no service matched but the unmatched-host
 	// policy permitted forwarding.
 	Passthrough bool
@@ -239,6 +243,9 @@ func (p *StoreCredentialProvider) Inject(ctx context.Context, vaultID, targetHos
 
 	if matched.Auth.Type == "passthrough" {
 		result.Substitutions = resolvedSubs
+		if matched.ResponseRedactionEnabled() {
+			result.Redactions = collectResponseRedactions(nil, nil, resolvedSubs)
+		}
 		return result, nil
 	}
 
@@ -249,7 +256,48 @@ func (p *StoreCredentialProvider) Inject(ctx context.Context, vaultID, targetHos
 
 	result.Headers = headers
 	result.Substitutions = resolvedSubs
+	if matched.ResponseRedactionEnabled() {
+		redactions, err := collectAuthResponseRedactions(matched.Auth.CredentialKeys(), getCredential, headers, resolvedSubs)
+		if err != nil {
+			return result, fmt.Errorf("%w: %v", ErrCredentialMissing, err)
+		}
+		result.Redactions = redactions
+	}
 	return result, nil
+}
+
+func collectAuthResponseRedactions(keys []string, getCredential func(key string) (string, error), headers map[string]string, subs []ResolvedSubstitution) ([]ResolvedRedaction, error) {
+	var raw []ResolvedRedaction
+	for _, key := range keys {
+		val, err := getCredential(key)
+		if err != nil {
+			return nil, err
+		}
+		raw = append(raw, ResolvedRedaction{Value: val, Source: "credential:" + key})
+	}
+	return collectResponseRedactions(raw, headers, subs), nil
+}
+
+func collectResponseRedactions(base []ResolvedRedaction, headers map[string]string, subs []ResolvedSubstitution) []ResolvedRedaction {
+	seen := map[string]bool{}
+	var out []ResolvedRedaction
+	add := func(r ResolvedRedaction) {
+		if r.Value == "" || seen[r.Value] {
+			return
+		}
+		seen[r.Value] = true
+		out = append(out, r)
+	}
+	for _, r := range base {
+		add(r)
+	}
+	for name, value := range headers {
+		add(ResolvedRedaction{Value: value, Source: "header:" + name})
+	}
+	for _, sub := range subs {
+		add(ResolvedRedaction{Value: sub.Value, Source: "substitution:" + sub.Placeholder})
+	}
+	return out
 }
 
 const oauthRefreshBuffer = 5 * time.Minute

--- a/internal/brokercore/credential_test.go
+++ b/internal/brokercore/credential_test.go
@@ -552,6 +552,59 @@ func TestInject_ResolvesSubstitutionAlongsideAuth(t *testing.T) {
 	}
 }
 
+func TestInject_ResponseRedactionsWhenEnabled(t *testing.T) {
+	key32 := make32(0xAC)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.example.com",
+		Auth: broker.Auth{Type: "bearer", Token: "API_TOKEN"},
+		Substitutions: []broker.Substitution{
+			{Key: "ACCOUNT_ID", Placeholder: "__account_id__", In: []string{"path"}},
+		},
+		ResponseRedaction: &broker.ResponseRedactionConfig{Enabled: true},
+	}})
+	f.setCred(t, key32, "v1", "API_TOKEN", "secret-token")
+	f.setCred(t, key32, "v1", "ACCOUNT_ID", "acct-123")
+
+	p := NewStoreCredentialProvider(f, key32)
+	res, err := p.Inject(context.Background(), "v1", "api.example.com", 0, "/")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, r := range res.Redactions {
+		got[r.Value] = true
+	}
+	for _, want := range []string{"secret-token", "Bearer secret-token", "acct-123"} {
+		if !got[want] {
+			t.Fatalf("expected redaction value %q in %+v", want, res.Redactions)
+		}
+	}
+	if f.getCredentialCalls != 2 {
+		t.Fatalf("expected credential cache to avoid extra lookups, got %d calls", f.getCredentialCalls)
+	}
+}
+
+func TestInject_ResponseRedactionsDisabledByDefault(t *testing.T) {
+	key32 := make32(0xAD)
+	f := newFakeCredStore()
+	f.setServices(t, "v1", []broker.Service{{
+		Host: "api.example.com",
+		Auth: broker.Auth{Type: "bearer", Token: "API_TOKEN"},
+	}})
+	f.setCred(t, key32, "v1", "API_TOKEN", "secret-token")
+
+	p := NewStoreCredentialProvider(f, key32)
+	res, err := p.Inject(context.Background(), "v1", "api.example.com", 0, "/")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(res.Redactions) != 0 {
+		t.Fatalf("expected no redactions by default, got %+v", res.Redactions)
+	}
+}
+
 func TestInject_ResolvesSubstitutionOnPassthrough(t *testing.T) {
 	key32 := make32(0xCD)
 	f := newFakeCredStore()

--- a/internal/brokercore/response_redaction.go
+++ b/internal/brokercore/response_redaction.go
@@ -1,0 +1,88 @@
+package brokercore
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+const DefaultRedactionReplacement = "[REDACTED]"
+
+// ResolvedRedaction is an exact response-body replacement rule.
+// Value is SECRET and must never be logged.
+type ResolvedRedaction struct {
+	Value       string
+	Replacement string
+	Source      string
+}
+
+// ApplyResponseRedactions replaces exact secret values in eligible
+// text-like response bodies. Callers should only invoke this after deciding
+// that the response can be safely materialized.
+func ApplyResponseRedactions(body io.ReadCloser, contentLength int64, contentType string, redactions []ResolvedRedaction) (io.ReadCloser, int64, bool, error) {
+	if len(redactions) == 0 {
+		return body, contentLength, false, nil
+	}
+	if body == nil || body == http.NoBody {
+		return body, contentLength, false, nil
+	}
+
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("reading body for response redaction: %w", err)
+	}
+	if len(data) == 0 {
+		return http.NoBody, 0, false, nil
+	}
+	if !ShouldRedactResponseContentType(contentType) {
+		return io.NopCloser(bytes.NewReader(data)), int64(len(data)), false, nil
+	}
+
+	ordered := make([]ResolvedRedaction, 0, len(redactions))
+	for _, r := range redactions {
+		if r.Value != "" {
+			ordered = append(ordered, r)
+		}
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return len(ordered[i].Value) > len(ordered[j].Value)
+	})
+
+	orig := string(data)
+	text := orig
+	for _, r := range ordered {
+		replacement := r.Replacement
+		if replacement == "" {
+			replacement = DefaultRedactionReplacement
+		}
+		text = strings.ReplaceAll(text, r.Value, replacement)
+	}
+	if text == orig {
+		return io.NopCloser(bytes.NewReader(data)), int64(len(data)), false, nil
+	}
+
+	modified := []byte(text)
+	return io.NopCloser(bytes.NewReader(modified)), int64(len(modified)), true, nil
+}
+
+// ShouldRedactResponseContentType reports whether response body redaction
+// should materialize and scan a response with the given Content-Type.
+func ShouldRedactResponseContentType(contentType string) bool {
+	mediaType, _, _ := mime.ParseMediaType(contentType)
+	if mediaType == "" {
+		return false
+	}
+	if strings.HasPrefix(mediaType, "text/") {
+		return mediaType != "text/event-stream"
+	}
+	switch mediaType {
+	case "application/json", "application/x-www-form-urlencoded", "application/xml":
+		return true
+	default:
+		return strings.HasSuffix(mediaType, "+json") || strings.HasSuffix(mediaType, "+xml")
+	}
+}

--- a/internal/brokercore/response_redaction_test.go
+++ b/internal/brokercore/response_redaction_test.go
@@ -1,0 +1,103 @@
+package brokercore
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func readCloserString(t *testing.T, body io.ReadCloser) string {
+	t.Helper()
+	data, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	return string(data)
+}
+
+func TestApplyResponseRedactionsJSONRawToken(t *testing.T) {
+	body := io.NopCloser(strings.NewReader(`{"token":"injected-secret"}`))
+	next, n, modified, err := ApplyResponseRedactions(body, 27, "application/json", []ResolvedRedaction{{
+		Value: "injected-secret",
+	}})
+	if err != nil {
+		t.Fatalf("ApplyResponseRedactions: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected body to be modified")
+	}
+	got := readCloserString(t, next)
+	if strings.Contains(got, "injected-secret") {
+		t.Fatalf("secret was not redacted: %s", got)
+	}
+	if got != `{"token":"[REDACTED]"}` {
+		t.Fatalf("body = %q", got)
+	}
+	if n != int64(len(got)) {
+		t.Fatalf("length = %d, want %d", n, len(got))
+	}
+}
+
+func TestApplyResponseRedactionsPrefersLongerRenderedValue(t *testing.T) {
+	body := io.NopCloser(strings.NewReader(`{"auth":"Bearer injected-secret","token":"injected-secret"}`))
+	next, _, modified, err := ApplyResponseRedactions(body, 0, "application/json", []ResolvedRedaction{
+		{Value: "injected-secret", Replacement: "[TOKEN]"},
+		{Value: "Bearer injected-secret", Replacement: "[AUTH]"},
+	})
+	if err != nil {
+		t.Fatalf("ApplyResponseRedactions: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected body to be modified")
+	}
+	got := readCloserString(t, next)
+	if got != `{"auth":"[AUTH]","token":"[TOKEN]"}` {
+		t.Fatalf("body = %q", got)
+	}
+}
+
+func TestApplyResponseRedactionsDisabledWhenNoRules(t *testing.T) {
+	body := io.NopCloser(strings.NewReader(`{"token":"injected-secret"}`))
+	next, n, modified, err := ApplyResponseRedactions(body, 27, "application/json", nil)
+	if err != nil {
+		t.Fatalf("ApplyResponseRedactions: %v", err)
+	}
+	if modified {
+		t.Fatal("expected body to be unchanged")
+	}
+	if next == nil {
+		t.Fatal("expected original body")
+	}
+	if n != 27 {
+		t.Fatalf("length = %d, want 27", n)
+	}
+}
+
+func TestApplyResponseRedactionsSkipsBinaryBody(t *testing.T) {
+	body := io.NopCloser(strings.NewReader("injected-secret"))
+	next, _, modified, err := ApplyResponseRedactions(body, 15, "application/octet-stream", []ResolvedRedaction{{
+		Value: "injected-secret",
+	}})
+	if err != nil {
+		t.Fatalf("ApplyResponseRedactions: %v", err)
+	}
+	if modified {
+		t.Fatal("expected binary body to be skipped")
+	}
+	if got := readCloserString(t, next); got != "injected-secret" {
+		t.Fatalf("body = %q", got)
+	}
+}
+
+func TestApplyResponseRedactionsNoBody(t *testing.T) {
+	next, n, modified, err := ApplyResponseRedactions(http.NoBody, 0, "application/json", []ResolvedRedaction{{
+		Value: "injected-secret",
+	}})
+	if err != nil {
+		t.Fatalf("ApplyResponseRedactions: %v", err)
+	}
+	if next != http.NoBody || n != 0 || modified {
+		t.Fatalf("next=%v length=%d modified=%v", next, n, modified)
+	}
+}

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -1,6 +1,7 @@
 package mitm
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -363,6 +364,7 @@ func (p *Proxy) forwardRequest(
 			retryReq.ContentLength = 0
 			if retryResp, retryRTErr := p.upstream.RoundTrip(retryReq); retryRTErr == nil {
 				resp = retryResp
+				inject = retryInject
 				p.logger.Debug("oauth 401 retry succeeded",
 					slog.String("host", host),
 					slog.String("path", r.URL.Path),
@@ -387,6 +389,26 @@ func (p *Proxy) forwardRequest(
 				resp.ContentLength, p.maxResponseBytes))
 		emit(http.StatusBadGateway, "response_too_large")
 		return
+	}
+
+	if inject != nil && len(inject.Redactions) > 0 {
+		modified, rErr := p.applyResponseRedactions(resp, inject.Redactions)
+		if rErr != nil {
+			p.logger.Warn("response redaction failed closed",
+				slog.String("host", target),
+				slog.String("path", r.URL.Path),
+				slog.String("error", rErr.Error()),
+			)
+			brokercore.WriteProxyError(w, http.StatusBadGateway, "response_redaction_error",
+				"Upstream response body could not be safely redacted.")
+			emit(http.StatusBadGateway, "response_redaction_error")
+			return
+		}
+		if modified {
+			resp.Header.Del("Etag")
+			resp.Header.Del("Content-Md5")
+			resp.Header.Del("Digest")
+		}
 	}
 
 	for k, vv := range resp.Header {
@@ -424,6 +446,60 @@ func (p *Proxy) forwardRequest(
 	}
 
 	emit(resp.StatusCode, "")
+}
+
+func (p *Proxy) applyResponseRedactions(resp *http.Response, redactions []brokercore.ResolvedRedaction) (bool, error) {
+	if resp == nil || resp.Body == nil || resp.Body == http.NoBody || len(redactions) == 0 {
+		return false, nil
+	}
+	contentType := resp.Header.Get("Content-Type")
+	if strings.HasPrefix(strings.ToLower(contentType), "text/event-stream") {
+		return false, errors.New("unsupported streaming response")
+	}
+	if !brokercore.ShouldRedactResponseContentType(contentType) {
+		return false, nil
+	}
+	if ce := resp.Header.Get("Content-Encoding"); ce != "" {
+		return false, fmt.Errorf("unsupported encoded response: %s", ce)
+	}
+
+	limit := brokercore.MaxMaterializeBytes
+	if p.maxResponseBytes > 0 && p.maxResponseBytes < limit {
+		limit = p.maxResponseBytes
+	}
+	if resp.ContentLength > limit {
+		return false, fmt.Errorf("response length %d exceeds redaction materialization limit %d", resp.ContentLength, limit)
+	}
+
+	data, err := readResponseBodyForRedaction(resp.Body, limit)
+	if err != nil {
+		return false, err
+	}
+	next, newLen, modified, err := brokercore.ApplyResponseRedactions(
+		io.NopCloser(bytes.NewReader(data)),
+		int64(len(data)),
+		contentType,
+		redactions,
+	)
+	if err != nil {
+		return false, err
+	}
+	resp.Body = next
+	resp.ContentLength = newLen
+	resp.Header.Set("Content-Length", fmt.Sprintf("%d", newLen))
+	return modified, nil
+}
+
+func readResponseBodyForRedaction(body io.ReadCloser, limit int64) ([]byte, error) {
+	defer func() { _ = body.Close() }()
+	data, err := io.ReadAll(io.LimitReader(body, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading response for redaction: %w", err)
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("response exceeds redaction materialization limit %d", limit)
+	}
+	return data, nil
 }
 
 // knownAPIKeyHeaders are non-Authorization headers that commonly carry

--- a/internal/mitm/response_redaction_test.go
+++ b/internal/mitm/response_redaction_test.go
@@ -1,0 +1,222 @@
+package mitm
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/Infisical/agent-vault/internal/brokercore"
+)
+
+func responseRedactionRule(value string) []brokercore.ResolvedRedaction {
+	return []brokercore.ResolvedRedaction{{
+		Value:       value,
+		Replacement: brokercore.DefaultRedactionReplacement,
+		Source:      "credential",
+	}}
+}
+
+type readTrackingBody struct {
+	read bool
+}
+
+func (b *readTrackingBody) Read([]byte) (int, error) {
+	b.read = true
+	return 0, io.EOF
+}
+
+func (b *readTrackingBody) Close() error {
+	return nil
+}
+
+func TestMITMDoesNotExposeInjectedCredentialEchoedInResponseBody(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"token":"injected-secret"}`)
+	}))
+	defer upstream.Close()
+
+	upstreamAuthority := strings.TrimPrefix(upstream.URL, "https://")
+	upstreamHost, _, _ := net.SplitHostPort(upstreamAuthority)
+
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{
+			Headers:    map[string]string{"Authorization": "Bearer injected-secret"},
+			Redactions: responseRedactionRule("injected-secret"),
+		}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: upstreamRoots}
+
+	client := newTrustingClient(proxyURL, url.User("av_sess_ok"), clientRoots)
+	resp, err := client.Get(upstream.URL + "/echo")
+	if err != nil {
+		t.Fatalf("client.Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(body), "injected-secret") {
+		t.Fatalf("response body exposed injected credential: %s", body)
+	}
+	if !strings.Contains(string(body), brokercore.DefaultRedactionReplacement) {
+		t.Fatalf("response body was not redacted: %s", body)
+	}
+}
+
+func TestMITMResponseRedactionDisabledDoesNotScanBody(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"token":"injected-secret"}`)
+	}))
+	defer upstream.Close()
+
+	upstreamAuthority := strings.TrimPrefix(upstream.URL, "https://")
+	upstreamHost, _, _ := net.SplitHostPort(upstreamAuthority)
+
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{
+			Headers: map[string]string{"Authorization": "Bearer injected-secret"},
+		}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: upstreamRoots}
+
+	client := newTrustingClient(proxyURL, url.User("av_sess_ok"), clientRoots)
+	resp, err := client.Get(upstream.URL + "/echo")
+	if err != nil {
+		t.Fatalf("client.Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "injected-secret") {
+		t.Fatalf("response body was unexpectedly redacted: %s", body)
+	}
+}
+
+func TestMITMResponseRedactionFailsClosedForEncodedBody(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "br")
+		_, _ = io.WriteString(w, `{"token":"injected-secret"}`)
+	}))
+	defer upstream.Close()
+
+	upstreamAuthority := strings.TrimPrefix(upstream.URL, "https://")
+	upstreamHost, _, _ := net.SplitHostPort(upstreamAuthority)
+
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{
+			Headers:    map[string]string{"Authorization": "Bearer injected-secret"},
+			Redactions: responseRedactionRule("injected-secret"),
+		}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: upstreamRoots}
+
+	client := newTrustingClient(proxyURL, url.User("av_sess_ok"), clientRoots)
+	resp, err := client.Get(upstream.URL + "/echo")
+	if err != nil {
+		t.Fatalf("client.Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d; body=%s", resp.StatusCode, http.StatusBadGateway, body)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(body), "injected-secret") {
+		t.Fatalf("fail-closed response exposed secret: %s", body)
+	}
+}
+
+func TestMITMResponseRedactionFailsClosedForOversizedBody(t *testing.T) {
+	secret := "injected-secret"
+	body := strings.Repeat("x", 128) + secret
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", "143")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer upstream.Close()
+
+	upstreamAuthority := strings.TrimPrefix(upstream.URL, "https://")
+	upstreamHost, _, _ := net.SplitHostPort(upstreamAuthority)
+
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{
+			Headers:    map[string]string{"Authorization": "Bearer " + secret},
+			Redactions: responseRedactionRule(secret),
+		}},
+	}}
+
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp, func(o *Options) {
+		o.MaxResponseBytes = 64
+	})
+	upstreamRoots := x509.NewCertPool()
+	upstreamRoots.AddCert(upstream.Certificate())
+	p.upstream.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: upstreamRoots}
+
+	client := newTrustingClient(proxyURL, url.User("av_sess_ok"), clientRoots)
+	resp, err := client.Get(upstream.URL + "/echo")
+	if err != nil {
+		t.Fatalf("client.Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d; body=%s", resp.StatusCode, http.StatusBadGateway, body)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(respBody), secret) {
+		t.Fatalf("fail-closed response exposed secret: %s", respBody)
+	}
+}
+
+func TestApplyResponseRedactionsSkipsLargeBinaryBodyBeforeRead(t *testing.T) {
+	body := &readTrackingBody{}
+	resp := &http.Response{
+		Body:          body,
+		ContentLength: brokercore.MaxMaterializeBytes + 1,
+		Header:        make(http.Header),
+	}
+	resp.Header.Set("Content-Type", "application/octet-stream")
+
+	p := &Proxy{}
+	modified, err := p.applyResponseRedactions(resp, responseRedactionRule("secret"))
+	if err != nil {
+		t.Fatalf("applyResponseRedactions: %v", err)
+	}
+	if modified {
+		t.Fatal("binary response was unexpectedly modified")
+	}
+	if body.read {
+		t.Fatal("binary response body was read before content-type skip")
+	}
+}

--- a/internal/proposal/merge.go
+++ b/internal/proposal/merge.go
@@ -49,9 +49,14 @@ func MergeServices(existing []broker.Service, proposed []Service) ([]broker.Serv
 		default: // ActionSet: upsert
 			idx, exists := nameIndex[p.Name]
 			switch {
-			case exists && p.Auth == nil && p.Enabled != nil:
-				// Enable/disable-only: preserve Auth/Host/Path.
-				merged[idx].Enabled = p.Enabled
+			case exists && p.Auth == nil && len(p.Substitutions) == 0 && (p.Enabled != nil || p.ResponseRedaction != nil):
+				// Metadata-only update: preserve Auth/Host/Path.
+				if p.Enabled != nil {
+					merged[idx].Enabled = p.Enabled
+				}
+				if p.ResponseRedaction != nil {
+					merged[idx].ResponseRedaction = p.ResponseRedaction
+				}
 			case exists:
 				next := toBrokerService(p)
 				// Empty Substitutions means "leave existing alone";
@@ -88,6 +93,9 @@ func toBrokerService(p Service) broker.Service {
 		Path:    p.Path,
 		Port:    p.Port,
 		Enabled: p.Enabled,
+	}
+	if p.ResponseRedaction != nil {
+		svc.ResponseRedaction = p.ResponseRedaction
 	}
 	if p.Auth != nil {
 		svc.Auth = *p.Auth

--- a/internal/proposal/proposal.go
+++ b/internal/proposal/proposal.go
@@ -42,14 +42,15 @@ const (
 // flow); Substitutions require Auth since merge only carries them on
 // full replacements.
 type Service struct {
-	Action        Action                `json:"action"`
-	Name          string                `json:"name,omitempty"`
-	Host          string                `json:"host"`
-	Path          string                `json:"path,omitempty"`
-	Port          *int                  `json:"-"`
-	Enabled       *bool                 `json:"enabled,omitempty"`
-	Auth          *broker.Auth          `json:"auth,omitempty"`
-	Substitutions []broker.Substitution `json:"substitutions,omitempty"`
+	Action            Action                          `json:"action"`
+	Name              string                          `json:"name,omitempty"`
+	Host              string                          `json:"host"`
+	Path              string                          `json:"path,omitempty"`
+	Port              *int                            `json:"-"`
+	Enabled           *bool                           `json:"enabled,omitempty"`
+	Auth              *broker.Auth                    `json:"auth,omitempty"`
+	Substitutions     []broker.Substitution           `json:"substitutions,omitempty"`
+	ResponseRedaction *broker.ResponseRedactionConfig `json:"response_redaction,omitempty"`
 }
 
 // MatcherPattern returns the joined inline form (`slack.com/api/*`),

--- a/internal/proposal/validate.go
+++ b/internal/proposal/validate.go
@@ -19,7 +19,6 @@ const (
 	MaxObtainInstructionsLen = 1000
 )
 
-
 // ValidateMessages checks length limits for proposal-level message fields.
 func ValidateMessages(message, userMessage string) error {
 	if len(message) > MaxMessageLen {
@@ -74,8 +73,8 @@ func Validate(services []Service, credentials []CredentialSlot) error {
 			return fmt.Errorf("service %d: %w", i, err)
 		}
 		if s.Action == ActionSet {
-			if s.Auth == nil && s.Enabled == nil {
-				return fmt.Errorf("service %d: set action requires auth or enabled change", i)
+			if s.Auth == nil && s.Enabled == nil && s.ResponseRedaction == nil {
+				return fmt.Errorf("service %d: set action requires auth, enabled change, or response_redaction change", i)
 			}
 			if s.Auth != nil {
 				if err := s.Auth.Validate(); err != nil {

--- a/internal/proposal/validate_test.go
+++ b/internal/proposal/validate_test.go
@@ -42,11 +42,11 @@ func TestValidateEmptyHost(t *testing.T) {
 	}
 }
 
-func TestValidateMissingAuthForSet(t *testing.T) {
+func TestValidateMissingSetChange(t *testing.T) {
 	services := []Service{{Action: ActionSet, Name: "example-com", Host: "example.com"}}
 	err := Validate(services, nil)
-	if err == nil || !strings.Contains(err.Error(), "auth or enabled") {
-		t.Fatalf("expected auth-or-enabled required error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "auth, enabled change, or response_redaction change") {
+		t.Fatalf("expected set-change required error, got %v", err)
 	}
 }
 
@@ -55,6 +55,18 @@ func TestValidateEnabledOnlySetValid(t *testing.T) {
 	services := []Service{{Action: ActionSet, Name: "example-com", Host: "example.com", Enabled: &disabled}}
 	if err := Validate(services, nil); err != nil {
 		t.Fatalf("expected enable-only set to validate, got %v", err)
+	}
+}
+
+func TestValidateResponseRedactionOnlySetValid(t *testing.T) {
+	services := []Service{{
+		Action:            ActionSet,
+		Name:              "example-com",
+		Host:              "example.com",
+		ResponseRedaction: &broker.ResponseRedactionConfig{Enabled: true},
+	}}
+	if err := Validate(services, nil); err != nil {
+		t.Fatalf("expected response-redaction-only set to validate, got %v", err)
 	}
 }
 
@@ -317,7 +329,7 @@ func TestValidateProposalSubstitutionWithoutAuth(t *testing.T) {
 	on := true
 	services := []Service{{
 		Action:  ActionSet,
-		Name:   "api-twilio-com",
+		Name:    "api-twilio-com",
 		Host:    "api.twilio.com",
 		Enabled: &on,
 		Substitutions: []broker.Substitution{


### PR DESCRIPTION
Problem
- Fixes #258.
- A service can broker credentials on the request, but an upstream route may echo the raw token or rendered auth value back in a response body.
- That makes the credential visible to the agent even though it never had the secret locally.

Fix
- Adds opt-in service config: response_redaction.enabled.
- Carries exact redaction values from credential injection: raw credential values, rendered auth header values, and substitution values.
- Redacts eligible text-like response bodies before returning them to the agent.
- Fails closed with 502 when response redaction is enabled but the body is encoded, streaming, or too large to safely materialize.
- Shows the setting in proposal review output and documents it in the service docs / CLI skill.

Tests
- go test ./internal/broker ./internal/proposal ./internal/brokercore ./internal/mitm ./cmd -count=1
- git diff --check
- go test ./... was also run; it only failed in internal/isolation on local environment/checkout issues unrelated to this change: Docker socket resolution and embedded asset file modes.

Risk
- Response redaction is disabled by default.
- For enabled services, encoded/streaming/oversized responses fail closed rather than leaking a body that could contain the brokered credential.