### PR TITLE
fix(server): serve embedded favicons and fonts instead of 404ing

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -935,8 +935,16 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 
 	// React app static assets (Vite outputs to /assets/ with base "/")
 	webFS, _ := fs.Sub(webDistFS, "webdist")
-	mux.Handle("GET /assets/", immutableStatic(http.FileServer(http.FS(webFS))))
-	mux.Handle("GET /vite.svg", http.FileServer(http.FS(webFS)))
+	static := http.FileServer(http.FS(webFS))
+	mux.Handle("GET /assets/", cacheStatic(cacheImmutable, static))
+	// Files Vite copies verbatim out of web/public/. index.html links the
+	// favicons and the built CSS references /fonts/, so without these routes
+	// they 404 despite being embedded, and the UI silently falls back to
+	// system fonts. Their names carry no content hash, so they get a modest
+	// lifetime instead of immutable.
+	mux.Handle("GET /fonts/", cacheStatic(cacheDay, static))
+	mux.Handle("GET /favicon.svg", cacheStatic(cacheDay, static))
+	mux.Handle("GET /favicon.png", cacheStatic(cacheDay, static))
 
 	// SPA catch-all: serve index.html for all frontend routes
 	mux.HandleFunc("GET /login", s.handleSPA)
@@ -957,42 +965,50 @@ func New(addr string, store Store, encKey []byte, notifier *notify.Notifier, ini
 	return s
 }
 
-// immutableStatic marks content-hashed build output as permanently cacheable.
-// Vite embeds a content hash in every /assets/ filename, so the bytes behind a
-// given URL never change and a rebuild emits new filenames instead. Without
-// this header browsers refetch every chunk on each load: embed.FS reports a
-// zero ModTime, so http.FileServer sends neither Last-Modified nor ETag and
-// there is nothing to revalidate against. index.html is served separately by
-// handleSPA with no-store, so new builds are still picked up immediately.
+// Cache lifetimes for the embedded frontend build output. /assets/ filenames
+// carry a Vite content hash, so those bytes never change and a rebuild emits
+// new names. Files copied verbatim from web/public/ (favicons, fonts) keep
+// stable names across builds, so they get a modest lifetime instead.
+const (
+	cacheImmutable = "public, max-age=31536000, immutable"
+	cacheDay       = "public, max-age=86400"
+)
+
+// cacheStatic sets Cache-Control on responses from the embedded build output.
+// Without it browsers refetch every asset on each load: embed.FS reports a zero
+// ModTime, so http.FileServer sends neither Last-Modified nor ETag and there is
+// nothing to revalidate against. index.html is served separately by handleSPA
+// with no-store, so new builds are still picked up immediately.
 //
 // Only successful responses are marked. During a rolling upgrade a browser can
 // load index.html from an already-updated instance and request its chunks from
 // one still serving the previous build; caching that 404 for a year would wedge
 // the UI for that browser until it cleared its cache.
-func immutableStatic(next http.Handler) http.Handler {
+func cacheStatic(cacheControl string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		next.ServeHTTP(&immutableWriter{ResponseWriter: w}, r)
+		next.ServeHTTP(&staticCacheWriter{ResponseWriter: w, cacheControl: cacheControl}, r)
 	})
 }
 
-// immutableWriter sets the long-lived Cache-Control header on 200 and 206
-// responses, just before the status line is written.
-type immutableWriter struct {
+// staticCacheWriter sets the Cache-Control header on 200 and 206 responses,
+// just before the status line is written.
+type staticCacheWriter struct {
 	http.ResponseWriter
-	wroteHeader bool
+	cacheControl string
+	wroteHeader  bool
 }
 
-func (w *immutableWriter) WriteHeader(code int) {
+func (w *staticCacheWriter) WriteHeader(code int) {
 	if !w.wroteHeader {
 		w.wroteHeader = true
 		if code == http.StatusOK || code == http.StatusPartialContent {
-			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+			w.Header().Set("Cache-Control", w.cacheControl)
 		}
 	}
 	w.ResponseWriter.WriteHeader(code)
 }
 
-func (w *immutableWriter) Write(b []byte) (int, error) {
+func (w *staticCacheWriter) Write(b []byte) (int, error) {
 	if !w.wroteHeader {
 		w.WriteHeader(http.StatusOK)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7506,14 +7506,14 @@ func TestVaultLeaveNoAccess(t *testing.T) {
 	}
 }
 
-func TestImmutableStaticSetsCacheHeaderOnlyOnSuccess(t *testing.T) {
+func TestCacheStaticSetsCacheHeaderOnlyOnSuccess(t *testing.T) {
 	cases := []struct {
 		name   string
 		status int
 		want   string
 	}{
-		{"hashed asset found", http.StatusOK, "public, max-age=31536000, immutable"},
-		{"range request", http.StatusPartialContent, "public, max-age=31536000, immutable"},
+		{"hashed asset found", http.StatusOK, cacheImmutable},
+		{"range request", http.StatusPartialContent, cacheImmutable},
 		// A rolling upgrade can route a chunk request to an instance still on
 		// the previous build; caching that 404 for a year would wedge the UI.
 		{"chunk missing", http.StatusNotFound, ""},
@@ -7522,7 +7522,7 @@ func TestImmutableStaticSetsCacheHeaderOnlyOnSuccess(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			h := immutableStatic(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := cacheStatic(cacheImmutable, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tc.status)
 			}))
 
@@ -7539,9 +7539,9 @@ func TestImmutableStaticSetsCacheHeaderOnlyOnSuccess(t *testing.T) {
 	}
 }
 
-func TestImmutableStaticSetsCacheHeaderOnImplicit200(t *testing.T) {
+func TestCacheStaticSetsCacheHeaderOnImplicit200(t *testing.T) {
 	// http.FileServer writes the body without an explicit WriteHeader call.
-	h := immutableStatic(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := cacheStatic(cacheImmutable, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("console.log(1)"))
 	}))
 
@@ -7551,11 +7551,28 @@ func TestImmutableStaticSetsCacheHeaderOnImplicit200(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", rec.Code)
 	}
-	want := "public, max-age=31536000, immutable"
-	if got := rec.Header().Get("Cache-Control"); got != want {
-		t.Fatalf("expected Cache-Control %q, got %q", want, got)
+	if got := rec.Header().Get("Cache-Control"); got != cacheImmutable {
+		t.Fatalf("expected Cache-Control %q, got %q", cacheImmutable, got)
 	}
 	if rec.Body.String() != "console.log(1)" {
 		t.Fatalf("body was altered: %q", rec.Body.String())
+	}
+}
+
+func TestCacheStaticUsesShorterLifetimeForUnhashedFiles(t *testing.T) {
+	// Favicons and fonts are copied verbatim from web/public/, so their names
+	// carry no content hash and they must stay revalidatable.
+	h := cacheStatic(cacheDay, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("woff2"))
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/fonts/UncutSans-Book.woff2", nil))
+
+	if got := rec.Header().Get("Cache-Control"); got != cacheDay {
+		t.Fatalf("expected Cache-Control %q, got %q", cacheDay, got)
+	}
+	if cacheDay == cacheImmutable {
+		t.Fatal("unhashed files must not share the immutable lifetime")
 	}
 }


### PR DESCRIPTION
> **Stacked on #389.** Base is `chore/web-build-warnings`; it retargets to `main` automatically once that merges. The diff shown here is only this commit.

## Summary

`webdist` embeds `favicon.svg`, `favicon.png` and 11 UncutSans font files that Vite copies from `web/public/`, but only `GET /assets/` and `GET /vite.svg` were ever routed. Everything else 404'd despite being compiled into the binary.

Against a running binary before this change:

| Path | Status |
|---|---|
| `/favicon.svg` | 404 |
| `/favicon.png` | 404 |
| `/fonts/UncutSans-Book.woff2` | 404 |
| `/vite.svg` (routed, file does not exist) | 404 |

These are live requests, not dead paths: `web/index.html` links both favicons and the built CSS references `/fonts/`. So the shipped UI has been falling back to system fonts and showing no favicon, on every deployment.

Found while reviewing #389, unrelated to that PR's build changes.

**Also drops the `GET /vite.svg` route.** No `vite.svg` exists anywhere under `web/`, so the route only ever produced a 404 from the file server rather than from the mux.

**Cache lifetime.** Fonts and favicons keep stable names across builds, unlike the content-hashed `/assets/` output, so they get `max-age=86400` rather than `immutable`. This generalizes `immutableStatic` from #389 into `cacheStatic(cacheControl, next)` so both lifetimes share one code path and the 200/206-only behavior.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] Existing tests pass (`make test`)
- [x] Added/updated tests for new behavior
- [x] Manual testing (describe below)

Verified against a running binary built from this branch:

- `/favicon.svg` (568 B), `/favicon.png` (523 B), `/fonts/UncutSans-Book.woff2` (39,300 B) and `/fonts/UncutSans-Semibold.woff` (43,928 B) all return 200 with `Cache-Control: public, max-age=86400`
- `Content-Type` is correct (`font/woff2`, `image/svg+xml`), with `X-Content-Type-Options: nosniff` still applied
- Hashed assets keep `Cache-Control: public, max-age=31536000, immutable`
- A missing font returns an uncached 404, so a rolling upgrade cannot poison a browser cache
- Path-traversal attempts (`/fonts/../../server.go`) get `http.FileServer`'s normalizing 307 and cannot escape: `fs.Sub` roots the FS at `webdist`

Added `TestCacheStaticUsesShorterLifetimeForUnhashedFiles` alongside the existing cache middleware tests, which were renamed for the generalized helper.

**Routing itself is deliberately not covered by a test.** The `go-test` CI job does not build the frontend, so `internal/server/webdist/` holds only `.gitkeep` there and any assertion against real font or favicon files would fail in CI while passing locally. Worth a follow-up if we want an injectable FS for the static routes.

## Security checklist

- [x] No secrets or credentials in code
- [x] No new unauthenticated endpoints — the newly routed paths serve already-public static build output that was always intended to be reachable
- [x] Input validation on new API surfaces (n/a)
- [x] Checked for OWASP top 10 (injection, XSS, etc.) — verified the file server cannot serve outside `webdist`; `nosniff` and the existing CSP still apply
