### PR TITLE
fix(invites): revoke pending user invites by ID

### DIFF
--- a/cmd/user_invite.go
+++ b/cmd/user_invite.go
@@ -132,8 +132,8 @@ var userInviteCmd = &cobra.Command{
 		}
 
 		var resp struct {
-			Email     string `json:"email"`
-			EmailSent bool   `json:"email_sent"`
+			Email      string `json:"email"`
+			EmailSent  bool   `json:"email_sent"`
 			InviteLink string `json:"invite_link"`
 		}
 		_ = json.Unmarshal(respBody, &resp)
@@ -171,6 +171,7 @@ var userInviteListCmd = &cobra.Command{
 
 		var resp struct {
 			Invites []struct {
+				ID        int    `json:"id"`
 				Email     string `json:"email"`
 				Role      string `json:"role"`
 				Status    string `json:"status"`
@@ -193,7 +194,7 @@ var userInviteListCmd = &cobra.Command{
 		}
 
 		t := newTable(cmd.OutOrStdout())
-		t.AppendHeader(table.Row{"EMAIL", "ROLE", "STATUS", "VAULTS", "INVITED BY", "CREATED", "EXPIRES"})
+		t.AppendHeader(table.Row{"ID", "EMAIL", "ROLE", "STATUS", "VAULTS", "INVITED BY", "CREATED", "EXPIRES"})
 		for _, inv := range resp.Invites {
 			var vaultParts []string
 			for _, v := range inv.Vaults {
@@ -211,7 +212,7 @@ var userInviteListCmd = &cobra.Command{
 			if parsed, err := time.Parse(time.RFC3339, inv.ExpiresAt); err == nil {
 				expires = parsed.Format("2006-01-02 15:04")
 			}
-			t.AppendRow(table.Row{inv.Email, inv.Role, inv.Status, vaults, inv.CreatedBy, created, expires})
+			t.AppendRow(table.Row{inv.ID, inv.Email, inv.Role, inv.Status, vaults, inv.CreatedBy, created, expires})
 		}
 		t.Render()
 		return nil
@@ -219,18 +220,18 @@ var userInviteListCmd = &cobra.Command{
 }
 
 var userInviteRevokeCmd = &cobra.Command{
-	Use:   "revoke <token_suffix>",
+	Use:   "revoke <invite_id>",
 	Short: "Revoke a pending invite",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		tokenSuffix := args[0]
+		inviteID := args[0]
 
 		sess, err := ensureSession()
 		if err != nil {
 			return err
 		}
 
-		reqURL := fmt.Sprintf("%s/v1/users/invites/%s", sess.Address, tokenSuffix)
+		reqURL := fmt.Sprintf("%s/v1/users/invites/by-id/%s", sess.Address, inviteID)
 		if err := doAdminRequest("DELETE", reqURL, sess.Token, nil); err != nil {
 			return err
 		}

--- a/internal/server/handle_users.go
+++ b/internal/server/handle_users.go
@@ -599,6 +599,19 @@ func (s *Server) handleUserInviteList(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]interface{}{"invites": items})
 }
 
+func (s *Server) canManageUserInvite(ctx context.Context, actor *Actor, inv *store.UserInvite) bool {
+	if inv.CreatedBy == actor.ID || actor.IsOwner() {
+		return true
+	}
+	for _, v := range inv.Vaults {
+		role, _ := s.store.GetVaultRole(ctx, actor.ID, v.VaultID)
+		if role == "admin" {
+			return true
+		}
+	}
+	return false
+}
+
 // handleUserInviteRevokeByID revokes a pending user invite by its database ID.
 // This is the authenticated administrative path; token-based revoke is only
 // for unauthenticated redemption flows.
@@ -627,18 +640,7 @@ func (s *Server) handleUserInviteRevokeByID(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Authorization: creator, owner, or admin of a pre-assigned vault
-	allowed := inv.CreatedBy == actor.ID || actor.IsOwner()
-	if !allowed {
-		for _, v := range inv.Vaults {
-			role, _ := s.store.GetVaultRole(ctx, actor.ID, v.VaultID)
-			if role == "admin" {
-				allowed = true
-				break
-			}
-		}
-	}
-	if !allowed {
+	if !s.canManageUserInvite(ctx, actor, inv) {
 		jsonError(w, http.StatusForbidden, "You don't have permission to revoke this invite")
 		return
 	}
@@ -679,17 +681,7 @@ func (s *Server) handleUserInviteReinviteByID(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	allowed := existing.CreatedBy == actor.ID || actor.IsOwner()
-	if !allowed {
-		for _, v := range existing.Vaults {
-			role, _ := s.store.GetVaultRole(ctx, actor.ID, v.VaultID)
-			if role == "admin" {
-				allowed = true
-				break
-			}
-		}
-	}
-	if !allowed {
+	if !s.canManageUserInvite(ctx, actor, existing) {
 		jsonError(w, http.StatusForbidden, "You don't have permission to reinvite")
 		return
 	}

--- a/internal/server/handle_users.go
+++ b/internal/server/handle_users.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -571,9 +572,9 @@ func (s *Server) handleUserInviteList(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type inviteItem struct {
+		ID        int                   `json:"id"`
 		Email     string                `json:"email"`
 		Role      string                `json:"role"`
-		Token     string                `json:"token"`
 		Status    string                `json:"status"`
 		CreatedBy string                `json:"created_by"`
 		Vaults    []userInviteVaultJSON `json:"vaults"`
@@ -584,9 +585,9 @@ func (s *Server) handleUserInviteList(w http.ResponseWriter, r *http.Request) {
 	items := make([]inviteItem, 0, len(invites))
 	for _, inv := range invites {
 		items = append(items, inviteItem{
+			ID:        inv.ID,
 			Email:     inv.Email,
 			Role:      inv.Role,
-			Token:     inv.Token,
 			Status:    inv.Status,
 			CreatedBy: inv.CreatedBy,
 			Vaults:    vaultsToJSON(inv.Vaults),
@@ -598,7 +599,10 @@ func (s *Server) handleUserInviteList(w http.ResponseWriter, r *http.Request) {
 	jsonOK(w, map[string]interface{}{"invites": items})
 }
 
-func (s *Server) handleUserInviteRevoke(w http.ResponseWriter, r *http.Request) {
+// handleUserInviteRevokeByID revokes a pending user invite by its database ID.
+// This is the authenticated administrative path; token-based revoke is only
+// for unauthenticated redemption flows.
+func (s *Server) handleUserInviteRevokeByID(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	actor, err := s.requireInstanceMember(w, r)
@@ -606,11 +610,20 @@ func (s *Server) handleUserInviteRevoke(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	token := r.PathValue("token")
+	idStr := r.PathValue("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, "Invalid invite ID")
+		return
+	}
 
-	inv, err := s.store.GetUserInviteByToken(ctx, token)
-	if err != nil || inv == nil || inv.Status != "pending" {
-		jsonError(w, http.StatusNotFound, "Invite not found or not pending")
+	inv, err := s.store.GetUserInviteByID(ctx, id)
+	if err != nil || inv == nil {
+		jsonError(w, http.StatusNotFound, "Invite not found")
+		return
+	}
+	if inv.Status != "pending" {
+		jsonError(w, http.StatusConflict, "Invite is not pending")
 		return
 	}
 
@@ -630,7 +643,7 @@ func (s *Server) handleUserInviteRevoke(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if err := s.store.RevokeUserInvite(ctx, token); err != nil {
+	if err := s.store.RevokeUserInviteByID(ctx, id); err != nil {
 		jsonError(w, http.StatusNotFound, "Invite not found or not pending")
 		return
 	}
@@ -638,9 +651,10 @@ func (s *Server) handleUserInviteRevoke(w http.ResponseWriter, r *http.Request) 
 	jsonOK(w, map[string]string{"message": "Invite revoked"})
 }
 
-// handleUserInviteReinvite revokes an existing pending invite and creates a
-// new one for the same email/vault assignments, generating a fresh token and link.
-func (s *Server) handleUserInviteReinvite(w http.ResponseWriter, r *http.Request) {
+// handleUserInviteReinviteByID revokes an existing pending invite by ID and
+// creates a new one for the same email/vault assignments, generating a fresh
+// token and link. This is the authenticated administrative path.
+func (s *Server) handleUserInviteReinviteByID(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	actor, err := s.requireInstanceMember(w, r)
@@ -648,9 +662,14 @@ func (s *Server) handleUserInviteReinvite(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	token := r.PathValue("token")
+	idStr := r.PathValue("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		jsonError(w, http.StatusBadRequest, "Invalid invite ID")
+		return
+	}
 
-	existing, err := s.store.GetUserInviteByToken(ctx, token)
+	existing, err := s.store.GetUserInviteByID(ctx, id)
 	if err != nil || existing == nil {
 		jsonError(w, http.StatusNotFound, "Invite not found")
 		return
@@ -660,7 +679,6 @@ func (s *Server) handleUserInviteReinvite(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Authorization: creator, owner, or admin of a pre-assigned vault
 	allowed := existing.CreatedBy == actor.ID || actor.IsOwner()
 	if !allowed {
 		for _, v := range existing.Vaults {
@@ -676,13 +694,11 @@ func (s *Server) handleUserInviteReinvite(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Revoke the old invite.
-	if err := s.store.RevokeUserInvite(ctx, token); err != nil {
+	if err := s.store.RevokeUserInviteByID(ctx, id); err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to revoke old invite")
 		return
 	}
 
-	// Create a new invite with the same email and vault assignments.
 	inv, err := s.store.CreateUserInvite(ctx, existing.Email, actor.ID, existing.Role, time.Now().Add(userInviteTTL), existing.Vaults)
 	if err != nil {
 		jsonError(w, http.StatusInternalServerError, "Failed to create new invite")
@@ -693,7 +709,7 @@ func (s *Server) handleUserInviteReinvite(w http.ResponseWriter, r *http.Request
 
 	emailSent := s.sendUserInviteEmail(w, existing.Email, actor.DisplayLabel(), inviteLink, "You've been re-invited to Agent Vault", existing.Vaults, inv.ExpiresAt)
 	if !emailSent && s.notifier.Enabled() {
-		return // error response already written by sendUserInviteEmail
+		return
 	}
 
 	resp := map[string]interface{}{

--- a/internal/server/handle_users.go
+++ b/internal/server/handle_users.go
@@ -635,13 +635,13 @@ func (s *Server) handleUserInviteRevokeByID(w http.ResponseWriter, r *http.Reque
 		jsonError(w, http.StatusNotFound, "Invite not found")
 		return
 	}
-	if inv.Status != "pending" {
-		jsonError(w, http.StatusConflict, "Invite is not pending")
-		return
-	}
 
 	if !s.canManageUserInvite(ctx, actor, inv) {
-		jsonError(w, http.StatusForbidden, "You don't have permission to revoke this invite")
+		jsonError(w, http.StatusNotFound, "Invite not found")
+		return
+	}
+	if inv.Status != "pending" {
+		jsonError(w, http.StatusConflict, "Invite is not pending")
 		return
 	}
 
@@ -676,13 +676,13 @@ func (s *Server) handleUserInviteReinviteByID(w http.ResponseWriter, r *http.Req
 		jsonError(w, http.StatusNotFound, "Invite not found")
 		return
 	}
-	if existing.Status != "pending" {
-		jsonError(w, http.StatusConflict, "Invite is not pending")
-		return
-	}
 
 	if !s.canManageUserInvite(ctx, actor, existing) {
-		jsonError(w, http.StatusForbidden, "You don't have permission to reinvite")
+		jsonError(w, http.StatusNotFound, "Invite not found")
+		return
+	}
+	if existing.Status != "pending" {
+		jsonError(w, http.StatusConflict, "Invite is not pending")
 		return
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -332,12 +332,12 @@ type Store interface {
 	// User invites (instance-level)
 	CreateUserInvite(ctx context.Context, email, createdBy, role string, expiresAt time.Time, vaults []store.UserInviteVault) (*store.UserInvite, error)
 	GetUserInviteByToken(ctx context.Context, token string) (*store.UserInvite, error)
+	GetUserInviteByID(ctx context.Context, id int) (*store.UserInvite, error)
 	GetPendingUserInviteByEmail(ctx context.Context, email string) (*store.UserInvite, error)
 	ListUserInvites(ctx context.Context, status string) ([]store.UserInvite, error)
 	ListUserInvitesByVault(ctx context.Context, vaultID, status string) ([]store.UserInvite, error)
 	AcceptUserInvite(ctx context.Context, token string) error
-	RevokeUserInvite(ctx context.Context, token string) error
-	UpdateUserInviteVaults(ctx context.Context, token string, vaults []store.UserInviteVault) error
+	RevokeUserInviteByID(ctx context.Context, id int) error
 	CountPendingUserInvites(ctx context.Context) (int, error)
 
 	// Email verification
@@ -910,8 +910,8 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	// Instance-level user invites
 	mux.HandleFunc("POST /v1/users/invites", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleUserInviteCreate)))))
 	mux.HandleFunc("GET /v1/users/invites", s.requireInitialized(s.requireAuth(actorAuthed(s.handleUserInviteList))))
-	mux.HandleFunc("DELETE /v1/users/invites/{token}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleUserInviteRevoke))))
-	mux.HandleFunc("POST /v1/users/invites/{token}/reinvite", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleUserInviteReinvite)))))
+	mux.HandleFunc("DELETE /v1/users/invites/by-id/{id}", s.requireInitialized(s.requireAuth(actorAuthed(s.handleUserInviteRevokeByID))))
+	mux.HandleFunc("POST /v1/users/invites/by-id/{id}/reinvite", s.requireInitialized(s.requireAuth(actorAuthed(limitBody(s.handleUserInviteReinviteByID)))))
 	mux.HandleFunc("GET /v1/users/invites/{token}/details", s.requireInitialized(ipUserInviteToken(s.handleUserInviteDetails)))
 	mux.HandleFunc("POST /v1/users/invites/{token}/accept", s.requireInitialized(ipUserInviteToken(limitBody(s.handleUserInviteAccept))))
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -717,6 +717,15 @@ func (m *mockStore) GetUserInviteByToken(_ context.Context, token string) (*stor
 	return inv, nil
 }
 
+func (m *mockStore) GetUserInviteByID(_ context.Context, id int) (*store.UserInvite, error) {
+	for _, inv := range m.userInvites {
+		if inv.ID == id {
+			return inv, nil
+		}
+	}
+	return nil, fmt.Errorf("user invite not found")
+}
+
 func (m *mockStore) GetPendingUserInviteByEmail(_ context.Context, email string) (*store.UserInvite, error) {
 	for _, inv := range m.userInvites {
 		if inv.Email == email && inv.Status == "pending" && time.Now().Before(inv.ExpiresAt) {
@@ -763,22 +772,17 @@ func (m *mockStore) AcceptUserInvite(_ context.Context, token string) error {
 	return nil
 }
 
-func (m *mockStore) RevokeUserInvite(_ context.Context, token string) error {
-	inv, ok := m.userInvites[token]
-	if !ok || inv.Status != "pending" {
-		return fmt.Errorf("not found or not pending")
+func (m *mockStore) RevokeUserInviteByID(_ context.Context, id int) error {
+	for _, inv := range m.userInvites {
+		if inv.ID == id {
+			if inv.Status != "pending" {
+				return fmt.Errorf("not found or not pending")
+			}
+			inv.Status = "revoked"
+			return nil
+		}
 	}
-	inv.Status = "revoked"
-	return nil
-}
-
-func (m *mockStore) UpdateUserInviteVaults(_ context.Context, token string, vaults []store.UserInviteVault) error {
-	inv, ok := m.userInvites[token]
-	if !ok || inv.Status != "pending" {
-		return fmt.Errorf("not found or not pending")
-	}
-	inv.Vaults = vaults
-	return nil
+	return fmt.Errorf("not found or not pending")
 }
 
 func (m *mockStore) CountPendingUserInvites(_ context.Context) (int, error) {
@@ -2101,6 +2105,117 @@ func TestScopedSessionEnforcesVaultOnSet(t *testing.T) {
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUserInviteListAndRevokeByID(t *testing.T) {
+	ms, ownerToken := setupMockStoreWithSession(t)
+	srv := newTestServer(withStore(ms))
+
+	inv, err := ms.CreateUserInvite(context.Background(), "pending@test.com", "owner-user-id", "member", time.Now().Add(time.Hour), nil)
+	if err != nil {
+		t.Fatalf("CreateUserInvite: %v", err)
+	}
+	// SQL-backed invite lists never expose the creation-only plaintext token.
+	inv.Token = ""
+
+	listReq := httptest.NewRequest(http.MethodGet, "/v1/users/invites?status=pending", nil)
+	listReq.Header.Set("Authorization", "Bearer "+ownerToken)
+	listRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(listRec, listReq)
+
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("expected list status 200, got %d: %s", listRec.Code, listRec.Body.String())
+	}
+	var listResp struct {
+		Invites []struct {
+			ID    int    `json:"id"`
+			Token string `json:"token"`
+		} `json:"invites"`
+	}
+	if err := json.NewDecoder(listRec.Body).Decode(&listResp); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	if len(listResp.Invites) != 1 {
+		t.Fatalf("expected 1 invite, got %d", len(listResp.Invites))
+	}
+	if listResp.Invites[0].ID != inv.ID {
+		t.Fatalf("expected listed ID %d, got %d", inv.ID, listResp.Invites[0].ID)
+	}
+	if listResp.Invites[0].Token != "" {
+		t.Fatalf("expected no plaintext token in list response, got %q", listResp.Invites[0].Token)
+	}
+
+	revokeReq := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/users/invites/by-id/%d", listResp.Invites[0].ID), nil)
+	revokeReq.Header.Set("Authorization", "Bearer "+ownerToken)
+	revokeRec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(revokeRec, revokeReq)
+
+	if revokeRec.Code != http.StatusOK {
+		t.Fatalf("expected revoke status 200, got %d: %s", revokeRec.Code, revokeRec.Body.String())
+	}
+	if inv.Status != "revoked" {
+		t.Fatalf("expected invite status revoked, got %q", inv.Status)
+	}
+}
+
+func TestUserInviteRevokeByIDRejectsInvalidAndNonPendingIDs(t *testing.T) {
+	ms, ownerToken := setupMockStoreWithSession(t)
+	srv := newTestServer(withStore(ms))
+
+	for _, tc := range []struct {
+		name string
+		path string
+		want int
+	}{
+		{name: "invalid", path: "/v1/users/invites/by-id/not-a-number", want: http.StatusBadRequest},
+		{name: "missing", path: "/v1/users/invites/by-id/999", want: http.StatusNotFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodDelete, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+ownerToken)
+			rec := httptest.NewRecorder()
+			srv.httpServer.Handler.ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("expected %d, got %d: %s", tc.want, rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	inv, err := ms.CreateUserInvite(context.Background(), "accepted@test.com", "owner-user-id", "member", time.Now().Add(time.Hour), nil)
+	if err != nil {
+		t.Fatalf("CreateUserInvite: %v", err)
+	}
+	inv.Status = "accepted"
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/users/invites/by-id/%d", inv.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUserInviteRevokeByIDRejectsUnrelatedMember(t *testing.T) {
+	ms, _ := setupMockStoreWithSession(t)
+	memberToken := setupMemberSession(t, ms)
+	srv := newTestServer(withStore(ms))
+
+	inv, err := ms.CreateUserInvite(context.Background(), "pending@test.com", "owner-user-id", "member", time.Now().Add(time.Hour), nil)
+	if err != nil {
+		t.Fatalf("CreateUserInvite: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/users/invites/by-id/%d", inv.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+memberToken)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if inv.Status != "pending" {
+		t.Fatalf("expected invite to remain pending, got %q", inv.Status)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2196,26 +2196,63 @@ func TestUserInviteRevokeByIDRejectsInvalidAndNonPendingIDs(t *testing.T) {
 	}
 }
 
-func TestUserInviteRevokeByIDRejectsUnrelatedMember(t *testing.T) {
+func TestUserInviteRevokeByIDDoesNotDiscloseInviteStateToUnrelatedMember(t *testing.T) {
 	ms, _ := setupMockStoreWithSession(t)
 	memberToken := setupMemberSession(t, ms)
 	srv := newTestServer(withStore(ms))
 
-	inv, err := ms.CreateUserInvite(context.Background(), "pending@test.com", "owner-user-id", "member", time.Now().Add(time.Hour), nil)
+	pending, err := ms.CreateUserInvite(context.Background(), "pending@test.com", "owner-user-id", "member", time.Now().Add(time.Hour), nil)
 	if err != nil {
 		t.Fatalf("CreateUserInvite: %v", err)
 	}
-
-	req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/users/invites/by-id/%d", inv.ID), nil)
-	req.Header.Set("Authorization", "Bearer "+memberToken)
-	rec := httptest.NewRecorder()
-	srv.httpServer.Handler.ServeHTTP(rec, req)
-
-	if rec.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
+	accepted, err := ms.CreateUserInvite(context.Background(), "accepted@test.com", "owner-user-id", "member", time.Now().Add(time.Hour), nil)
+	if err != nil {
+		t.Fatalf("CreateUserInvite: %v", err)
 	}
-	if inv.Status != "pending" {
-		t.Fatalf("expected invite to remain pending, got %q", inv.Status)
+	accepted.Status = "accepted"
+
+	for _, inv := range []*store.UserInvite{pending, accepted} {
+		req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/users/invites/by-id/%d", inv.ID), nil)
+		req.Header.Set("Authorization", "Bearer "+memberToken)
+		rec := httptest.NewRecorder()
+		srv.httpServer.Handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("expected 404 for invite %d, got %d: %s", inv.ID, rec.Code, rec.Body.String())
+		}
+	}
+	if pending.Status != "pending" {
+		t.Fatalf("expected pending invite to remain pending, got %q", pending.Status)
+	}
+}
+
+func TestUserInviteReinviteByIDDoesNotDiscloseInviteStateToUnrelatedMember(t *testing.T) {
+	ms, _ := setupMockStoreWithSession(t)
+	memberToken := setupMemberSession(t, ms)
+	srv := newTestServer(withStore(ms))
+
+	pending, err := ms.CreateUserInvite(context.Background(), "pending@test.com", "owner-user-id", "member", time.Now().Add(time.Hour), nil)
+	if err != nil {
+		t.Fatalf("CreateUserInvite: %v", err)
+	}
+	accepted, err := ms.CreateUserInvite(context.Background(), "accepted@test.com", "owner-user-id", "member", time.Now().Add(time.Hour), nil)
+	if err != nil {
+		t.Fatalf("CreateUserInvite: %v", err)
+	}
+	accepted.Status = "accepted"
+
+	for _, inv := range []*store.UserInvite{pending, accepted} {
+		req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/v1/users/invites/by-id/%d/reinvite", inv.ID), nil)
+		req.Header.Set("Authorization", "Bearer "+memberToken)
+		rec := httptest.NewRecorder()
+		srv.httpServer.Handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("expected 404 for invite %d, got %d: %s", inv.ID, rec.Code, rec.Body.String())
+		}
+	}
+	if pending.Status != "pending" {
+		t.Fatalf("expected pending invite to remain pending, got %q", pending.Status)
 	}
 }
 

--- a/internal/store/sql_store.go
+++ b/internal/store/sql_store.go
@@ -43,8 +43,6 @@ func utcTimePtr(t *time.Time) *time.Time {
 	return &u
 }
 
-
-
 // nullableString returns nil for empty strings, enabling SQL NULL inserts.
 func nullableString(s string) interface{} {
 	if s == "" {
@@ -2271,6 +2269,23 @@ func (s *SQLStore) GetUserInviteByToken(ctx context.Context, token string) (*Use
 	return inv, nil
 }
 
+func (s *SQLStore) GetUserInviteByID(ctx context.Context, id int) (*UserInvite, error) {
+	row := s.db.QueryRowContext(ctx,
+		s.dialect.Rebind(`SELECT id, email, role, status, created_by, created_at, expires_at, accepted_at
+		 FROM user_invites WHERE id = ?`), id,
+	)
+	inv, err := s.scanUserInvite(row)
+	if err != nil {
+		return nil, err
+	}
+	vaults, err := s.loadUserInviteVaults(ctx, inv.ID)
+	if err != nil {
+		return nil, err
+	}
+	inv.Vaults = vaults
+	return inv, nil
+}
+
 func (s *SQLStore) GetPendingUserInviteByEmail(ctx context.Context, email string) (*UserInvite, error) {
 	nowStr := s.now()
 	row := s.db.QueryRowContext(ctx,
@@ -2381,55 +2396,20 @@ func (s *SQLStore) AcceptUserInvite(ctx context.Context, token string) error {
 	return nil
 }
 
-func (s *SQLStore) RevokeUserInvite(ctx context.Context, token string) error {
+func (s *SQLStore) RevokeUserInviteByID(ctx context.Context, id int) error {
 	res, err := s.db.ExecContext(ctx,
 		s.dialect.Rebind(`UPDATE user_invites SET status = 'revoked'
-		 WHERE token_hash = ? AND status = 'pending'`),
-		hashToken(token),
+		 WHERE id = ? AND status = 'pending'`),
+		id,
 	)
 	if err != nil {
-		return fmt.Errorf("revoking user invite: %w", err)
+		return fmt.Errorf("revoking user invite by id: %w", err)
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
 		return sql.ErrNoRows
 	}
 	return nil
-}
-
-func (s *SQLStore) UpdateUserInviteVaults(ctx context.Context, token string, vaults []UserInviteVault) error {
-	// Look up invite ID by token hash
-	var inviteID int
-	err := s.db.QueryRowContext(ctx,
-		s.dialect.Rebind(`SELECT id FROM user_invites WHERE token_hash = ? AND status = 'pending'`),
-		hashToken(token),
-	).Scan(&inviteID)
-	if err != nil {
-		return fmt.Errorf("finding user invite: %w", err)
-	}
-
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	_, err = tx.ExecContext(ctx, s.dialect.Rebind(`DELETE FROM user_invite_vaults WHERE user_invite_id = ?`), inviteID)
-	if err != nil {
-		return fmt.Errorf("clearing user invite vaults: %w", err)
-	}
-
-	for _, v := range vaults {
-		_, err := tx.ExecContext(ctx,
-			s.dialect.Rebind(`INSERT INTO user_invite_vaults (user_invite_id, vault_id, vault_role) VALUES (?, ?, ?)`),
-			inviteID, v.VaultID, v.VaultRole,
-		)
-		if err != nil {
-			return fmt.Errorf("inserting user invite vault: %w", err)
-		}
-	}
-
-	return tx.Commit()
 }
 
 func (s *SQLStore) CountPendingUserInvites(ctx context.Context) (int, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -526,12 +526,12 @@ type Store interface {
 	// User invites (instance-level)
 	CreateUserInvite(ctx context.Context, email, createdBy, role string, expiresAt time.Time, vaults []UserInviteVault) (*UserInvite, error)
 	GetUserInviteByToken(ctx context.Context, token string) (*UserInvite, error)
+	GetUserInviteByID(ctx context.Context, id int) (*UserInvite, error)
 	GetPendingUserInviteByEmail(ctx context.Context, email string) (*UserInvite, error)
 	ListUserInvites(ctx context.Context, status string) ([]UserInvite, error)
 	ListUserInvitesByVault(ctx context.Context, vaultID, status string) ([]UserInvite, error)
 	AcceptUserInvite(ctx context.Context, token string) error
-	RevokeUserInvite(ctx context.Context, token string) error
-	UpdateUserInviteVaults(ctx context.Context, token string, vaults []UserInviteVault) error
+	RevokeUserInviteByID(ctx context.Context, id int) error
 	CountPendingUserInvites(ctx context.Context) (int, error)
 
 	// Email verification

--- a/internal/store/user_invite_test.go
+++ b/internal/store/user_invite_test.go
@@ -1,0 +1,135 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestUserInviteRevokeByID(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	// Create a vault for pre-assignment.
+	vault, err := s.CreateVault(ctx, "test-vault")
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+
+	vaults := []UserInviteVault{{VaultID: vault.ID, VaultName: vault.Name, VaultRole: "member"}}
+
+	// Create a pending invite.
+	inv, err := s.CreateUserInvite(ctx, "alice@test.com", "creator-id", "member", time.Now().Add(time.Hour), vaults)
+	if err != nil {
+		t.Fatalf("CreateUserInvite: %v", err)
+	}
+	if inv.Token == "" {
+		t.Fatal("expected non-empty token at creation")
+	}
+
+	// List pending invites — should contain the invite with an ID but empty token.
+	pending, err := s.ListUserInvites(ctx, "pending")
+	if err != nil {
+		t.Fatalf("ListUserInvites: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending invite, got %d", len(pending))
+	}
+	if pending[0].ID != inv.ID {
+		t.Fatalf("expected ID %d, got %d", inv.ID, pending[0].ID)
+	}
+	if pending[0].Token != "" {
+		t.Fatalf("expected empty token in list response, got %q", pending[0].Token)
+	}
+
+	// Revoke by ID using the ID from the list.
+	if err := s.RevokeUserInviteByID(ctx, pending[0].ID); err != nil {
+		t.Fatalf("RevokeUserInviteByID: %v", err)
+	}
+
+	// Verify it's now revoked.
+	revoked, err := s.ListUserInvites(ctx, "revoked")
+	if err != nil {
+		t.Fatalf("ListUserInvites revoked: %v", err)
+	}
+	if len(revoked) != 1 {
+		t.Fatalf("expected 1 revoked invite, got %d", len(revoked))
+	}
+
+	// Pending list should be empty now.
+	pendingAfter, err := s.ListUserInvites(ctx, "pending")
+	if err != nil {
+		t.Fatalf("ListUserInvites pending after: %v", err)
+	}
+	if len(pendingAfter) != 0 {
+		t.Fatalf("expected 0 pending after revoke, got %d", len(pendingAfter))
+	}
+}
+
+func TestUserInviteRevokeByIDNotFound(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	err := s.RevokeUserInviteByID(ctx, 99999)
+	if err == nil {
+		t.Fatal("expected error for nonexistent invite ID")
+	}
+}
+
+func TestUserInviteRevokeByIDNotPending(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	// Create and accept an invite.
+	inv, err := s.CreateUserInvite(ctx, "bob@test.com", "creator-id", "member", time.Now().Add(time.Hour), nil)
+	if err != nil {
+		t.Fatalf("CreateUserInvite: %v", err)
+	}
+	if err := s.AcceptUserInvite(ctx, inv.Token); err != nil {
+		t.Fatalf("AcceptUserInvite: %v", err)
+	}
+
+	// Revoke by ID should fail (not pending).
+	err = s.RevokeUserInviteByID(ctx, inv.ID)
+	if err == nil {
+		t.Fatal("expected error for non-pending invite")
+	}
+}
+
+func TestGetUserInviteByID(t *testing.T) {
+	s := openTestDB(t)
+	ctx := context.Background()
+
+	// Create a vault for pre-assignment.
+	vault, err := s.CreateVault(ctx, "test-vault-2")
+	if err != nil {
+		t.Fatalf("CreateVault: %v", err)
+	}
+
+	vaults := []UserInviteVault{{VaultID: vault.ID, VaultName: vault.Name, VaultRole: "admin"}}
+	inv, err := s.CreateUserInvite(ctx, "carol@test.com", "creator-id", "member", time.Now().Add(time.Hour), vaults)
+	if err != nil {
+		t.Fatalf("CreateUserInvite: %v", err)
+	}
+
+	// Fetch by ID.
+	fetched, err := s.GetUserInviteByID(ctx, inv.ID)
+	if err != nil {
+		t.Fatalf("GetUserInviteByID: %v", err)
+	}
+	if fetched.Email != "carol@test.com" {
+		t.Fatalf("expected carol@test.com, got %s", fetched.Email)
+	}
+	if fetched.Status != "pending" {
+		t.Fatalf("expected pending, got %s", fetched.Status)
+	}
+	if len(fetched.Vaults) != 1 || fetched.Vaults[0].VaultName != "test-vault-2" {
+		t.Fatalf("expected 1 vault 'test-vault-2', got %+v", fetched.Vaults)
+	}
+
+	// Nonexistent ID should error.
+	_, err = s.GetUserInviteByID(ctx, 99999)
+	if err == nil {
+		t.Fatal("expected error for nonexistent invite ID")
+	}
+}

--- a/web/src/pages/home/AllUsersTab.tsx
+++ b/web/src/pages/home/AllUsersTab.tsx
@@ -19,7 +19,7 @@ interface PublicUser {
   status: "active" | "pending";
   vaults?: { vault_name: string; vault_role: string }[];
   created_at: string;
-  invite_token?: string;
+  invite_id?: number;
 }
 
 interface VaultOption {
@@ -108,13 +108,13 @@ export default function AllUsersTab() {
       if (invResp.ok) {
         const invData = await invResp.json();
         pendingUsers = (invData.invites ?? []).map(
-          (inv: { email: string; role?: string; token: string; created_at: string; vaults?: { vault_name: string; vault_role: string }[] }) => ({
+          (inv: { email: string; role?: string; id: number; created_at: string; vaults?: { vault_name: string; vault_role: string }[] }) => ({
             email: inv.email,
             role: inv.role || "member",
             status: "pending" as const,
             vaults: inv.vaults ?? [],
             created_at: inv.created_at,
-            invite_token: inv.token,
+            invite_id: inv.id,
           })
         );
       }
@@ -134,9 +134,11 @@ export default function AllUsersTab() {
   async function handleDeleteUser() {
     if (!deleteTarget) return;
     if (deleteTarget.status === "pending") {
-      if (!deleteTarget.invite_token) return;
+      if (!deleteTarget.invite_id) {
+        throw new Error("Missing invite ID - cannot revoke invite");
+      }
       const resp = await apiFetch(
-        `/v1/users/invites/${encodeURIComponent(deleteTarget.invite_token)}`,
+        `/v1/users/invites/by-id/${deleteTarget.invite_id}`,
         { method: "DELETE" }
       );
       if (!resp.ok) {
@@ -263,6 +265,19 @@ export default function AllUsersTab() {
           rowKey={(u) => u.email + u.status}
           emptyTitle="No users"
           emptyDescription="No users have registered yet."
+        />
+      )}
+
+      {auth.is_owner && deleteTarget?.status === "pending" && (
+        <ConfirmDeleteModal
+          open={deleteTarget !== null}
+          onClose={() => setDeleteTarget(null)}
+          onConfirm={handleDeleteUser}
+          title="Revoke invite"
+          description={`This will revoke the pending invitation for "${deleteTarget?.email}". They will no longer be able to accept it. Type the email to confirm.`}
+          confirmLabel="Revoke invite"
+          confirmValue={deleteTarget?.email ?? ""}
+          inputLabel="Email address"
         />
       )}
 


### PR DESCRIPTION
## Summary

Fixes pending user-invite revocation.

The Users page listed pending invitations with a plaintext token field. The token is available only when an invitation is created. The database stores only its hash. As a result, listed invitations had an empty token and could not be revoked.

The page also did not render the confirmation dialog for pending invitations. Clicking **Revoke invite** closed the menu without sending a request.

This change:

- returns the invitation ID from `GET /v1/users/invites`;
- uses authenticated ID-based endpoints for revoke and reinvite;
- keeps the secret token for invitation details and acceptance only;
- shows a pending-invitation confirmation dialog;
- updates the CLI to list and revoke invitations by ID;
- shares the authorization check for revoke and reinvite.

This follows the pending-agent invite pattern from #172.

### Security follow-up

The ID is sequential. An unrelated authenticated member must not learn whether an invitation exists or whether it is pending. Revoke and reinvite now authorize the caller before checking invitation status. Unauthorized callers receive `404` for both pending and non-pending invitations.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

- [ ] Existing tests pass (`make test`)
- [x] Added/updated tests for new behavior
- [ ] Manual testing (describe below)

Passed:

- `go test ./internal/store ./internal/server`
- `make build`
- `go test ./internal/server` after the security follow-up

Added coverage for:

- listing a pending invitation with its ID and no plaintext token;
- revoking a pending invitation by ID;
- invalid, missing, accepted, and unauthorized revoke attempts;
- store lookup and revocation by ID;
- non-disclosure of pending and accepted invitation state to unrelated members for revoke and reinvite.

`make test` has one unrelated environment-dependent CLI failure: `TestResolveVaultWithProjectFile/falls_back_to_default_when_no_file` reads an existing local default vault (`user-default`) instead of the test's expected `default`. The store and server packages pass.

Manual verification still needed:

1. Create a pending user invitation.
2. Open Users as an owner.
3. Select **Revoke invite**.
4. Confirm using the invitee email.
5. Verify one DELETE request to `/v1/users/invites/by-id/{id}`.
6. Verify the pending row disappears.

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces
- [x] Checked for OWASP top 10 (injection, XSS, etc.)
