### PR TITLE
fix(netguard): explain blocked address errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ Content-Type: application/json
 | 401 | Invalid or expired token | Check `AGENT_VAULT_TOKEN` |
 | 403 | Host not allowed | Propose a proposal |
 | 429 | Too many pending proposals | Wait for review |
+| 502 `network_policy_blocked` | Target address denied by outbound network policy | Ask the operator to allowlist an intentional private destination; cloud metadata endpoints cannot be allowed |
 | 502 | Missing credential or upstream unreachable | Tell user a credential may need to be added |
 
 ## Rules

--- a/cmd/skill_cli.md
+++ b/cmd/skill_cli.md
@@ -182,6 +182,7 @@ WSS and WS connections also go through the proxy with credential injection — i
 - 401: invalid or expired token
 - 403 with `proposal_hint`: host not allowed — create a proposal
 - 403 `service_disabled`: host is configured but disabled by operator — tell the user
+- 502 `network_policy_blocked`: target resolved to an address denied by outbound network policy — tell the operator to allowlist an intentional private destination; cloud metadata endpoints cannot be allowed
 - 502: missing credential or upstream unreachable
 - 502 `oauth_not_connected`: OAuth credential approved but not yet connected — tell the user to complete the connection in the dashboard
 - 502 `oauth_refresh_failed`: OAuth token expired and refresh failed — tell the user to reconnect in the dashboard

--- a/docs/agents/protocol.mdx
+++ b/docs/agents/protocol.mdx
@@ -159,6 +159,7 @@ See [Proposals](/learn/proposals) for the full proposal lifecycle, including sto
 | 403 `service_disabled` | Host is configured but disabled | Surface to the user — don't create a duplicate proposal. |
 | 409 `multiple services match host …` | Service mutation (`PATCH`/`DELETE`) used a bare host that matches several path-scoped services | Retry with the canonical service `name` from `/discover`. The response body includes a `candidates` array. |
 | 429 | Rate limited | Respect the `Retry-After` header. |
+| 502 `network_policy_blocked` | The target resolved to an address denied by Agent Vault's outbound network policy | For an intentional private destination, add its IP or CIDR to `AGENT_VAULT_NETWORK_ALLOWLIST`, or enable `AGENT_VAULT_ALLOW_PRIVATE_RANGES` for a trusted local deployment. Cloud metadata endpoints cannot be allowed. |
 | 502 | Missing credential or upstream unreachable | Tell the user a credential may need to be added. |
 
 <Note>

--- a/docs/learn/security.mdx
+++ b/docs/learn/security.mdx
@@ -107,6 +107,8 @@ RFC-1918 and other reserved ranges are additionally blocked under the default po
 
 Agent Vault resolves hostnames to IP addresses, validates every resolved IP against the block list, then connects directly to the validated IP. This prevents DNS rebinding attacks where a hostname resolves to a safe IP during validation but a different (internal) IP during connection.
 
+When a proxy request resolves to a blocked address, Agent Vault returns a `502` response with the error code `network_policy_blocked` and records the same code in the vault request log. For an intentional private-network destination, add the narrowest practical IP or CIDR to `AGENT_VAULT_NETWORK_ALLOWLIST`. Alternatively, trusted local deployments can set `AGENT_VAULT_ALLOW_PRIVATE_RANGES=true` to permit all private and reserved ranges. Cloud metadata endpoints remain blocked in both cases.
+
 ## Transport security
 
 All proxied requests are forwarded over **HTTPS**. The agent's session token never reaches the target service: it travels in `Proxy-Authorization` (which is hop-by-hop and never forwarded). Real credentials are injected server-side based on the vault's [services](/learn/services).

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Infisical/agent-vault/internal/brokercore"
+	"github.com/Infisical/agent-vault/internal/netguard"
 	"github.com/Infisical/agent-vault/internal/ratelimit"
 	"github.com/Infisical/agent-vault/internal/requestlog"
 )
@@ -168,6 +169,35 @@ func hostHeaderForScheme(scheme, target string) string {
 		return "[" + host + "]"
 	}
 	return host
+}
+
+// networkPolicyBlockedMessage translates the internal policy reason into safe,
+// actionable client guidance. The resolved IP is intentionally omitted: it is
+// retained in the server-side error for diagnostics but is not needed by an
+// untrusted proxy client.
+func networkPolicyBlockedMessage(reason netguard.BlockReason) string {
+	message := "The target resolved to an address blocked by Agent Vault's network policy."
+	switch reason {
+	case netguard.BlockReasonMetadata:
+		return message + " Cloud metadata endpoints are always blocked."
+	case netguard.BlockReasonPrivateRange:
+		return message + " If access to this private or reserved address is intentional, add it to AGENT_VAULT_NETWORK_ALLOWLIST or set AGENT_VAULT_ALLOW_PRIVATE_RANGES=true."
+	default:
+		return message
+	}
+}
+
+// writeNetworkPolicyProxyError converts a typed netguard rejection into the
+// standard broker error shape. It returns false for ordinary dial, TLS, and
+// upstream failures so callers can preserve their existing error handling.
+func writeNetworkPolicyProxyError(w http.ResponseWriter, err error) bool {
+	var blockedErr *netguard.BlockedAddressError
+	if !errors.As(err, &blockedErr) {
+		return false
+	}
+	brokercore.WriteProxyError(w, http.StatusBadGateway, "network_policy_blocked",
+		networkPolicyBlockedMessage(blockedErr.Reason))
+	return true
 }
 
 // forwardHandler returns an http.Handler that forwards each request to
@@ -342,6 +372,10 @@ func (p *Proxy) forwardRequest(
 			slog.String("target_host", target),
 			slog.String("error", err.Error()),
 		)
+		if writeNetworkPolicyProxyError(w, err) {
+			emit(http.StatusBadGateway, "network_policy_blocked")
+			return
+		}
 		http.Error(w, "bad gateway", http.StatusBadGateway)
 		emit(http.StatusBadGateway, "upstream_error")
 		return

--- a/internal/mitm/forward_test.go
+++ b/internal/mitm/forward_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -78,6 +79,46 @@ func writeRawRequestLine(t *testing.T, conn net.Conn, line string, headers map[s
 		t.Fatalf("read response: %v", err)
 	}
 	return resp
+}
+
+func TestNetworkPolicyBlockedMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		reason     netguard.BlockReason
+		want       string
+		notContain string
+	}{
+		{
+			name:       "private range has remediation",
+			reason:     netguard.BlockReasonPrivateRange,
+			want:       "AGENT_VAULT_NETWORK_ALLOWLIST",
+			notContain: "metadata endpoints are always blocked",
+		},
+		{
+			name:       "metadata endpoint is unconditional",
+			reason:     netguard.BlockReasonMetadata,
+			want:       "metadata endpoints are always blocked",
+			notContain: "AGENT_VAULT_NETWORK_ALLOWLIST",
+		},
+		{
+			name:       "unknown reason remains safe",
+			reason:     netguard.BlockReason("future_reason"),
+			want:       "blocked by Agent Vault's network policy",
+			notContain: "AGENT_VAULT_NETWORK_ALLOWLIST",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			message := networkPolicyBlockedMessage(tt.reason)
+			if !strings.Contains(message, tt.want) {
+				t.Errorf("message = %q, want it to contain %q", message, tt.want)
+			}
+			if tt.notContain != "" && strings.Contains(message, tt.notContain) {
+				t.Errorf("message = %q, do not want it to contain %q", message, tt.notContain)
+			}
+		})
+	}
 }
 
 // TestMITMForwardPlainHTTPInjectsCredentials is the flagship test for
@@ -451,7 +492,8 @@ func TestMITMForwardSSRFLoopbackBlocked(t *testing.T) {
 	cp := &fakeCredProvider{byHost: map[string]fakeInjectResult{
 		upstreamHost: {result: &brokercore.InjectResult{Passthrough: true}},
 	}}
-	proxyURL, clientRoots, p := setupProxy(t, sr, cp)
+	sink := &recordingSink{}
+	proxyURL, clientRoots, p := setupProxy(t, sr, cp, func(o *Options) { o.LogSink = sink })
 	// Override the dialler with a stricter SafeDialContext that blocks
 	// loopback (setupProxy seeded ALLOW_PRIVATE_RANGES=true for the
 	// other tests; we bypass that policy here directly).
@@ -465,6 +507,27 @@ func TestMITMForwardSSRFLoopbackBlocked(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502 (loopback blocked at dial)", resp.StatusCode)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response body: %v", err)
+	}
+	if got := resp.Header.Get(brokercore.ProxyErrorHeader); got != "true" {
+		t.Errorf("%s = %q, want true", brokercore.ProxyErrorHeader, got)
+	}
+	if body["error"] != "network_policy_blocked" {
+		t.Errorf("response error = %q, want network_policy_blocked", body["error"])
+	}
+	if !strings.Contains(body["message"], "AGENT_VAULT_NETWORK_ALLOWLIST") {
+		t.Errorf("response message = %q, want actionable allowlist guidance", body["message"])
+	}
+
+	records := sink.snapshot()
+	if len(records) != 1 {
+		t.Fatalf("request log rows = %d, want 1", len(records))
+	}
+	if records[0].ErrorCode != "network_policy_blocked" {
+		t.Errorf("request log error_code = %q, want network_policy_blocked", records[0].ErrorCode)
 	}
 }
 

--- a/internal/mitm/websocket.go
+++ b/internal/mitm/websocket.go
@@ -61,8 +61,12 @@ func (p *Proxy) forwardWebSocket(
 ) {
 	upstreamConn, upstreamReader, resp, err := p.dialWebSocketUpstream(r.Context(), outReq)
 	if err != nil {
-		http.Error(w, "bad gateway", http.StatusBadGateway)
-		emit(http.StatusBadGateway, "upstream_error")
+		if writeNetworkPolicyProxyError(w, err) {
+			emit(http.StatusBadGateway, "network_policy_blocked")
+		} else {
+			http.Error(w, "bad gateway", http.StatusBadGateway)
+			emit(http.StatusBadGateway, "upstream_error")
+		}
 		return
 	}
 	defer func() {

--- a/internal/mitm/websocket_test.go
+++ b/internal/mitm/websocket_test.go
@@ -2,14 +2,19 @@ package mitm
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
+	"encoding/json"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/Infisical/agent-vault/internal/brokercore"
+	"github.com/Infisical/agent-vault/internal/netguard"
 )
 
 // fakeConn implements net.Conn for testing. Only SetReadDeadline is used
@@ -19,12 +24,12 @@ type fakeConn struct {
 	io.Writer
 }
 
-func (fakeConn) Close() error                       { return nil }
-func (fakeConn) LocalAddr() net.Addr                { return nil }
-func (fakeConn) RemoteAddr() net.Addr               { return nil }
-func (fakeConn) SetDeadline(time.Time) error        { return nil }
-func (fakeConn) SetReadDeadline(time.Time) error    { return nil }
-func (fakeConn) SetWriteDeadline(time.Time) error   { return nil }
+func (fakeConn) Close() error                     { return nil }
+func (fakeConn) LocalAddr() net.Addr              { return nil }
+func (fakeConn) RemoteAddr() net.Addr             { return nil }
+func (fakeConn) SetDeadline(time.Time) error      { return nil }
+func (fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (fakeConn) SetWriteDeadline(time.Time) error { return nil }
 
 func maskedTextFrame(t *testing.T, text string) []byte {
 	t.Helper()
@@ -63,6 +68,44 @@ func readFrameText(t *testing.T, r io.Reader) string {
 		t.Fatalf("readWebSocketTextFrame: %v", err)
 	}
 	return text
+}
+
+func TestForwardWebSocketReportsNetworkPolicyBlock(t *testing.T) {
+	p := &Proxy{upstream: &http.Transport{
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			return nil, &netguard.BlockedAddressError{
+				Host:   "private.example",
+				IP:     net.ParseIP("10.0.0.1"),
+				Reason: netguard.BlockReasonPrivateRange,
+			}
+		},
+	}}
+	r := httptest.NewRequest(http.MethodGet, "http://broker.test/socket", nil)
+	outReq := httptest.NewRequest(http.MethodGet, "http://private.example/socket", nil)
+	w := httptest.NewRecorder()
+
+	var emittedStatus int
+	var emittedCode string
+	p.forwardWebSocket(w, r, outReq, nil, func(status int, code string) {
+		emittedStatus = status
+		emittedCode = code
+	})
+
+	resp := w.Result()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response body: %v", err)
+	}
+	if body["error"] != "network_policy_blocked" {
+		t.Errorf("response error = %q, want network_policy_blocked", body["error"])
+	}
+	if emittedStatus != http.StatusBadGateway || emittedCode != "network_policy_blocked" {
+		t.Errorf("emitted status/code = %d/%q, want 502/network_policy_blocked", emittedStatus, emittedCode)
+	}
 }
 
 func TestCopyWSFramesSubstitutesTextFrame(t *testing.T) {

--- a/internal/netguard/netguard.go
+++ b/internal/netguard/netguard.go
@@ -11,6 +11,36 @@ import (
 	"time"
 )
 
+// BlockReason identifies the network-policy rule that rejected an outbound
+// address. It is intentionally coarse: callers can provide actionable errors
+// without exposing the specific CIDR layout of the broker host.
+type BlockReason string
+
+const (
+	// BlockReasonMetadata is used for cloud metadata endpoints, which remain
+	// blocked even when private ranges are enabled or explicitly allowlisted.
+	BlockReasonMetadata BlockReason = "metadata_endpoint"
+
+	// BlockReasonPrivateRange is used for private, loopback, link-local, CGN,
+	// and other reserved ranges controlled by the operator's private-range
+	// policy and allowlist.
+	BlockReasonPrivateRange BlockReason = "private_range"
+)
+
+// BlockedAddressError reports that an outbound address was rejected by
+// Agent Vault's network policy. Host and IP are retained for structured server
+// diagnostics; proxy handlers should avoid returning the resolved IP to
+// untrusted clients.
+type BlockedAddressError struct {
+	Host   string
+	IP     net.IP
+	Reason BlockReason
+}
+
+func (e *BlockedAddressError) Error() string {
+	return fmt.Sprintf("netguard: connection to %s (%s) blocked by network policy", e.Host, e.IP.String())
+}
+
 // AllowPrivateFromEnv reads AGENT_VAULT_ALLOW_PRIVATE_RANGES and returns whether
 // the proxy should allow connections to private/reserved IP ranges (RFC-1918,
 // loopback, link-local, IPv6 ULA, CGN). Defaults to false (block) when unset
@@ -131,33 +161,39 @@ func parseCIDR(s string) net.IPNet {
 	return *ipNet
 }
 
-// isBlockedIP checks if an IP is blocked. When allowPrivate is false,
-// private/reserved ranges are blocked unless the IP is in the allowlist.
-// IMDS endpoints are always blocked, even when allowlisted.
-func isBlockedIP(ip net.IP, allowPrivate bool, allowed []net.IPNet) bool {
+// blockReason checks if an IP is blocked and returns the policy rule that
+// rejected it. When allowPrivate is false, private/reserved ranges are blocked
+// unless the IP is in the allowlist. IMDS endpoints are always blocked, even
+// when allowlisted.
+func blockReason(ip net.IP, allowPrivate bool, allowed []net.IPNet) (BlockReason, bool) {
 	for _, n := range alwaysBlocked {
 		if n.Contains(ip) {
-			return true
+			return BlockReasonMetadata, true
 		}
 	}
 
 	if allowPrivate {
-		return false
+		return "", false
 	}
 
 	for _, n := range allowed {
 		if n.Contains(ip) {
-			return false
+			return "", false
 		}
 	}
 
 	for _, n := range privateRanges {
 		if n.Contains(ip) {
-			return true
+			return BlockReasonPrivateRange, true
 		}
 	}
 
-	return false
+	return "", false
+}
+
+func isBlockedIP(ip net.IP, allowPrivate bool, allowed []net.IPNet) bool {
+	_, blocked := blockReason(ip, allowPrivate, allowed)
+	return blocked
 }
 
 // SafeDialContext returns a DialContext function that blocks connections to
@@ -189,9 +225,12 @@ func SafeDialContext(allowPrivate bool) func(ctx context.Context, network, addr 
 
 		// Check all resolved IPs before connecting.
 		for _, ipAddr := range ips {
-			if isBlockedIP(ipAddr.IP, allowPrivate, allowed) {
-				return nil, fmt.Errorf("netguard: connection to %s (%s) blocked by network policy",
-					host, ipAddr.IP.String())
+			if reason, blocked := blockReason(ipAddr.IP, allowPrivate, allowed); blocked {
+				return nil, &BlockedAddressError{
+					Host:   host,
+					IP:     ipAddr.IP,
+					Reason: reason,
+				}
 			}
 		}
 

--- a/internal/netguard/netguard_test.go
+++ b/internal/netguard/netguard_test.go
@@ -1,9 +1,62 @@
 package netguard
 
 import (
+	"context"
+	"errors"
 	"net"
 	"testing"
 )
+
+func TestSafeDialContextReturnsTypedPolicyError(t *testing.T) {
+	tests := []struct {
+		name         string
+		address      string
+		allowPrivate bool
+		wantReason   BlockReason
+		wantHost     string
+		wantIP       string
+	}{
+		{
+			name:         "private range",
+			address:      "127.0.0.1:443",
+			allowPrivate: false,
+			wantReason:   BlockReasonPrivateRange,
+			wantHost:     "127.0.0.1",
+			wantIP:       "127.0.0.1",
+		},
+		{
+			name:         "metadata endpoint",
+			address:      "169.254.169.254:80",
+			allowPrivate: true,
+			wantReason:   BlockReasonMetadata,
+			wantHost:     "169.254.169.254",
+			wantIP:       "169.254.169.254",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := SafeDialContext(tt.allowPrivate)(context.Background(), "tcp", tt.address)
+			if err == nil {
+				t.Fatal("SafeDialContext() error = nil, want a network-policy error")
+			}
+
+			var blockedErr *BlockedAddressError
+			if !errors.As(err, &blockedErr) {
+				t.Fatalf("SafeDialContext() error type = %T, want *BlockedAddressError", err)
+			}
+			if blockedErr.Reason != tt.wantReason {
+				t.Errorf("BlockedAddressError.Reason = %q, want %q", blockedErr.Reason, tt.wantReason)
+			}
+			if blockedErr.Host != tt.wantHost {
+				t.Errorf("BlockedAddressError.Host = %q, want %q", blockedErr.Host, tt.wantHost)
+			}
+			if got := blockedErr.IP.String(); got != tt.wantIP {
+				t.Errorf("BlockedAddressError.IP = %q, want %q", got, tt.wantIP)
+			}
+		})
+	}
+}
 
 func TestIsBlockedIP_AlwaysBlocked(t *testing.T) {
 	// IMDS endpoints are blocked regardless of policy (allowlist does NOT bypass).


### PR DESCRIPTION
## Summary

Fixes #305.

Network-policy denials currently collapse into the same plain `502 bad gateway` response as DNS, TLS, timeout, and connection failures. This makes intentional private-network deployments difficult to diagnose even though netguard already knows that it rejected the resolved address.

This change:

- returns typed `BlockedAddressError` values from netguard, with coarse reasons for private/reserved ranges and permanently blocked metadata endpoints;
- maps those errors to the standard broker JSON response with `error: network_policy_blocked` while preserving the existing HTTP 502 status;
- records `network_policy_blocked` in request logs for both HTTP requests and WebSocket handshakes;
- gives operators actionable allowlist/private-range guidance without returning the resolved IP to an untrusted proxy client;
- documents the response in the security guide, agent protocol, and embedded agent skill.

Example response for an intentional private destination:

```json
{
  "error": "network_policy_blocked",
  "message": "The target resolved to an address blocked by Agent Vault's network policy. If access to this private or reserved address is intentional, add it to AGENT_VAULT_NETWORK_ALLOWLIST or set AGENT_VAULT_ALLOW_PRIVATE_RANGES=true."
}
```

Metadata endpoints receive distinct guidance that they are always blocked.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] CI / build

## Test plan

- [x] Existing tests pass (`go test ./...`)
- [x] Added/updated tests for new behavior
- [ ] Manual testing (automated proxy integration coverage described below)

Validation completed:

- `go test ./...`
- `go test -race ./internal/netguard ./internal/mitm`
- `go vet ./...`
- `golangci-lint v2.11.0 run --new-from-rev=origin/main ./...` (`0 issues`)
- `go build -trimpath`
- `git diff --check`

Regression coverage verifies:

- private-range and metadata denials remain distinguishable through wrapped transport errors;
- plain HTTP proxy requests return `502`, `X-Agent-Vault-Proxy-Error: true`, and `network_policy_blocked`;
- request-log rows persist the new error code;
- WebSocket upstream dials return and log the same policy-specific error;
- private-range guidance mentions the supported operator controls;
- metadata guidance does not suggest an allowlist bypass.

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces (no new API surface)
- [x] Checked for OWASP top 10 (injection, XSS, etc.)

### Security invariants

- Netguard's blocked ranges, allowlist precedence, and DNS-rebinding protections are unchanged.
- Cloud metadata endpoints remain blocked even when private ranges are enabled or the address is allowlisted.
- The resolved blocked IP remains available in server-side diagnostics but is intentionally omitted from the client response.
- Existing clients continue to receive HTTP 502; the change adds a structured broker error and actionable message.
- Non-policy upstream failures retain the existing plain `bad gateway` / `upstream_error` behavior.

## Coordination

#374 also updates `SafeDialContext` to add multi-address fallback. This PR's typed error is designed to survive normal Go error wrapping (`errors.As`), including joined/wrapped dial errors. The two branches touch nearby netguard code, so I am happy to rebase promptly if #374 lands first.
