### PR TITLE
fix(mitm): deflake the two request-log assertions

### DIFF
--- a/internal/mitm/forward_test.go
+++ b/internal/mitm/forward_test.go
@@ -44,6 +44,26 @@ func (s *recordingSink) snapshot() []requestlog.Record {
 	return out
 }
 
+// waitForRows polls until the sink holds at least n records, then returns
+// them. forwardRequest emits its log row *after* the response body has been
+// flushed to the client, so a test that reads the sink the instant its
+// request returns races the server goroutine and can observe a short count.
+func (s *recordingSink) waitForRows(t *testing.T, n int) []requestlog.Record {
+	t.Helper()
+	const timeout = 2 * time.Second
+	deadline := time.Now().Add(timeout)
+	for {
+		rows := s.snapshot()
+		if len(rows) >= n {
+			return rows
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("got %d log rows after %s, want at least %d", len(rows), timeout, n)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 // dialProxy opens a plain TCP connection to the proxy listener (no
 // CONNECT, no absolute-form request). Tests use it to write malformed
 // or hand-shaped request lines so we can exercise the dispatch
@@ -508,7 +528,7 @@ func TestMITMForwardEmitsRequestLogRow(t *testing.T) {
 	}
 	_ = resp.Body.Close()
 
-	rows := sink.snapshot()
+	rows := sink.waitForRows(t, 1)
 	if len(rows) != 1 {
 		t.Fatalf("got %d records, want 1", len(rows))
 	}
@@ -590,7 +610,7 @@ func TestMITMForwardKeepalivePersistsAcrossRequests(t *testing.T) {
 	if got := hits.Load(); got != 2 {
 		t.Fatalf("upstream hits = %d, want 2", got)
 	}
-	if rows := sink.snapshot(); len(rows) != 2 {
+	if rows := sink.waitForRows(t, 2); len(rows) != 2 {
 		t.Fatalf("got %d log rows, want 2", len(rows))
 	}
 }


### PR DESCRIPTION
## Problem

`internal/mitm` has two request-log assertions, and **both failed CI during a single dependency-bump batch**, on PRs that cannot affect them:

| PR | Test | Failure |
|---|---|---|
| #383 | `TestMITMForwardKeepalivePersistsAcrossRequests` | `got 1 log rows, want 2` |
| #350 | `TestMITMForwardEmitsRequestLogRow` | short row count |

#383 changes only the Dockerfile, which `go-test` never builds.

## Cause

[`forwardRequest`](internal/mitm/forward.go) calls `emit(...)` — which writes the log row — **after** `io.Copy(dst, src)` has already streamed the body to the client through a flushing writer:

```go
n, _ := io.Copy(dst, src)   // client can now finish and return
...
emit(resp.StatusCode, "")   // row is written only here
```

So the client can read the body, close it, and let the test call `sink.snapshot()` before the server goroutine reaches `emit`. Assertions on upstream hit counts still pass — only the row count is short, which is exactly the observed signature.

These are the only two `sink.snapshot()` call sites in the package.

## Fix

`waitForRows(t, n)` polls for the expected count with a 2s deadline. The exact-count assertions are kept *after* the wait, so an unexpected extra row still fails the test. Test-only; no production code changed.

## Verification

The window is too narrow to reproduce on an idle machine (200 unpatched runs at `-cpu=1` all passed), so I confirmed the mechanism by injecting a temporary 50ms delay before `emit` to widen it:

- **Unpatched + delay** → both tests fail, reproducing CI's exact `got 1 log rows, want 2`
- **Patched + same delay** → 20/20 pass
- **Patched, delay removed** → full package green at `-race -count=10`

The delay was only ever a local probe and is not part of this diff.