### PR TITLE
chore(web): patch nanoid advisory and split framework into vendor chunks

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -935,7 +935,7 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 
 	// React app static assets (Vite outputs to /assets/ with base "/")
 	webFS, _ := fs.Sub(webDistFS, "webdist")
-	mux.Handle("GET /assets/", http.FileServer(http.FS(webFS)))
+	mux.Handle("GET /assets/", immutableStatic(http.FileServer(http.FS(webFS))))
 	mux.Handle("GET /vite.svg", http.FileServer(http.FS(webFS)))
 
 	// SPA catch-all: serve index.html for all frontend routes
@@ -955,6 +955,48 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	mux.HandleFunc("GET /{$}", s.handleSPA)
 
 	return s
+}
+
+// immutableStatic marks content-hashed build output as permanently cacheable.
+// Vite embeds a content hash in every /assets/ filename, so the bytes behind a
+// given URL never change and a rebuild emits new filenames instead. Without
+// this header browsers refetch every chunk on each load: embed.FS reports a
+// zero ModTime, so http.FileServer sends neither Last-Modified nor ETag and
+// there is nothing to revalidate against. index.html is served separately by
+// handleSPA with no-store, so new builds are still picked up immediately.
+//
+// Only successful responses are marked. During a rolling upgrade a browser can
+// load index.html from an already-updated instance and request its chunks from
+// one still serving the previous build; caching that 404 for a year would wedge
+// the UI for that browser until it cleared its cache.
+func immutableStatic(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(&immutableWriter{ResponseWriter: w}, r)
+	})
+}
+
+// immutableWriter sets the long-lived Cache-Control header on 200 and 206
+// responses, just before the status line is written.
+type immutableWriter struct {
+	http.ResponseWriter
+	wroteHeader bool
+}
+
+func (w *immutableWriter) WriteHeader(code int) {
+	if !w.wroteHeader {
+		w.wroteHeader = true
+		if code == http.StatusOK || code == http.StatusPartialContent {
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		}
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *immutableWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(b)
 }
 
 // requireInitialized returns 503 when no owner account exists yet.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -935,8 +935,16 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 
 	// React app static assets (Vite outputs to /assets/ with base "/")
 	webFS, _ := fs.Sub(webDistFS, "webdist")
-	mux.Handle("GET /assets/", immutableStatic(http.FileServer(http.FS(webFS))))
-	mux.Handle("GET /vite.svg", http.FileServer(http.FS(webFS)))
+	static := http.FileServer(http.FS(webFS))
+	mux.Handle("GET /assets/", cacheStatic(cacheImmutable, static))
+	// Files Vite copies verbatim out of web/public/. index.html links the
+	// favicons and the built CSS references /fonts/, so without these routes
+	// they 404 despite being embedded, and the UI silently falls back to
+	// system fonts. Their names carry no content hash, so they get a modest
+	// lifetime instead of immutable.
+	mux.Handle("GET /fonts/", cacheStatic(cacheDay, static))
+	mux.Handle("GET /favicon.svg", cacheStatic(cacheDay, static))
+	mux.Handle("GET /favicon.png", cacheStatic(cacheDay, static))
 
 	// SPA catch-all: serve index.html for all frontend routes
 	mux.HandleFunc("GET /login", s.handleSPA)
@@ -957,42 +965,50 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	return s
 }
 
-// immutableStatic marks content-hashed build output as permanently cacheable.
-// Vite embeds a content hash in every /assets/ filename, so the bytes behind a
-// given URL never change and a rebuild emits new filenames instead. Without
-// this header browsers refetch every chunk on each load: embed.FS reports a
-// zero ModTime, so http.FileServer sends neither Last-Modified nor ETag and
-// there is nothing to revalidate against. index.html is served separately by
-// handleSPA with no-store, so new builds are still picked up immediately.
+// Cache lifetimes for the embedded frontend build output. /assets/ filenames
+// carry a Vite content hash, so those bytes never change and a rebuild emits
+// new names. Files copied verbatim from web/public/ (favicons, fonts) keep
+// stable names across builds, so they get a modest lifetime instead.
+const (
+	cacheImmutable = "public, max-age=31536000, immutable"
+	cacheDay       = "public, max-age=86400"
+)
+
+// cacheStatic sets Cache-Control on responses from the embedded build output.
+// Without it browsers refetch every asset on each load: embed.FS reports a zero
+// ModTime, so http.FileServer sends neither Last-Modified nor ETag and there is
+// nothing to revalidate against. index.html is served separately by handleSPA
+// with no-store, so new builds are still picked up immediately.
 //
 // Only successful responses are marked. During a rolling upgrade a browser can
 // load index.html from an already-updated instance and request its chunks from
 // one still serving the previous build; caching that 404 for a year would wedge
 // the UI for that browser until it cleared its cache.
-func immutableStatic(next http.Handler) http.Handler {
+func cacheStatic(cacheControl string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		next.ServeHTTP(&immutableWriter{ResponseWriter: w}, r)
+		next.ServeHTTP(&staticCacheWriter{ResponseWriter: w, cacheControl: cacheControl}, r)
 	})
 }
 
-// immutableWriter sets the long-lived Cache-Control header on 200 and 206
-// responses, just before the status line is written.
-type immutableWriter struct {
+// staticCacheWriter sets the Cache-Control header on 200 and 206 responses,
+// just before the status line is written.
+type staticCacheWriter struct {
 	http.ResponseWriter
-	wroteHeader bool
+	cacheControl string
+	wroteHeader  bool
 }
 
-func (w *immutableWriter) WriteHeader(code int) {
+func (w *staticCacheWriter) WriteHeader(code int) {
 	if !w.wroteHeader {
 		w.wroteHeader = true
 		if code == http.StatusOK || code == http.StatusPartialContent {
-			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+			w.Header().Set("Cache-Control", w.cacheControl)
 		}
 	}
 	w.ResponseWriter.WriteHeader(code)
 }
 
-func (w *immutableWriter) Write(b []byte) (int, error) {
+func (w *staticCacheWriter) Write(b []byte) (int, error) {
 	if !w.wroteHeader {
 		w.WriteHeader(http.StatusOK)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7505,3 +7505,57 @@ func TestVaultLeaveNoAccess(t *testing.T) {
 		t.Fatalf("expected 403, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
+
+func TestImmutableStaticSetsCacheHeaderOnlyOnSuccess(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		want   string
+	}{
+		{"hashed asset found", http.StatusOK, "public, max-age=31536000, immutable"},
+		{"range request", http.StatusPartialContent, "public, max-age=31536000, immutable"},
+		// A rolling upgrade can route a chunk request to an instance still on
+		// the previous build; caching that 404 for a year would wedge the UI.
+		{"chunk missing", http.StatusNotFound, ""},
+		{"server error", http.StatusInternalServerError, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := immutableStatic(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/assets/index-abc123.js", nil))
+
+			if rec.Code != tc.status {
+				t.Fatalf("expected status %d, got %d", tc.status, rec.Code)
+			}
+			if got := rec.Header().Get("Cache-Control"); got != tc.want {
+				t.Fatalf("expected Cache-Control %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestImmutableStaticSetsCacheHeaderOnImplicit200(t *testing.T) {
+	// http.FileServer writes the body without an explicit WriteHeader call.
+	h := immutableStatic(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("console.log(1)"))
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/assets/index-abc123.js", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	want := "public, max-age=31536000, immutable"
+	if got := rec.Header().Get("Cache-Control"); got != want {
+		t.Fatalf("expected Cache-Control %q, got %q", want, got)
+	}
+	if rec.Body.String() != "console.log(1)" {
+		t.Fatalf("body was altered: %q", rec.Body.String())
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7506,14 +7506,14 @@ func TestVaultLeaveNoAccess(t *testing.T) {
 	}
 }
 
-func TestImmutableStaticSetsCacheHeaderOnlyOnSuccess(t *testing.T) {
+func TestCacheStaticSetsCacheHeaderOnlyOnSuccess(t *testing.T) {
 	cases := []struct {
 		name   string
 		status int
 		want   string
 	}{
-		{"hashed asset found", http.StatusOK, "public, max-age=31536000, immutable"},
-		{"range request", http.StatusPartialContent, "public, max-age=31536000, immutable"},
+		{"hashed asset found", http.StatusOK, cacheImmutable},
+		{"range request", http.StatusPartialContent, cacheImmutable},
 		// A rolling upgrade can route a chunk request to an instance still on
 		// the previous build; caching that 404 for a year would wedge the UI.
 		{"chunk missing", http.StatusNotFound, ""},
@@ -7522,7 +7522,7 @@ func TestImmutableStaticSetsCacheHeaderOnlyOnSuccess(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			h := immutableStatic(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := cacheStatic(cacheImmutable, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tc.status)
 			}))
 
@@ -7539,9 +7539,9 @@ func TestImmutableStaticSetsCacheHeaderOnlyOnSuccess(t *testing.T) {
 	}
 }
 
-func TestImmutableStaticSetsCacheHeaderOnImplicit200(t *testing.T) {
+func TestCacheStaticSetsCacheHeaderOnImplicit200(t *testing.T) {
 	// http.FileServer writes the body without an explicit WriteHeader call.
-	h := immutableStatic(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := cacheStatic(cacheImmutable, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("console.log(1)"))
 	}))
 
@@ -7551,11 +7551,28 @@ func TestImmutableStaticSetsCacheHeaderOnImplicit200(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", rec.Code)
 	}
-	want := "public, max-age=31536000, immutable"
-	if got := rec.Header().Get("Cache-Control"); got != want {
-		t.Fatalf("expected Cache-Control %q, got %q", want, got)
+	if got := rec.Header().Get("Cache-Control"); got != cacheImmutable {
+		t.Fatalf("expected Cache-Control %q, got %q", cacheImmutable, got)
 	}
 	if rec.Body.String() != "console.log(1)" {
 		t.Fatalf("body was altered: %q", rec.Body.String())
+	}
+}
+
+func TestCacheStaticUsesShorterLifetimeForUnhashedFiles(t *testing.T) {
+	// Favicons and fonts are copied verbatim from web/public/, so their names
+	// carry no content hash and they must stay revalidatable.
+	h := cacheStatic(cacheDay, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("woff2"))
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/fonts/UncutSans-Book.woff2", nil))
+
+	if got := rec.Header().Get("Cache-Control"); got != cacheDay {
+		t.Fatalf("expected Cache-Control %q, got %q", cacheDay, got)
+	}
+	if cacheDay == cacheImmutable {
+		t.Fatal("unhashed files must not share the immutable lifetime")
 	}
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1613,9 +1613,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -13,6 +13,26 @@ export default defineConfig({
   build: {
     outDir: "../internal/server/webdist",
     emptyOutDir: true,
+    rolldownOptions: {
+      output: {
+        // Split the framework out of the app bundle. Roughly half of the
+        // output is React + the router, which only changes when we bump those
+        // deps; keeping them in their own chunks means a new agent-vault
+        // release only invalidates the app chunk in the browser cache.
+        codeSplitting: {
+          groups: [
+            {
+              name: "vendor-react",
+              test: /node_modules[\\/](react|react-dom|scheduler)[\\/]/,
+            },
+            {
+              name: "vendor-router",
+              test: /node_modules[\\/]@tanstack[\\/]/,
+            },
+          ],
+        },
+      },
+    },
   },
   server: {
     proxy: {


### PR DESCRIPTION
## Summary

`make build` printed two warnings on every run. This clears both, plus a follow-up from review.

**1. High-severity npm advisory.** `nanoid@3.3.16` → `3.3.18` ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)), pulled in transitively via `vite → postcss`. Dev-only, so it never reaches the shipped binary, but it made every build and CI run noisy.

Bumped by hand rather than committing `npm audit fix` output. npm 11.7.0 also strips the `libc` fields from the 10 optional native rollup/tailwind packages, and the frontend Docker stage runs `npm ci` on `node:26-alpine` — those fields are what select the musl builds there. The lockfile diff here is 3 lines.

**2. The 500 kB chunk warning.** The app built to a single 525 kB chunk. Roughly half is framework code that can't be shrunk:

| | Raw | Gzip |
|---|---|---|
| App code (`src/`) | 253 kB | 53 kB |
| react + react-dom + scheduler | 190 kB | 60 kB |
| @tanstack/react-router | 81 kB | 27 kB |

Split the framework into its own chunks with rolldown's `build.rolldownOptions.output.codeSplitting`. Largest chunk is now 253 kB, under the threshold, without raising `chunkSizeWarningLimit` to hide it. Totals go 556 kB → 560 kB, so no module duplication.

Note `advancedChunks` (the older name for this option) now emits a deprecation warning on vite 8.1.5, so `codeSplitting` is the correct key.

**3. `Cache-Control` on `/assets/` (added after review).** The split above is only worth doing if vendor chunks actually survive in the browser across releases, and they did not. `/assets/` is served by a bare `http.FileServer` over the embed FS, which sends no `Cache-Control`, no `ETag`, and no `Last-Modified` (`embed.FS` reports a zero ModTime, so `ServeContent` omits it). With no validator and no freshness lifetime, browsers refetched every chunk on every load — an `If-Modified-Since` dated in the future still returned a full 200 with all 189,644 bytes of the react chunk.

Vite content-hashes every `/assets/` filename, so those bytes never change and a rebuild emits new names. `index.html` keeps its existing `no-store`, so new builds are picked up immediately.

Only 200 and 206 are marked. During a rolling upgrade a browser can load `index.html` from an already-updated instance and request its chunks from one still serving the previous build; caching that 404 for a year would wedge the UI for that browser until it cleared its cache. That matters for the Postgres HA deployment mode, where several instances serve the same origin.

Route-level lazy loading was considered and skipped. It would split the app chunk ~20 ways but add a round trip per navigation to a UI usually served over a private network. Happy to add it if wanted.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / build

## Test plan

- [x] Existing tests pass (`make test`)
- [x] Added/updated tests for new behavior
- [x] Manual testing (describe below)

Added `TestImmutableStaticSetsCacheHeaderOnlyOnSuccess` (table-driven over 200/206/404/500) and `TestImmutableStaticSetsCacheHeaderOnImplicit200`, which covers the `http.FileServer` path that writes a body without calling `WriteHeader`.

- `make build` runs clean, no vuln warning and no chunk warning
- `go test ./...` exits 0
- `npx tsc --noEmit` exits 0; also typechecked `vite.config.ts` directly (it sits outside the `include: ["src"]` scope) to confirm `codeSplitting` is a valid option and not an untyped passthrough
- `npm ci` from a clean slate reinstalls with `found 0 vulnerabilities`, all 10 `libc` entries intact
- Against a running binary: hashed asset returns `Cache-Control: public, max-age=31536000, immutable`; a missing chunk returns 404 with no `Cache-Control`; `index.html` still `no-store`; all four chunks serve 200 with unchanged byte counts from the `go:embed` FS and SPA deep links resolve

The two pre-existing `gofmt` complaints in `internal/server/` (struct field alignment in `Server`, and one block in `server_test.go`) are untouched, to keep this diff free of unrelated churn.

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints
- [x] Input validation on new API surfaces (n/a)
- [x] Checked for OWASP top 10 (injection, XSS, etc.) — the new header applies only to already-public, content-hashed static build output; no auth-bearing or user-specific response is cached
