### PR TITLE
fix(mitm): serve cleartext HTTP tunnelled over CONNECT

### DIFF
--- a/internal/mitm/connect.go
+++ b/internal/mitm/connect.go
@@ -1,6 +1,7 @@
 package mitm
 
 import (
+	"bufio"
 	"crypto/tls"
 	"errors"
 	"io"
@@ -104,6 +105,34 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A CONNECT tunnel conventionally carries TLS, and terminating it is how
+	// the MITM sees the request to inject credentials. But some proxy clients
+	// tunnel http:// upstreams over CONNECT too and then speak cleartext HTTP
+	// inside — undici's EnvHttpProxyAgent does this, so Node-based agents
+	// (Pi and others in knownAgents) land here with a plain-HTTP payload.
+	// Committing to a TLS handshake unconditionally drops those tunnels. Peek
+	// the first byte to disambiguate without consuming it: a TLS record for a
+	// handshake begins with 0x16, while every HTTP method starts with an
+	// uppercase ASCII letter.
+	br := bufio.NewReader(clientConn)
+	_ = clientConn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	first, err := br.Peek(1)
+	_ = clientConn.SetReadDeadline(time.Time{})
+	if err != nil {
+		p.logger.Warn("mitm tunnel peek failed", "host", host, "err", err.Error())
+		_ = clientConn.Close()
+		return
+	}
+	tunnel := &prefixedConn{Conn: clientConn, r: br}
+
+	// Cleartext inside the tunnel ⟹ the upstream is plain http://; serve it
+	// directly without terminating TLS. forwardRequest picks the same scheme
+	// via useTLSUpstream, so the outbound leg stays http as well.
+	if first[0] != tlsRecordTypeHandshake {
+		p.serveTunnel(tunnel, target, host, port, false, scope)
+		return
+	}
+
 	tlsConf := &tls.Config{
 		MinVersion: tls.VersionTLS12,
 		NextProtos: []string{"http/1.1"},
@@ -116,7 +145,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	tlsConn := tls.Server(clientConn, tlsConf)
+	tlsConn := tls.Server(tunnel, tlsConf)
 	_ = tlsConn.SetDeadline(time.Now().Add(10 * time.Second))
 	if err := tlsConn.Handshake(); err != nil {
 		// err may carry TLS alert detail from the client — diagnostic, not secret.
@@ -126,14 +155,26 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = tlsConn.SetDeadline(time.Time{})
 
-	// Serve HTTP/1.1 requests off the terminated TLS connection. The
-	// listener yields the connection once, then blocks until Close so
-	// http.Serve stays alive while the connection goroutine is active.
-	// ConnState tracks when the connection leaves the hijacked state and
-	// closes the listener so Serve returns.
-	listener := newOneShotListener(tlsConn)
+	p.serveTunnel(tlsConn, target, host, port, true, scope)
+}
+
+// tlsRecordTypeHandshake is the TLS record content type for a handshake
+// (RFC 8446 §5.1). It is the first byte of a ClientHello and never a valid
+// leading byte of an HTTP request line, which distinguishes a TLS tunnel
+// from a cleartext one.
+const tlsRecordTypeHandshake = 0x16
+
+// serveTunnel serves HTTP/1.1 requests off an established tunnel connection —
+// either a terminated TLS conn or a cleartext one. useTLSUpstream selects the
+// scheme forwardRequest uses for the upstream leg (https for a TLS tunnel,
+// http for a cleartext one). The one-shot listener yields conn once, then
+// blocks until Close so http.Serve stays alive while the connection goroutine
+// is active; ConnState closes the listener once the connection leaves the
+// hijacked state so Serve returns.
+func (p *Proxy) serveTunnel(conn net.Conn, target, host string, port int, useTLSUpstream bool, scope *brokercore.ProxyScope) {
+	listener := newOneShotListener(conn)
 	srv := &http.Server{
-		Handler: p.forwardHandler(target, host, port, scope),
+		Handler: p.forwardHandler(target, host, port, useTLSUpstream, scope),
 		// ReadHeaderTimeout and ReadTimeout bound the request side
 		// (slow-loris defense). IdleTimeout caps keep-alives between
 		// requests. The upstream transport's ResponseHeaderTimeout
@@ -154,6 +195,17 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = srv.Serve(listener)
 }
+
+// prefixedConn is a net.Conn whose Read draws from a bufio.Reader wrapping
+// the underlying conn, so bytes Peeked before the conn is handed to
+// tls.Server / http.Server are not lost. All other methods (Write, Close,
+// deadlines) delegate to the embedded conn.
+type prefixedConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (c *prefixedConn) Read(p []byte) (int, error) { return c.r.Read(p) }
 
 // recordAuthFailure records one auth-failure event against the per-IP
 // TierAuth budget so the read-only pre-gate in handleConnect /

--- a/internal/mitm/connect_cleartext_test.go
+++ b/internal/mitm/connect_cleartext_test.go
@@ -1,0 +1,100 @@
+package mitm
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Infisical/agent-vault/internal/brokercore"
+)
+
+// TestMITMCleartextConnectTunnel reproduces an undici-style client
+// (Pi and other agents whose HTTP stack is undici's EnvHttpProxyAgent):
+// it opens a CONNECT tunnel even for an http:// upstream and then speaks
+// cleartext HTTP inside the tunnel, not TLS. The MITM must detect the
+// non-TLS first byte, serve the tunnel in cleartext, forward to the
+// http:// upstream, inject the credential, and pass arbitrary client
+// headers through.
+//
+// Before the first-byte sniff, handleConnect ran an unconditional TLS
+// handshake on the tunnel and dropped the connection here.
+func TestMITMCleartextConnectTunnel(t *testing.T) {
+	var sawAuth, sawUserID, sawTrace, sawProxyAuth, sawHost string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		sawUserID = r.Header.Get("Af-User-Id")
+		sawTrace = r.Header.Get("X-Trace-Id")
+		sawProxyAuth = r.Header.Get("Proxy-Authorization")
+		sawHost = r.Host
+		_, _ = io.WriteString(w, "cleartext-upstream-ok")
+	}))
+	defer upstream.Close()
+
+	upstreamAuthority := strings.TrimPrefix(upstream.URL, "http://") // host:port
+	upstreamHost, _, _ := net.SplitHostPort(upstreamAuthority)
+
+	sr := validTokenResolver("av_sess_ok",
+		&brokercore.ProxyScope{VaultID: "v1", VaultName: "default", VaultRole: "proxy"})
+	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
+		upstreamHost: {result: &brokercore.InjectResult{
+			Headers: map[string]string{"Authorization": "Bearer injected-secret"},
+		}},
+	}}
+
+	proxyURL, clientRoots, _ := setupProxy(t, sr, cp)
+
+	// Open the CONNECT tunnel, then — unlike every other CONNECT test —
+	// do NOT wrap the conn in tls.Client. Speak cleartext HTTP directly,
+	// exactly as undici does for an http:// upstream tunnelled over CONNECT.
+	conn := openMITMTunnel(t, proxyURL, clientRoots, upstreamAuthority, "av_sess_ok")
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	_, _ = fmt.Fprintf(conn,
+		"POST /mcp HTTP/1.1\r\n"+
+			"Host: %s\r\n"+
+			"Authorization: Bearer client-should-not-win\r\n"+
+			"Af-User-Id: u_test_123\r\n"+
+			"X-Trace-Id: trace-123\r\n"+
+			"Content-Length: 0\r\n\r\n",
+		upstreamAuthority,
+	)
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodPost})
+	if err != nil {
+		t.Fatalf("read cleartext response through tunnel: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "cleartext-upstream-ok" {
+		t.Fatalf("body = %q, want cleartext-upstream-ok", body)
+	}
+	// Injected credential wins the auth slot even in a cleartext tunnel.
+	if sawAuth != "Bearer injected-secret" {
+		t.Fatalf("upstream Authorization = %q, want injected value", sawAuth)
+	}
+	// Arbitrary client headers pass through (identity + tracing).
+	if sawUserID != "u_test_123" {
+		t.Fatalf("upstream Af-User-Id = %q, want passthrough", sawUserID)
+	}
+	if sawTrace != "trace-123" {
+		t.Fatalf("upstream X-Trace-Id = %q, want passthrough", sawTrace)
+	}
+	// Broker-scoped Proxy-Authorization must never reach the upstream.
+	if sawProxyAuth != "" {
+		t.Fatalf("upstream saw Proxy-Authorization %q; must be stripped", sawProxyAuth)
+	}
+	if sawHost != upstreamAuthority {
+		t.Errorf("upstream Host = %q, want %q", sawHost, upstreamAuthority)
+	}
+}

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -175,9 +175,11 @@ func hostHeaderForScheme(scheme, target string) string {
 // a closed-over target rather than r.Host defeats post-tunnel host
 // rewriting. host is the port-stripped form, already validated in
 // handleConnect; scope is the vault context resolved at CONNECT time.
-func (p *Proxy) forwardHandler(target, host string, port int, scope *brokercore.ProxyScope) http.Handler {
+// useTLSUpstream selects the outbound scheme: https for a TLS-terminated
+// tunnel, http for a cleartext one.
+func (p *Proxy) forwardHandler(target, host string, port int, useTLSUpstream bool, scope *brokercore.ProxyScope) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		p.forwardRequest(w, r, target, host, port, true, scope)
+		p.forwardRequest(w, r, target, host, port, useTLSUpstream, scope)
 	})
 }
 


### PR DESCRIPTION
## Problem

`handleConnect` terminates every CONNECT tunnel with an unconditional TLS handshake (`internal/mitm/connect.go`) — reasonable, since CONNECT is conventionally used only for `https://` upstreams and terminating TLS is how the MITM sees the request to inject credentials.

But undici's `EnvHttpProxyAgent` tunnels **`http://`** upstreams over CONNECT too, then speaks **cleartext HTTP** inside the tunnel. Clients built on it never use the absolute-form ingress that #150 added — they always CONNECT. When the tunnel payload is cleartext, the unconditional `tls.Server(...).Handshake()` reads a plain HTTP request line as a TLS record, fails, and drops the connection (`mitm TLS handshake failed`).

This hits agents already listed in `knownAgents` — Pi and other Node-based agents — whenever they target a plain-http remote through the vault proxy.

Minimal reproduction of the client behaviour: with `HTTP_PROXY` set, `undici.EnvHttpProxyAgent` issues `CONNECT host:80` (not an absolute-form `GET http://...`) for an `http://` upstream, then writes the request in cleartext inside the tunnel.

## Fix

Peek the first byte of the tunnel before deciding how to serve it:

- `0x16` (TLS handshake record, RFC 8446 §5.1) → the existing MITM-TLS path, unchanged.
- anything else (every HTTP method starts with an uppercase ASCII letter) → serve the tunnel as cleartext HTTP and forward to the `http://` upstream (`useTLSUpstream=false`).

The peeked byte is preserved via a small `prefixedConn` (a `net.Conn` whose `Read` draws from the `bufio.Reader`), so neither `tls.Server` nor `http.Server` loses it. The `http.Server` setup is extracted into `serveTunnel` and shared by both paths.

This is not a change in security posture: it extends the plain-http upstream support already present on the absolute-form ingress (#150) to the CONNECT path that undici clients actually use. Credential injection, the deny-list, `Proxy-Authorization` stripping, and header passthrough are identical for both tunnel types.

## Testing

- New `TestMITMCleartextConnectTunnel`: opens a real CONNECT tunnel, then speaks cleartext HTTP inside it (exactly as undici does), and asserts the upstream receives the request, the injected credential wins the auth slot, arbitrary client headers pass through, and `Proxy-Authorization` is stripped. Fails before the change (`unexpected EOF`), passes after.
- Full `internal/mitm` suite passes with `-race`, including all existing TLS-CONNECT and WebSocket cases (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)