### PR TITLE
Feat/credential key suggestions

### DIFF
--- a/web/src/components/Combobox.tsx
+++ b/web/src/components/Combobox.tsx
@@ -17,13 +17,15 @@ interface ComboboxProps {
   /** Called when an option is explicitly picked from the list. */
   onSelect: (id: string) => void;
   placeholder?: string;
+  /** Overrides the input's default styling (compact/inline variants). */
+  inputClassName?: string;
 }
 
 /**
  * A text input with a suggestion popover. Typing filters the options;
  * text that matches nothing behaves exactly like a plain Input.
  */
-export default function Combobox({ value, onChange, options, onSelect, placeholder }: ComboboxProps) {
+export default function Combobox({ value, onChange, options, onSelect, placeholder, inputClassName }: ComboboxProps) {
   const [open, setOpen] = useState(false);
   const [highlighted, setHighlighted] = useState(0);
   const [typing, setTyping] = useState(false);
@@ -54,11 +56,26 @@ export default function Combobox({ value, onChange, options, onSelect, placehold
     return () => document.removeEventListener("mousedown", handleClick);
   }, [open]);
 
+  function reposition() {
+    if (!inputRef.current) return;
+    const rect = inputRef.current.getBoundingClientRect();
+    setPos({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+  }
+
+  // The popover is position:fixed, so scrolling any ancestor (page or the
+  // sheet body) would leave it stranded — track the input while open.
+  useEffect(() => {
+    if (!open) return;
+    window.addEventListener("scroll", reposition, true);
+    window.addEventListener("resize", reposition);
+    return () => {
+      window.removeEventListener("scroll", reposition, true);
+      window.removeEventListener("resize", reposition);
+    };
+  }, [open]);
+
   function show() {
-    if (inputRef.current) {
-      const rect = inputRef.current.getBoundingClientRect();
-      setPos({ top: rect.bottom + 4, left: rect.left, width: rect.width });
-    }
+    reposition();
     setHighlighted(0);
     setOpen(true);
   }
@@ -103,7 +120,7 @@ export default function Combobox({ value, onChange, options, onSelect, placehold
         role="combobox"
         aria-expanded={open && filtered.length > 0}
         autoComplete="off"
-        className="w-full px-4 py-3 pr-10 bg-surface-raised border border-border rounded-lg text-text text-sm outline-none transition-colors focus:border-border-focus focus:shadow-[0_0_0_3px_var(--color-primary-ring)]"
+        className={inputClassName ?? "w-full px-4 py-3 pr-10 bg-surface-raised border border-border rounded-lg text-text text-sm outline-none transition-colors focus:border-border-focus focus:shadow-[0_0_0_3px_var(--color-primary-ring)]"}
       />
       <button
         type="button"

--- a/web/src/components/Combobox.tsx
+++ b/web/src/components/Combobox.tsx
@@ -16,6 +16,8 @@ interface ComboboxProps {
   options: ComboboxOption[];
   /** Called when an option is explicitly picked from the list. */
   onSelect: (id: string) => void;
+  /** Called on Enter when the suggestion popover is closed. */
+  onEnter?: () => void;
   placeholder?: string;
   /** Overrides the input's default styling (compact/inline variants). */
   inputClassName?: string;
@@ -27,7 +29,7 @@ interface ComboboxProps {
  * A text input with a suggestion popover. Typing filters the options;
  * text that matches nothing behaves exactly like a plain Input.
  */
-export default function Combobox({ value, onChange, options, onSelect, placeholder, inputClassName, menuMaxHeightClassName }: ComboboxProps) {
+export default function Combobox({ value, onChange, options, onSelect, onEnter, placeholder, inputClassName, menuMaxHeightClassName }: ComboboxProps) {
   const [open, setOpen] = useState(false);
   const [highlighted, setHighlighted] = useState(0);
   const [typing, setTyping] = useState(false);
@@ -89,7 +91,10 @@ export default function Combobox({ value, onChange, options, onSelect, placehold
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
-    if (!open || filtered.length === 0) return;
+    if (!open || filtered.length === 0) {
+      if (e.key === "Enter") onEnter?.();
+      return;
+    }
     if (e.key === "ArrowDown") {
       e.preventDefault();
       setHighlighted((h) => (h + 1) % filtered.length);
@@ -118,6 +123,7 @@ export default function Combobox({ value, onChange, options, onSelect, placehold
           show();
         }}
         onFocus={() => { setTyping(false); show(); }}
+        onBlur={() => setOpen(false)}
         onKeyDown={handleKeyDown}
         role="combobox"
         aria-expanded={open && filtered.length > 0}

--- a/web/src/components/Combobox.tsx
+++ b/web/src/components/Combobox.tsx
@@ -19,13 +19,15 @@ interface ComboboxProps {
   placeholder?: string;
   /** Overrides the input's default styling (compact/inline variants). */
   inputClassName?: string;
+  /** Overrides the popover's max-height (e.g. for inputs low on the sheet). */
+  menuMaxHeightClassName?: string;
 }
 
 /**
  * A text input with a suggestion popover. Typing filters the options;
  * text that matches nothing behaves exactly like a plain Input.
  */
-export default function Combobox({ value, onChange, options, onSelect, placeholder, inputClassName }: ComboboxProps) {
+export default function Combobox({ value, onChange, options, onSelect, placeholder, inputClassName, menuMaxHeightClassName }: ComboboxProps) {
   const [open, setOpen] = useState(false);
   const [highlighted, setHighlighted] = useState(0);
   const [typing, setTyping] = useState(false);
@@ -147,8 +149,8 @@ export default function Combobox({ value, onChange, options, onSelect, placehold
         createPortal(
           <div
             ref={listRef}
-            className="fixed z-50 bg-surface border border-border rounded-lg shadow-[0_4px_16px_rgba(0,0,0,0.12)] py-1 max-h-64 overflow-y-auto"
-            style={{ top: pos.top, left: pos.left, width: pos.width, scrollbarWidth: "thin", scrollbarColor: "var(--color-border) var(--color-surface)" }}
+            className={`fixed z-50 bg-surface border border-border rounded-lg shadow-[0_4px_16px_rgba(0,0,0,0.12)] py-1 overflow-y-auto thin-scrollbar ${menuMaxHeightClassName ?? "max-h-64"}`}
+            style={{ top: pos.top, left: pos.left, width: pos.width }}
           >
             {filtered.map((option, i) => (
               <button

--- a/web/src/components/CreatableSelect.tsx
+++ b/web/src/components/CreatableSelect.tsx
@@ -170,8 +170,8 @@ export default function CreatableSelect({ values, onChange, options = [], placeh
         createPortal(
           <div
             ref={listRef}
-            className="fixed z-50 bg-surface border border-border rounded-lg shadow-[0_4px_16px_rgba(0,0,0,0.12)] py-1 max-h-64 overflow-y-auto"
-            style={{ top: pos.top, left: pos.left, width: pos.width, scrollbarWidth: "thin", scrollbarColor: "var(--color-border) var(--color-surface)" }}
+            className="fixed z-50 bg-surface border border-border rounded-lg shadow-[0_4px_16px_rgba(0,0,0,0.12)] py-1 max-h-64 overflow-y-auto thin-scrollbar"
+            style={{ top: pos.top, left: pos.left, width: pos.width }}
           >
             {items.map((item, i) => {
               if (item.type === "create") {

--- a/web/src/components/TemplateInput.tsx
+++ b/web/src/components/TemplateInput.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface TemplateInputProps {
+  value: string;
+  onChange: (text: string) => void;
+  /** Credential keys suggested while the caret sits inside a {{ … placeholder. */
+  suggestions: string[];
+  placeholder?: string;
+  /** Called on Enter when the suggestion popover is closed. */
+  onEnter?: () => void;
+}
+
+/**
+ * Finds the unclosed {{ token the caret is inside, if any: the last "{{"
+ * before the caret with no closing brace between it and the caret.
+ */
+function openToken(value: string, caret: number): { start: number; partial: string } | null {
+  const before = value.slice(0, caret);
+  const start = before.lastIndexOf("{{");
+  if (start === -1) return null;
+  const inner = before.slice(start + 2);
+  if (inner.includes("}")) return null;
+  return { start, partial: inner.trim() };
+}
+
+/**
+ * A text input for header-value templates. Typing "{{" opens a popover
+ * listing stored credential keys; picking one inserts "{{ KEY }}" at the
+ * caret. Outside a placeholder it behaves exactly like a plain Input.
+ */
+export default function TemplateInput({
+  value,
+  onChange,
+  suggestions,
+  placeholder,
+  onEnter,
+}: TemplateInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const [caret, setCaret] = useState(0);
+  const [focused, setFocused] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const [highlighted, setHighlighted] = useState(0);
+  const [pos, setPos] = useState({ top: 0, left: 0, width: 0 });
+  // Caret restore target after a programmatic insert, applied post-render.
+  const pendingCaret = useRef<number | null>(null);
+
+  const token = focused && !dismissed ? openToken(value, caret) : null;
+  const query = token?.partial.toLowerCase() ?? "";
+  const matches = token
+    ? suggestions.filter((k) => !query || k.toLowerCase().includes(query))
+    : [];
+  const open = matches.length > 0;
+
+  useEffect(() => {
+    setDismissed(false);
+  }, [value]);
+
+  useEffect(() => {
+    if (highlighted >= matches.length) setHighlighted(0);
+  }, [matches.length, highlighted]);
+
+  // The popover is position:fixed, so scrolling any ancestor (page or the
+  // sheet body) would leave it stranded — track the input while open.
+  useEffect(() => {
+    if (!open) return;
+    function reposition() {
+      if (!inputRef.current) return;
+      const rect = inputRef.current.getBoundingClientRect();
+      setPos({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+    }
+    reposition();
+    window.addEventListener("scroll", reposition, true);
+    window.addEventListener("resize", reposition);
+    return () => {
+      window.removeEventListener("scroll", reposition, true);
+      window.removeEventListener("resize", reposition);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (pendingCaret.current === null || !inputRef.current) return;
+    inputRef.current.setSelectionRange(pendingCaret.current, pendingCaret.current);
+    setCaret(pendingCaret.current);
+    pendingCaret.current = null;
+  }, [value]);
+
+  function syncCaret(el: HTMLInputElement) {
+    setCaret(el.selectionStart ?? 0);
+  }
+
+  function insert(key: string) {
+    const t = openToken(value, caret);
+    if (!t) return;
+    // Consume a closing "}}" the user may have already typed after the caret.
+    const after = value.slice(caret).replace(/^\s*\}\}/, "");
+    const inserted = `{{ ${key} }}`;
+    pendingCaret.current = t.start + inserted.length;
+    onChange(value.slice(0, t.start) + inserted + after);
+    inputRef.current?.focus();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (!open) {
+      if (e.key === "Enter") onEnter?.();
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlighted((h) => (h + 1) % matches.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlighted((h) => (h - 1 + matches.length) % matches.length);
+    } else if (e.key === "Enter" || e.key === "Tab") {
+      e.preventDefault();
+      insert(matches[Math.min(highlighted, matches.length - 1)]);
+    } else if (e.key === "Escape") {
+      e.stopPropagation();
+      setDismissed(true);
+    }
+  }
+
+  return (
+    <div className="relative w-full">
+      <input
+        ref={inputRef}
+        value={value}
+        placeholder={placeholder}
+        autoComplete="off"
+        onChange={(e) => {
+          onChange(e.target.value);
+          syncCaret(e.target);
+          setHighlighted(0);
+        }}
+        onSelect={(e) => syncCaret(e.currentTarget)}
+        onFocus={(e) => {
+          setFocused(true);
+          syncCaret(e.currentTarget);
+        }}
+        onBlur={() => setFocused(false)}
+        onKeyDown={handleKeyDown}
+        role="combobox"
+        aria-expanded={open}
+        className="w-full px-4 py-3 bg-surface-raised border border-border rounded-lg text-text text-sm outline-none transition-colors focus:border-border-focus focus:shadow-[0_0_0_3px_var(--color-primary-ring)]"
+      />
+      {open &&
+        createPortal(
+          <div
+            ref={listRef}
+            className="fixed z-50 bg-surface border border-border rounded-lg shadow-[0_4px_16px_rgba(0,0,0,0.12)] py-1 max-h-64 overflow-y-auto"
+            style={{ top: pos.top, left: pos.left, width: pos.width, scrollbarWidth: "thin", scrollbarColor: "var(--color-border) var(--color-surface)" }}
+          >
+            <div className="px-4 py-1.5 text-[11px] font-mono uppercase tracking-[0.18em] text-text-dim">
+              Credentials
+            </div>
+            {matches.map((key, i) => (
+              <button
+                key={key}
+                type="button"
+                // mousedown so selection wins over the input's blur handling
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  insert(key);
+                }}
+                onMouseEnter={() => setHighlighted(i)}
+                className={`w-full text-left px-4 py-2 font-mono text-sm text-text transition-colors ${i === highlighted ? "bg-bg" : ""}`}
+              >
+                {key}
+              </button>
+            ))}
+          </div>,
+          document.body
+        )}
+    </div>
+  );
+}

--- a/web/src/components/TemplateInput.tsx
+++ b/web/src/components/TemplateInput.tsx
@@ -148,8 +148,8 @@ export default function TemplateInput({
         createPortal(
           <div
             ref={listRef}
-            className="fixed z-50 bg-surface border border-border rounded-lg shadow-[0_4px_16px_rgba(0,0,0,0.12)] py-1 max-h-64 overflow-y-auto"
-            style={{ top: pos.top, left: pos.left, width: pos.width, scrollbarWidth: "thin", scrollbarColor: "var(--color-border) var(--color-surface)" }}
+            className="fixed z-50 bg-surface border border-border rounded-lg shadow-[0_4px_16px_rgba(0,0,0,0.12)] py-1 max-h-64 overflow-y-auto thin-scrollbar"
+            style={{ top: pos.top, left: pos.left, width: pos.width }}
           >
             <div className="px-4 py-1.5 text-[11px] font-mono uppercase tracking-[0.18em] text-text-dim">
               Credentials

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -133,10 +133,8 @@ export default function ServicesTab() {
         `/v1/credentials?vault=${encodeURIComponent(vaultName)}`
       );
       if (resp.ok) {
-        const data = await resp.json();
-        const keys: string[] =
-          data.credentials?.map((c: { key: string }) => c.key) ?? data.keys ?? [];
-        setCredentialKeys([...new Set(keys)].sort());
+        const data: { keys?: string[] } = await resp.json();
+        setCredentialKeys([...new Set(data.keys ?? [])].sort());
       }
     } catch {
       // Suggestions are optional — degrade silently to manual entry.
@@ -752,6 +750,7 @@ function ServiceModal({
                 value={token}
                 onChange={setToken}
                 onSelect={setToken}
+                onEnter={handleSubmit}
                 options={credentialOptions}
               />
             </FormField>
@@ -769,6 +768,7 @@ function ServiceModal({
                   value={username}
                   onChange={setUsername}
                   onSelect={setUsername}
+                  onEnter={handleSubmit}
                   options={credentialOptions}
                 />
               </FormField>
@@ -781,6 +781,7 @@ function ServiceModal({
                   value={password}
                   onChange={setPassword}
                   onSelect={setPassword}
+                  onEnter={handleSubmit}
                   options={credentialOptions}
                 />
               </FormField>

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -15,6 +15,8 @@ import Input from "../../components/Input";
 import FormField from "../../components/FormField";
 import Toggle from "../../components/Toggle";
 import SegmentedTabs from "../../components/SegmentedTabs";
+import Combobox from "../../components/Combobox";
+import TemplateInput from "../../components/TemplateInput";
 import {
   type Auth,
   type Substitution,
@@ -77,6 +79,7 @@ export default function ServicesTab() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [catalog, setCatalog] = useState<CatalogTemplate[]>([]);
+  const [credentialKeys, setCredentialKeys] = useState<string[]>([]);
   const presetApplied = useRef(false);
 
   // Add/Edit modal state: null = closed, -1 = add, 0+ = edit index
@@ -100,6 +103,7 @@ export default function ServicesTab() {
     fetchServices();
     fetchCatalog();
     fetchDiscoveredHosts();
+    fetchCredentialKeys();
   }, []);
 
   useEffect(() => {
@@ -120,6 +124,22 @@ export default function ServicesTab() {
       setCatalog(entries);
     } catch {
       // Catalog is optional — degrade silently to manual entry.
+    }
+  }
+
+  async function fetchCredentialKeys() {
+    try {
+      const resp = await apiFetch(
+        `/v1/credentials?vault=${encodeURIComponent(vaultName)}`
+      );
+      if (resp.ok) {
+        const data = await resp.json();
+        const keys: string[] =
+          data.credentials?.map((c: { key: string }) => c.key) ?? data.keys ?? [];
+        setCredentialKeys([...new Set(keys)].sort());
+      }
+    } catch {
+      // Suggestions are optional — degrade silently to manual entry.
     }
   }
 
@@ -420,6 +440,7 @@ export default function ServicesTab() {
           defaultAuthHeader={editingIndex === -1 ? addWithHost?.authHeader : undefined}
           defaultPreset={editingIndex === -1 && !addWithHost ? presetParam : undefined}
           catalog={catalog}
+          credentialKeys={credentialKeys}
           onClose={() => {
             setEditingIndex(null);
             setAddWithHost(null);
@@ -452,6 +473,7 @@ function ServiceModal({
   defaultAuthHeader,
   defaultPreset,
   catalog,
+  credentialKeys,
   onClose,
   onSave,
 }: {
@@ -463,9 +485,11 @@ function ServiceModal({
   defaultAuthHeader?: string;
   defaultPreset?: string;
   catalog: CatalogTemplate[];
+  credentialKeys: string[];
   onClose: () => void;
   onSave: (service: Service) => Promise<void>;
 }) {
+  const credentialOptions = credentialKeys.map((k) => ({ id: k, label: k }));
   const [name, setName] = useState(initial?.name ?? defaultName ?? "");
   const [pattern, setPattern] = useState(initial?.host ?? defaultHost ?? "");
   const [enabled, setEnabled] = useState(initial ? initial.enabled !== false : true);
@@ -723,13 +747,12 @@ function ServiceModal({
               tooltip="The UPPER_SNAKE_CASE name of the credential storing the token."
               required
             >
-              <Input
+              <Combobox
                 placeholder="e.g. STRIPE_KEY"
                 value={token}
-                onChange={(e) => setToken(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleSubmit();
-                }}
+                onChange={setToken}
+                onSelect={setToken}
+                options={credentialOptions}
               />
             </FormField>
           )}
@@ -741,23 +764,24 @@ function ServiceModal({
                 tooltip="Credential key for the Basic Auth username."
                 required
               >
-                <Input
+                <Combobox
                   placeholder="e.g. ASHBY_API_KEY"
                   value={username}
-                  onChange={(e) => setUsername(e.target.value)}
+                  onChange={setUsername}
+                  onSelect={setUsername}
+                  options={credentialOptions}
                 />
               </FormField>
               <FormField
                 label="Password Credential Key"
                 tooltip="Optional — leave empty if the service only requires a username."
               >
-                <Input
+                <Combobox
                   placeholder="e.g. ASHBY_PASSWORD"
                   value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") handleSubmit();
-                  }}
+                  onChange={setPassword}
+                  onSelect={setPassword}
+                  options={credentialOptions}
                 />
               </FormField>
             </>
@@ -770,10 +794,12 @@ function ServiceModal({
                 tooltip="The UPPER_SNAKE_CASE name of the credential storing the API key."
                 required
               >
-                <Input
+                <Combobox
                   placeholder="e.g. OPENAI_API_KEY"
                   value={apiKey}
-                  onChange={(e) => setApiKey(e.target.value)}
+                  onChange={setApiKey}
+                  onSelect={setApiKey}
+                  options={credentialOptions}
                 />
               </FormField>
               <FormField
@@ -829,17 +855,16 @@ function ServiceModal({
                         )
                       }
                     />
-                    <Input
+                    <TemplateInput
                       placeholder="e.g. Bearer {{ STRIPE_KEY }}"
                       value={header.value}
-                      onChange={(e) =>
+                      onChange={(value) =>
                         setCustomHeaders((prev) =>
-                          prev.map((h, j) => (j === i ? { ...h, value: e.target.value } : h))
+                          prev.map((h, j) => (j === i ? { ...h, value } : h))
                         )
                       }
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") handleSubmit();
-                      }}
+                      suggestions={credentialKeys}
+                      onEnter={handleSubmit}
                     />
                     {customHeaders.length > 1 && (
                       <IconButton
@@ -935,16 +960,24 @@ function ServiceModal({
                     );
                   })}
                   <span>with value of</span>
-                  <InlineInput
-                    widthClass="w-48"
-                    placeholder="CREDENTIAL_KEY"
-                    value={sub.key}
-                    onChange={(value) =>
-                      setSubs((prev) =>
-                        prev.map((s, j) => (j === i ? { ...s, key: value } : s))
-                      )
-                    }
-                  />
+                  <div className="w-48">
+                    <Combobox
+                      placeholder="CREDENTIAL_KEY"
+                      value={sub.key}
+                      onChange={(value) =>
+                        setSubs((prev) =>
+                          prev.map((s, j) => (j === i ? { ...s, key: value } : s))
+                        )
+                      }
+                      onSelect={(key) =>
+                        setSubs((prev) =>
+                          prev.map((s, j) => (j === i ? { ...s, key } : s))
+                        )
+                      }
+                      options={credentialOptions}
+                      inputClassName="w-full px-3 py-1.5 pr-8 bg-surface-raised border border-border rounded-md font-mono text-sm text-text outline-none transition-colors focus:border-border-focus focus:shadow-[0_0_0_3px_var(--color-primary-ring)]"
+                    />
+                  </div>
                 </div>
                 <IconButton
                   onClick={() => setSubs((prev) => prev.filter((_, j) => j !== i))}

--- a/web/src/pages/vault/ServicesTab.tsx
+++ b/web/src/pages/vault/ServicesTab.tsx
@@ -976,6 +976,7 @@ function ServiceModal({
                       }
                       options={credentialOptions}
                       inputClassName="w-full px-3 py-1.5 pr-8 bg-surface-raised border border-border rounded-md font-mono text-sm text-text outline-none transition-colors focus:border-border-focus focus:shadow-[0_0_0_3px_var(--color-primary-ring)]"
+                      menuMaxHeightClassName="max-h-40"
                     />
                   </div>
                 </div>

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -68,4 +68,22 @@
   button, [role="button"] {
     cursor: pointer;
   }
+
+  .thin-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-border) var(--color-surface);
+  }
+
+  .thin-scrollbar::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .thin-scrollbar::-webkit-scrollbar-track {
+    background: var(--color-surface);
+  }
+
+  .thin-scrollbar::-webkit-scrollbar-thumb {
+    background-color: var(--color-border);
+    border-radius: 9999px;
+  }
 }


### PR DESCRIPTION
Fixes #316 

Every credential-reference field in the Add/Edit Service sheet now offers the vault's stored credential keys instead of requiring the key name to be typed from memory:

Summary

- Wires the bearer/basic/api-key credential fields and the URL-substitution key field in the Add/Edit Service sheet into the existing Combobox, sourced from GET /v1/credentials — shows all vault keys on focus, filters as you type, and still allows free text.
- Adds a new TemplateInput component for custom header values that opens a credential picker when the caret sits inside an unclosed {{ ... }} placeholder and inserts {{ KEY }} on selection.
- Both suggestion popovers are position:fixed portals that now track their anchor input on ancestor scroll/resize, so they don't strand when the sheet body scrolls.
- Suggestions degrade silently to plain inputs if /v1/credentials is unavailable.
- Fixed Issue of ComboBox getting stranded at on place on scrolling the container.

Screenshots-

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/b11be877-42e9-4b13-af37-4eccc96bb050" />
<img width="519" height="801" alt="image" src="https://github.com/user-attachments/assets/08d8df76-ce5a-4de4-837e-ccdfe19864a9" />
<img width="431" height="402" alt="image" src="https://github.com/user-attachments/assets/08a308a9-edf1-47a2-aa49-c82de01d7f21" />
