### PR TITLE
Fix punctuation in master password documentation

### DIFF
--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -1042,7 +1042,7 @@ description: "Complete reference for all Agent Vault CLI commands."
 
 ## Master password
 
-Manage the master password that wraps the data encryption key (DEK). All commands require the server to be stopped. When `DATABASE_URL` is set, these commands require `--force` because multiple instances may share the database -- stop all instances first.
+Manage the master password that wraps the data encryption key (DEK). All commands require the server to be stopped. When `DATABASE_URL` is set, these commands require `--force` because multiple instances may share the database - stop all instances first.
 
 Password changes only re-wrap the encryption key (one database row). No credentials are re-encrypted and no data is lost. If an instance restarts before the secret store is updated, it will fail to start with "wrong password" -- update the secret and restart to resolve.
 


### PR DESCRIPTION
Corrected punctuation in master password section.

## Summary

<!-- What does this PR do and why? -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

<!-- How did you verify this works? -->

- [ ] Existing tests pass (`make test`)
- [ ] Added/updated tests for new behavior
- [ ] Manual testing (describe below)

## Security checklist

- [ ] No secrets or credentials in code
- [ ] No new unauthenticated endpoints
- [ ] Input validation on new API surfaces
- [ ] Checked for OWASP top 10 (injection, XSS, etc.)
