### PR TITLE
feat: add declarative agent run profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,27 @@ agent-vault vault run -- codex
 agent-vault vault run -- opencode
 ```
 
+For repeatable least-privilege roles, define named launch profiles in
+`~/.agent-vault/profiles.yaml`:
+
+```yaml
+profiles:
+  planner:
+    vault: planning
+    ttl: 1800
+    isolation: container
+    mounts:
+      - ./specs:/workspace/specs:ro
+```
+
+```bash
+agent-vault run --profile planner -- claude
+```
+
+Profiles make the vault, session lifetime, isolation mode, image, mounts, and
+container persistence settings reviewable as code. Explicit CLI flags override
+profile values.
+
 Alternatively, if your agent is running with Docker, you can install the Agent Vault CLI via a Dockerfile by copying the binary into your own image and using it to start up your agent process:
 
 ```dockerfile

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"errors"
-	"time"
 	"fmt"
 	"net"
 	"net/http"
@@ -17,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/Infisical/agent-vault/internal/isolation"
 	"github.com/Infisical/agent-vault/internal/session"
@@ -51,6 +51,10 @@ Two modes:
     --ttl has no effect in agent mode and is rejected (the token's lifetime
     is fixed at mint time).
 
+Named profiles can supply the vault, role, TTL, isolation, image, mounts, and
+safe container persistence settings from ~/.agent-vault/profiles.yaml. Explicit
+CLI flags override profile values.
+
 Environment variables set on the child:
   AGENT_VAULT_TOKEN  — bearer token for the Agent Vault server
   AGENT_VAULT_ADDR   — base URL of the Agent Vault HTTP control server
@@ -72,6 +76,7 @@ for http:// on the same port. The root CA PEM is written to
 
 Example:
   ` + examplePrefix + ` -- claude
+  ` + examplePrefix + ` --profile planner -- claude
   ` + examplePrefix + ` --vault myproject -- claude`,
 		Args:                  cobra.MinimumNArgs(1),
 		DisableFlagsInUseLine: true,
@@ -83,6 +88,8 @@ Example:
 
 	c.Flags().String("address", "", "Agent Vault server address (defaults to session address)")
 	c.Flags().Int("ttl", 0, "Session TTL in seconds (300–604800; default: server default 24h)")
+	c.Flags().String("profile", "", "Named run profile from profiles.yaml")
+	c.Flags().String("profiles-file", "", "Run profiles YAML path (default: ~/.agent-vault/profiles.yaml)")
 
 	c.Flags().String("image", "", "Container image override (requires --isolation=container)")
 	c.Flags().StringArray("mount", nil, "Extra bind mount src:dst[:ro] (repeatable; requires --isolation=container)")
@@ -98,9 +105,11 @@ var runCmd = newRunCmd("agent-vault vault run")
 var topRunCmd = newRunCmd("agent-vault run")
 
 func runCmdRunE(cmd *cobra.Command, args []string) error {
-	// 0. Resolve isolation mode and validate flag compatibility before any
-	//    network I/O — the user sees conflicts immediately, not after
-	//    a slow session-mint round-trip.
+	// 0. Apply a named profile, then validate the resolved launch before any
+	//    login or network I/O. Explicit CLI flags always win over profile values.
+	if err := applyRunProfile(cmd); err != nil {
+		return err
+	}
 	mode := *cmd.Flags().Lookup("isolation").Value.(*IsolationMode)
 	if mode == "" {
 		if v := os.Getenv("AGENT_VAULT_ISOLATION"); v != "" {
@@ -113,6 +122,9 @@ func runCmdRunE(cmd *cobra.Command, args []string) error {
 		mode = IsolationHost
 	}
 	if err := validateIsolationFlagConflicts(cmd, mode); err != nil {
+		return err
+	}
+	if err := validateContainerFlagCombos(cmd); err != nil {
 		return err
 	}
 
@@ -580,7 +592,6 @@ func augmentEnvWithMITM(env []string, addr, token, vault, caPath string) ([]stri
 	if err := os.WriteFile(caPath, pem, 0o600); err != nil { //nolint:gosec
 		return env, 0, false, fmt.Errorf("write CA: %w", err)
 	}
-
 
 	env = stripEnvKeys(env, mitmInjectedKeys)
 	env = append(env, isolation.BuildProxyEnv(isolation.ProxyEnvParams{

--- a/cmd/run_container.go
+++ b/cmd/run_container.go
@@ -61,11 +61,9 @@ func runContainer(cmd *cobra.Command, args []string, scopedToken, addr, vault st
 		return errors.New("--isolation=container: `docker` not found in PATH")
 	}
 
-	// Validate flag combos + set up host-side state for --share-agent-dir
-	// before any expensive ops (MITM fetch, network create, image build).
-	if err := validateContainerFlagCombos(cmd); err != nil {
-		return err
-	}
+	// Set up host-side state for --share-agent-dir before any expensive ops
+	// (MITM fetch, network create, image build). Flag combinations were already
+	// validated by runCmdRunE before session minting.
 	homeShared, _ := cmd.Flags().GetBool("home-volume-shared")
 	shareAgentDir, _ := cmd.Flags().GetBool("share-agent-dir")
 

--- a/cmd/run_profile.go
+++ b/cmd/run_profile.go
@@ -1,0 +1,160 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+const defaultRunProfilesFile = "profiles.yaml"
+
+type runProfilesConfig struct {
+	Profiles map[string]runProfile `yaml:"profiles"`
+}
+
+type runProfile struct {
+	Vault            string   `yaml:"vault"`
+	TTL              int      `yaml:"ttl"`
+	Isolation        string   `yaml:"isolation"`
+	Image            string   `yaml:"image"`
+	Mounts           []string `yaml:"mounts"`
+	Keep             bool     `yaml:"keep"`
+	HomeVolumeShared bool     `yaml:"home_volume_shared"`
+	ShareAgentDir    bool     `yaml:"share_agent_dir"`
+}
+
+func applyRunProfile(cmd *cobra.Command) error {
+	profileName, _ := cmd.Flags().GetString("profile")
+	profilesFile, _ := cmd.Flags().GetString("profiles-file")
+	if profileName == "" {
+		if cmd.Flags().Changed("profiles-file") {
+			return errors.New("--profiles-file requires --profile")
+		}
+		return nil
+	}
+	if strings.TrimSpace(profileName) != profileName {
+		return errors.New("--profile may not have leading or trailing whitespace")
+	}
+
+	path, err := resolveRunProfilesPath(profilesFile)
+	if err != nil {
+		return err
+	}
+	profiles, err := loadRunProfiles(path)
+	if err != nil {
+		return err
+	}
+	profile, ok := profiles[profileName]
+	if !ok {
+		return fmt.Errorf("run profile %q not found in %s", profileName, path)
+	}
+	if err := validateRunProfile(profileName, profile); err != nil {
+		return err
+	}
+	return applyRunProfileFlags(cmd, profile)
+}
+
+func resolveRunProfilesPath(explicit string) (string, error) {
+	if explicit != "" {
+		return filepath.Clean(explicit), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory for run profiles: %w", err)
+	}
+	return filepath.Join(home, ".agent-vault", defaultRunProfilesFile), nil
+}
+
+func loadRunProfiles(path string) (map[string]runProfile, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open run profiles %s: %w", path, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	decoder := yaml.NewDecoder(file)
+	decoder.KnownFields(true)
+	var config runProfilesConfig
+	if err := decoder.Decode(&config); err != nil {
+		return nil, fmt.Errorf("parse run profiles %s: %w", path, err)
+	}
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("parse run profiles %s: multiple YAML documents are not supported", path)
+		}
+		return nil, fmt.Errorf("parse run profiles %s: %w", path, err)
+	}
+	if len(config.Profiles) == 0 {
+		return nil, fmt.Errorf("run profiles %s contains no profiles", path)
+	}
+	return config.Profiles, nil
+}
+
+func validateRunProfile(name string, profile runProfile) error {
+	if strings.TrimSpace(name) == "" || strings.TrimSpace(name) != name {
+		return fmt.Errorf("run profile name %q is invalid", name)
+	}
+	if profile.TTL != 0 && (profile.TTL < 300 || profile.TTL > 604800) {
+		return fmt.Errorf("run profile %q: ttl must be between 300 and 604800 seconds", name)
+	}
+	if profile.Isolation != "" && profile.Isolation != string(IsolationHost) && profile.Isolation != string(IsolationContainer) {
+		return fmt.Errorf("run profile %q: isolation must be host or container", name)
+	}
+	return nil
+}
+
+func applyRunProfileFlags(cmd *cobra.Command, profile runProfile) error {
+	values := []struct {
+		name  string
+		value string
+	}{
+		{"vault", profile.Vault},
+		{"isolation", profile.Isolation},
+		{"image", profile.Image},
+	}
+	if profile.TTL > 0 {
+		values = append(values, struct {
+			name  string
+			value string
+		}{"ttl", fmt.Sprintf("%d", profile.TTL)})
+	}
+	for _, value := range values {
+		if value.value == "" || cmd.Flags().Changed(value.name) {
+			continue
+		}
+		if err := cmd.Flags().Set(value.name, value.value); err != nil {
+			return fmt.Errorf("apply run profile flag --%s: %w", value.name, err)
+		}
+	}
+	if !cmd.Flags().Changed("mount") {
+		for _, mount := range profile.Mounts {
+			if err := cmd.Flags().Set("mount", mount); err != nil {
+				return fmt.Errorf("apply run profile flag --mount: %w", err)
+			}
+		}
+	}
+	bools := []struct {
+		name  string
+		value bool
+	}{
+		{"keep", profile.Keep},
+		{"home-volume-shared", profile.HomeVolumeShared},
+		{"share-agent-dir", profile.ShareAgentDir},
+	}
+	for _, value := range bools {
+		if !value.value || cmd.Flags().Changed(value.name) {
+			continue
+		}
+		if err := cmd.Flags().Set(value.name, "true"); err != nil {
+			return fmt.Errorf("apply run profile flag --%s: %w", value.name, err)
+		}
+	}
+	return nil
+}

--- a/cmd/run_profile_test.go
+++ b/cmd/run_profile_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func writeRunProfiles(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "profiles.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write profiles: %v", err)
+	}
+	return path
+}
+
+func profileTestCommand() *cobra.Command {
+	cmd := newRunCmd("agent-vault run")
+	cmd.Flags().String("vault", "", "target vault")
+	return cmd
+}
+
+func TestApplyRunProfile(t *testing.T) {
+	path := writeRunProfiles(t, `profiles:
+  planner:
+    vault: planning
+    ttl: 1800
+    isolation: container
+    image: agent-vault/planner:latest
+    mounts:
+      - ./specs:/workspace/specs:ro
+    keep: true
+`)
+	cmd := profileTestCommand()
+	if err := cmd.ParseFlags([]string{"--profile", "planner", "--profiles-file", path}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if err := applyRunProfile(cmd); err != nil {
+		t.Fatalf("applyRunProfile: %v", err)
+	}
+
+	assertStringFlag(t, cmd, "vault", "planning")
+	assertStringFlag(t, cmd, "ttl", "1800")
+	assertStringFlag(t, cmd, "isolation", "container")
+	assertStringFlag(t, cmd, "image", "agent-vault/planner:latest")
+	mounts, _ := cmd.Flags().GetStringArray("mount")
+	if len(mounts) != 1 || mounts[0] != "./specs:/workspace/specs:ro" {
+		t.Fatalf("unexpected mounts: %v", mounts)
+	}
+	keep, _ := cmd.Flags().GetBool("keep")
+	if !keep {
+		t.Fatal("expected profile to enable keep")
+	}
+}
+
+func TestRunProfileExplicitFlagsWin(t *testing.T) {
+	path := writeRunProfiles(t, `profiles:
+  worker:
+    vault: profile-vault
+    ttl: 1800
+    isolation: container
+    mounts: ["profile:/workspace/profile:ro"]
+    keep: true
+`)
+	cmd := profileTestCommand()
+	args := []string{
+		"--profile", "worker",
+		"--profiles-file", path,
+		"--vault", "cli-vault",
+		"--ttl", "600",
+		"--mount", "cli:/workspace/cli:ro",
+		"--keep=false",
+	}
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if err := applyRunProfile(cmd); err != nil {
+		t.Fatalf("applyRunProfile: %v", err)
+	}
+
+	assertStringFlag(t, cmd, "vault", "cli-vault")
+	assertStringFlag(t, cmd, "ttl", "600")
+	mounts, _ := cmd.Flags().GetStringArray("mount")
+	if len(mounts) != 1 || mounts[0] != "cli:/workspace/cli:ro" {
+		t.Fatalf("explicit mount did not replace profile mounts: %v", mounts)
+	}
+	keep, _ := cmd.Flags().GetBool("keep")
+	if keep {
+		t.Fatal("explicit --keep=false must override profile")
+	}
+}
+
+func TestRunProfileRejectsUnknownFields(t *testing.T) {
+	path := writeRunProfiles(t, `profiles:
+  planner:
+    vault: planning
+    network: unrestricted
+`)
+	cmd := profileTestCommand()
+	if err := cmd.ParseFlags([]string{"--profile", "planner", "--profiles-file", path}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	err := applyRunProfile(cmd)
+	if err == nil || !strings.Contains(err.Error(), "field network not found") {
+		t.Fatalf("expected strict unknown-field error, got %v", err)
+	}
+}
+
+func TestRunProfileValidationPrecedesSessionLookup(t *testing.T) {
+	cmd := profileTestCommand()
+	cmd.SetArgs([]string{"--profile", "missing", "--profiles-file", filepath.Join(t.TempDir(), "missing.yaml"), "--", "echo"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "open run profiles") {
+		t.Fatalf("expected profile file error before session lookup, got %v", err)
+	}
+}
+
+func TestRunProfileIsolationConflictPrecedesSessionLookup(t *testing.T) {
+	path := writeRunProfiles(t, `profiles:
+  planner:
+    isolation: host
+    image: agent-vault/planner:latest
+`)
+	cmd := profileTestCommand()
+	cmd.SetArgs([]string{"--profile", "planner", "--profiles-file", path, "--", "echo"})
+	err := cmd.Execute()
+	if err == nil || err.Error() != "--image requires --isolation=container" {
+		t.Fatalf("expected isolation conflict before session lookup, got %v", err)
+	}
+}
+
+func TestProfilesFileRequiresProfile(t *testing.T) {
+	cmd := profileTestCommand()
+	if err := cmd.ParseFlags([]string{"--profiles-file", "profiles.yaml"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if err := applyRunProfile(cmd); err == nil || err.Error() != "--profiles-file requires --profile" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertStringFlag(t *testing.T, cmd *cobra.Command, name, want string) {
+	t.Helper()
+	flag := cmd.Flags().Lookup(name)
+	if flag == nil {
+		t.Fatalf("missing flag %s", name)
+	}
+	if got := flag.Value.String(); got != want {
+		t.Fatalf("--%s = %q, want %q", name, got, want)
+	}
+}

--- a/docs/guides/connect-coding-agent.mdx
+++ b/docs/guides/connect-coding-agent.mdx
@@ -34,8 +34,31 @@ Use `--vault` to target a specific vault:
 agent-vault vault run --vault my-vault -- claude
 ```
 
+For stable agent roles, put launch policy in `~/.agent-vault/profiles.yaml`:
+
+```yaml
+profiles:
+  planner:
+    vault: planning
+    ttl: 1800
+    isolation: container
+    mounts:
+      - ./specs:/workspace/specs:ro
+```
+
+Then launch by role:
+
+```bash
+agent-vault vault run --profile planner -- claude
+```
+
+Explicit command-line flags override profile values. Agent Vault rejects unknown
+profile fields and incompatible isolation settings before login or network I/O.
+
 <Note>
-`vault run` is a convenience wrapper, not a sandbox. A child process can unset `HTTPS_PROXY`/`HTTP_PROXY` or bypass the injected CA and reach the network directly — local credentials and network access are still fully available to the agent. Stronger isolation for local development is on the roadmap.
+Host isolation is cooperative: a child can bypass the injected proxy. Use
+`isolation: container` (or `--isolation=container`) when the agent must have no
+network path except the Agent Vault proxy.
 </Note>
 
 ## Option 2: Create a named agent

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -368,10 +368,33 @@ description: "Complete reference for all Agent Vault CLI commands."
 
     **Agent mode (containerized / unattended deployments).** When `AGENT_VAULT_TOKEN` and `AGENT_VAULT_ADDR` are pre-set on the environment, `vault run` skips the admin-session login and uses the env-supplied token as the credential — `--ttl` is rejected in this mode since the token's lifetime is fixed at mint time. The token is validated against the broker once at startup so bad/expired tokens fail fast with a clear error rather than producing 401s on every proxied call. See [Deploy your agent in a container](/guides/deploy-agent-container).
 
+    `--profile` loads a named profile from `~/.agent-vault/profiles.yaml` (or
+    `--profiles-file`). Profiles can set `vault`, `ttl`, `isolation`, `image`,
+    `mounts`, `keep`, `home_volume_shared`, and `share_agent_dir`.
+    Unknown YAML fields fail closed. Precedence is explicit CLI flag, profile,
+    environment default, then built-in default.
+
+    ```yaml
+    profiles:
+      planner:
+        vault: planning
+        ttl: 1800
+        isolation: container
+        mounts:
+          - ./specs:/workspace/specs:ro
+    ```
+
+    ```bash
+    agent-vault run --profile planner -- claude
+    ```
+
     | Flag | Default | Description |
     |------|---------|-------------|
     | `--address` | | Server address override |
+    | `--vault` | active context | Target vault for the scoped session |
     | `--ttl` | `0` | Session TTL in seconds (300–604800). Default: server default (24h). |
+    | `--profile` | | Named profile from the run profiles YAML |
+    | `--profiles-file` | `~/.agent-vault/profiles.yaml` | Alternate run profiles YAML path; requires `--profile` |
     | `--isolation` | `host` | Isolation mode for the child: `host` (default, cooperative — runs on the host with `HTTPS_PROXY`/`HTTP_PROXY`) or `container` (non-cooperative Docker container; see [Container isolation](/guides/container-isolation)). Also read from `AGENT_VAULT_ISOLATION`. |
     | `--image` | | Override the bundled container image (`--isolation=container` only). |
     | `--mount` | | Extra bind mount `src:dst[:ro]`; repeatable (`--isolation=container` only). Host paths are EvalSymlinks-resolved; reserved paths rejected. |


### PR DESCRIPTION
## Summary

- load strict named agent launch profiles from `~/.agent-vault/profiles.yaml` or `--profiles-file`
- support vault, TTL, isolation, image, mounts, and safe container persistence settings
- preserve explicit CLI flag precedence and existing no-profile behavior
- validate malformed profiles and isolation conflicts before login or network I/O
- document configuration, precedence, and sandboxed role usage

## Verification

- `env -u AGENT_VAULT_VAULT go test ./...`
- `npm --prefix web ci && npm --prefix web run build`
- built the binary with embedded web assets
- launched `claude --version` through `reviewer-sandbox`; container egress was iptables-locked and Claude 2.1.233 completed

Linear: RED-3086

---

**Supersedes #368** (closed; unreopenable after the head branch was force-pushed to fix commit authorship — the two feature commits were re-authored from a sandbox fixture identity to this account so the CLA check can attribute them; trees are byte-identical, no content changes).
