### PR TITLE
fix: key mitm auth-failure flood gate on credential, not peer IP

### DIFF
--- a/internal/mitm/connect.go
+++ b/internal/mitm/connect.go
@@ -1,7 +1,9 @@
 package mitm
 
 import (
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"errors"
 	"io"
 	"net"
@@ -25,6 +27,23 @@ func mitmIPKey(r *http.Request) string {
 		host = r.RemoteAddr
 	}
 	return "mitm:" + host
+}
+
+// mitmFloodKey is the rate-limit key actually used for the auth-failure
+// flood gate. It keys on the presented credential, not the peer IP:
+// behind an L4 ingress or NAT the backend's RemoteAddr collapses to a
+// small set of shared proxy IPs, so an IP-keyed bucket lets one
+// client's bad credentials exhaust the budget and 429 every other
+// client arriving through the same ingress. The credential is hashed so
+// tokens never appear in rate-limit keys (which may surface in logs or
+// metrics). Requests without a Proxy-Authorization header fall back to
+// the peer IP so unauthenticated garbage is still gated.
+func mitmFloodKey(r *http.Request) string {
+	if creds := r.Header.Get("Proxy-Authorization"); creds != "" {
+		sum := sha256.Sum256([]byte(creds))
+		return "mitm:cred:" + hex.EncodeToString(sum[:8])
+	}
+	return mitmIPKey(r)
 }
 
 // isLoopbackPeer reports whether the HTTP request came from a loopback
@@ -53,7 +72,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// (below) so legitimate agents don't burn the budget. Loopback
 	// is exempt — see isLoopbackPeer.
 	if p.rateLimit != nil && !isLoopbackPeer(r) {
-		if d := p.rateLimit.Check(ratelimit.TierAuth, mitmIPKey(r)); !d.Allow {
+		if d := p.rateLimit.Check(ratelimit.TierAuth, mitmFloodKey(r)); !d.Allow {
 			ratelimit.WriteDenial(w, d, "Too many CONNECT attempts")
 			return
 		}
@@ -162,7 +181,7 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 // TierAuth entirely (TierProxy covers them). Loopback peers are exempt.
 func (p *Proxy) recordAuthFailure(r *http.Request) {
 	if p.rateLimit != nil && !isLoopbackPeer(r) {
-		p.rateLimit.Allow(ratelimit.TierAuth, mitmIPKey(r))
+		p.rateLimit.Allow(ratelimit.TierAuth, mitmFloodKey(r))
 	}
 }
 

--- a/internal/mitm/flood_gate_credential_key_test.go
+++ b/internal/mitm/flood_gate_credential_key_test.go
@@ -1,0 +1,63 @@
+package mitm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Infisical/agent-vault/internal/ratelimit"
+)
+
+// Regression test for https://github.com/Infisical/agent-vault/issues/380.
+//
+// The auth-failure flood gate must key on the presented credential, not
+// the peer IP: behind a shared ingress or NAT the backend's RemoteAddr
+// collapses to a small set of proxy IPs, so an IP-keyed bucket lets one
+// client's bad credentials exhaust the budget and 429 every other
+// client arriving through the same ingress — including fully
+// authenticated ones.
+func TestConnectFloodGateKeysOnCredential(t *testing.T) {
+	cfg := ratelimit.DefaultsFor(ratelimit.ProfileDefault)
+	cfg.Tiers[ratelimit.TierAuth].Max = 3
+	p := &Proxy{rateLimit: ratelimit.New(cfg)}
+
+	const sharedIP = "203.0.113.7:5555" // one ingress IP for everyone
+
+	badConnect := func(proxyAuth string) int {
+		r := httptest.NewRequest(http.MethodConnect, "http://github.com:443", nil)
+		r.RemoteAddr = sharedIP
+		if proxyAuth != "" {
+			r.Header.Set("Proxy-Authorization", proxyAuth)
+		}
+		w := httptest.NewRecorder()
+		p.handleConnect(w, r)
+		return w.Code
+	}
+
+	// Client A burns its whole auth-failure budget with bad credentials.
+	for i := 0; i < 3; i++ {
+		if code := badConnect("Basic !!!bad-a!!!"); code == http.StatusTooManyRequests {
+			t.Fatalf("attempt %d: client A gated before its budget was spent", i+1)
+		}
+	}
+	// Client A is now gated.
+	if code := badConnect("Basic !!!bad-a!!!"); code != http.StatusTooManyRequests {
+		t.Fatalf("exhausted credential: want 429, got %d", code)
+	}
+	// A different credential from the SAME source IP must not be gated.
+	if code := badConnect("Basic !!!bad-b!!!"); code == http.StatusTooManyRequests {
+		t.Fatal("credential B from the same source IP was 429'd by client A's failures")
+	}
+	// An unauthenticated request from the same IP must not be gated either
+	// (its first failure starts a fresh IP-fallback budget).
+	if code := badConnect(""); code == http.StatusTooManyRequests {
+		t.Fatal("unauthenticated request from the same source IP was 429'd by client A's failures")
+	}
+	// The IP fallback still gates unauthenticated floods.
+	for i := 0; i < 3; i++ {
+		badConnect("")
+	}
+	if code := badConnect(""); code != http.StatusTooManyRequests {
+		t.Fatalf("unauthenticated flood: want 429 after budget exhausted, got %d", code)
+	}
+}

--- a/internal/mitm/forward.go
+++ b/internal/mitm/forward.go
@@ -85,7 +85,7 @@ func (p *Proxy) handleForward(w http.ResponseWriter, r *http.Request) {
 	// exhausted. Only auth failures are recorded (below). Shares the
 	// TierAuth budget and key shape with CONNECT. Loopback is exempt.
 	if p.rateLimit != nil && !isLoopbackPeer(r) {
-		if d := p.rateLimit.Check(ratelimit.TierAuth, mitmIPKey(r)); !d.Allow {
+		if d := p.rateLimit.Check(ratelimit.TierAuth, mitmFloodKey(r)); !d.Allow {
 			ratelimit.WriteDenial(w, d, "Too many proxy requests")
 			return
 		}


### PR DESCRIPTION
## Root cause

The mitm auth-failure flood gate keys on `r.RemoteAddr` only, and both `handleConnect` (connect.go:56) and `handleForward` (forward.go:88) gate on it before `Proxy-Authorization` is even parsed. Behind shared ingress, one bad client exhausts the shared bucket and every other tenant behind the same peer IP gets 429 - the proxy can't tell tenants apart at that layer.

## Fix

Key the flood gate on the presented credential instead: `sha256(Proxy-Authorization)[:16]`, so each credential gets its own budget and tokens never appear in rate-limit keys or logs. Requests with no credential at all fall back to the peer IP, so pre-auth garbage floods are still gated.

## Verification

`TestConnectFloodGateKeysOnCredential` drives CONNECTs with two credentials through one source IP: pre-fix the second credential 429s after 3 failures on the first; post-fix it connects, and the unauthenticated flood path still gates. Full `internal/mitm` package passes (Go 1.26.6); gofmt clean on touched files.

Fixes #380

> Built by breken, your AI support engineer - breken.ai - this one's on us.
