### PR TITLE
fix(docker): exclude local build artifacts and node_modules from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,9 @@ sb
 .gitignore
 *.md
 !README.md
+web/node_modules
+web/dist
+agent-vault
+internal/server/webdist
+.env
+.idea


### PR DESCRIPTION
## Problem

The Dockerfile frontend stage runs `npm ci` and then `COPY web/ .`. Because `.dockerignore` does not exclude `web/node_modules`, the developer's local `node_modules` is part of the build context and gets **overlaid on top of the fresh `npm ci` install** (Docker COPY merges directories, overwriting same-named files).

If the local install is older than the lockfile — e.g. after pulling a dependency bump (#311 bumped vite 8.0.16 → 8.1.0) without re-running `npm ci` locally — the image ends up with mixed package versions: old JS from the host plus new Linux-native bindings from `npm ci`. The build then fails with:

```
Error: value "builtin:vite-wasm-fallback" does not match any variant of enum BindingBuiltinPluginName on BindingBuiltinPlugin.__name
    at makeBuiltinPluginCallable (rolldown/dist/shared/...)
    at viteWasmFallbackPlugin (rolldown/dist/shared/...)
    at resolvePlugins (vite/dist/node/chunks/node.js...)
```

because rolldown **1.0.3 JS** (which still registers the `vite-wasm-fallback` builtin, removed in rolldown 1.1.2) drives a rolldown **1.1.4 native binding**. CI builds from clean checkouts are unaffected, which is why this only bites local `docker build` / `docker buildx` runs.

## Fix

Add to `.dockerignore`:

- `web/node_modules` — the actual fix: the frontend stage only ever uses the `npm ci` install; also removes hundreds of MB from the build context
- `internal/server/webdist` — same overlay-class hazard: `COPY . .` brings a locally built webdist, then `COPY --from=frontend` merges over it; stale local files could leak into the embedded frontend
- `agent-vault`, `web/dist` — local build artifacts / context bloat
- `.env` — secrets should never enter the build context
- `.idea` — editor config

🤖 Generated with [Claude Code](https://claude.com/claude-code)