### PR TITLE
docs: point to Infisical Agent Proxy from readme and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Read the full backstory behind Agent Vault [here](https://infisical.com/blog/age
 - **Agent Vault** is the simpler, self-contained option: a single open-source binary that stores credentials itself and runs entirely on infrastructure you control, with no dependency on any other system.
 - **[Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)** is the commercial-grade option, built directly into Infisical. Your secrets, the services they are brokered to, and access control all live in one place, and it comes with everything Infisical supports around secrets management, including dynamic secrets, secret rotation, versioning, and more.
 
-For production and enterprise use cases we recommend Agent Proxy.
+For production and enterprise use cases we recommend Agent Proxy. It is part of Infisical Secrets Management and available on every plan, including the free one.
 
 ## Use Cases
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Read the full backstory behind Agent Vault [here](https://infisical.com/blog/age
 [Infisical](https://infisical.com) offers two ways to broker credentials to agents.
 
 - **Agent Vault** is the self-contained, open-source option: a single binary that stores credentials itself and runs entirely on infrastructure you control, with no dependency on any other system.
-- **[Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)** is the native option, built directly into Infisical. Your secrets, the services they are brokered to, and access control all live in one place, and it comes with everything Infisical supports around secrets management, including dynamic secrets, secret rotation, and versioning.
+- **[Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)** is the native option, built directly into Infisical. Your secrets, the services they are brokered to, and access control all live in one place, and it comes with everything Infisical supports around secrets management, including dynamic secrets, secret rotation, versioning, and more.
 
 For most use cases we recommend Agent Proxy. There is less to set up, and brokering lives alongside the rest of your secrets management instead of in a system of its own.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Read the full backstory behind Agent Vault [here](https://infisical.com/blog/age
 - **Agent Vault** is the self-contained, open-source option: a single MIT-licensed binary that stores credentials itself and runs entirely on infrastructure you control, with no dependency on any other system.
 - **[Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)** is the native option, built directly into Infisical. Your secrets, the services they are brokered to, and agent access all live in one place, and it comes with everything Infisical supports around secrets management, including dynamic secrets, secret rotation, and identity-based access control.
 
-For most use cases we recommend Agent Proxy. It takes less to set up, and it is where our work on brokering credentials to agents is focused going forward.
+For most use cases we recommend Agent Proxy. There is less to set up, and brokering lives alongside the rest of your secrets management instead of in a system of its own.
 
 ## Use Cases
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ By default, requests not matching any service forward as plain proxy traffic; fl
 
 Read the full backstory behind Agent Vault [here](https://infisical.com/blog/agent-vault-the-open-source-credential-proxy-and-vault-for-agents).
 
+## Agent Vault and Infisical Agent Proxy
+
+[Infisical](https://infisical.com) offers two ways to broker credentials to agents.
+
+- **Agent Vault** is the self-contained, open-source option: a single MIT-licensed binary that stores credentials itself and runs entirely on infrastructure you control, with no dependency on any other system.
+- **[Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)** is the native option, built directly into Infisical. Your secrets, the services they are brokered to, and agent access all live in one place, and it comes with everything Infisical supports around secrets management, including dynamic secrets, secret rotation, and identity-based access control.
+
+For most use cases we recommend Agent Proxy. It takes less to set up, and it is where our work on brokering credentials to agents is focused going forward.
+
 ## Use Cases
 
 Agent Vault works with all kinds of AI Agent use-cases including secure remote coding agents, all-purpose agents, custom agents + harnesses, secure ephemeral sandboxes and more.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Read the full backstory behind Agent Vault [here](https://infisical.com/blog/age
 
 [Infisical](https://infisical.com) offers two ways to broker credentials to agents.
 
-- **Agent Vault** is the self-contained, open-source option: a single MIT-licensed binary that stores credentials itself and runs entirely on infrastructure you control, with no dependency on any other system.
+- **Agent Vault** is the self-contained, open-source option: a single binary that stores credentials itself and runs entirely on infrastructure you control, with no dependency on any other system.
 - **[Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)** is the native option, built directly into Infisical. Your secrets, the services they are brokered to, and agent access all live in one place, and it comes with everything Infisical supports around secrets management, including dynamic secrets, secret rotation, and identity-based access control.
 
 For most use cases we recommend Agent Proxy. There is less to set up, and brokering lives alongside the rest of your secrets management instead of in a system of its own.

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Read the full backstory behind Agent Vault [here](https://infisical.com/blog/age
 
 [Infisical](https://infisical.com) offers two ways to broker credentials to agents.
 
-- **Agent Vault** is the self-contained, open-source option: a single binary that stores credentials itself and runs entirely on infrastructure you control, with no dependency on any other system.
-- **[Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)** is the native option, built directly into Infisical. Your secrets, the services they are brokered to, and access control all live in one place, and it comes with everything Infisical supports around secrets management, including dynamic secrets, secret rotation, versioning, and more.
+- **Agent Vault** is the simpler, self-contained option: a single open-source binary that stores credentials itself and runs entirely on infrastructure you control, with no dependency on any other system.
+- **[Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)** is the commercial-grade option, built directly into Infisical. Your secrets, the services they are brokered to, and access control all live in one place, and it comes with everything Infisical supports around secrets management, including dynamic secrets, secret rotation, versioning, and more.
 
-For most use cases we recommend Agent Proxy. There is less to set up, and brokering lives alongside the rest of your secrets management instead of in a system of its own.
+For production and enterprise use cases we recommend Agent Proxy.
 
 ## Use Cases
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Read the full backstory behind Agent Vault [here](https://infisical.com/blog/age
 [Infisical](https://infisical.com) offers two ways to broker credentials to agents.
 
 - **Agent Vault** is the self-contained, open-source option: a single binary that stores credentials itself and runs entirely on infrastructure you control, with no dependency on any other system.
-- **[Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)** is the native option, built directly into Infisical. Your secrets, the services they are brokered to, and agent access all live in one place, and it comes with everything Infisical supports around secrets management, including dynamic secrets, secret rotation, and identity-based access control.
+- **[Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)** is the native option, built directly into Infisical. Your secrets, the services they are brokered to, and access control all live in one place, and it comes with everything Infisical supports around secrets management, including dynamic secrets, secret rotation, and versioning.
 
 For most use cases we recommend Agent Proxy. There is less to set up, and brokering lives alongside the rest of your secrets management instead of in a system of its own.
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -4,8 +4,11 @@ description: "Get a server running in under a minute."
 ---
 
 import InstallCommand from "/snippets/install-command.mdx";
+import EnterpriseCTA from "/snippets/enterprise-cta.mdx";
 
 Agent Vault ships as a single binary that acts as both a server and CLI client.
+
+<EnterpriseCTA />
 
 Each install method below configures a master password at startup. Store it somewhere safe. The password wraps the [data encryption key](/learn/security) and is held only in memory once the server is unlocked.
 

--- a/docs/snippets/enterprise-cta.mdx
+++ b/docs/snippets/enterprise-cta.mdx
@@ -1,4 +1,7 @@
 <Info>
-  **Need an enterprise-grade solution?** Infisical offers managed Agent Vault with enterprise support, SLAs, and advanced features.
+  **Looking for a more complete solution?**
+  [Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)
+  brokers credentials to agents from within Infisical, so your secrets, the services they
+  are brokered to, and access control all live in one place.
   [Book a demo with us](https://infisical.com/schedule-demo) to learn more.
 </Info>

--- a/docs/snippets/enterprise-cta.mdx
+++ b/docs/snippets/enterprise-cta.mdx
@@ -1,5 +1,5 @@
 <Info>
-  **Looking for credential brokering inside Infisical?**
+  **Looking for a managed solution?**
   [Infisical Agent Proxy](https://infisical.com/blog/agent-proxy) brokers credentials to
   agents from within Infisical, so your secrets, the services they are brokered to, and
   access control all live in one place.

--- a/docs/snippets/enterprise-cta.mdx
+++ b/docs/snippets/enterprise-cta.mdx
@@ -1,7 +1,6 @@
 <Info>
-  **Looking for a managed solution?**
-  [Infisical Agent Proxy](https://infisical.com/blog/agent-proxy) brokers credentials to
-  agents from within Infisical, so your secrets, the services they are brokered to, and
-  access control all live in one place.
+  **Need an enterprise-grade solution?** Infisical offers
+  [Agent Proxy](https://infisical.com/blog/agent-proxy) with enterprise support, SLAs, and
+  advanced features.
   [Book a demo with us](https://infisical.com/schedule-demo) to learn more.
 </Info>

--- a/docs/snippets/enterprise-cta.mdx
+++ b/docs/snippets/enterprise-cta.mdx
@@ -1,5 +1,5 @@
 <Info>
-  **Want credential brokering built into Infisical?**
+  **Looking for credential brokering inside Infisical?**
   [Infisical Agent Proxy](https://infisical.com/blog/agent-proxy) brokers credentials to
   agents from within Infisical, so your secrets, the services they are brokered to, and
   access control all live in one place.

--- a/docs/snippets/enterprise-cta.mdx
+++ b/docs/snippets/enterprise-cta.mdx
@@ -1,7 +1,6 @@
 <Info>
-  **Looking for a more complete solution?**
-  [Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)
-  brokers credentials to agents from within Infisical, so your secrets, the services they
-  are brokered to, and access control all live in one place.
+  **[Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)** brokers credentials to
+  agents from within Infisical, so your secrets, the services they are brokered to, and
+  access control all live in one place.
   [Book a demo with us](https://infisical.com/schedule-demo) to learn more.
 </Info>

--- a/docs/snippets/enterprise-cta.mdx
+++ b/docs/snippets/enterprise-cta.mdx
@@ -1,5 +1,6 @@
 <Info>
-  **[Infisical Agent Proxy](https://infisical.com/blog/agent-proxy)** brokers credentials to
+  **Want credential brokering built into Infisical?**
+  [Infisical Agent Proxy](https://infisical.com/blog/agent-proxy) brokers credentials to
   agents from within Infisical, so your secrets, the services they are brokered to, and
   access control all live in one place.
   [Book a demo with us](https://infisical.com/schedule-demo) to learn more.


### PR DESCRIPTION
## Summary

Agent Vault's readme and docs never mentioned Infisical Agent Proxy, so anyone evaluating the two had no way to tell them apart from here (#353).

Adds an "Agent Vault and Infisical Agent Proxy" section to the readme that describes both options and recommends Agent Proxy for most use cases, and rewrites the shared `enterprise-cta.mdx` snippet to point at Agent Proxy instead of managed Agent Vault.

- Readme section frames Agent Vault as the self-contained open-source option and Agent Proxy as the native one built into Infisical, closing on the recommendation
- `enterprise-cta.mdx` now leads with Agent Proxy and keeps the existing `Book a demo with us` link; it already renders on 7 pages, so the pointer picks up that distribution for free
- `installation.mdx` imports the snippet too (previously had no CTA), putting it in front of readers at the point they decide to install
- Both Agent Proxy links go to https://infisical.com/blog/agent-proxy rather than the docs overview

Copy deliberately avoids calling Agent Proxy "managed" (it ships in the Infisical CLI or as a container and you deploy it yourself) and avoids "successor" framing, keeping the readme softer than the launch post.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / build

## Test plan

Docs and readme only, no Go or web changes.

- [ ] Existing tests pass (`make test`)
- [ ] Added/updated tests for new behavior
- [x] Manual testing (describe below)

Rendered the docs locally with `mint dev` and checked the snippet on `/`, `/installation`, and the other pages that import it.

Note: `self-hosting/postgres.mdx` renders `<EnterpriseCTA />` three times (pre-existing), so the Agent Proxy pointer now repeats three times on that page. Left as-is; happy to trim it to one.

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [ ] Input validation on new API surfaces
- [ ] Checked for OWASP top 10 (injection, XSS, etc.)
