### PR TITLE
Add credential version history and rollback for the built-in store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,11 @@
 # AGENT_VAULT_LOGS_MAX_ROWS_PER_VAULT=10000 # Keep at most this many rows per vault (default 10000).
 # AGENT_VAULT_LOGS_RETENTION_LOCK=false     # When true, ignore any owner UI overrides (operator pin).
 
+# Credential history retention (optional) — how many prior values of a
+# built-in credential are kept (per vault+key) after being overwritten.
+# See `agent-vault vault credential history`/`rollback`. 0 = unbounded.
+# AGENT_VAULT_CREDENTIAL_HISTORY_MAX_VERSIONS=10
+
 # Rate limiting (optional) — tiered limits with sensible defaults.
 # Profile: default | strict (≈0.5×) | loose (≈2×) | off (disable all limits).
 # AGENT_VAULT_RATELIMIT_PROFILE=default

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Features:
 - **Purpose-Built Design**: Existing forward proxies like `mitmproxy` or `squid` require modification to perform credential brokering and integrate well with agents. Agent Vault is purpose-built to work with the ergonomics of all types of agent use-cases with a dedicated CLI, multi-tenancy, and agent-specific roadmap backed by [Infisical](https://github.com/Infisical/infisical).
 - **Egress Filtering**: Control which agents should have access to which services and API endpoints on them since authenticated requests flow through Agent Vault.
 - **Request Logging**: Inspect authenticated traffic to monitor and diagnose agent behavior.
+- **Credential History & Rollback**: Every overwrite of a built-in credential archives the value it replaces, so an accidental overwrite is never destructive. Inspect and restore with `vault credential history`/`rollback`. See [credentials](docs/learn/credentials.mdx#credential-history-and-rollback).
 
 By default, requests not matching any service forward as plain proxy traffic; flip a vault into strict deny mode (`unmatched_host_policy=deny`) to reject them with 403 instead.
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -40,6 +40,29 @@ func TestCommandsRegistered(t *testing.T) {
 	}
 }
 
+func TestCredentialSubcommandsRegistered(t *testing.T) {
+	vaultCmd := findSubcommand(rootCmd, "vault")
+	if vaultCmd == nil {
+		t.Fatal("vault command not found")
+	}
+	credCmd := findSubcommand(vaultCmd, "credential")
+	if credCmd == nil {
+		t.Fatal("credential command not found")
+	}
+
+	registered := make(map[string]bool)
+	for _, c := range credCmd.Commands() {
+		registered[c.Name()] = true
+	}
+
+	expected := []string{"list", "get", "set", "delete", "history", "rollback"}
+	for _, name := range expected {
+		if !registered[name] {
+			t.Errorf("expected credential subcommand %q to be registered, but it was not", name)
+		}
+	}
+}
+
 func TestCASubcommandsRegistered(t *testing.T) {
 	caCmd := findSubcommand(rootCmd, "ca")
 	if caCmd == nil {

--- a/cmd/credential.go
+++ b/cmd/credential.go
@@ -250,11 +250,137 @@ required — there is no project-file or interactive-picker fallback.`,
 	},
 }
 
+var credentialHistoryCmd = &cobra.Command{
+	Use:   "history <key>",
+	Short: "List archived versions of a credential",
+	Long: `List past values a credential held before being overwritten, most recent
+first, with the timestamp and actor (user/agent) responsible for each
+overwrite. Requires member+ role — the same rule as "credential get"/--reveal.
+
+Values are not shown unless --reveal is also passed. Roll one back with
+"agent-vault vault credential rollback <key> --version N".
+
+In agent mode (AGENT_VAULT_TOKEN set), AGENT_VAULT_VAULT (or --vault) is
+required — there is no project-file or interactive-picker fallback.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sess, tokenSource, err := resolveSession()
+		if err != nil {
+			return err
+		}
+
+		vault, err := resolveVaultForCommand(cmd, tokenSource)
+		if err != nil {
+			return err
+		}
+		key := args[0]
+		reveal, _ := cmd.Flags().GetBool("reveal")
+
+		reqURL := sess.Address + "/v1/credentials/history?vault=" + url.QueryEscape(vault) + "&key=" + url.QueryEscape(key)
+		if reveal {
+			reqURL += "&reveal=true"
+		}
+		respBody, err := doAdminRequestWithBody("GET", reqURL, sess.Token, nil)
+		if err != nil {
+			return err
+		}
+
+		var result struct {
+			Versions []struct {
+				Version   int    `json:"version"`
+				ActorType string `json:"actor_type"`
+				ActorID   string `json:"actor_id"`
+				CreatedAt string `json:"created_at"`
+				Value     string `json:"value"`
+			} `json:"versions"`
+		}
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			return fmt.Errorf("parsing response: %w", err)
+		}
+
+		if len(result.Versions) == 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No archived versions for credential %q in vault %q.\n", key, vault)
+			return nil
+		}
+
+		t := newTable(cmd.OutOrStdout())
+		header := table.Row{"VERSION", "REPLACED AT", "ACTOR"}
+		if reveal {
+			header = append(header, "VALUE")
+		}
+		t.AppendHeader(header)
+		for _, v := range result.Versions {
+			actor := "unknown"
+			if v.ActorType != "" || v.ActorID != "" {
+				actor = fmt.Sprintf("%s:%s", v.ActorType, v.ActorID)
+			}
+			row := table.Row{v.Version, v.CreatedAt, actor}
+			if reveal {
+				row = append(row, v.Value)
+			}
+			t.AppendRow(row)
+		}
+		t.Render()
+		return nil
+	},
+}
+
+var credentialRollbackCmd = &cobra.Command{
+	Use:   "rollback <key>",
+	Short: "Restore an archived version of a credential as its current value",
+	Long: `Restore a prior version of a credential (see "credential history") as its
+current value. The value being replaced is itself archived as a new version
+first, so a rollback is never destructive — you can always roll back a
+rollback. Requires member+ role, same as "credential set".
+
+In agent mode (AGENT_VAULT_TOKEN set), AGENT_VAULT_VAULT (or --vault) is
+required — there is no project-file or interactive-picker fallback.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sess, tokenSource, err := resolveSession()
+		if err != nil {
+			return err
+		}
+
+		vault, err := resolveVaultForCommand(cmd, tokenSource)
+		if err != nil {
+			return err
+		}
+		key := args[0]
+
+		version, err := cmd.Flags().GetInt("version")
+		if err != nil || version <= 0 {
+			return fmt.Errorf("--version is required and must be a positive integer (see \"credential history %s\")", key)
+		}
+
+		body, err := json.Marshal(map[string]interface{}{
+			"vault":   vault,
+			"key":     key,
+			"version": version,
+		})
+		if err != nil {
+			return err
+		}
+
+		reqURL := sess.Address + "/v1/credentials/rollback"
+		if _, err := doAdminRequestWithBody("POST", reqURL, sess.Token, body); err != nil {
+			return err
+		}
+
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Rolled back credential %q in vault %q to version %d\n", successText("✓"), key, vault, version)
+		return nil
+	},
+}
+
 func init() {
 	credentialListCmd.Flags().Bool("reveal", false, "Show decrypted credential values (requires member+ role)")
+	credentialHistoryCmd.Flags().Bool("reveal", false, "Show decrypted values for each version (requires member+ role)")
+	credentialRollbackCmd.Flags().Int("version", 0, "Version number to restore (see \"credential history\")")
 	credentialCmd.AddCommand(credentialListCmd)
 	credentialCmd.AddCommand(credentialGetCmd)
 	credentialCmd.AddCommand(credentialSetCmd)
 	credentialCmd.AddCommand(credentialDeleteCmd)
+	credentialCmd.AddCommand(credentialHistoryCmd)
+	credentialCmd.AddCommand(credentialRollbackCmd)
 	vaultCmd.AddCommand(credentialCmd)
 }

--- a/docs/learn/credentials.mdx
+++ b/docs/learn/credentials.mdx
@@ -65,7 +65,30 @@ This mode is useful for:
 agent-vault vault credential set STRIPE_KEY=sk_test_abc123 --vault my-vault
 ```
 
-The `vault credential` command (alias: `vault creds`) uses `KEY=VALUE` format. Multiple credentials can be set at once (e.g. `agent-vault vault credential set A=1 B=2`). If `STRIPE_KEY` already exists, it is overwritten.
+The `vault credential` command (alias: `vault creds`) uses `KEY=VALUE` format. Multiple credentials can be set at once (e.g. `agent-vault vault credential set A=1 B=2`). If `STRIPE_KEY` already exists, it is overwritten — but the previous value isn't gone, see below.
+
+## Credential history and rollback
+
+Every overwrite of a built-in credential — whether from `vault credential set` or a [proposal](/learn/proposals) being approved — archives the value it replaces first. If a bad value gets written, you can list what changed and roll back:
+
+```bash
+# List past versions, most recent first (timestamp + who changed it, not the value)
+agent-vault vault credential history STRIPE_KEY --vault my-vault
+
+# Include decrypted values (requires member+ role, same as credential get)
+agent-vault vault credential history STRIPE_KEY --vault my-vault --reveal
+
+# Restore version 3 as the current value
+agent-vault vault credential rollback STRIPE_KEY --version 3 --vault my-vault
+```
+
+Rollback is never destructive: restoring an old version archives whatever was live as a new version first, so you can always roll back a rollback. The number of versions kept per credential is configurable via [`AGENT_VAULT_CREDENTIAL_HISTORY_MAX_VERSIONS`](/self-hosting/environment-variables#credential-history-and-rollback) (default 10).
+
+<Note>
+  This applies only to the built-in credential store. Vaults backed by an
+  external [credential store](/learn/credential-stores) (e.g., Infisical) are
+  read-only from Agent Vault and already have their own versioning upstream.
+</Note>
 
 ## Delete a credential
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -54,6 +54,7 @@ description: "Complete reference for all Agent Vault CLI commands."
     | `AGENT_VAULT_LOGS_MAX_AGE_HOURS` | Retention ceiling for the per-vault request log. Default `168` (7 days). Rows older than this are trimmed by a background job every 15 minutes. Only non-secret metadata is stored. |
     | `AGENT_VAULT_LOGS_MAX_ROWS_PER_VAULT` | Per-vault row cap for the request log. Default `10000`. Whichever limit (age or rows) fills first wins. Set `0` to disable the cap. |
     | `AGENT_VAULT_LOGS_RETENTION_LOCK` | When `true`, owner-UI overrides for log retention are ignored and env values (or defaults) are pinned. |
+    | `AGENT_VAULT_CREDENTIAL_HISTORY_MAX_VERSIONS` | Maximum number of prior versions kept per built-in credential (per vault + key) after being overwritten. Default `10`. Set `0` to disable pruning. See `agent-vault vault credential history`/`rollback`. |
     | `INFISICAL_URL` | Base URL of an Infisical instance. When set, the server constructs a machine-identity client from one of the auth-method groups below and enables `--credential-store=infisical` on `vault create`. See [Credential stores](/learn/credential-stores) for the conceptual overview and [Environment variables: Infisical credential store](/self-hosting/environment-variables#infisical-credential-store) for the priority order when multiple groups are configured. |
     | `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID` | Universal Auth client ID. Set together with `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET`. |
     | `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET` | Universal Auth client secret. Set together with `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID`. |
@@ -670,6 +671,32 @@ description: "Complete reference for all Agent Vault CLI commands."
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--vault` | `default` | Target vault |
+  </Accordion>
+
+  <Accordion title="agent-vault vault credential history">
+    ```bash
+    agent-vault vault credential history <KEY> [flags]
+    ```
+
+    List past values a credential held before being overwritten, most recent first, with the timestamp and actor responsible for each overwrite. Requires member+ role — the same rule as `credential get`/`--reveal`. Alias: `agent-vault vault creds history`. In agent mode (`AGENT_VAULT_TOKEN` set), `AGENT_VAULT_VAULT` (or `--vault`) is required — there is no project-file or interactive-picker fallback.
+
+    | Flag | Default | Description |
+    |------|---------|-------------|
+    | `--vault` | `default` | Target vault |
+    | `--reveal` | `false` | Show decrypted values for each version (requires member+ role) |
+  </Accordion>
+
+  <Accordion title="agent-vault vault credential rollback">
+    ```bash
+    agent-vault vault credential rollback <KEY> --version <N> [flags]
+    ```
+
+    Restore an archived version (see `credential history`) as the credential's current value. Whatever is currently live is itself archived as a new version first, so a rollback is never destructive. Requires member+ role, same as `credential set`. Alias: `agent-vault vault creds rollback`. In agent mode (`AGENT_VAULT_TOKEN` set), `AGENT_VAULT_VAULT` (or `--vault`) is required — there is no project-file or interactive-picker fallback.
+
+    | Flag | Default | Description |
+    |------|---------|-------------|
+    | `--vault` | `default` | Target vault |
+    | `--version` | (required) | Version number to restore (see `credential history`) |
   </Accordion>
 </AccordionGroup>
 

--- a/docs/self-hosting/environment-variables.mdx
+++ b/docs/self-hosting/environment-variables.mdx
@@ -22,12 +22,35 @@ description: "Configuration for deploying an instance of Agent Vault."
 | `AGENT_VAULT_LOGS_MAX_AGE_HOURS` | Optional (defaults to `168`) | Maximum age, in hours, of rows retained in the per-vault request log. |
 | `AGENT_VAULT_LOGS_MAX_ROWS_PER_VAULT` | Optional (defaults to `10000`) | Maximum number of rows retained per vault in the request log. Set to `0` to disable the row cap. |
 | `AGENT_VAULT_LOGS_RETENTION_LOCK` | Optional (defaults to `false`) | Whether to ignore owner-UI overrides for log retention and pin to env values. |
+| `AGENT_VAULT_CREDENTIAL_HISTORY_MAX_VERSIONS` | Optional (defaults to `10`) | Maximum number of prior versions kept per built-in credential (per vault + key) after being overwritten. See [Credential history and rollback](/self-hosting/environment-variables#credential-history-and-rollback). Set to `0` to disable pruning (unbounded). |
 | `AGENT_VAULT_MAX_RESPONSE_BYTES` | Optional (defaults to `0` = unlimited) | Maximum response body bytes the MITM proxy streams back to agents. Responses are streamed with a small buffer so unlimited is safe. When set and exceeded, the proxy returns 502 or aborts the connection. Overridden by `--max-response-bytes`. |
 | `AGENT_VAULT_MAX_REQUEST_BYTES` | Optional (defaults to `1073741824` = 1 GiB) | Maximum request body bytes the MITM proxy forwards to upstreams. Requests exceeding this receive HTTP 413. Overridden by `--max-request-bytes`. |
 | `AGENT_VAULT_ISOLATION` | Optional (defaults to `host`) | Default isolation mode for `agent-vault vault run`. One of: `host`, `container` (see [Container isolation](/guides/container-isolation)). Overridden by `--isolation`. |
 | `DB_MAX_OPEN_CONNS` | Optional (defaults to `25`) | Maximum number of open Postgres connections per instance. Only applies when `DATABASE_URL` is set. See [connection pooling](/self-hosting/postgres#operational-notes). |
 | `DB_MAX_IDLE_CONNS` | Optional (defaults to `10`) | Maximum number of idle Postgres connections kept in the pool per instance. Only applies when `DATABASE_URL` is set. See [connection pooling](/self-hosting/postgres#operational-notes). |
 | `DB_CONN_MAX_LIFETIME` | Optional (defaults to `5m`) | Maximum lifetime of a Postgres connection before it is closed and replaced. Go duration string (e.g. `5m`, `1h`). Only applies when `DATABASE_URL` is set. See [connection pooling](/self-hosting/postgres#operational-notes). |
+
+## Credential history and rollback
+
+Every overwrite of a built-in credential (a direct `credential set`, or a proposal being applied) archives the value it replaces before writing the new one, so an accidental overwrite is always recoverable. This applies only to the **built-in** credential store — vaults backed by the [Infisical credential store](/learn/credential-stores) already have their own versioning upstream.
+
+`AGENT_VAULT_CREDENTIAL_HISTORY_MAX_VERSIONS` (default `10`) caps how many archived versions are kept per credential; older ones are pruned automatically as new overwrites happen. Set to `0` to keep every version indefinitely.
+
+Use the CLI to inspect and restore history:
+
+```bash
+# List past versions of STRIPE_KEY, most recent first (timestamp + actor, not the value)
+agent-vault vault credential history STRIPE_KEY --vault my-vault
+
+# Same, but also show the decrypted value of each version (requires member+ role)
+agent-vault vault credential history STRIPE_KEY --vault my-vault --reveal
+
+# Restore version 3 as the current value — this archives whatever is
+# currently live as a new version first, so rollback is never destructive
+agent-vault vault credential rollback STRIPE_KEY --version 3 --vault my-vault
+```
+
+Both commands require member+ role on the vault — the same rule as `credential set`/`credential get --reveal` — so proxy-role agents can never read or rewrite history.
 
 ## Email SMTP configuration
 

--- a/internal/server/handle_credentials.go
+++ b/internal/server/handle_credentials.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -61,6 +63,8 @@ func (s *Server) handleCredentialsSet(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	actorType, actorID := s.actorTypeAndID(r)
+
 	var setKeys []string
 	for key, value := range req.Credentials {
 		ciphertext, nonce, err := crypto.Encrypt([]byte(value), s.encKey)
@@ -68,7 +72,7 @@ func (s *Server) handleCredentialsSet(w http.ResponseWriter, r *http.Request) {
 			jsonError(w, http.StatusInternalServerError, "Encryption failed")
 			return
 		}
-		if _, err := s.store.SetCredential(ctx, ns.ID, key, ciphertext, nonce); err != nil {
+		if _, err := s.store.SetCredential(ctx, ns.ID, key, ciphertext, nonce, actorType, actorID); err != nil {
 			jsonError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to set credential %q", key))
 			return
 		}
@@ -389,4 +393,150 @@ func (s *Server) listCredentialKeys(ctx context.Context, vaultID string) []strin
 		keys[i] = cred.Key
 	}
 	return keys
+}
+
+type credentialVersionEntry struct {
+	Version   int    `json:"version"`
+	ActorType string `json:"actor_type,omitempty"`
+	ActorID   string `json:"actor_id,omitempty"`
+	CreatedAt string `json:"created_at"`
+	Value     string `json:"value,omitempty"`
+}
+
+type credentialHistoryResponse struct {
+	Key      string                   `json:"key"`
+	Versions []credentialVersionEntry `json:"versions"`
+}
+
+// handleCredentialHistory lists archived versions of a built-in credential,
+// most recent first. Gated at member+ for the whole endpoint (not just
+// ?reveal=true) — even the actor/timestamp metadata is sensitive, so this
+// follows credential list's --reveal rule rather than its default
+// any-vault-access rule. Values are included only when reveal=true.
+func (s *Server) handleCredentialHistory(w http.ResponseWriter, r *http.Request) {
+	vault := r.URL.Query().Get("vault")
+	if vault == "" {
+		vault = store.DefaultVault
+	}
+	key := r.URL.Query().Get("key")
+	if key == "" {
+		jsonError(w, http.StatusBadRequest, "key query parameter is required")
+		return
+	}
+	reveal := r.URL.Query().Get("reveal") == "true"
+
+	ctx := r.Context()
+
+	ns, err := s.store.GetVault(ctx, vault)
+	if err != nil || ns == nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", vault))
+		return
+	}
+
+	if _, err := s.requireVaultMember(w, r, ns.ID); err != nil {
+		return
+	}
+
+	if !s.assertBuiltinCredentialStore(w, ctx, ns.ID, ns.Name) {
+		return
+	}
+
+	versions, err := s.store.ListCredentialVersions(ctx, ns.ID, key)
+	if err != nil {
+		jsonError(w, http.StatusInternalServerError, "Failed to list credential history")
+		return
+	}
+
+	entries := make([]credentialVersionEntry, len(versions))
+	for i, v := range versions {
+		entries[i] = credentialVersionEntry{
+			Version:   v.Version,
+			ActorType: v.ActorType,
+			ActorID:   v.ActorID,
+			CreatedAt: v.CreatedAt.Format(time.RFC3339),
+		}
+		if reveal {
+			plaintext, err := crypto.Decrypt(v.Ciphertext, v.Nonce, s.encKey)
+			if err != nil {
+				jsonError(w, http.StatusInternalServerError, "Failed to decrypt credential version")
+				return
+			}
+			entries[i].Value = string(plaintext)
+		}
+	}
+
+	jsonOK(w, credentialHistoryResponse{Key: key, Versions: entries})
+}
+
+type credentialRollbackRequest struct {
+	Vault   string `json:"vault"`
+	Key     string `json:"key"`
+	Version int    `json:"version"`
+}
+
+type credentialRollbackResponse struct {
+	Key     string `json:"key"`
+	Version int    `json:"version"`
+}
+
+// handleCredentialRollback restores an archived version as the current
+// value of a built-in credential. This is implemented as a plain
+// SetCredential call with the archived ciphertext/nonce — whatever is
+// currently live gets archived as a new version before the rollback target
+// becomes current (see SQLStore.archiveCredentialVersionTx), so rollback is
+// itself just another recorded version, never a destructive rewrite.
+func (s *Server) handleCredentialRollback(w http.ResponseWriter, r *http.Request) {
+	var req credentialRollbackRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	if req.Vault == "" {
+		req.Vault = store.DefaultVault
+	}
+	if req.Key == "" {
+		jsonError(w, http.StatusBadRequest, "key is required")
+		return
+	}
+	if req.Version <= 0 {
+		jsonError(w, http.StatusBadRequest, "version must be a positive integer")
+		return
+	}
+
+	ctx := r.Context()
+
+	ns, err := s.store.GetVault(ctx, req.Vault)
+	if err != nil || ns == nil {
+		jsonError(w, http.StatusNotFound, fmt.Sprintf("Vault %q not found", req.Vault))
+		return
+	}
+
+	// Rollback is a write, same rule as credential set/delete.
+	if _, err := s.requireVaultMember(w, r, ns.ID); err != nil {
+		return
+	}
+
+	if !s.assertBuiltinCredentialStore(w, ctx, ns.ID, ns.Name) {
+		return
+	}
+
+	target, err := s.store.GetCredentialVersion(ctx, ns.ID, req.Key, req.Version)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			jsonError(w, http.StatusNotFound, fmt.Sprintf("Version %d of credential %q not found", req.Version, req.Key))
+			return
+		}
+		jsonError(w, http.StatusInternalServerError, "Failed to load credential version")
+		return
+	}
+
+	actorType, actorID := s.actorTypeAndID(r)
+	if _, err := s.store.SetCredential(ctx, ns.ID, req.Key, target.Ciphertext, target.Nonce, actorType, actorID); err != nil {
+		jsonError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to roll back credential %q", req.Key))
+		return
+	}
+
+	actor, _ := s.actorFromSession(r.Context(), sessionFromContext(r.Context()))
+	s.captureEvent(r, "av.credential-rollback", actor, nil)
+	jsonOK(w, credentialRollbackResponse{Key: req.Key, Version: req.Version})
 }

--- a/internal/server/handle_proposals.go
+++ b/internal/server/handle_proposals.go
@@ -537,8 +537,10 @@ func (s *Server) handleAdminProposalApprove(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Apply atomically.
-	if err := s.store.ApplyProposal(ctx, ns.ID, cs.ID, string(mergedJSON), finalCredentials, deleteCredentialKeys, oauthConfigs); err != nil {
+	// Apply atomically. Attributed to whoever approved the proposal, so any
+	// credential value it overwrites is archived under their identity.
+	actorType, actorID := s.actorTypeAndID(r)
+	if err := s.store.ApplyProposal(ctx, ns.ID, cs.ID, string(mergedJSON), finalCredentials, deleteCredentialKeys, oauthConfigs, actorType, actorID); err != nil {
 		jsonError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to apply proposal: %v", err))
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -59,18 +59,18 @@ type agentVaultJSON struct {
 
 // Server is the Agent Vault HTTP server.
 type Server struct {
-	httpServer  *http.Server
-	store       Store
-	encKey      []byte // 32-byte encryption key, held in memory while running
-	notifier    *notify.Notifier
-	initialized    bool                // true when at least one owner account exists
-	lastInitCheck  atomic.Int64        // unix-millis of last DB check for initialization (throttle)
-	baseURL     string              // externally-reachable base URL (e.g. "https://sb.example.com")
-	skillCLI    []byte              // embedded CLI skill content (served at GET /v1/skills/cli)
-	mitm        *mitm.Proxy         // transparent MITM proxy; nil only when --mitm-port 0
-	logger      *slog.Logger        // structured logger for per-request observability
-	rateLimit   *ratelimit.Registry // tiered rate limiter; shared with the MITM ingress
-	logSink     requestlog.Sink     // per-request persistence sink; never nil (Nop default)
+	httpServer    *http.Server
+	store         Store
+	encKey        []byte // 32-byte encryption key, held in memory while running
+	notifier      *notify.Notifier
+	initialized   bool                // true when at least one owner account exists
+	lastInitCheck atomic.Int64        // unix-millis of last DB check for initialization (throttle)
+	baseURL       string              // externally-reachable base URL (e.g. "https://sb.example.com")
+	skillCLI      []byte              // embedded CLI skill content (served at GET /v1/skills/cli)
+	mitm          *mitm.Proxy         // transparent MITM proxy; nil only when --mitm-port 0
+	logger        *slog.Logger        // structured logger for per-request observability
+	rateLimit     *ratelimit.Registry // tiered rate limiter; shared with the MITM ingress
+	logSink       requestlog.Sink     // per-request persistence sink; never nil (Nop default)
 	// touchCache short-circuits per-request session-touch writes. With
 	// db.SetMaxOpenConns(1), every UPDATE — even a no-op — opens the
 	// single WAL writer slot. Caching the last-touch wall-clock per
@@ -297,10 +297,12 @@ type Store interface {
 	ActivateUser(ctx context.Context, userID string) error
 
 	// Credentials
-	SetCredential(ctx context.Context, vaultID, key string, ciphertext, nonce []byte) (*store.Credential, error)
+	SetCredential(ctx context.Context, vaultID, key string, ciphertext, nonce []byte, actorType, actorID string) (*store.Credential, error)
 	GetCredential(ctx context.Context, vaultID, key string) (*store.Credential, error)
 	ListCredentials(ctx context.Context, vaultID string) ([]store.Credential, error)
 	DeleteCredential(ctx context.Context, vaultID, key string) error
+	ListCredentialVersions(ctx context.Context, vaultID, key string) ([]store.CredentialVersion, error)
+	GetCredentialVersion(ctx context.Context, vaultID, key string, version int) (*store.CredentialVersion, error)
 
 	// OAuth credentials
 	GetCredentialOAuth(ctx context.Context, vaultID, key string) (*store.CredentialOAuth, error)
@@ -326,7 +328,7 @@ type Store interface {
 	CountPendingProposals(ctx context.Context, vaultID string) (int, error)
 	UpdateProposalStatus(ctx context.Context, vaultID string, id int, status, reviewNote string) error
 	GetProposalCredentials(ctx context.Context, vaultID string, proposalID int) (map[string]store.EncryptedCredential, error)
-	ApplyProposal(ctx context.Context, vaultID string, proposalID int, mergedServicesJSON string, credentials map[string]store.EncryptedCredential, deleteCredentialKeys []string, oauthConfigs []store.OAuthCredentialConfig) error
+	ApplyProposal(ctx context.Context, vaultID string, proposalID int, mergedServicesJSON string, credentials map[string]store.EncryptedCredential, deleteCredentialKeys []string, oauthConfigs []store.OAuthCredentialConfig, actorType, actorID string) error
 	ExpirePendingProposals(ctx context.Context, before time.Time) (int, error)
 
 	// User invites (instance-level)
@@ -500,6 +502,23 @@ func (s *Server) actorFromSession(ctx context.Context, sess *store.Session) (*Ac
 		return &Actor{ID: agent.ID, Type: "agent", Role: agent.Role, Agent: agent}, nil
 	}
 	return nil, fmt.Errorf("session has no actor")
+}
+
+// actorTypeAndID resolves the request's session to an (actorType, actorID)
+// pair suitable for attribution on a CredentialVersion row. Falls back to
+// ("session", sess.ID) for scoped session tokens with no attached user/agent
+// record, and ("", "") if there's no session at all (should not normally
+// happen on an authenticated route, but versioning must never block the
+// write it's attached to).
+func (s *Server) actorTypeAndID(r *http.Request) (actorType, actorID string) {
+	sess := sessionFromContext(r.Context())
+	if actor, err := s.actorFromSession(r.Context(), sess); err == nil && actor != nil {
+		return actor.Type, actor.ID
+	}
+	if sess != nil {
+		return "session", sess.ID
+	}
+	return "", ""
 }
 
 // requireActor checks that the request is from any authenticated actor (user or agent).
@@ -822,6 +841,8 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("GET /v1/credentials", s.requireInitialized(s.requireAuth(actorAuthed(s.handleCredentialsList))))
 	mux.HandleFunc("POST /v1/credentials", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleCredentialsSet)))))
 	mux.HandleFunc("DELETE /v1/credentials", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleCredentialsDelete)))))
+	mux.HandleFunc("GET /v1/credentials/history", s.requireInitialized(s.requireAuth(actorAuthed(s.handleCredentialHistory))))
+	mux.HandleFunc("POST /v1/credentials/rollback", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleCredentialRollback)))))
 
 	// OAuth credential flow
 	mux.HandleFunc("POST /v1/credentials/oauth/connect", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleOAuthConnect)))))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -33,12 +33,13 @@ type mockStore struct {
 	masterKeyRecord    *store.MasterKeyRecord
 	sessions           map[string]*store.Session
 	vaults             map[string]*store.Vault
-	credentials        map[string]*store.Credential   // keyed by "vaultID:key"
-	brokerConfigs      map[string]*store.BrokerConfig // keyed by vaultID
-	proposals          map[string][]store.Proposal    // keyed by vaultID
-	users              map[string]*store.User         // keyed by email
-	grants             map[string]map[string]string   // keyed by userID -> vaultID -> role
-	userInvites        map[string]*store.UserInvite   // keyed by token
+	credentials        map[string]*store.Credential         // keyed by "vaultID:key"
+	credentialVersions map[string][]store.CredentialVersion // keyed by "vaultID:key", ascending version order
+	brokerConfigs      map[string]*store.BrokerConfig       // keyed by vaultID
+	proposals          map[string][]store.Proposal          // keyed by vaultID
+	users              map[string]*store.User               // keyed by email
+	grants             map[string]map[string]string         // keyed by userID -> vaultID -> role
+	userInvites        map[string]*store.UserInvite         // keyed by token
 	emailVerifications []*store.EmailVerification
 	passwordResets     []*store.PasswordReset
 	agents             map[string]*store.Agent                // keyed by name
@@ -52,16 +53,17 @@ type mockStore struct {
 
 func newMockStore() *mockStore {
 	ms := &mockStore{
-		sessions:      make(map[string]*store.Session),
-		vaults:        make(map[string]*store.Vault),
-		credentials:   make(map[string]*store.Credential),
-		brokerConfigs: make(map[string]*store.BrokerConfig),
-		users:         make(map[string]*store.User),
-		userInvites:   make(map[string]*store.UserInvite),
-		agents:        make(map[string]*store.Agent),
-		settings:      make(map[string]string),
-		vaultSettings: make(map[string]map[string]string),
-		credStores:    make(map[string]*store.VaultCredentialStore),
+		sessions:           make(map[string]*store.Session),
+		vaults:             make(map[string]*store.Vault),
+		credentials:        make(map[string]*store.Credential),
+		credentialVersions: make(map[string][]store.CredentialVersion),
+		brokerConfigs:      make(map[string]*store.BrokerConfig),
+		users:              make(map[string]*store.User),
+		userInvites:        make(map[string]*store.UserInvite),
+		agents:             make(map[string]*store.Agent),
+		settings:           make(map[string]string),
+		vaultSettings:      make(map[string]map[string]string),
+		credStores:         make(map[string]*store.VaultCredentialStore),
 	}
 	// Seed root vault
 	ms.vaults["default"] = &store.Vault{ID: "root-ns-id", Name: "default"}
@@ -244,7 +246,22 @@ func (m *mockStore) GetVault(_ context.Context, name string) (*store.Vault, erro
 	return ns, nil
 }
 
-func (m *mockStore) SetCredential(_ context.Context, vaultID, key string, ciphertext, nonce []byte) (*store.Credential, error) {
+func (m *mockStore) SetCredential(_ context.Context, vaultID, key string, ciphertext, nonce []byte, actorType, actorID string) (*store.Credential, error) {
+	k := vaultID + ":" + key
+	if existing, ok := m.credentials[k]; ok {
+		versions := m.credentialVersions[k]
+		m.credentialVersions[k] = append(versions, store.CredentialVersion{
+			ID:         fmt.Sprintf("credential-version-%s-%d", key, len(versions)+1),
+			VaultID:    vaultID,
+			Key:        key,
+			Version:    len(versions) + 1,
+			Ciphertext: existing.Ciphertext,
+			Nonce:      existing.Nonce,
+			ActorType:  actorType,
+			ActorID:    actorID,
+			CreatedAt:  time.Now(),
+		})
+	}
 	s := &store.Credential{
 		ID:         "credential-" + key,
 		VaultID:    vaultID,
@@ -252,8 +269,27 @@ func (m *mockStore) SetCredential(_ context.Context, vaultID, key string, cipher
 		Ciphertext: ciphertext,
 		Nonce:      nonce,
 	}
-	m.credentials[vaultID+":"+key] = s
+	m.credentials[k] = s
 	return s, nil
+}
+
+func (m *mockStore) ListCredentialVersions(_ context.Context, vaultID, key string) ([]store.CredentialVersion, error) {
+	versions := m.credentialVersions[vaultID+":"+key]
+	out := make([]store.CredentialVersion, len(versions))
+	// Reverse to most-recent-first, matching SQLStore's ORDER BY version DESC.
+	for i, v := range versions {
+		out[len(versions)-1-i] = v
+	}
+	return out, nil
+}
+
+func (m *mockStore) GetCredentialVersion(_ context.Context, vaultID, key string, version int) (*store.CredentialVersion, error) {
+	for _, v := range m.credentialVersions[vaultID+":"+key] {
+		if v.Version == version {
+			return &v, nil
+		}
+	}
+	return nil, sql.ErrNoRows
 }
 
 func (m *mockStore) ListCredentials(_ context.Context, vaultID string) ([]store.Credential, error) {
@@ -367,7 +403,7 @@ func (m *mockStore) GetProposalCredentials(_ context.Context, vaultID string, pr
 	return map[string]store.EncryptedCredential{}, nil
 }
 
-func (m *mockStore) ApplyProposal(_ context.Context, vaultID string, proposalID int, mergedServicesJSON string, credentials map[string]store.EncryptedCredential, deleteCredentialKeys []string, _ []store.OAuthCredentialConfig) error {
+func (m *mockStore) ApplyProposal(_ context.Context, vaultID string, proposalID int, mergedServicesJSON string, credentials map[string]store.EncryptedCredential, deleteCredentialKeys []string, _ []store.OAuthCredentialConfig, _, _ string) error {
 	// Update proposal status to applied.
 	css := m.proposals[vaultID]
 	for i, cs := range css {
@@ -389,9 +425,9 @@ func (m *mockStore) ExpirePendingProposals(_ context.Context, before time.Time) 
 	return 0, nil
 }
 
-func (m *mockStore) Close() error                                     { return nil }
-func (m *mockStore) Ping(_ context.Context) error                      { return nil }
-func (m *mockStore) DialectName() string                               { return "sqlite" }
+func (m *mockStore) Close() error                                         { return nil }
+func (m *mockStore) Ping(_ context.Context) error                         { return nil }
+func (m *mockStore) DialectName() string                                  { return "sqlite" }
 func (m *mockStore) GetCAState(_ context.Context) (*store.CAState, error) { return nil, nil }
 func (m *mockStore) SetCAState(_ context.Context, _ *store.CAState) error { return nil }
 
@@ -2309,6 +2345,189 @@ func TestCredentialsRevealProxyBlocked(t *testing.T) {
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCredentialHistoryRequiresMember(t *testing.T) {
+	// Scoped session with proxy role — should be blocked, same as reveal.
+	ms, token := setupMockStoreWithScopedSessionRole(t, "default", "root-ns-id", "proxy")
+	encKey := make([]byte, 32)
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/credentials/history?vault=default&key=SECRET", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCredentialHistoryListsArchivedVersionsMostRecentFirst(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	encKey := make([]byte, 32)
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+
+	for _, v := range []string{"v1", "v2", "v3"} {
+		ciphertext, nonce, err := crypto.Encrypt([]byte(v), encKey)
+		if err != nil {
+			t.Fatalf("encrypt: %v", err)
+		}
+		if _, err := ms.SetCredential(context.Background(), "root-ns-id", "SECRET", ciphertext, nonce, "user", "owner-user-id"); err != nil {
+			t.Fatalf("SetCredential: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/credentials/history?vault=default&key=SECRET", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp credentialHistoryResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// v1 and v2 were archived when overwritten (v3 is current); v2 first.
+	if len(resp.Versions) != 2 {
+		t.Fatalf("expected 2 archived versions, got %d: %+v", len(resp.Versions), resp.Versions)
+	}
+	if resp.Versions[0].Version != 2 || resp.Versions[1].Version != 1 {
+		t.Fatalf("expected versions ordered [2, 1], got [%d, %d]", resp.Versions[0].Version, resp.Versions[1].Version)
+	}
+	for _, v := range resp.Versions {
+		if v.Value != "" {
+			t.Fatalf("expected no value without ?reveal=true, got %q", v.Value)
+		}
+		if v.ActorType != "user" || v.ActorID != "owner-user-id" {
+			t.Fatalf("expected actor attribution on each version, got %s/%s", v.ActorType, v.ActorID)
+		}
+	}
+}
+
+func TestCredentialHistoryRevealIncludesDecryptedValue(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	encKey := make([]byte, 32)
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+
+	for _, v := range []string{"old-value", "new-value"} {
+		ciphertext, nonce, err := crypto.Encrypt([]byte(v), encKey)
+		if err != nil {
+			t.Fatalf("encrypt: %v", err)
+		}
+		if _, err := ms.SetCredential(context.Background(), "root-ns-id", "SECRET", ciphertext, nonce, "user", "owner-user-id"); err != nil {
+			t.Fatalf("SetCredential: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/credentials/history?vault=default&key=SECRET&reveal=true", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp credentialHistoryResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Versions) != 1 || resp.Versions[0].Value != "old-value" {
+		t.Fatalf("expected 1 archived version with decrypted value %q, got %+v", "old-value", resp.Versions)
+	}
+}
+
+func TestCredentialRollbackRequiresMember(t *testing.T) {
+	ms, token := setupMockStoreWithScopedSessionRole(t, "default", "root-ns-id", "proxy")
+	encKey := make([]byte, 32)
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+
+	body := `{"vault":"default","key":"SECRET","version":1}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/credentials/rollback", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCredentialRollbackRestoresPriorValueAndArchivesCurrent(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	encKey := make([]byte, 32)
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+
+	for _, v := range []string{"good-value", "oops-typo"} {
+		ciphertext, nonce, err := crypto.Encrypt([]byte(v), encKey)
+		if err != nil {
+			t.Fatalf("encrypt: %v", err)
+		}
+		if _, err := ms.SetCredential(context.Background(), "root-ns-id", "SECRET", ciphertext, nonce, "user", "owner-user-id"); err != nil {
+			t.Fatalf("SetCredential: %v", err)
+		}
+	}
+	// Live value is now "oops-typo"; version 1 archived "good-value".
+
+	body := `{"vault":"default","key":"SECRET","version":1}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/credentials/rollback", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	cred := ms.credentials["root-ns-id:SECRET"]
+	plaintext, err := crypto.Decrypt(cred.Ciphertext, cred.Nonce, encKey)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if string(plaintext) != "good-value" {
+		t.Fatalf("expected rollback to restore %q as current, got %q", "good-value", plaintext)
+	}
+
+	// The rolled-back-from value ("oops-typo") must still be recoverable,
+	// not lost — rollback is itself just another recorded version.
+	versions, err := ms.ListCredentialVersions(context.Background(), "root-ns-id", "SECRET")
+	if err != nil {
+		t.Fatalf("ListCredentialVersions: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("expected 2 archived versions after rollback, got %d", len(versions))
+	}
+	if versions[0].Version != 2 {
+		t.Fatalf("expected the rollback itself to be recorded as version 2, got %d", versions[0].Version)
+	}
+}
+
+func TestCredentialRollbackUnknownVersionReturns404(t *testing.T) {
+	ms, token := setupMockStoreWithSession(t)
+	encKey := make([]byte, 32)
+	srv := newTestServer(withStore(ms), withEncKey(encKey))
+
+	seedEncryptedCredential(t, ms, encKey, "root-ns-id", "SECRET", "current-value")
+
+	body := `{"vault":"default","key":"SECRET","version":99}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/credentials/rollback", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/store/20260723161000_credential_versions.go
+++ b/internal/store/20260723161000_credential_versions.go
@@ -1,0 +1,60 @@
+package store
+
+import "gorm.io/gorm"
+
+// credential_versions archives the value a built-in credential held before
+// each overwrite (SetCredential / proposal apply), so operators and agents
+// have a rollback path instead of an "oops, it's just gone" outcome. See
+// internal/store/credential_history.go for retention (pruned per key, not
+// time-based like request_logs — see internal/requestlog/retention.go for
+// that pattern) and SQLStore.archiveCredentialVersionTx for where rows are
+// written.
+func init() {
+	RegisterGORMMigration(func(db *gorm.DB) error {
+		if db.Migrator().HasTable("credential_versions") {
+			return nil
+		}
+
+		var stmts []string
+		if db.Name() == "postgres" {
+			stmts = []string{
+				`CREATE TABLE credential_versions (
+					id         TEXT PRIMARY KEY,
+					vault_id   TEXT NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+					key        TEXT NOT NULL,
+					version    INTEGER NOT NULL,
+					ciphertext BYTEA NOT NULL,
+					nonce      BYTEA NOT NULL,
+					actor_type TEXT NOT NULL DEFAULT '',
+					actor_id   TEXT NOT NULL DEFAULT '',
+					created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+					UNIQUE(vault_id, key, version)
+				)`,
+				`CREATE INDEX idx_credential_versions_vault_key ON credential_versions(vault_id, key)`,
+			}
+		} else {
+			stmts = []string{
+				`CREATE TABLE credential_versions (
+					id         TEXT PRIMARY KEY,
+					vault_id   TEXT NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+					key        TEXT NOT NULL,
+					version    INTEGER NOT NULL,
+					ciphertext BLOB NOT NULL,
+					nonce      BLOB NOT NULL,
+					actor_type TEXT NOT NULL DEFAULT '',
+					actor_id   TEXT NOT NULL DEFAULT '',
+					created_at TEXT NOT NULL DEFAULT (datetime('now')),
+					UNIQUE(vault_id, key, version)
+				)`,
+				`CREATE INDEX idx_credential_versions_vault_key ON credential_versions(vault_id, key)`,
+			}
+		}
+
+		for _, stmt := range stmts {
+			if err := db.Exec(stmt).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/internal/store/credential_history.go
+++ b/internal/store/credential_history.go
@@ -1,0 +1,31 @@
+package store
+
+import (
+	"os"
+	"strconv"
+)
+
+// envCredentialHistoryMaxVersions names the environment variable that caps
+// how many archived CredentialVersion rows are kept per (vault, key).
+const envCredentialHistoryMaxVersions = "AGENT_VAULT_CREDENTIAL_HISTORY_MAX_VERSIONS"
+
+// DefaultCredentialHistoryMaxVersions is used when the env var is unset or
+// invalid. Small on purpose — history is for "undo the last few mistakes",
+// not a full audit log (request logs already serve that role, with their
+// own retention knobs).
+const DefaultCredentialHistoryMaxVersions = 10
+
+// CredentialHistoryMaxVersionsFromEnv reads AGENT_VAULT_CREDENTIAL_HISTORY_MAX_VERSIONS.
+// Returns DefaultCredentialHistoryMaxVersions if unset or not a valid
+// non-negative integer. 0 disables pruning (unbounded retention).
+func CredentialHistoryMaxVersionsFromEnv() int {
+	raw := os.Getenv(envCredentialHistoryMaxVersions)
+	if raw == "" {
+		return DefaultCredentialHistoryMaxVersions
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v < 0 {
+		return DefaultCredentialHistoryMaxVersions
+	}
+	return v
+}

--- a/internal/store/sql_store.go
+++ b/internal/store/sql_store.go
@@ -43,8 +43,6 @@ func utcTimePtr(t *time.Time) *time.Time {
 	return &u
 }
 
-
-
 // nullableString returns nil for empty strings, enabling SQL NULL inserts.
 func nullableString(s string) interface{} {
 	if s == "" {
@@ -689,12 +687,26 @@ func (s *SQLStore) RenameVault(ctx context.Context, oldName string, newName stri
 
 // --- Credentials ---
 
-func (s *SQLStore) SetCredential(ctx context.Context, vaultID, key string, ciphertext, nonce []byte) (*Credential, error) {
+// SetCredential upserts a built-in credential. If a value already exists
+// for (vaultID, key), it is archived as a CredentialVersion — attributed to
+// actorType/actorID — before being overwritten, so the previous value is
+// never silently lost (see ListCredentialVersions).
+func (s *SQLStore) SetCredential(ctx context.Context, vaultID, key string, ciphertext, nonce []byte, actorType, actorID string) (*Credential, error) {
 	id := newUUID()
 	now := time.Now().UTC()
 	nowStr := s.dialect.FormatTime(now)
 
-	_, err := s.db.ExecContext(ctx,
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := s.archiveCredentialVersionTx(ctx, tx, vaultID, key, actorType, actorID); err != nil {
+		return nil, err
+	}
+
+	_, err = tx.ExecContext(ctx,
 		s.dialect.Rebind(`INSERT INTO credentials (id, vault_id, key, type, ciphertext, nonce, created_at, updated_at)
 		 VALUES (?, ?, ?, 'static', ?, ?, ?, ?)
 		 ON CONFLICT(vault_id, key) DO UPDATE SET
@@ -707,11 +719,116 @@ func (s *SQLStore) SetCredential(ctx context.Context, vaultID, key string, ciphe
 		return nil, fmt.Errorf("setting credential: %w", err)
 	}
 
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("committing credential set: %w", err)
+	}
+
 	return &Credential{
 		ID: id, VaultID: vaultID, Key: key, Type: "static",
 		Ciphertext: ciphertext, Nonce: nonce,
 		CreatedAt: now, UpdatedAt: now,
 	}, nil
+}
+
+// archiveCredentialVersionTx snapshots the current value of (vaultID, key)
+// into credential_versions — if one exists; a brand-new key has nothing to
+// archive — then prunes older versions beyond CredentialHistoryMaxVersionsFromEnv.
+// Must run before the caller overwrites the live row, in the same
+// transaction, so the snapshot and the overwrite are atomic.
+func (s *SQLStore) archiveCredentialVersionTx(ctx context.Context, tx *sql.Tx, vaultID, key, actorType, actorID string) error {
+	var ciphertext, nonce []byte
+	err := tx.QueryRowContext(ctx,
+		s.dialect.Rebind("SELECT ciphertext, nonce FROM credentials WHERE vault_id = ? AND key = ?"),
+		vaultID, key,
+	).Scan(&ciphertext, &nonce)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading credential for versioning: %w", err)
+	}
+
+	versionID := newUUID()
+	nowStr := s.dialect.FormatTime(time.Now().UTC())
+	_, err = tx.ExecContext(ctx,
+		s.dialect.Rebind(`INSERT INTO credential_versions (id, vault_id, key, version, ciphertext, nonce, actor_type, actor_id, created_at)
+		 VALUES (?, ?, ?, (SELECT COALESCE(MAX(version), 0) + 1 FROM credential_versions WHERE vault_id = ? AND key = ?), ?, ?, ?, ?, ?)`),
+		versionID, vaultID, key, vaultID, key, ciphertext, nonce, actorType, actorID, nowStr,
+	)
+	if err != nil {
+		return fmt.Errorf("recording credential version: %w", err)
+	}
+
+	maxVersions := CredentialHistoryMaxVersionsFromEnv()
+	if maxVersions <= 0 {
+		return nil
+	}
+	_, err = tx.ExecContext(ctx,
+		s.dialect.Rebind(`DELETE FROM credential_versions WHERE vault_id = ? AND key = ? AND version <= (
+			SELECT COALESCE(MAX(version), 0) - ? FROM credential_versions WHERE vault_id = ? AND key = ?
+		)`),
+		vaultID, key, maxVersions, vaultID, key,
+	)
+	if err != nil {
+		return fmt.Errorf("pruning credential versions: %w", err)
+	}
+	return nil
+}
+
+// ListCredentialVersions returns archived versions of (vaultID, key), most
+// recent first.
+func (s *SQLStore) ListCredentialVersions(ctx context.Context, vaultID, key string) ([]CredentialVersion, error) {
+	rows, err := s.db.QueryContext(ctx,
+		s.dialect.Rebind(`SELECT id, vault_id, key, version, ciphertext, nonce, actor_type, actor_id, created_at
+		 FROM credential_versions WHERE vault_id = ? AND key = ? ORDER BY version DESC`),
+		vaultID, key,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing credential versions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var versions []CredentialVersion
+	for rows.Next() {
+		v, err := s.scanCredentialVersion(rows)
+		if err != nil {
+			return nil, err
+		}
+		versions = append(versions, v)
+	}
+	return versions, rows.Err()
+}
+
+// GetCredentialVersion returns one archived version by its per-key version
+// number. Returns sql.ErrNoRows if it doesn't exist (e.g. pruned, or never
+// existed).
+func (s *SQLStore) GetCredentialVersion(ctx context.Context, vaultID, key string, version int) (*CredentialVersion, error) {
+	row := s.db.QueryRowContext(ctx,
+		s.dialect.Rebind(`SELECT id, vault_id, key, version, ciphertext, nonce, actor_type, actor_id, created_at
+		 FROM credential_versions WHERE vault_id = ? AND key = ? AND version = ?`),
+		vaultID, key, version,
+	)
+	v, err := s.scanCredentialVersion(row)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+// credentialVersionScanner abstracts over *sql.Row and *sql.Rows, both of
+// which implement Scan with the same signature.
+type credentialVersionScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+func (s *SQLStore) scanCredentialVersion(row credentialVersionScanner) (CredentialVersion, error) {
+	var v CredentialVersion
+	var createdAt interface{}
+	if err := row.Scan(&v.ID, &v.VaultID, &v.Key, &v.Version, &v.Ciphertext, &v.Nonce, &v.ActorType, &v.ActorID, &createdAt); err != nil {
+		return CredentialVersion{}, err
+	}
+	v.CreatedAt, _ = s.dialect.ScanTime(createdAt)
+	return v, nil
 }
 
 func (s *SQLStore) GetCredential(ctx context.Context, vaultID, key string) (*Credential, error) {
@@ -1998,7 +2115,7 @@ func (s *SQLStore) GetProposalCredentials(ctx context.Context, vaultID string, p
 	return creds, rows.Err()
 }
 
-func (s *SQLStore) ApplyProposal(ctx context.Context, vaultID string, proposalID int, mergedServicesJSON string, credentials map[string]EncryptedCredential, deleteCredentialKeys []string, oauthConfigs []OAuthCredentialConfig) error {
+func (s *SQLStore) ApplyProposal(ctx context.Context, vaultID string, proposalID int, mergedServicesJSON string, credentials map[string]EncryptedCredential, deleteCredentialKeys []string, oauthConfigs []OAuthCredentialConfig, actorType, actorID string) error {
 	nowStr := s.now()
 
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -2016,8 +2133,14 @@ func (s *SQLStore) ApplyProposal(ctx context.Context, vaultID string, proposalID
 		return fmt.Errorf("updating broker config: %w", err)
 	}
 
-	// 2. Upsert each static credential.
+	// 2. Upsert each static credential. Archive the value it replaces (if
+	// any) first, same as the direct SetCredential path — an agent's
+	// proposed value overwriting a credential is exactly the kind of
+	// mutation credential history exists to protect against.
 	for key, enc := range credentials {
+		if err := s.archiveCredentialVersionTx(ctx, tx, vaultID, key, actorType, actorID); err != nil {
+			return fmt.Errorf("recording credential version for %q: %w", key, err)
+		}
 		id := newUUID()
 		_, err = tx.ExecContext(ctx,
 			s.dialect.Rebind(`INSERT INTO credentials (id, vault_id, key, type, ciphertext, nonce, created_at, updated_at)

--- a/internal/store/sql_store.go
+++ b/internal/store/sql_store.go
@@ -735,10 +735,18 @@ func (s *SQLStore) SetCredential(ctx context.Context, vaultID, key string, ciphe
 // archive — then prunes older versions beyond CredentialHistoryMaxVersionsFromEnv.
 // Must run before the caller overwrites the live row, in the same
 // transaction, so the snapshot and the overwrite are atomic.
+//
+// On PostgreSQL the initial SELECT locks the credentials row FOR UPDATE, so
+// two concurrent overwrites of the same (vaultID, key) — e.g. a manual
+// credential set racing a proposal apply — are serialized rather than both
+// computing the same "next version" number and one of them failing on the
+// UNIQUE(vault_id, key, version) constraint. A brand-new key has no row to
+// lock, but that's fine: there's no existing version sequence to race on
+// until a first overwrite happens. SQLite's ForUpdateClause is a no-op.
 func (s *SQLStore) archiveCredentialVersionTx(ctx context.Context, tx *sql.Tx, vaultID, key, actorType, actorID string) error {
 	var ciphertext, nonce []byte
 	err := tx.QueryRowContext(ctx,
-		s.dialect.Rebind("SELECT ciphertext, nonce FROM credentials WHERE vault_id = ? AND key = ?"),
+		s.dialect.Rebind("SELECT ciphertext, nonce FROM credentials WHERE vault_id = ? AND key = ? "+s.dialect.ForUpdateClause()),
 		vaultID, key,
 	).Scan(&ciphertext, &nonce)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -231,7 +231,7 @@ func TestCredentialCRUD(t *testing.T) {
 	nonce := []byte("random-nonce")
 
 	// Set
-	cred, err := s.SetCredential(ctx, ns.ID, "API_KEY", ct, nonce)
+	cred, err := s.SetCredential(ctx, ns.ID, "API_KEY", ct, nonce, "user", "user-1")
 	if err != nil {
 		t.Fatalf("SetCredential: %v", err)
 	}
@@ -274,8 +274,8 @@ func TestSetCredentialUpsert(t *testing.T) {
 	ns, _ := s.CreateVault(ctx, "ns")
 
 	// Set twice with same key, should upsert.
-	s.SetCredential(ctx, ns.ID, "KEY", []byte("v1"), []byte("n1"))
-	s.SetCredential(ctx, ns.ID, "KEY", []byte("v2"), []byte("n2"))
+	s.SetCredential(ctx, ns.ID, "KEY", []byte("v1"), []byte("n1"), "user", "user-1")
+	s.SetCredential(ctx, ns.ID, "KEY", []byte("v2"), []byte("n2"), "user", "user-1")
 
 	got, err := s.GetCredential(ctx, ns.ID, "KEY")
 	if err != nil {
@@ -286,13 +286,241 @@ func TestSetCredentialUpsert(t *testing.T) {
 	}
 }
 
+// --- Credential version history ---
+
+func TestSetCredentialArchivesPreviousVersionOnOverwrite(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+	ns, _ := s.CreateVault(ctx, "history-test")
+
+	if _, err := s.SetCredential(ctx, ns.ID, "KEY", []byte("v1"), []byte("n1"), "user", "user-1"); err != nil {
+		t.Fatalf("SetCredential v1: %v", err)
+	}
+
+	// A brand-new key has nothing to archive yet.
+	versions, err := s.ListCredentialVersions(ctx, ns.ID, "KEY")
+	if err != nil {
+		t.Fatalf("ListCredentialVersions: %v", err)
+	}
+	if len(versions) != 0 {
+		t.Fatalf("expected no archived versions before any overwrite, got %d", len(versions))
+	}
+
+	if _, err := s.SetCredential(ctx, ns.ID, "KEY", []byte("v2"), []byte("n2"), "agent", "agent-1"); err != nil {
+		t.Fatalf("SetCredential v2: %v", err)
+	}
+
+	versions, err = s.ListCredentialVersions(ctx, ns.ID, "KEY")
+	if err != nil {
+		t.Fatalf("ListCredentialVersions: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("expected 1 archived version after one overwrite, got %d", len(versions))
+	}
+	v := versions[0]
+	if v.Version != 1 || string(v.Ciphertext) != "v1" || string(v.Nonce) != "n1" {
+		t.Fatalf("expected archived v1 (version 1), got version=%d ciphertext=%q nonce=%q", v.Version, v.Ciphertext, v.Nonce)
+	}
+	// Attributed to whoever performed the overwrite (the second SetCredential
+	// call), not whoever originally created the value being archived.
+	if v.ActorType != "agent" || v.ActorID != "agent-1" {
+		t.Fatalf("expected archived version to be attributed to the actor who overwrote it (agent/agent-1), got %s/%s", v.ActorType, v.ActorID)
+	}
+
+	// Current value is still the live row, unaffected by archiving.
+	current, err := s.GetCredential(ctx, ns.ID, "KEY")
+	if err != nil {
+		t.Fatalf("GetCredential: %v", err)
+	}
+	if string(current.Ciphertext) != "v2" {
+		t.Fatalf("expected current value v2, got %q", current.Ciphertext)
+	}
+}
+
+func TestListCredentialVersionsOrderedMostRecentFirst(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+	ns, _ := s.CreateVault(ctx, "history-order-test")
+
+	for i, v := range []string{"v1", "v2", "v3", "v4"} {
+		if _, err := s.SetCredential(ctx, ns.ID, "KEY", []byte(v), []byte("n"), "user", "user-1"); err != nil {
+			t.Fatalf("SetCredential #%d: %v", i, err)
+		}
+	}
+
+	versions, err := s.ListCredentialVersions(ctx, ns.ID, "KEY")
+	if err != nil {
+		t.Fatalf("ListCredentialVersions: %v", err)
+	}
+	// v1, v2, v3 were archived (v4 is still current); most recent (v3) first.
+	if len(versions) != 3 {
+		t.Fatalf("expected 3 archived versions, got %d", len(versions))
+	}
+	wantOrder := []string{"v3", "v2", "v1"}
+	for i, want := range wantOrder {
+		if string(versions[i].Ciphertext) != want {
+			t.Fatalf("versions[%d]: expected ciphertext %q, got %q", i, want, versions[i].Ciphertext)
+		}
+	}
+	if versions[0].Version != 3 || versions[2].Version != 1 {
+		t.Fatalf("expected version numbers 3..1 descending, got %d..%d", versions[0].Version, versions[2].Version)
+	}
+}
+
+func TestGetCredentialVersionNotFound(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+	ns, _ := s.CreateVault(ctx, "history-notfound-test")
+
+	_, err := s.GetCredentialVersion(ctx, ns.ID, "NOPE", 1)
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected sql.ErrNoRows for a version that was never recorded, got %v", err)
+	}
+}
+
+func TestCredentialHistoryMaxVersionsPrunesOldest(t *testing.T) {
+	t.Setenv("AGENT_VAULT_CREDENTIAL_HISTORY_MAX_VERSIONS", "2")
+
+	s := openTestDB(t)
+	ctx := context.Background()
+	ns, _ := s.CreateVault(ctx, "history-prune-test")
+
+	for _, v := range []string{"v1", "v2", "v3", "v4"} {
+		if _, err := s.SetCredential(ctx, ns.ID, "KEY", []byte(v), []byte("n"), "", ""); err != nil {
+			t.Fatalf("SetCredential: %v", err)
+		}
+	}
+
+	versions, err := s.ListCredentialVersions(ctx, ns.ID, "KEY")
+	if err != nil {
+		t.Fatalf("ListCredentialVersions: %v", err)
+	}
+	// v1, v2, v3 were archived, capped to the 2 most recent: v3, v2.
+	if len(versions) != 2 {
+		t.Fatalf("expected pruning to cap history at 2 versions, got %d", len(versions))
+	}
+	if string(versions[0].Ciphertext) != "v3" || string(versions[1].Ciphertext) != "v2" {
+		t.Fatalf("expected the 2 most recent versions (v3, v2) to survive pruning, got %q, %q",
+			versions[0].Ciphertext, versions[1].Ciphertext)
+	}
+	// Version *numbers* are never reused/renumbered by pruning, even though
+	// the row for version 1 is gone.
+	if versions[0].Version != 3 || versions[1].Version != 2 {
+		t.Fatalf("expected surviving version numbers 3 and 2, got %d and %d", versions[0].Version, versions[1].Version)
+	}
+}
+
+func TestCredentialHistoryMaxVersionsZeroDisablesPruning(t *testing.T) {
+	t.Setenv("AGENT_VAULT_CREDENTIAL_HISTORY_MAX_VERSIONS", "0")
+
+	s := openTestDB(t)
+	ctx := context.Background()
+	ns, _ := s.CreateVault(ctx, "history-unbounded-test")
+
+	for i := 0; i < 15; i++ {
+		if _, err := s.SetCredential(ctx, ns.ID, "KEY", []byte{byte(i)}, []byte("n"), "", ""); err != nil {
+			t.Fatalf("SetCredential #%d: %v", i, err)
+		}
+	}
+
+	versions, err := s.ListCredentialVersions(ctx, ns.ID, "KEY")
+	if err != nil {
+		t.Fatalf("ListCredentialVersions: %v", err)
+	}
+	if len(versions) != 14 {
+		t.Fatalf("expected all 14 archived versions to survive with pruning disabled, got %d", len(versions))
+	}
+}
+
+func TestApplyProposalArchivesOverwrittenCredential(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+	ns, _ := s.CreateVault(ctx, "apply-history-test")
+
+	if _, err := s.SetCredential(ctx, ns.ID, "STRIPE_KEY", []byte("old-enc"), []byte("old-nonce"), "user", "owner-1"); err != nil {
+		t.Fatalf("SetCredential: %v", err)
+	}
+
+	s.CreateProposal(ctx, ns.ID, "s1",
+		`[{"host":"api.stripe.com","auth":{"type":"bearer","token":"STRIPE_KEY"}}]`,
+		`[{"key":"STRIPE_KEY"}]`, "rotate key", "", nil)
+
+	creds := map[string]EncryptedCredential{
+		"STRIPE_KEY": {Ciphertext: []byte("new-enc"), Nonce: []byte("new-nonce")},
+	}
+	if err := s.ApplyProposal(ctx, ns.ID, 1, `[{"host":"api.stripe.com","auth":{"type":"bearer","token":"STRIPE_KEY"}}]`, creds, nil, nil, "user", "approver-1"); err != nil {
+		t.Fatalf("ApplyProposal: %v", err)
+	}
+
+	versions, err := s.ListCredentialVersions(ctx, ns.ID, "STRIPE_KEY")
+	if err != nil {
+		t.Fatalf("ListCredentialVersions: %v", err)
+	}
+	if len(versions) != 1 {
+		t.Fatalf("expected the pre-existing value to be archived by proposal apply, got %d versions", len(versions))
+	}
+	if string(versions[0].Ciphertext) != "old-enc" {
+		t.Fatalf("expected archived version to hold the pre-proposal value, got %q", versions[0].Ciphertext)
+	}
+	// Attributed to whoever approved the proposal, not whoever originally set it.
+	if versions[0].ActorType != "user" || versions[0].ActorID != "approver-1" {
+		t.Fatalf("expected archived version attributed to the approving actor (user/approver-1), got %s/%s",
+			versions[0].ActorType, versions[0].ActorID)
+	}
+}
+
+func TestRollbackViaSetCredentialArchivesCurrentAndRestoresPrior(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+	ns, _ := s.CreateVault(ctx, "rollback-test")
+
+	if _, err := s.SetCredential(ctx, ns.ID, "KEY", []byte("v1"), []byte("n1"), "user", "user-1"); err != nil {
+		t.Fatalf("SetCredential v1: %v", err)
+	}
+	if _, err := s.SetCredential(ctx, ns.ID, "KEY", []byte("v2-bad"), []byte("n2"), "agent", "agent-1"); err != nil {
+		t.Fatalf("SetCredential v2: %v", err)
+	}
+
+	// Simulate a rollback: fetch version 1 and set it as current again —
+	// this is exactly what the /v1/credentials/rollback handler does.
+	target, err := s.GetCredentialVersion(ctx, ns.ID, "KEY", 1)
+	if err != nil {
+		t.Fatalf("GetCredentialVersion: %v", err)
+	}
+	if _, err := s.SetCredential(ctx, ns.ID, "KEY", target.Ciphertext, target.Nonce, "user", "user-2"); err != nil {
+		t.Fatalf("SetCredential (rollback): %v", err)
+	}
+
+	current, err := s.GetCredential(ctx, ns.ID, "KEY")
+	if err != nil {
+		t.Fatalf("GetCredential: %v", err)
+	}
+	if string(current.Ciphertext) != "v1" {
+		t.Fatalf("expected rollback to restore v1 as current, got %q", current.Ciphertext)
+	}
+
+	// The bad value (v2-bad) must not have been lost — it's archived as
+	// version 2, so rollback is never destructive.
+	versions, err := s.ListCredentialVersions(ctx, ns.ID, "KEY")
+	if err != nil {
+		t.Fatalf("ListCredentialVersions: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("expected 2 archived versions after the rollback (v1, then v2-bad), got %d", len(versions))
+	}
+	if versions[0].Version != 2 || string(versions[0].Ciphertext) != "v2-bad" {
+		t.Fatalf("expected the rollback to archive v2-bad as version 2, got version=%d value=%q",
+			versions[0].Version, versions[0].Ciphertext)
+	}
+}
+
 func TestCascadeDeleteVaultRemovesCredentials(t *testing.T) {
 	s := openTestDB(t)
 	ctx := context.Background()
 
 	ns, _ := s.CreateVault(ctx, "cascade")
-	s.SetCredential(ctx, ns.ID, "S1", []byte("a"), []byte("b"))
-	s.SetCredential(ctx, ns.ID, "S2", []byte("c"), []byte("d"))
+	s.SetCredential(ctx, ns.ID, "S1", []byte("a"), []byte("b"), "", "")
+	s.SetCredential(ctx, ns.ID, "S2", []byte("c"), []byte("d"), "", "")
 
 	if err := s.DeleteVault(ctx, "cascade"); err != nil {
 		t.Fatal(err)
@@ -1354,7 +1582,7 @@ func TestApplyProposal(t *testing.T) {
 		"STRIPE_KEY": {Ciphertext: []byte("real-enc"), Nonce: []byte("real-nonce")},
 	}
 
-	err := s.ApplyProposal(ctx, ns.ID, 1, mergedServices, creds, nil, nil)
+	err := s.ApplyProposal(ctx, ns.ID, 1, mergedServices, creds, nil, nil, "user", "user-1")
 	if err != nil {
 		t.Fatalf("ApplyProposal: %v", err)
 	}
@@ -1391,7 +1619,7 @@ func TestApplyProposalWithCredentialDeletion(t *testing.T) {
 	ns, _ := s.CreateVault(ctx, "apply-delete-test")
 
 	// Pre-seed a credential that will be deleted.
-	s.SetCredential(ctx, ns.ID, "old_key", []byte("old-enc"), []byte("old-nonce"))
+	s.SetCredential(ctx, ns.ID, "old_key", []byte("old-enc"), []byte("old-nonce"), "", "")
 
 	// Create a proposal.
 	s.CreateProposal(ctx, ns.ID, "s1",
@@ -1403,7 +1631,7 @@ func TestApplyProposalWithCredentialDeletion(t *testing.T) {
 		"new_key": {Ciphertext: []byte("new-enc"), Nonce: []byte("new-nonce")},
 	}
 
-	err := s.ApplyProposal(ctx, ns.ID, 1, mergedServices, creds, []string{"old_key"}, nil)
+	err := s.ApplyProposal(ctx, ns.ID, 1, mergedServices, creds, []string{"old_key"}, nil, "user", "user-1")
 	if err != nil {
 		t.Fatalf("ApplyProposal with delete: %v", err)
 	}
@@ -1448,7 +1676,6 @@ func TestCascadeDeleteVaultRemovesProposals(t *testing.T) {
 		t.Fatalf("expected 0 proposal credentials after cascade delete, got %d", len(csCreds))
 	}
 }
-
 
 // --- UUID ---
 
@@ -1676,7 +1903,6 @@ func TestDeleteUserSessions(t *testing.T) {
 		t.Fatalf("expected sql.ErrNoRows after deleting user sessions, got %v", err)
 	}
 }
-
 
 func TestDeleteUserCascadesGrants(t *testing.T) {
 	s := openTestDB(t)
@@ -1954,7 +2180,6 @@ func TestGetSessionBackwardCompat(t *testing.T) {
 		t.Fatalf("expected empty agent_id for old session, got %q", fetched.AgentID)
 	}
 }
-
 
 func TestDeleteAgentTokens(t *testing.T) {
 	s := openTestDB(t)
@@ -2471,7 +2696,7 @@ func TestSetVaultExternalStoreOverwritesBuiltin(t *testing.T) {
 		t.Fatalf("CreateVault: %v", err)
 	}
 	// Seed built-in credentials that the connect should overwrite.
-	if _, err := s.SetCredential(ctx, v.ID, "OLD_KEY", []byte("c-old"), []byte("n-old")); err != nil {
+	if _, err := s.SetCredential(ctx, v.ID, "OLD_KEY", []byte("c-old"), []byte("n-old"), "", ""); err != nil {
 		t.Fatalf("SetCredential: %v", err)
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -46,6 +46,28 @@ type Credential struct {
 	UpdatedAt  time.Time
 }
 
+// CredentialVersion is an archived prior value of a built-in credential,
+// captured at the moment it was overwritten. Version numbers are
+// sequential per (VaultID, Key), starting at 1, and never reused —
+// rollback restores a version's value as the new current value (recording
+// yet another version for whatever it replaced), it never rewrites history.
+type CredentialVersion struct {
+	ID         string
+	VaultID    string
+	Key        string
+	Version    int
+	Ciphertext []byte
+	Nonce      []byte
+	// ActorType/ActorID identify who performed the overwrite that archived
+	// this version — "user"/"agent" (matching Actor.Type) when resolvable,
+	// or "session" with the session ID as a fallback for scoped tokens with
+	// no attached user/agent record. Both may be empty for older rows or
+	// system-initiated writes.
+	ActorType string
+	ActorID   string
+	CreatedAt time.Time
+}
+
 // CredentialOAuth stores the OAuth configuration and refresh state for
 // an OAuth-type credential. The access token lives in credentials.ciphertext;
 // this table stores everything needed to refresh it.
@@ -432,11 +454,22 @@ type Store interface {
 	DeleteVault(ctx context.Context, name string) error
 	RenameVault(ctx context.Context, oldName string, newName string) error
 
-	// Credentials
-	SetCredential(ctx context.Context, vaultID, key string, ciphertext, nonce []byte) (*Credential, error)
+	// Credentials. SetCredential's actorType/actorID identify who performed
+	// the write, recorded on the archived CredentialVersion if this call
+	// overwrites an existing value (see CredentialVersion) — pass "", "" if
+	// unknown (e.g. system-initiated writes; the version is still recorded,
+	// just without attribution).
+	SetCredential(ctx context.Context, vaultID, key string, ciphertext, nonce []byte, actorType, actorID string) (*Credential, error)
 	GetCredential(ctx context.Context, vaultID, key string) (*Credential, error)
 	ListCredentials(ctx context.Context, vaultID string) ([]Credential, error)
 	DeleteCredential(ctx context.Context, vaultID, key string) error
+
+	// Credential version history. Rollback has no dedicated store method —
+	// callers fetch the target version with GetCredentialVersion and pass
+	// its Ciphertext/Nonce back through SetCredential, which naturally
+	// archives whatever was current as a new version before restoring it.
+	ListCredentialVersions(ctx context.Context, vaultID, key string) ([]CredentialVersion, error)
+	GetCredentialVersion(ctx context.Context, vaultID, key string, version int) (*CredentialVersion, error)
 
 	// OAuth credentials
 	GetCredentialOAuth(ctx context.Context, vaultID, key string) (*CredentialOAuth, error)
@@ -521,7 +554,7 @@ type Store interface {
 	CountPendingProposals(ctx context.Context, vaultID string) (int, error)
 	ExpirePendingProposals(ctx context.Context, before time.Time) (int, error)
 	GetProposalCredentials(ctx context.Context, vaultID string, proposalID int) (map[string]EncryptedCredential, error)
-	ApplyProposal(ctx context.Context, vaultID string, proposalID int, mergedServicesJSON string, credentials map[string]EncryptedCredential, deleteCredentialKeys []string, oauthConfigs []OAuthCredentialConfig) error
+	ApplyProposal(ctx context.Context, vaultID string, proposalID int, mergedServicesJSON string, credentials map[string]EncryptedCredential, deleteCredentialKeys []string, oauthConfigs []OAuthCredentialConfig, actorType, actorID string) error
 
 	// User invites (instance-level)
 	CreateUserInvite(ctx context.Context, email, createdBy, role string, expiresAt time.Time, vaults []UserInviteVault) (*UserInvite, error)


### PR DESCRIPTION
Closes #330.

## Problem

Per the [credentials doc](https://docs.agent-vault.dev/learn/credentials): "If `STRIPE_KEY` already exists, it is overwritten." There's no history and no rollback for the built-in credential store — if an operator (or an agent proposing a `value` back into a credential slot) overwrites a key with a bad value, the previous value is just gone.

This is scoped to the **built-in** credential store only — vaults backed by the [Infisical credential store](https://docs.agent-vault.dev/learn/credential-stores) already have their own versioning upstream and are unaffected.

## What this adds

- **`credential_versions` table** (SQLite + Postgres, `internal/store/20260723161000_credential_versions.go`): archives the ciphertext/nonce a credential held before each overwrite, plus a timestamp and the actor (`user`/`agent`/session fallback) responsible. Rows are pruned per `(vault, key)` down to `AGENT_VAULT_CREDENTIAL_HISTORY_MAX_VERSIONS` (default `10`, mirroring the existing `AGENT_VAULT_LOGS_MAX_*` env-driven retention pattern for request logs; `0` disables pruning).
- **`SetCredential` and `ApplyProposal`** now archive the value they replace *before* overwriting it, in the same transaction — this covers both a direct `credential set` and an agent's proposed value being approved.
- **API**: `GET /v1/credentials/history` and `POST /v1/credentials/rollback`, both gated at member+ role (never proxy-role agents) — the same rule `credential get --reveal` already uses. Rollback has no bespoke store method: it just calls `SetCredential` with the archived ciphertext, so whatever was live gets archived as a new version first — a rollback is itself just another recorded version, never destructive.
- **CLI**: `agent-vault vault credential history <key> [--reveal]` and `agent-vault vault credential rollback <key> --version N`.
- **Docs**: `docs/self-hosting/environment-variables.mdx`, `docs/reference/cli.mdx`, `docs/learn/credentials.mdx`, `README.md`.

Deliberately out of scope (per the issue's own suggested phasing): versioning on `credential delete` (soft-delete). Happy to follow up separately if useful.

## Testing

- New store-level tests (`internal/store/sqlite_test.go`): archiving on overwrite, ordering, pruning (including the `0` = unbounded case), proposal-apply archiving with actor attribution, and a rollback round-trip that confirms the "rolled-back-from" value survives.
- New handler tests (`internal/server/server_test.go`): member+ gating on both endpoints (proxy role blocked), history listing/ordering, `--reveal` decryption, rollback restoring the target version and archiving the current one, and 404 on an unknown version.
- New CLI registration test (`cmd/cmd_test.go`).
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass (one pre-existing, unrelated failure in `internal/isolation` — a local Docker-socket-path test, fails the same way on `main`).